### PR TITLE
    Prefer From<T> for Cursor (over <&T>), From<&T> for Span (over <T>)

### DIFF
--- a/crates/css_ast/src/rules/media/features/hack.rs
+++ b/crates/css_ast/src/rules/media/features/hack.rs
@@ -13,7 +13,7 @@ impl<'a> Parse<'a> for HackMediaFeature {
 		let open = p.parse::<T!['(']>()?;
 		let keyword = p.parse::<T![Ident]>()?;
 		if !p.eq_ignore_ascii_case(keyword.into(), "min-width") {
-			Err(diagnostics::UnexpectedIdent(p.parse_str(keyword.into()).into(), keyword.into()))?
+			Err(diagnostics::UnexpectedIdent(p.parse_str(keyword.into()).into(), (&keyword).into()))?
 		}
 		let colon = p.parse::<T![:]>()?;
 		let dimension = p.parse::<T![Dimension]>()?;

--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -1,4 +1,3 @@
-use css_lexer::Span;
 use css_parse::{Parse, Parser, Result as ParserResult, T};
 use csskit_derives::ToCursors;
 use csskit_proc_macro::visit;
@@ -32,19 +31,6 @@ impl<'a> Parse<'a> for Combinator {
 			Ok(Self::Column(p.parse::<T![||]>()?))
 		} else {
 			Ok(Self::Descendant(p.parse::<T![' ']>()?))
-		}
-	}
-}
-
-impl From<&Combinator> for Span {
-	fn from(value: &Combinator) -> Self {
-		match value {
-			Combinator::Descendant(c) => c.into(),
-			Combinator::Child(c) => c.into(),
-			Combinator::NextSibling(c) => c.into(),
-			Combinator::SubsequentSibling(c) => c.into(),
-			Combinator::Column(c) => c.into(),
-			Combinator::Nesting(c) => c.into(),
 		}
 	}
 }

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,4 +1,4 @@
-use css_lexer::{Cursor, KindSet, Span};
+use css_lexer::{Cursor, KindSet};
 use css_parse::{Build, Parse, Parser, Peek, Result as ParserResult, T};
 use csskit_derives::ToCursors;
 use csskit_proc_macro::visit;
@@ -43,16 +43,6 @@ impl<'a> Parse<'a> for Namespace {
 	}
 }
 
-impl From<&Namespace> for Span {
-	fn from(value: &Namespace) -> Self {
-		if let Some(prefix) = value.prefix {
-			Into::<Span>::into(&prefix) + (&value.tag).into()
-		} else {
-			(&value.tag).into()
-		}
-	}
-}
-
 impl<'a> Visitable<'a> for Namespace {
 	fn accept<V: Visit<'a>>(&self, v: &mut V) {
 		v.visit_namespace(self);
@@ -90,16 +80,6 @@ impl<'a> Parse<'a> for NamespacePrefix {
 	}
 }
 
-impl From<&NamespacePrefix> for Span {
-	fn from(value: &NamespacePrefix) -> Self {
-		match value {
-			NamespacePrefix::None(pipe) => pipe.into(),
-			NamespacePrefix::Name(ident, pipe) => Into::<Span>::into(ident) + pipe.into(),
-			NamespacePrefix::Wildcard(star, pipe) => Into::<Span>::into(star) + pipe.into(),
-		}
-	}
-}
-
 #[derive(ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NamespaceTag {
@@ -125,12 +105,6 @@ impl From<NamespaceTag> for Cursor {
 			NamespaceTag::Tag(c) => c.into(),
 			NamespaceTag::Wildcard(c) => c.into(),
 		}
