### PR TITLE
Reintroduce derive(Parse/Peek/ToCursors)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "criterion 0.6.0",
  "css_lexer",
  "css_parse",
+ "csskit_derives",
  "csskit_proc_macro",
  "glob",
  "grep-matcher",
@@ -497,6 +498,15 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "csskit_derives"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/csskit/csskit"
 [workspace.dependencies]
 # Local packages
 csskit = { version = "0.0.1", path = "crates/csskit" }
+csskit_derives = { version = "0.0.0", path = "crates/csskit_derives" }
 csskit_proc_macro = { version = "0.0.0", path = "crates/csskit_proc_macro" }
 css_parse = { version = "0.0.1", path = "crates/css_parse" }
 css_lexer = { version = "0.0.1", path = "crates/css_lexer" }

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 css_lexer = { workspace = true }
 css_parse = { workspace = true }
 csskit_proc_macro = { workspace = true }
+csskit_derives = { workspace = true }
 
 bumpalo = { workspace = true, features = ["collections", "boxed"] }
 miette = { workspace = true, features = ["derive"] }

--- a/crates/css_ast/src/types/anchor_name.rs
+++ b/crates/css_ast/src/types/anchor_name.rs
@@ -1,3 +1,7 @@
 use css_parse::T;
+use csskit_derives::{Parse, Peek, ToCursors};
 
-pub type AnchorName = T![DashedIdent];
+// https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-name
+#[derive(Parse, Peek, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+pub struct AnchorName(T![DashedIdent]);

--- a/crates/css_ast/src/types/bg_image.rs
+++ b/crates/css_ast/src/types/bg_image.rs
@@ -1,11 +1,12 @@
 use css_lexer::Cursor;
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics};
+use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
+use csskit_derives::ToCursors;
 
 use super::Image;
 
 // https://drafts.csswg.org/css-backgrounds/#typedef-bg-image
 // <bg-image> = <image> | none
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 pub enum BgImage<'a> {
 	None(T![Ident]),
@@ -34,11 +35,19 @@ impl<'a> Parse<'a> for BgImage<'a> {
 	}
 }
 
-impl ToCursors for BgImage<'_> {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		match self {
-			Self::None(ident) => s.append(ident.into()),
-			Self::Image(image) => ToCursors::to_cursors(image, s),
-		}
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use css_parse::assert_parse;
+
+	#[test]
+	fn size_test() {
+		assert_eq!(std::mem::size_of::<BgImage>(), 208);
+	}
+
+	#[test]
+	fn test_writes() {
+		assert_parse!(BgImage, "none");
+		assert_parse!(BgImage, "url(foo)");
 	}
 }

--- a/crates/css_ast/src/types/counter_style.rs
+++ b/crates/css_ast/src/types/counter_style.rs
@@ -1,9 +1,10 @@
 use css_lexer::Cursor;
-use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, ToCursors, keyword_set};
+use css_parse::{Parser, Peek, T, keyword_set};
+use csskit_derives::{Parse, ToCursors};
 
 use super::Symbols;
 
-#[derive(Debug, Clone, PartialEq, Hash)]
+#[derive(Parse, ToCursors, Debug, Clone, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum CounterStyle<'a> {
 	Predefined(PredefinedCounter),
@@ -14,28 +15,6 @@ pub enum CounterStyle<'a> {
 impl<'a> Peek<'a> for CounterStyle<'a> {
 	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
 		<T![Ident]>::peek(p, c) || <Symbols>::peek(p, c)
-	}
-}
-
-impl<'a> Parse<'a> for CounterStyle<'a> {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		if p.peek::<PredefinedCounter>() {
-			p.parse::<PredefinedCounter>().map(Self::Predefined)
-		} else if p.peek::<T![Ident]>() {
-			p.parse::<T![Ident]>().map(Self::Named)
-		} else {
-			p.parse::<Symbols>().map(Self::Symbols)
-		}
-	}
-}
-
-impl<'a> ToCursors for CounterStyle<'a> {
-	fn to_cursors(&self, s: &mut impl css_parse::CursorSink) {
-		match self {
-			Self::Predefined(c) => s.append(c.into()),
-			Self::Named(c) => s.append(c.into()),
-			Self::Symbols(symbols) => ToCursors::to_cursors(symbols, s),
-		}
 	}
 }
 

