### PR TITLE
css_ast: Implement text-combine-upright style value.

### DIFF
--- a/crates/css_ast/src/values/writing_modes/impls.rs
+++ b/crates/css_ast/src/values/writing_modes/impls.rs
@@ -7,9 +7,13 @@ mod tests {
 	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
-	fn test_parse_error() {
-		assert_parse_error!(GlyphOrientationVerticalStyleValue, "128");
-		assert_parse_error!(GlyphOrientationVerticalStyleValue, "50deg");
+	fn size_test() {
+		assert_eq!(std::mem::size_of::<DirectionStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<UnicodeBidiStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<WritingModeStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<TextOrientationStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<GlyphOrientationVerticalStyleValue>(), 16);
+		assert_eq!(std::mem::size_of::<TextCombineUprightStyleValue>(), 28);
 	}
 
 	#[test]
@@ -18,5 +22,20 @@ mod tests {
 		assert_parse!(GlyphOrientationVerticalStyleValue, "0");
 		assert_parse!(GlyphOrientationVerticalStyleValue, "90");
 		assert_parse!(GlyphOrientationVerticalStyleValue, "90deg");
+		assert_parse!(TextCombineUprightStyleValue, "none");
+		assert_parse!(TextCombineUprightStyleValue, "all");
+		assert_parse!(TextCombineUprightStyleValue, "digits");
+		assert_parse!(TextCombineUprightStyleValue, "digits 2");
+		assert_parse!(TextCombineUprightStyleValue, "digits 4");
+	}
+
+	#[test]
+	fn test_parse_error() {
+		assert_parse_error!(GlyphOrientationVerticalStyleValue, "128");
+		assert_parse_error!(GlyphOrientationVerticalStyleValue, "50deg");
+		assert_parse_error!(GlyphOrientationVerticalStyleValue, "50deg");
+		assert_parse_error!(TextCombineUprightStyleValue, "digits 1");
+		assert_parse_error!(TextCombineUprightStyleValue, "digits 2 2");
+		assert_parse_error!(TextCombineUprightStyleValue, "digits 5");
 	}
 }

--- a/crates/css_ast/src/values/writing_modes/mod.rs
+++ b/crates/css_ast/src/values/writing_modes/mod.rs
@@ -125,26 +125,26 @@ pub enum TextOrientationStyleValue {}
 #[versions(safari:4,safari_ios:3.2)]
 pub enum GlyphOrientationVerticalStyleValue {}
 
-// /// Represents the style value for `text-combine-upright` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#text-combine-upright).
-// ///
-// /// The text-combine-upright CSS property displays multiple characters in the space of a single character in vertical text. This is used in East Asian documents to display Latin-based strings such as components of a date or letters of an initialism.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | all | [ digits <integer [2,4]>? ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-writing-modes-4/#text-combine-upright
-// #[value(" none | all | [ digits <integer [2,4]>? ] ")]
-// #[initial("none")]
-// #[applies_to("inline boxes and text")]
-// #[inherited("yes")]
-// #[percentages("n/a")]
-// #[canonical_order("n/a")]
-// #[animation_type("not animatable")]
-// #[popularity(Unknown)]
-// #[caniuse(Unknown)]
-// #[baseline(widely)]
-// #[versions(chrome:48,chrome_android:48,edge:79,firefox:48,firefox_android:48,safari:15.4,safari_ios:15.4)]
-// pub enum TextCombineUprightStyleValue {}
+/// Represents the style value for `text-combine-upright` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#text-combine-upright).
+///
+/// The text-combine-upright CSS property displays multiple characters in the space of a single character in vertical text. This is used in East Asian documents to display Latin-based strings such as components of a date or letters of an initialism.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | all | [ digits <integer [2,4]>? ]
+/// ```
+///
+// https://drafts.csswg.org/css-writing-modes-4/#text-combine-upright
+#[value(" none | all | [ digits <integer [2,4]>? ] ")]
+#[initial("none")]
+#[applies_to("inline boxes and text")]
+#[inherited("yes")]
+#[percentages("n/a")]
+#[canonical_order("n/a")]
+#[animation_type("not animatable")]
+#[popularity(Unknown)]
+#[caniuse(Unknown)]
+#[baseline(widely)]
+#[versions(chrome:48,chrome_android:48,edge:79,firefox:48,firefox_android:48,safari:15.4,safari_ios:15.4)]
+pub enum TextCombineUprightStyleValue {}

--- a/tasks/generate-values/mod.ts
+++ b/tasks/generate-values/mod.ts
@@ -169,7 +169,6 @@ const todoPropertiesThatWillBeCommentedOut = new Map([
 	["transforms", new Set(["rotate", "scale", "transform-box", "transform-origin", "translate"])],
 	["ui", new Set(["cursor", "nav-down", "nav-left", "nav-right", "nav-up", "outline"])],
 	["variables", new Set(["--*"])],
-	["writing-modes", new Set(["text-combine-upright"])],
 ]);
 
 const ucfirst = (name: string) => name[0].toUpperCase() + name.slice(1);
@@ -498,7 +497,7 @@ async function getSpec(name: string, index: Record<string, number[]>) {
 			description = `\n${l}/// ${meta.description}`;
 		}
 
-		let applies_to = `"${table.applies_to.replace(/\n/g, " ")}"`
+		let applies_to = `"${table.applies_to.replace(/\n/g, " ")}"`;
 		if (applies_to.length > 105) {
 			applies_to = `\n${l}\t${applies_to}\n${l}`;
 		}


### PR DESCRIPTION
Thanks to https://github.com/csskit/csskit/pull/243 & https://github.com/csskit/csskit/pull/246 we can now uncomment this rule!