-	}
-}
-
-impl From<&NamespaceTag> for Span {
-	fn from(value: &NamespaceTag) -> Self {
-		Into::<Cursor>::into(*value).into()
 	}
 }
 

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -113,9 +113,9 @@ impl<'a> Parse<'a> for Nth<'a> {
 impl<'a> ToCursors for Nth<'a> {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		match self {
-			Self::Odd(c) => s.append(c.into()),
-			Self::Even(c) => s.append(c.into()),
-			Self::Integer(c) => s.append((*c).into()),
+			Self::Odd(c) => ToCursors::to_cursors(c, s),
+			Self::Even(c) => ToCursors::to_cursors(c, s),
+			Self::Integer(c) => ToCursors::to_cursors(c, s),
 			Self::Anb(_, _, cursors) => {
 				for c in cursors {
 					s.append(*c);

--- a/crates/css_ast/src/selector/pseudo_class.rs
+++ b/crates/css_ast/src/selector/pseudo_class.rs
@@ -124,7 +124,7 @@ impl<'a> Parse<'a> for PseudoClass {
 	}
 }
 
-impl<'a> From<&PseudoClass> for Span {
+impl From<&PseudoClass> for Span {
 	fn from(value: &PseudoClass) -> Self {
 		macro_rules! match_keyword {
 			( $($ident: ident: $str: tt $(,)*)+ ) => {

--- a/crates/css_ast/src/selector/tag.rs
+++ b/crates/css_ast/src/selector/tag.rs
@@ -58,9 +58,9 @@ impl From<Tag> for Cursor {
 	}
 }
 
-impl From<Tag> for Span {
-	fn from(value: Tag) -> Self {
-		let c: Cursor = value.into();
+impl From<&Tag> for Span {
+	fn from(value: &Tag) -> Self {
+		let c: Cursor = (*value).into();
 		c.into()
 	}
 }
@@ -152,9 +152,9 @@ impl From<CustomElementTag> for Cursor {
 	}
 }
 
-impl From<CustomElementTag> for Span {
-	fn from(value: CustomElementTag) -> Self {
-		let c: Cursor = value.into();
+impl From<&CustomElementTag> for Span {
+	fn from(value: &CustomElementTag) -> Self {
+		let c: Cursor = (*value).into();
 		c.into()
 	}
 }
@@ -625,9 +625,9 @@ impl<'a> Build<'a> for UnknownTag {
 	}
 }
 
-impl From<UnknownTag> for Span {
-	fn from(value: UnknownTag) -> Self {
-		let c: Cursor = value.into();
+impl From<&UnknownTag> for Span {
+	fn from(value: &UnknownTag) -> Self {
+		let c: Cursor = (*value).into();
 		c.into()
 	}
 }

--- a/crates/css_ast/src/types/bg_image.rs
+++ b/crates/css_ast/src/types/bg_image.rs
@@ -28,7 +28,7 @@ impl<'a> Parse<'a> for BgImage<'a> {
 			let ident = p.parse::<T![Ident]>()?;
 			let c: Cursor = ident.into();
 			if !p.eq_ignore_ascii_case(c, "none") {
-				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), ident.into()))?;
+				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), (&ident).into()))?;
 			}
 			Ok(Self::None(ident))
 		}

--- a/crates/css_ast/src/types/gradient.rs
+++ b/crates/css_ast/src/types/gradient.rs
@@ -173,7 +173,7 @@ impl<'a> Parse<'a> for LinearDirection {
 			let to = p.parse::<T![Ident]>()?;
 			let c: Cursor = to.into();
 			if !p.eq_ignore_ascii_case(c, "to") {
-				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), to.into()))?
+				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), (&to).into()))?
 			}
 			let first = p.parse::<NamedDirection>()?;
 			let second = p.parse_if_peek::<NamedDirection>()?;

--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -30,7 +30,7 @@ impl<'a> Parse<'a> for Image<'a> {
 		} else {
 			let func = p.parse::<T![Function]>()?;
 			if !p.eq_ignore_ascii_case(func.into(), "url") {
-				Err(diagnostics::UnexpectedFunction(p.parse_str(func.into()).into(), func.into()))?
+				Err(diagnostics::UnexpectedFunction(p.parse_str(func.into()).into(), (&func).into()))?
 			}
 			let string = p.parse::<T![String]>()?;
 			let close = p.parse::<T![')']>()?;

--- a/crates/css_ast/src/units/int.rs
+++ b/crates/css_ast/src/units/int.rs
@@ -17,12 +17,6 @@ impl From<CSSInt> for i32 {
 	}
 }
 