--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -1,10 +1,11 @@
 use css_lexer::Cursor;
-use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics};
+use css_parse::{Parse, Parser, Peek, Result as ParserResult, T, diagnostics};
+use csskit_derives::ToCursors;
 
 use super::Gradient;
 
 // https://drafts.csswg.org/css-images-3/#typedef-image
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Image<'a> {
 	Url(T![Url]),
@@ -34,20 +35,6 @@ impl<'a> Parse<'a> for Image<'a> {
 			let string = p.parse::<T![String]>()?;
 			let close = p.parse::<T![')']>()?;
 			return Ok(Self::UrlFunction(func, string, close));
-		}
-	}
-}
-
-impl<'a> ToCursors for Image<'a> {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		match self {
-			Self::Url(c) => s.append(c.into()),
-			Self::UrlFunction(func, string, close) => {
-				s.append(func.into());
-				s.append(string.into());
-				s.append(close.into());
-			}
-			Self::Gradient(c) => ToCursors::to_cursors(c, s),
 		}
 	}
 }

--- a/crates/css_ast/src/types/palette_identifier.rs
+++ b/crates/css_ast/src/types/palette_identifier.rs
@@ -1,4 +1,7 @@
 use css_parse::T;
+use csskit_derives::{Parse, Peek, ToCursors};
 
 // https://www.w3.org/TR/css-fonts-4/#typedef-font-palette-palette-identifier
-pub type PaletteIdentifier = T![DashedIdent];
+#[derive(Parse, Peek, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+pub struct PaletteIdentifier(T![DashedIdent]);

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -1,7 +1,6 @@
 use css_lexer::{Cursor, Kind, Token};
-use css_parse::{
-	Build, CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics, keyword_set,
-};
+use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
+use csskit_derives::ToCursors;
 
 use crate::units::LengthPercentage;
 
@@ -17,7 +16,7 @@ use crate::units::LengthPercentage;
 //   [ [ left | right ] <length-percentage> ] &&
 //   [ [ top | bottom ] <length-percentage> ]
 // ]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Position {
 	SingleValue(PositionSingleValue),
@@ -89,26 +88,6 @@ impl<'a> Parse<'a> for Position {
 		} else {
 			let cursor: Cursor = second.into();
 			Err(diagnostics::Unexpected(cursor.into(), cursor.into()))?
-		}
-	}
-}
-
-impl<'a> ToCursors for Position {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		match *self {
-			Self::SingleValue(v) => {
-				s.append(v.into());
-			}
-			Self::TwoValue(a, b) => {
-				s.append(a.into());
-				s.append(b.into());
-			}
-			Self::FourValue(a, b, c, d) => {
-				s.append(a.into());
-				s.append(b.into());
-				s.append(c.into());
-				s.append(d.into());
-			}
 		}
 	}
 }

--- a/crates/css_ast/src/types/symbols.rs
+++ b/crates/css_ast/src/types/symbols.rs
@@ -1,6 +1,7 @@
 use bumpalo::collections::Vec;
 use css_lexer::Cursor;
 use css_parse::{CursorSink, Parse, Parser, Peek, Result as ParserResult, T, ToCursors, diagnostics, keyword_set};
+use csskit_derives::ToCursors;
 
 use crate::types::Image;
 
@@ -64,20 +65,11 @@ impl<'a> ToCursors for Symbols<'a> {
 }
 
 // https://drafts.csswg.org/css-counter-styles-3/#funcdef-symbols
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Symbol<'a> {
 	String(T![String]),
 	Image(Image<'a>),
-}
-
-impl<'a> ToCursors for Symbol<'a> {
-	fn to_cursors(&self, s: &mut impl CursorSink) {
-		match self {
-			Self::String(c) => s.append(c.into()),
-			Self::Image(c) => ToCursors::to_cursors(c, s),
-		}
-	}
 }
 
 // https://drafts.csswg.org/css-counter-styles-3/#typedef-symbols-type

