### PR TITLE
Fix windows ci builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
     name: Build & Test on ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}
     steps:
+      - run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
@@ -36,11 +39,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: release-${{ matrix.target }}
-      - if: matrix.os != 'windows-latest'
-        run: cargo test --all-features
+      - run: cargo test --all-features
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-
-      # Because quirks, we won't test on Windows for now. But we still should see it build
-      - if: matrix.os == 'windows-latest'
-        run: cargo build
+ 


### PR DESCRIPTION
Windows builds always used to work fine for me locally, because my .gitconfig has `autocrlf = input`. But it seems as though there are some line-endings in our fixtures that may not always be `lf` like they are when we generate snapshots, presumably on Linux/Mac.

So this PR simply tells CI, hey autocrlf first. And yay, things pass!! I also added a .gitattributes to force `lf` line-endings on all source files.

Here is a sample of CI passing on Windows: https://github.com/maraisr/hdx/actions/runs/15894577728/job/44823352507

closes: https://github.com/csskit/csskit/issues/66