-impl From<&CSSInt> for i32 {
-	fn from(value: &CSSInt) -> Self {
-		value.0.into()
-	}
-}
-
 impl From<CSSInt> for f32 {
 	fn from(value: CSSInt) -> Self {
 		value.0.into()

--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -114,20 +114,6 @@ impl From<Length> for Token {
 	}
 }
 
-impl From<&Length> for Token {
-	fn from(value: &Length) -> Self {
-		macro_rules! match_length {
-				( $($name: ident),+ $(,)* ) => {
-					match value {
-						Length::Zero(l) => l.into(),
-						$(Length::$name(l) => l.into(),)+
-					}
-				}
-			}
-		apply_lengths!(match_length)
-	}
-}
-
 impl<'a> Peek<'a> for Length {
 	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
 		macro_rules! is_checks {
@@ -199,21 +185,6 @@ impl From<LengthPercentage> for f32 {
 
 impl From<LengthPercentage> for Token {
 	fn from(value: LengthPercentage) -> Self {
-		macro_rules! match_length {
-				( $($name: ident),+ $(,)* ) => {
-					match value {
-						LengthPercentage::Zero(l) => l.into(),
-						LengthPercentage::Percent(l) => l.into(),
-						$(LengthPercentage::$name(l) => l.into(),)+
-					}
-				}
-			}
-		apply_lengths!(match_length)
-	}
-}
-
-impl From<&LengthPercentage> for Token {
-	fn from(value: &LengthPercentage) -> Self {
 		macro_rules! match_length {
 				( $($name: ident),+ $(,)* ) => {
 					match value {
@@ -304,15 +275,6 @@ impl From<LengthPercentageOrAuto> for Token {
 	}
 }
 
-impl From<&LengthPercentageOrAuto> for Token {
-	fn from(value: &LengthPercentageOrAuto) -> Self {
-		match value {
-			LengthPercentageOrAuto::Auto(l) => l.into(),
-			LengthPercentageOrAuto::LengthPercentage(l) => l.into(),
-		}
-	}
-}
-
 impl From<LengthPercentageOrAuto> for Cursor {
 	fn from(value: LengthPercentageOrAuto) -> Self {
 		match value {
@@ -351,12 +313,6 @@ impl From<LengthPercentageOrFlex> for Token {
 			LengthPercentageOrFlex::Flex(l) => l.into(),
 			LengthPercentageOrFlex::LengthPercentage(l) => l.into(),
 		}
-	}
-}
-
-impl From<&LengthPercentageOrFlex> for Token {
-	fn from(value: &LengthPercentageOrFlex) -> Self {
-		(*value).into()
 	}
 }
 

--- a/crates/css_ast/src/units/resolution.rs
+++ b/crates/css_ast/src/units/resolution.rs
@@ -24,16 +24,6 @@ impl From<Resolution> for f32 {
 	}
 }
 
-impl From<&Resolution> for f32 {
-	fn from(res: &Resolution) -> Self {
-		match res {
-			Resolution::Dpi(r) => r.into(),
-			Resolution::Dpcm(r) => r.into(),
-			Resolution::Dppx(r) => r.into(),
-		}
-	}
-}
-
 impl<'a> Peek<'a> for Resolution {
 	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
 		<T![Dimension]>::peek(p, c) && matches!(p.parse_str_lower(c), "dpi" | "dpcm" | "dppx")

--- a/crates/css_parse/src/comparison.rs
+++ b/crates/css_parse/src/comparison.rs
@@ -53,11 +53,11 @@ impl<'a> Parse<'a> for Comparison {
 impl<'a> ToCursors for Comparison {
 	fn to_cursors(&self, s: &mut impl crate::CursorSink) {
 		match self {
-			Self::LessThan(c) => s.append(c.into()),
-			Self::GreaterThan(c) => s.append(c.into()),
+			Self::LessThan(c) => ToCursors::to_cursors(c, s),
+			Self::GreaterThan(c) => ToCursors::to_cursors(c, s),
 			Self::GreaterThanEqual(c) => ToCursors::to_cursors(c, s),
 			Self::LessThanEqual(c) => ToCursors::to_cursors(c, s),
-			Self::Equal(c) => s.append(c.into()),
+			Self::Equal(c) => ToCursors::to_cursors(c, s),
 		}
 	}
 }

--- a/crates/css_parse/src/macros/pseudo_class.rs
+++ b/crates/css_parse/src/macros/pseudo_class.rs
@@ -63,7 +63,7 @@ macro_rules! pseudo_class {
 						$(Self::$variant(_, _) => Ok(Self::$variant(colon, ident)),)+
 					}
 				} else {
-					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.into()))?
+					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), (&ident).into()))?
 				}
 			}
 		}
@@ -72,14 +72,6 @@ macro_rules! pseudo_class {
 			const MAP: phf::Map<&'static str, $name> = phf::phf_map! {
 					$($variant_str => $name::$variant(<$crate::T![:]>::dummy(), <$crate::T![Ident]>::dummy()),)+
 			};
-		}
-
-		impl From<$name> for css_lexer::Span {
-			fn from(value: $name) -> Self {
-				match value {
-					$($name::$variant(a, b) => Into::<::css_lexer::Span>::into(a) + b.into(),)+
-				}
-			}
 		}
 
 		impl From<&$name> for css_lexer::Span {

--- a/crates/css_parse/src/macros/pseudo_element.rs
+++ b/crates/css_parse/src/macros/pseudo_element.rs
@@ -61,7 +61,7 @@ macro_rules! pseudo_element {
 						$(Self::$variant(_, _) => Ok(Self::$variant(colons, ident)),)+
 					}
 				} else {
-					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.into()))?
+					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), (&ident).into()))?
 				}
 			}
 		}