--- a/crates/csskit_derives/Cargo.toml
+++ b/crates/csskit_derives/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "csskit_derives"
+version = "0.0.0"
+authors.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+bench = false
+proc-macro = true
+
+[dependencies]
+syn = { workspace = true, features = ["extra-traits"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+
+[features]
+default = []

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -1,0 +1,31 @@
+#![deny(warnings)]
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use syn::Error;
+
+mod parse;
+mod peek;
+mod to_cursors;
+
+#[proc_macro_derive(ToCursors, attributes(to_cursors))]
+pub fn derive_to_cursors(stream: TokenStream) -> TokenStream {
+	let input = syn::parse(stream).unwrap();
+	to_cursors::derive(input).into()
+}
+
+#[proc_macro_derive(Parse, attributes(parse))]
+pub fn derive_parse(stream: TokenStream) -> TokenStream {
+	let input = syn::parse(stream).unwrap();
+	parse::derive(input).into()
+}
+
+#[proc_macro_derive(Peek, attributes(peek))]
+pub fn derive_peek(stream: TokenStream) -> TokenStream {
+	let input = syn::parse(stream).unwrap();
+	peek::derive(input).into()
+}
+
+fn err(span: Span, msg: &str) -> proc_macro2::TokenStream {
+	let err = Error::new(span, msg).into_compile_error();
+	quote::quote! {#err}
+}

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -1,0 +1,76 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, FieldsUnnamed, spanned::Spanned};
+
+use crate::err;
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+	let ident = input.ident;
+	let generics = &mut input.generics.clone();
+	let (impl_generics, _, _) = generics.split_for_impl();
+	let body = match input.data {
+		Data::Struct(DataStruct { fields: Fields::Unnamed(fields), .. }) => {
+			if fields.unnamed.len() != 1 {
+				err(ident.span(), "Cannot derive Parse on a struct with multiple unnamed fields")
+			} else {
+				let ty = &fields.unnamed.first().unwrap().ty;
+				quote! { p.parse::<#ty>().map(Self) }
+			}
+		}
+
+		Data::Struct(_) => err(ident.span(), "Cannot derive Parse on a struct with named fields"),
+
+		Data::Union(_) => err(ident.span(), "Cannot derive Parse on a Union"),
+
+		Data::Enum(DataEnum { variants, .. }) => {
+			let mut steps = vec![];
+			let mut first = true;
+			for var in variants {
+				let var_ident = var.ident;
+				match var.fields {
+					Fields::Unit => {
+						steps.push(err(ident.span(), "Cannot derive Parse on a Field Unit Variant"));
+					}
+					Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
+						if unnamed.len() != 1 {
+							steps
+								.push(err(ident.span(), "Cannot derive Parse on a struct with multiple unnamed fields"))
+						} else {
+							let field = unnamed.first().unwrap();
+							let field_ty = &field.ty;
+							if first {
+								steps.push(quote! {
+									p.parse_if_peek::<#field_ty>().ok().flatten().map(Self::#var_ident)
+								});
+							} else {
+								steps.push(quote! {
+									.or_else(|| p.parse_if_peek::<#field_ty>().ok().flatten().map(Self::#var_ident))
+								});
+							}
+						}
+					}
+					Fields::Named(_) => {
+						steps.push(err(var.fields.span(), "Cannot derive on Parse on a Named Field Variant"));
+					}
+				}
+				first = false;
+			}
+			quote! {
+				#(#steps)*
+					.ok_or_else(|| {
+						let c = p.next();
+						::css_parse::diagnostics::Unexpected(c.into(), c.into()).into()
+					})
+			}
+		}
+	};
+	quote! {
+		#[automatically_derived]
+		impl<'a> ::css_parse::Parse<'a> for #ident #impl_generics {
+			fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+				use css_parse::{Parse};
+				#body
+			}
+		}
+	}
+}

