### PR TITLE
Enhances CI to also run doc builds

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./website
         env:
           NODE_ENV: production
-      - run: cargo doc --all-features --keep-going --release
+      - run: cargo doc --all-features --no-deps --keep-going --release
       - run: mkdir -p ./website/_site/docs/internal/
       - run: cp -rf ./target/doc/* ./website/_site/docs/internal/
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./website
         env:
           NODE_ENV: production
-      - run: cargo doc --all-features
+      - run: cargo doc --all-features --keep-going --release
       - run: mkdir -p ./website/_site/docs/internal/
       - run: cp -rf ./target/doc/* ./website/_site/docs/internal/
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,3 +66,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         # Ensure that docs can also build
       - run: cargo doc --all-features --no-deps
+
+  results:
+    runs-on: ubuntu-latest
+    needs: [build, docs]
+    steps:
+      - name: results
+        run: echo ${{ toJSON(needs.*.result) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,25 @@ jobs:
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
 
+          - os: windows-latest
+            target: aarch64-pc-windows-msvc
+            code-target: win32-arm64
+
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
 
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            code-target: linux-arm64
+
           - os: macos-latest
             target: x86_64-apple-darwin
             code-target: darwin-x64
+
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            code-target: darwin-arm64
 
     name: Build & Test on ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,6 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
       - uses: actions/checkout@v4
       - name: Cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,4 +72,4 @@ jobs:
     needs: [build, docs]
     steps:
       - name: results
-        run: echo ${{ toJSON(needs.*.result) }}
+        run: echo '${{ toJSON(needs.*.result) }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,16 @@
-# mostly copied from https://raw.githubusercontent.com/web-infra-dev/oxc/main/.github/workflows/release_cli.yml
 name: test
 on:
   push:
     branches: ["main"]
   pull_request:
+
 permissions:
   contents: read
   id-token: write
+
+env:
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+
 jobs:
   build:
     strategy:
@@ -40,8 +44,14 @@ jobs:
         with:
           shared-key: release-${{ matrix.target }}
       - run: cargo test --all-features
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
       - run: cargo fmt --check
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+
+  docs:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        # Ensure that docs can also build
+      - run: cargo doc --all-features --no-deps

--- a/crates/css_parse/src/traits/to_cursors.rs
+++ b/crates/css_parse/src/traits/to_cursors.rs
@@ -1,12 +1,12 @@
 use crate::CursorSink;
 use bumpalo::collections::Vec;
 
-/// This trait allows AST nodes to decompose themselves back into a set of (ordered) [Cursors][Cursor].
+/// This trait allows AST nodes to decompose themselves back into a set of (ordered) [Cursors][css_lexer::Cursor].
 ///
 /// This trait is useful to implement because downstream operations can use it to reconstruct source text from Nodes,
 /// including after mutating Nodes, such as transforming them (e.g. minification or formatting).
 ///
-/// Nodes that implement this trait should call `s.append()` in the order that those [Cursors][Cursor] were parsed,
+/// Nodes that implement this trait should call `s.append()` in the order that those [Cursors][css_lexer::Cursor] were parsed,
 /// unless there's a good reason not to. Some good reasons not to:
 ///
 ///  - The specification supplies a specific grammar order.


### PR DESCRIPTION
We have been failing CI for releasing the docs site, due to a broken `cargo doc`. What this PR does is;

1. Builds docs as part of the tests checks run—so we can see if they also break
2. Runs the production docs with `--keep-going --release`, so if there are still errors—still build the docs (`--keep-going`) them, as well as build them in release mode (`--release`)
3. Copied the same matrix from release into test, as arguably tests should pass on what we release 
4. Fixes up the docs so they actually pass green again
5. Similarly to how we do things on dotcom, adds a "result" check—which we can then mark as the required check, so we can add/remove matrix builds without syncing them in the UI.