@@ -71,7 +71,7 @@ macro_rules! pseudo_element {
 				match self {
 					$(Self::$variant(colons, ident) => {
 						$crate::ToCursors::to_cursors(colons, s);
-						s.append(ident.into());
+						s.append((*ident).into());
 					})+
 				}
 			}
@@ -81,14 +81,6 @@ macro_rules! pseudo_element {
 			const MAP: phf::Map<&'static str, $name> = phf::phf_map! {
 					$($variant_str => $name::$variant(<$crate::T![::]>::dummy(), <$crate::T![Ident]>::dummy()),)+
 			};
-		}
-
-		impl From<$name> for css_lexer::Span {
-			fn from(value: $name) -> Self {
-				match value {
-					$($name::$variant(a, b) => Into::<::css_lexer::Span>::into(a) + b.into(),)+
-				}
-			}
 		}
 
 		impl From<&$name> for css_lexer::Span {

--- a/crates/css_parse/src/syntax/bang_important.rs
+++ b/crates/css_parse/src/syntax/bang_important.rs
@@ -42,7 +42,7 @@ impl<'a> Parse<'a> for BangImportant {
 		let bang = p.parse::<T![!]>()?;
 		let important = p.parse::<T![Ident]>()?;
 		if !p.eq_ignore_ascii_case(important.into(), "important") {
-			Err(diagnostics::ExpectedIdentOf("important", p.parse_str(important.into()).into(), important.into()))?
+			Err(diagnostics::ExpectedIdentOf("important", p.parse_str(important.into()).into(), (&important).into()))?
 		}
 		Ok(Self { bang, important })
 	}

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -34,18 +34,6 @@ macro_rules! define_kinds {
 			}
 		}
 
