### PR TITLE
tidy up many warnings in css_ast types

### DIFF
--- a/crates/css_ast/src/types/auto_line_color_list.rs
+++ b/crates/css_ast/src/types/auto_line_color_list.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-color-list
+// <auto-line-color-list> = [ <line-color-or-repeat> ]* <auto-repeat-line-color> [ <line-color-or-repeat> ]*
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct AutoLineColorList;

--- a/crates/css_ast/src/types/auto_line_style_list.rs
+++ b/crates/css_ast/src/types/auto_line_style_list.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-style-list
+// <auto-line-style-list> = [ <line-style-or-repeat> ]* <auto-repeat-line-style> [ <line-style-or-repeat> ]*
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct AutoLineStyleList;

--- a/crates/css_ast/src/types/auto_line_width_list.rs
+++ b/crates/css_ast/src/types/auto_line_width_list.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-width-list
+// <auto-line-width-list>     = [ <line-width-or-repeat> ]* <auto-repeat-line-width> [ <line-width-or-repeat> ]*
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct AutoLineWidthList;

--- a/crates/css_ast/src/types/autospace.rs
+++ b/crates/css_ast/src/types/autospace.rs
@@ -1,6 +1,10 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-text-4/#typedef-autospace
+//
+// <autospace> = no-autospace | [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Autospace;