--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -1,0 +1,65 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, FieldsUnnamed, spanned::Spanned};
+
+use crate::err;
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+	let ident = input.ident;
+	let generics = &mut input.generics.clone();
+	let (impl_generics, _, _) = generics.split_for_impl();
+	let body = match input.data {
+		Data::Struct(DataStruct { fields: Fields::Unnamed(fields), .. }) => {
+			let ty = &fields.unnamed.first().unwrap().ty;
+			quote! { <#ty>::peek(p, c) }
+		}
+
+		Data::Struct(_) => err(ident.span(), "Cannot derive Peek on a struct with named fields"),
+
+		Data::Union(_) => err(ident.span(), "Cannot derive Peek on a Union"),
+
+		Data::Enum(DataEnum { variants, .. }) => {
+			let mut steps = vec![];
+			let mut first = true;
+			for var in variants {
+				match var.fields {
+					Fields::Unit => {
+						steps.push(err(ident.span(), "Cannot derive Parse on a Field Unit Variant"));
+					}
+					Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
+						if unnamed.len() != 1 {
+							steps
+								.push(err(ident.span(), "Cannot derive Parse on a struct with multiple unnamed fields"))
+						} else {
+							let field = unnamed.first().unwrap();
+							let field_ty = &field.ty;
+							if first {
+								steps.push(quote! {
+									<#field_ty>::peek(p, c)
+								});
+							} else {
+								steps.push(quote! {
+									|| <#field_ty>::peek(p, c)
+								});
+							}
+						}
+					}
+					Fields::Named(_) => {
+						steps.push(err(var.fields.span(), "Cannot derive on Parse on a Named Field Variant"));
+					}
+				}
+				first = false;
+			}
+			quote! { #(#steps)* }
+		}
+	};
+	quote! {
+		#[automatically_derived]
+		impl<'a> #impl_generics ::css_parse::Peek<'a> for #ident #impl_generics {
+			fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+				use ::css_parse::{Peek};
+				#body
+			}
+		}
+	}
+}

--- a/crates/csskit_derives/src/to_cursors.rs
+++ b/crates/csskit_derives/src/to_cursors.rs
@@ -1,0 +1,73 @@
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, Index};
+
+use crate::err;
+
+pub fn derive(input: DeriveInput) -> TokenStream {
+	let ident = input.ident;
+	let generics = &mut input.generics.clone();
+	let (impl_generics, _, _) = generics.split_for_impl();
+	let body = match input.data {
+		Data::Struct(DataStruct { fields: Fields::Unnamed(fields), .. }) => {
+			let steps: Vec<TokenStream> = fields
+				.unnamed
+				.into_iter()
+				.enumerate()
+				.map(|(i, _)| {
+					let index = Index { index: i as u32, span: Span::call_site() };
+					quote! {
+						::css_parse::ToCursors::to_cursors(&self.#index, s);
+					}
+				})
+				.collect();
+			quote! { #(#steps)* }
+		}
+
+		Data::Struct(_) => err(ident.span(), "Cannot derive ToCursors on a struct with named fields"),
+
+		Data::Union(_) => err(ident.span(), "Cannot derive ToCursors on a Union"),
+
+		Data::Enum(DataEnum { variants, .. }) => {
+			let mut steps = vec![];
+			for var in variants {
+				let var_ident = var.ident;
+				if var.fields.len() == 1 {
+					steps.push(quote! {
+						Self::#var_ident(val) => { ::css_parse::ToCursors::to_cursors(val, s); }
+					});
+				} else {
+					let mut idents = vec![];
+					let field_steps: Vec<_> = var
+						.fields
+						.into_iter()
+						.enumerate()
+						.map(|(i, _)| {
+							let ident = format_ident!("v{}", i);
+							idents.push(ident.clone());
+							quote! { ::css_parse::ToCursors::to_cursors(#ident, s); }
+						})
+						.collect();
+					steps.push(quote! {
+						Self::#var_ident(#(#idents),*) => { #(#field_steps)* }
+					});
+				}
+			}
+			quote! {
+				match self {
+					#(#steps)*
+				}
+			}
+		}
+	};
+
+	quote! {
+		#[automatically_derived]
+		impl #impl_generics ::css_parse::ToCursors for #ident #impl_generics {
+			fn to_cursors(&self, s: &mut impl ::css_parse::CursorSink) {
+				use ::css_parse::ToCursors;
+				#body
+			}
+		}
+	}
+}


### PR DESCRIPTION
We used to have `derive(Parse)` & `derive(Peek)` but these were deemed unnecessary when we introduced `csskit_proc_macro`. Since then we've added a lot of new types in `src/types/` and some of these have been simple enough (including some new type structs) that they could benefit from deriving Parse, Peek or even ToCursors.

This PR re-introduces `Parse` & `Peek` derive macros, which simply call `parse` on their underlying types. This also introduces the `ToCursors` derive macro. 

All of these now mean for trivial impls of these, we can simply `#[derive(Peek, Parse, ToCursors)]`.

Of course for single token impls `Build` & `Into<Cursor>` may be better.

This also removes a bunch of trivial implementations in favour of using the derives, which also helped prove out these implementations!