-		impl From<&$ident> for ::css_lexer::Token {
-			fn from(value: &$ident) -> Self {
-				value.0.token()
-			}
-		}
-
-		impl From<$ident> for ::css_lexer::Span {
-			fn from(value: $ident) -> Self {
-				value.0.span()
-			}
-		}
-
 		impl From<&$ident> for ::css_lexer::Span {
 			fn from(value: &$ident) -> Self {
 				value.0.span()
@@ -81,33 +69,15 @@ macro_rules! define_kind_idents {
 			}
 		}
 
-		impl From<&$ident> for ::css_lexer::Cursor {
-			fn from(value: &$ident) -> Self {
-				value.0
-			}
-		}
-
 		impl $crate::ToCursors for $ident {
 			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
-				s.append(self.into());
+				s.append((*self).into());
 			}
 		}
 
 		impl From<$ident> for ::css_lexer::Token {
 			fn from(value: $ident) -> Self {
 				value.0.token()
-			}
-		}
-
-		impl From<&$ident> for ::css_lexer::Token {
-			fn from(value: &$ident) -> Self {
-				value.0.token()
-			}
-		}
-
-		impl From<$ident> for ::css_lexer::Span {
-			fn from(value: $ident) -> Self {
-				value.0.span()
 			}
 		}
 
@@ -171,15 +141,9 @@ macro_rules! custom_delim {
 			}
 		}
 
-		impl From<&$ident> for ::css_lexer::Cursor {
-			fn from(value: &$ident) -> Self {
-				value.0.into()
-			}
-		}
-
 		impl $crate::ToCursors for $ident {
 			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
-				s.append(self.into());
+				s.append((*self).into());
 			}
 		}
 
@@ -189,21 +153,9 @@ macro_rules! custom_delim {
 			}
 		}
 
-		impl From<&$ident> for ::css_lexer::Token {
-			fn from(value: &$ident) -> Self {
-				value.0.into()
-			}
-		}
-
-		impl From<$ident> for ::css_lexer::Span {
-			fn from(value: $ident) -> Self {
-				value.0.into()
-			}
-		}
-
 		impl From<&$ident> for ::css_lexer::Span {
 			fn from(value: &$ident) -> Self {
-				value.0.into()
+				(&value.0).into()
 			}
 		}
 
@@ -253,20 +205,8 @@ macro_rules! custom_dimension {
 			}
 		}
 
-		impl From<&$ident> for ::css_lexer::Token {
-			fn from(value: &$ident) -> Self {
-				value.0.token()
-			}
-		}
-
 		impl From<$ident> for ::css_lexer::Cursor {
 			fn from(value: $ident) -> Self {
-				value.0
-			}
-		}
-
-		impl From<&$ident> for ::css_lexer::Cursor {
-			fn from(value: &$ident) -> Self {
 				value.0
 			}
 		}
@@ -302,20 +242,8 @@ macro_rules! custom_dimension {
 			}
 		}
 
-		impl From<&$ident> for i32 {
-			fn from(value: &$ident) -> Self {
-				value.value() as i32
-			}
-		}
-
 		impl From<$ident> for f32 {
 			fn from(value: $ident) -> Self {
-				value.value()
-			}
-		}
-
-		impl From<&$ident> for f32 {
-			fn from(value: &$ident) -> Self {
 				value.value()
 			}
 		}
@@ -383,15 +311,9 @@ macro_rules! custom_double_delim {
 			}
 		}
 
-		impl From<$ident> for ::css_lexer::Span {
-			fn from(value: $ident) -> Self {
-				Into::<::css_lexer::Span>::into(value.0) + Into::<::css_lexer::Span>::into(value.1)
-			}
-		}
-
 		impl From<&$ident> for ::css_lexer::Span {
 			fn from(value: &$ident) -> Self {
-				Into::<::css_lexer::Span>::into(value.0) + Into::<::css_lexer::Span>::into(value.1)
+				Into::<::css_lexer::Span>::into(&value.0) + Into::<::css_lexer::Span>::into(&value.1)
 			}
 		}
 	};
@@ -461,14 +383,6 @@ macro_rules! keyword_set {
 			}
 		}
 
