### PR TITLE
csskit_proc_macro: implement bounded multiplier of keywords

### DIFF
--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
@@ -1,0 +1,36 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(
+    pub enum FooKeywords { None : "none", Some : "some", None : "none", Some : "some", }
+);
+#[derive(
+    ::csskit_derives::ToSpan,
+    ::csskit_derives::ToCursors,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+struct Foo<'a>(pub css_parse::T![Ident], pub Option<css_parse::T![Ident]>);
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
+    fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
+        use ::css_parse::Peek;
+        <::css_parse::T![Ident]>::peek(p, c)
+    }
+}
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
+    fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
+        use ::css_parse::{Parse, Peek};
+        let val0 = FooKeywords::parse(p);
+        let val1 = FooKeywords::parse(p);
+        Ok(Self(val0, val1))
+    }
+}

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -686,6 +686,13 @@ fn multiplier_with_just_keywords() {
 }
 
 #[test]
+fn bounded_multiplier_of_keywords() {
+	let syntax = to_valuedef! { [ none | some ]{1,2} };
+	let data = to_deriveinput! { struct Foo<'a> {} };
+	assert_snapshot!(syntax, data, "bounded_multiplier_of_keywords");
+}
+
+#[test]
 fn multiplier_with_comma_separated_keywords() {
 	let syntax = to_valuedef! { [ outset | inset ]# };
 	let data = to_deriveinput! { struct Foo<'a> {} };


### PR DESCRIPTION
We have multipliers of keywords in various types, such as `[ foo | bar ]#`, but bounded multipliers like `[ foo | bar
]{1,2}` have yet to be implemented.

This change alters the generator to check if a bounded multiplier consists of just keywords, so that the types/impls
generated can be simplified to just parsing the keyword set.
