### PR TITLE
Make all StyleValues visitable.

### DIFF
--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -9,12 +9,12 @@ use std::{fmt::Debug, hash::Hash};
 // The build.rs generates a list of CSS properties from the value mods
 include!(concat!(env!("OUT_DIR"), "/css_apply_properties.rs"));
 
-#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[parse(state = State::Nested, stop = KindSet::RIGHT_CURLY_OR_SEMICOLON)]
 pub struct Custom<'a>(pub ComponentValues<'a>);
 
-#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[parse(state = State::Nested, stop = KindSet::RIGHT_CURLY_OR_SEMICOLON)]
 pub struct Computed<'a>(pub ComponentValues<'a>);
@@ -38,7 +38,7 @@ impl<'a> Peek<'a> for Computed<'a> {
 	}
 }
 
-#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[parse(state = State::Nested, stop = KindSet::RIGHT_CURLY_OR_SEMICOLON)]
 pub struct Unknown<'a>(pub ComponentValues<'a>);
@@ -47,12 +47,17 @@ macro_rules! style_value {
 	( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $str: tt,)+ ) => {
 		#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type", rename_all = "kebab-case"))]
-		#[visit(self)]
+		#[visit]
 		pub enum StyleValue<'a> {
+			#[visit(skip)]
 			Initial(T![Ident]),
+			#[visit(skip)]
 			Inherit(T![Ident]),
+			#[visit(skip)]
 			Unset(T![Ident]),
+			#[visit(skip)]
 			Revert(T![Ident]),
+			#[visit(skip)]
 			RevertLayer(T![Ident]),
 			#[cfg_attr(feature = "serde", serde(untagged))]
 			Custom(Custom<'a>),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Length(crate::Length, Option<crate::Length>),
     Auto(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo<'a>(pub css_parse::T![Ident], pub Option<css_parse::T![Ident]>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo(
     pub crate::AnimateableFeature,
     pub Option<crate::AnimateableFeature>,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo<'a>(
     pub crate::BorderTopColorStyleValue<'a>,
     pub Option<crate::BorderTopColorStyleValue<'a>>,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Foo(::css_parse::T![Ident]),
     Bar(Option<crate::Color>, Option<crate::Color>, ::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
@@ -8,6 +8,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -17,6 +18,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo {
     pub foo: Option<::css_parse::T![Ident]>,
     pub bar: Option<::css_parse::T![Ident]>,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Foo(::css_parse::T![Ident]),
     Bar(Option<crate::Color>, ::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo {
     pub foo: Option<::css_parse::T![Ident]>,
     pub bar: Option<crate::Bar>,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Foo(::css_parse::T![Ident]),
     Bar(::css_parse::T![Ident], Option<crate::Color>),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo {
     pub caret_color: Option<crate::CaretColorStyleValue>,
     pub caret_animation: Option<crate::CaretAnimationStyleValue>,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo<'a> {
     None(::css_parse::T![Ident]),
     CalcSizeFunction(crate::CalcSizeFunction<'a>),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     FitContent(::css_parse::T![Ident]),
     FitContentFunction(

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo<'a> {
     Normal(::css_parse::T![Ident]),
     StylesetFunction(

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     None(::css_parse::T![Ident]),
     LengthPercentage(crate::LengthPercentage),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo<'a> {
     Color(crate::Color),
     Image(crate::Image1D<'a>),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo<'a> {
     Auto(::css_parse::T![Ident]),
     AnimateableFeatures(::css_parse::CommaSeparated<'a, crate::AnimateableFeature>),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Normal(::css_parse::T![Ident]),
     SelfPosition(Option<crate::OverflowPosition>, crate::SelfPosition),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo(pub Option<crate::Color>, pub Option<crate::Color>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Foo(::css_parse::T![Ident]),
     Oblique(::css_parse::T![Ident], Option<crate::Angle>),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Keyword(::css_parse::T![Ident]),
     Literal2(crate::CSSInt),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Keyword(::css_parse::T![Ident]),
     Literal1(crate::CSSInt),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     None(::css_parse::T![Ident]),
     CustomIdent(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
@@ -9,6 +9,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -18,6 +19,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Black(::css_parse::T![Ident]),
     White(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::FooKeywords>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
@@ -42,6 +42,7 @@ impl<'a> ::css_parse::Parse<'a> for SingleFoo {
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -51,6 +52,7 @@ impl<'a> ::css_parse::Parse<'a> for SingleFoo {
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::SingleFoo>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo<'a>(pub ::bumpalo::collections::Vec<'a, crate::FooKeywords>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo(pub crate::CaretColorStyleValue, pub Option<crate::CaretAnimationStyleValue>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_one_or_more_commas.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_one_or_more_commas.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::AnimateableFeature>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::AnimateableFeature>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Auto(::css_parse::T![Ident]),
     Color(crate::Color, crate::Color),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo(pub crate::Color, pub crate::Color);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo {
     Length(crate::Length),
     LineThrough(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo(pub ::css_parse::T![Ident]);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo(pub crate::CSSInt);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo<'a>(pub crate::Image<'a>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::Image<'a>>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
@@ -6,6 +6,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,6 +16,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 enum Foo<'a> {
     Foo(::css_parse::T![Ident]),
     Lengths(::bumpalo::collections::Vec<'a, crate::Length>),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
@@ -5,6 +5,7 @@ expression: pretty
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -14,6 +15,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(self)]
 struct Foo(
     pub crate::Length,
     pub crate::Length,

--- a/crates/csskit_proc_macro/src/value.rs
+++ b/crates/csskit_proc_macro/src/value.rs
@@ -45,8 +45,9 @@ pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 		#additonal_defs
 
 		#(#attrs)*
-		#[derive(::csskit_derives::ToSpan, ::csskit_derives::ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(::csskit_derives::ToSpan, ::csskit_derives::ToCursors, ::csskit_derives::Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+		#[visit(self)]
 		#def
 		#peek_impl
 		#parse_impl


### PR DESCRIPTION
StyleValues don't derive `Visitable` in `csskit_proc_macro`, but also the `StyleValue` type had `#[visit(self)]`.

This change fixes both of those issues.