-		impl From<&$name> for css_lexer::Token {
-			fn from(value: &$name) -> Self {
-				match value {
-					$($name::$variant(t) => (*t).into(),)+
-				}
-			}
-		}
-
 		impl From<$name> for css_lexer::Cursor {
 			fn from(value: $name) -> Self {
 				match value {
@@ -477,25 +391,9 @@ macro_rules! keyword_set {
 			}
 		}
 
-		impl From<&$name> for css_lexer::Cursor {
-			fn from(value: &$name) -> Self {
-				match value {
-					$($name::$variant(t) => (*t),)+
-				}
-			}
-		}
-
 		impl $crate::ToCursors for $name {
 			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
-				s.append(self.into());
-			}
-		}
-
-		impl From<$name> for css_lexer::Span {
-			fn from(value: $name) -> Self {
-				match value {
-					$($name::$variant(t) => (t.span()),)+
-				}
+				s.append((*self).into());
 			}
 		}
 
@@ -573,14 +471,6 @@ macro_rules! function_set {
 			}
 		}
 
-		impl From<&$name> for css_lexer::Token {
-			fn from(value: &$name) -> Self {
-				match value {
-					$($name::$variant(t) => (*t).into(),)+
-				}
-			}
-		}
-
 		impl From<$name> for css_lexer::Cursor {
 			fn from(value: $name) -> Self {
 				match value {
@@ -589,25 +479,9 @@ macro_rules! function_set {
 			}
 		}
 
-		impl From<&$name> for css_lexer::Cursor {
-			fn from(value: &$name) -> Self {
-				match value {
-					$($name::$variant(t) => (*t),)+
-				}
-			}
-		}
-
 		impl $crate::ToCursors for $name {
 			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
-				s.append(self.into());
-			}
-		}
-
-		impl From<$name> for css_lexer::Span {
-			fn from(value: $name) -> Self {
-				match value {
-					$($name::$variant(t) => (t.span()),)+
-				}
+				s.append((*self).into());
 			}
 		}
 
@@ -685,14 +559,6 @@ macro_rules! atkeyword_set {
 			}
 		}
 
-		impl From<&$name> for css_lexer::Token {
-			fn from(value: &$name) -> Self {
-				match value {
-					$($name::$variant(t) => (*t).into(),)+
-				}
-			}
-		}
-
 		impl From<$name> for css_lexer::Cursor {
 			fn from(value: $name) -> Self {
 				match value {
@@ -701,25 +567,9 @@ macro_rules! atkeyword_set {
 			}
 		}
 
-		impl From<&$name> for css_lexer::Cursor {
-			fn from(value: &$name) -> Self {
-				match value {
-					$($name::$variant(t) => (*t),)+
-				}
-			}
-		}
-
 		impl $crate::ToCursors for $name {
 			fn to_cursors(&self, s: &mut impl $crate::CursorSink) {
-				s.append(self.into());
-			}
-		}
-
-		impl From<$name> for css_lexer::Span {
-			fn from(value: $name) -> Self {
-				match value {
-					$($name::$variant(t) => (t.span()),)+
-				}
+				s.append((*self).into());
 			}
 		}
 
@@ -818,33 +668,15 @@ impl From<Whitespace> for Cursor {
 	}
 }
 
-impl From<&Whitespace> for Cursor {
-	fn from(value: &Whitespace) -> Self {
-		value.0
-	}
-}
-
 impl ToCursors for Whitespace {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
-		s.append(self.into());
+		s.append((*self).into());
 	}
 }
 
 impl From<Whitespace> for Token {
 	fn from(value: Whitespace) -> Self {
 		value.0.token()
-	}
-}
-
-impl From<&Whitespace> for Token {
-	fn from(value: &Whitespace) -> Self {
-		value.0.token()
-	}
-}
-
-impl From<Whitespace> for Span {
-	fn from(value: Whitespace) -> Self {
-		value.0.span()
 	}
 }
 
@@ -894,9 +726,9 @@ impl ToCursors for DashedIdent {
 	}
 }
 