--- a/crates/css_ast/src/types/content_distribution.rs
+++ b/crates/css_ast/src/types/content_distribution.rs
@@ -1,6 +1,3 @@
-use css_lexer::Cursor;
-use css_parse::{diagnostics, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
-
 use css_parse::keyword_set;
 
 // https://drafts.csswg.org/css-align-3/#typedef-content-distribution

--- a/crates/css_ast/src/types/content_position.rs
+++ b/crates/css_ast/src/types/content_position.rs
@@ -1,6 +1,3 @@
-use css_lexer::Cursor;
-use css_parse::{diagnostics, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
-
 use css_parse::keyword_set;
 
 // https://drafts.csswg.org/css-align-3/#typedef-content-position

--- a/crates/css_ast/src/types/easing_function.rs
+++ b/crates/css_ast/src/types/easing_function.rs
@@ -1,8 +1,8 @@
 use bumpalo::collections::Vec;
-use css_lexer::{Cursor, SourceOffset};
+use css_lexer::Cursor;
 use css_parse::{
-	diagnostics, function_set, keyword_set, Build, CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors,
-	T,
+	Build, CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics, function_set,
+	keyword_set,
 };
 
 use crate::CSSInt;
@@ -57,7 +57,11 @@ pub enum EasingFunction<'a> {
 	EaseInOut(T![Ident]),
 	StepStart(T![Ident]),
 	StepEnd(T![Ident]),
-	LinearFunction(T![Function], Vec<'a, (T![Number], Option<T![Dimension::%]>, Option<T![Dimension::%]>, Option<T![,]>)>, Option<T![')']>),
+	LinearFunction(
+		T![Function],
+		Vec<'a, (T![Number], Option<T![Dimension::%]>, Option<T![Dimension::%]>, Option<T![,]>)>,
+		Option<T![')']>,
+	),
 	CubicBezierFunction(
 		T![Function],
 		T![Number],
@@ -85,13 +89,13 @@ impl<'a> Parse<'a> for EasingFunction<'a> {
 			let c = keyword.into();
 			let ident = <T![Ident]>::build(p, c);
 			return match keyword {
-				EasingKeyword::Linear(c) => Ok(Self::Linear(ident)),
-				EasingKeyword::Ease(c) => Ok(Self::Ease(ident)),
-				EasingKeyword::EaseIn(c) => Ok(Self::EaseIn(ident)),
-				EasingKeyword::EaseOut(c) => Ok(Self::EaseOut(ident)),
-				EasingKeyword::EaseInOut(c) => Ok(Self::EaseInOut(ident)),
-				EasingKeyword::StepStart(c) => Ok(Self::StepStart(ident)),
-				EasingKeyword::StepEnd(c) => Ok(Self::StepEnd(ident)),
+				EasingKeyword::Linear(_) => Ok(Self::Linear(ident)),
+				EasingKeyword::Ease(_) => Ok(Self::Ease(ident)),
+				EasingKeyword::EaseIn(_) => Ok(Self::EaseIn(ident)),
+				EasingKeyword::EaseOut(_) => Ok(Self::EaseOut(ident)),
+				EasingKeyword::EaseInOut(_) => Ok(Self::EaseInOut(ident)),
+				EasingKeyword::StepStart(_) => Ok(Self::StepStart(ident)),
+				EasingKeyword::StepEnd(_) => Ok(Self::StepEnd(ident)),
 			};
 		}
 		let keyword = p.parse::<EasingFunctionKeyword>()?;
@@ -104,7 +108,6 @@ impl<'a> Parse<'a> for EasingFunction<'a> {
 					if p.at_end() || p.peek::<T![')']>() {
 						break;
 					}
-					let c = p.peek_n(1);
 					let mut num = p.parse_if_peek::<T![Number]>()?;
 					let percent = p.parse_if_peek::<T![Dimension::%]>()?;
 					let percent2 = p.parse_if_peek::<T![Dimension::%]>()?;

--- a/crates/css_ast/src/types/font_weight_absolute.rs
+++ b/crates/css_ast/src/types/font_weight_absolute.rs
@@ -1,5 +1,5 @@
 use css_lexer::Cursor;
-use css_parse::{diagnostics, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
+use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
 
 use crate::CSSInt;
 

--- a/crates/css_ast/src/types/gap_auto_rule_list.rs
+++ b/crates/css_ast/src/types/gap_auto_rule_list.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-gaps-1/#typedef-gap-auto-rule-list
+// <gap-auto-rule-list> = <gap-rule-or-repeat>#? , <gap-auto-repeat-rule> , <gap-rule-or-repeat>#?
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct GapAutoRuleList;

--- a/crates/css_ast/src/types/gap_rule_list.rs
+++ b/crates/css_ast/src/types/gap_rule_list.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule-list
+// <gap-rule-list> = <gap-rule-or-repeat>#
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct GapRuleList;

--- a/crates/css_ast/src/types/line_color_list.rs
+++ b/crates/css_ast/src/types/line_color_list.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-gaps-1/#typedef-line-color-list
+// <line-color-list> = [ <line-color-or-repeat> ]+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LineColorList;

--- a/crates/css_ast/src/types/line_style_list.rs
+++ b/crates/css_ast/src/types/line_style_list.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list
+// <line-style-list> = [ <line-style-or-repeat> ]+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LineStyleList;

--- a/crates/css_ast/src/types/line_width_list.rs
+++ b/crates/css_ast/src/types/line_width_list.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-gaps-1/#typedef-line-width-list
+// <line-width-list> = [ <line-width-or-repeat> ]+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LineWidthList;

--- a/crates/css_ast/src/types/mod.rs
+++ b/crates/css_ast/src/types/mod.rs
@@ -1,4 +1,3 @@
-#![allow(warnings)]
 mod autospace;
 mod anchor_name;
 mod animateable_feature;

--- a/crates/css_ast/src/types/shadow.rs
+++ b/crates/css_ast/src/types/shadow.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-backgrounds-3/#typedef-shadow
+// <shadow> = <color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Shadow;

--- a/crates/css_ast/src/types/single_animation_iteration_count.rs
+++ b/crates/css_ast/src/types/single_animation_iteration_count.rs
@@ -1,5 +1,5 @@
 use css_lexer::Cursor;
-use css_parse::{diagnostics, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
+use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
 
 use crate::units::CSSFloat;
 

--- a/crates/css_ast/src/types/single_animation_trigger.rs
+++ b/crates/css_ast/src/types/single_animation_trigger.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-animations-2/#typedef-single-animation-trigger
+// <single-animation-trigger> = <single-animation-trigger-behavior> || [ none | auto | [ [ <dashed-ident> | <scroll()> | <view()> ] [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]{0,4} ] ]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SingleAnimationTrigger;

--- a/crates/css_ast/src/types/single_animation_trigger_behavior.rs
+++ b/crates/css_ast/src/types/single_animation_trigger_behavior.rs
@@ -1,29 +1,10 @@
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
+use css_parse::keyword_set;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct SingleAnimationTriggerBehavior;
-
-impl<'a> Peek<'a> for SingleAnimationTriggerBehavior {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for SingleAnimationTriggerBehavior {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for SingleAnimationTriggerBehavior {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-}
+// https://drafts.csswg.org/css-animations-2/#typedef-single-animation-trigger-behavior
+// <single-animation-trigger-behavior> = once | repeat | alternate | state
+keyword_set!(SingleAnimationTriggerBehavior {
+	Once: "once",
+	Repeat: "repeat",
+	Alternate: "alternate",
+	State: "state",
+});

--- a/crates/css_ast/src/types/single_transition.rs
+++ b/crates/css_ast/src/types/single_transition.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-transitions-1/#single-transition
+// <single-transition-property> = all | <custom-ident>
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SingleTransition;

--- a/crates/css_ast/src/types/single_transition_property.rs
+++ b/crates/css_ast/src/types/single_transition_property.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-transitions-1/#single-transition-property
+// <single-transition-property> = all | <custom-ident>
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SingleTransitionProperty;

--- a/crates/css_ast/src/types/spacing_trim.rs
+++ b/crates/css_ast/src/types/spacing_trim.rs
@@ -1,29 +1,12 @@
-use css_lexer::{Cursor, SourceOffset};
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
+use css_parse::{keyword_set};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct SpacingTrim;
-
-impl<'a> Peek<'a> for SpacingTrim {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		todo!();
-	}
-}
-
-impl<'a> Parse<'a> for SpacingTrim {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		todo!();
-	}
-}
-
-impl<'a> ToCursors for SpacingTrim {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		todo!();
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-}
+// https://drafts.csswg.org/css-text-4/#typedef-spacing-trim
+// <spacing-trim> = space-all | normal | space-first | trim-start | trim-both | trim-all
+keyword_set!(SpacingTrim {
+	SpaceAll: "space-all",
+	Normal: "normal",
+	SpaceFirst: "space-first",
+	TrimStart: "trim-start",
+	TrimBoth: "trim-both",
+	TrimAll: "trim-all",
+});

--- a/crates/css_ast/src/types/spread_shadow.rs
+++ b/crates/css_ast/src/types/spread_shadow.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-borders-4/#typedef-spread-shadow
+// <spread-shadow> = <'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SpreadShadow;

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -1,6 +1,9 @@
+#![allow(warnings)]
 use css_lexer::{Cursor, SourceOffset};
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, ToCursors, T};
 
+// https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
+// <transform-list> = <transform-function>+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct TransformList;


### PR DESCRIPTION
This removes `allow(warnings)` in `types/mod` instead further scoping them down (adding some `allow(warnings)` inside the sub-mods). 

Also some easy stuff got implemented, such as keyword_sets.