### PR TITLE
clean up double comment

### DIFF
--- a/crates/css_ast/src/values/fonts/mod.rs
+++ b/crates/css_ast/src/values/fonts/mod.rs
@@ -16,7 +16,7 @@ use impls::*;
 // #[animation_type("discrete")]
 // pub enum FontFamilyStyleValue<'a> {}
 
-// // https://drafts.csswg.org/css-fonts-5/#font-weight
+// https://drafts.csswg.org/css-fonts-5/#font-weight
 #[value(" <font-weight-absolute> | bolder | lighter ")]
 #[initial("normal")]
 #[applies_to("all elements and text")]


### PR DESCRIPTION
Running `mise run generate-values -- fonts` I noticed this double comment.