-impl From<DashedIdent> for Span {
-	fn from(value: DashedIdent) -> Self {
-		value.0.into()
+impl From<&DashedIdent> for Span {
+	fn from(value: &DashedIdent) -> Self {
+		(&value.0).into()
 	}
 }
 
@@ -923,15 +755,9 @@ impl From<Dimension> for Cursor {
 	}
 }
 
-impl From<&Dimension> for Cursor {
-	fn from(value: &Dimension) -> Self {
-		value.0
-	}
-}
-
 impl ToCursors for Dimension {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
-		s.append(self.into());
+		s.append((*self).into());
 	}
 }
 
@@ -953,20 +779,14 @@ impl<'a> Build<'a> for Dimension {
 	}
 }
 
-impl From<Dimension> for Span {
-	fn from(value: Dimension) -> Self {
+impl From<&Dimension> for Span {
+	fn from(value: &Dimension) -> Self {
 		value.0.span()
 	}
 }
 
 impl From<Dimension> for f32 {
 	fn from(value: Dimension) -> Self {
-		value.0.token().value()
-	}
-}
-
-impl From<&Dimension> for f32 {
-	fn from(value: &Dimension) -> Self {
 		value.0.token().value()
 	}
 }
@@ -1026,27 +846,9 @@ impl From<Number> for Cursor {
 	}
 }
 
-impl From<&Number> for Cursor {
-	fn from(value: &Number) -> Self {
-		value.0
-	}
-}
-
 impl From<Number> for Token {
 	fn from(value: Number) -> Self {
 		value.0.token()
-	}
-}
-
-impl From<&Number> for Token {
-	fn from(value: &Number) -> Self {
-		value.0.token()
-	}
-}
-
-impl From<Number> for Span {
-	fn from(value: Number) -> Self {
-		value.0.span()
 	}
 }
 
@@ -1307,15 +1109,9 @@ pub mod double {
 		}
 	}
 
-	impl From<ColonColon> for Span {
-		fn from(value: ColonColon) -> Self {
-			Into::<Span>::into(value.0) + Into::<Span>::into(value.1)
-		}
-	}
-
 	impl From<&ColonColon> for Span {
 		fn from(value: &ColonColon) -> Self {
-			Into::<Span>::into(value.0) + Into::<Span>::into(value.1)
+			Into::<Span>::into(&value.0) + Into::<Span>::into(&value.1)
 		}
 	}
 }
@@ -1656,12 +1452,6 @@ impl From<Any> for Cursor {
 	}
 }
 
-impl From<&Any> for Cursor {
-	fn from(value: &Any) -> Self {
-		value.0
-	}
-}
-
 impl ToCursors for Any {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		s.append(self.0);
@@ -1692,20 +1482,8 @@ impl From<PairWiseStart> for Cursor {
 	}
 }
 
-impl From<&PairWiseStart> for Cursor {
-	fn from(value: &PairWiseStart) -> Self {
-		Cursor::dummy(value.0)
-	}
-}
-
 impl From<PairWiseStart> for Token {
 	fn from(value: PairWiseStart) -> Self {
-		value.0
-	}
-}
-
-impl From<&PairWiseStart> for Token {
-	fn from(value: &PairWiseStart) -> Self {
 		value.0
 	}
 }
@@ -1747,20 +1525,8 @@ impl From<PairWiseEnd> for Cursor {
 	}
 }
 
-impl From<&PairWiseEnd> for Cursor {
-	fn from(value: &PairWiseEnd) -> Self {
-		Cursor::dummy(value.0)
-	}
-}
-
 impl From<PairWiseEnd> for Token {
 	fn from(value: PairWiseEnd) -> Self {
-		value.0
-	}
-}
-
-impl From<&PairWiseEnd> for Token {
-	fn from(value: &PairWiseEnd) -> Self {
 		value.0
 	}
 }

--- a/crates/css_parse/src/traits/rules/at_rule.rs
+++ b/crates/css_parse/src/traits/rules/at_rule.rs
@@ -60,7 +60,7 @@ use css_lexer::{Cursor, KindSet};
 ///     if let Some(prelude) = prelude {
 ///       Ok(Self { name, prelude, block })
 ///     } else {
-///       Err(diagnostics::MissingAtRulePrelude(name.into()))?
+///       Err(diagnostics::MissingAtRulePrelude((&name).into()))?
 ///     }
 ///   }
 /// }

--- a/crates/csskit_highlight/src/css.rs
+++ b/crates/csskit_highlight/src/css.rs
@@ -8,7 +8,7 @@ use crate::{SemanticKind, SemanticModifier, TokenHighlighter};
 
 impl<'a> Visit<'a> for TokenHighlighter {
 	fn visit_tag(&mut self, tag: &Tag) {
-		let span: Span = (*tag).into();
+		let span: Span = tag.into();
 		let mut modifier = SemanticModifier::none();
 		match tag {
 			Tag::HtmlNonConforming(_) => {
@@ -43,14 +43,14 @@ impl<'a> Visit<'a> for TokenHighlighter {
 	}
 
 	fn visit_style_declaration(&mut self, rule: &StyleDeclaration<'a>) {
-		self.insert(rule.open.into(), SemanticKind::Punctuation, SemanticModifier::none());
+		self.insert((&rule.open).into(), SemanticKind::Punctuation, SemanticModifier::none());
 		if let Some(close) = rule.close {
-			self.insert(close.into(), SemanticKind::Punctuation, SemanticModifier::none());
+			self.insert((&close).into(), SemanticKind::Punctuation, SemanticModifier::none());
 		}
 	}
 
 	fn visit_property(&mut self, property: &Property<'a>) {
-		let span: Span = property.name.into();
+		let span: Span = (&property.name).into();
 		let mut modifier = SemanticModifier::none();
 		if matches!(&property.value, StyleValue::Unknown(_)) {
 			modifier |= SemanticModifier::Unknown;
@@ -59,16 +59,16 @@ impl<'a> Visit<'a> for TokenHighlighter {
 			modifier |= SemanticModifier::Custom;
 		}
 		self.insert(span, SemanticKind::Declaration, modifier);
-		self.insert(property.colon.into(), SemanticKind::Punctuation, SemanticModifier::none());
+		self.insert((&property.colon).into(), SemanticKind::Punctuation, SemanticModifier::none());
 	}
 
 	fn visit_property_rule(&mut self, property: &PropertyRule<'a>) {
-		let span: Span = property.name.into();
+		let span: Span = (&property.name).into();
 		self.insert(span, SemanticKind::Declaration, SemanticModifier::Custom);
 	}
 
 	fn visit_property_rule_property(&mut self, property: &PropertyRuleProperty<'a>) {
-		let span: Span = property.name.into();
+		let span: Span = (&property.name).into();
 		let mut modifier = SemanticModifier::none();
 		if matches!(&property.value, PropertyRuleStyleValue::Unknown(_)) {
 			modifier |= SemanticModifier::Unknown;
@@ -77,6 +77,6 @@ impl<'a> Visit<'a> for TokenHighlighter {
 			modifier |= SemanticModifier::Custom;
 		}
 		self.insert(span, SemanticKind::Declaration, modifier);
-		self.insert(property.colon.into(), SemanticKind::Punctuation, SemanticModifier::none());
+		self.insert((&property.colon).into(), SemanticKind::Punctuation, SemanticModifier::none());
 	}
 }


### PR DESCRIPTION
This tries to clean up the `From<T> for Span` and `From<T> for Cursor` types, to reduce the amount of boilerplate. As most things that can `From<T> for Cursor` are likey to be stack allocated, then `From<T>` has been chosen over `From<&T>` - and all `From<&T>` implementations have been dropped, and their callsites cleaned up to deref. Conversely, `From<&T> for Span` has been chosen because the aim is to let every AST be `Into<Span>` and some AST nodes have to allocate on the heap, so it would be bad to `.clone()` these just to get the span.