### PR TITLE
Simplify Function<'a, FT, T> to Function<FT, T>

### DIFF
--- a/crates/css_ast/src/functions/attr_function.rs
+++ b/crates/css_ast/src/functions/attr_function.rs
@@ -16,11 +16,11 @@ function_set!(pub struct AttrFunctionName "attr");
 /// ```
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct AttrFunction<'a>(Function<'a, AttrFunctionName, AttrFunctionParams<'a>>);
+pub struct AttrFunction<'a>(Function<AttrFunctionName, AttrFunctionParams<'a>>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct AttrFunctionParams<'a>(AttrName, Option<AttrType<'a>>, Option<T![,]>, Option<ComponentValues<'a>>);
+pub struct AttrFunctionParams<'a>(AttrName, Option<AttrType>, Option<T![,]>, Option<ComponentValues<'a>>);
 
 // <attr-name> = [ <ident-token>? '|' ]? <ident-token>
 #[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -65,19 +65,19 @@ function_set!(pub struct AttrTypeFunctionName "type");
 // <attr-type> = type( <syntax> ) | raw-string | <attr-unit>
 #[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub enum AttrType<'a> {
-	Type(Function<'a, AttrTypeFunctionName, Syntax>),
+pub enum AttrType {
+	Type(Function<AttrTypeFunctionName, Syntax>),
 	RawString(T![Ident]),
 	Unit(T![DimensionIdent]),
 }
 
-impl<'a> Peek<'a> for AttrType<'a> {
+impl<'a> Peek<'a> for AttrType {
 	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
 		AttrTypeKeywords::peek(p, c) || <T![DimensionIdent]>::peek(p, c) || AttrTypeFunctionName::peek(p, c)
 	}
 }
 
-impl<'a> Parse<'a> for AttrType<'a> {
+impl<'a> Parse<'a> for AttrType {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		if let Some(raw) = p.parse_if_peek::<AttrTypeKeywords>()? {
 			return Ok(Self::RawString(raw.into()));
@@ -85,7 +85,7 @@ impl<'a> Parse<'a> for AttrType<'a> {
 		if let Some(unit) = p.parse_if_peek::<T![DimensionIdent]>()? {
 			return Ok(Self::Unit(unit));
 		}
-		p.parse::<Function<'a, AttrTypeFunctionName, Syntax>>().map(Self::Type)
+		p.parse::<Function<AttrTypeFunctionName, Syntax>>().map(Self::Type)
 	}
 }
 

--- a/crates/css_ast/src/functions/calc_size_function.rs
+++ b/crates/css_ast/src/functions/calc_size_function.rs
@@ -16,7 +16,7 @@ function_set!(pub struct CalcSizeFunctionName "calc-size");
 /// For example, in width, it matches auto, min-content, stretch, etc.
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-pub struct CalcSizeFunction<'a>(Function<'a, CalcSizeFunctionName, Todo>);
+pub struct CalcSizeFunction(Function<CalcSizeFunctionName, Todo>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/functions/content_function.rs
+++ b/crates/css_ast/src/functions/content_function.rs
@@ -10,7 +10,7 @@ function_set!(pub struct ContentFunctionName "content");
 /// ```
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct ContentFunction<'a>(Function<'a, ContentFunctionName, Option<ContentKeywords>>);
+pub struct ContentFunction(Function<ContentFunctionName, Option<ContentKeywords>>);
 
 keyword_set!(
 	pub enum ContentKeywords {

--- a/crates/css_ast/src/functions/counter_functions.rs
+++ b/crates/css_ast/src/functions/counter_functions.rs
@@ -13,7 +13,7 @@ function_set!(pub struct CountersFunctionName "counters");
 /// ```
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct CounterFunction<'a>(Function<'a, CounterFunctionName, CounterFunctionParams<'a>>);
+pub struct CounterFunction<'a>(Function<CounterFunctionName, CounterFunctionParams<'a>>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -27,7 +27,7 @@ pub struct CounterFunctionParams<'a>(T![Ident], Option<T![,]>, Option<CounterSty
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[allow(clippy::type_complexity)] // TODO: simplify types
-pub struct CountersFunction<'a>(Function<'a, CountersFunctionName, CountersFunctionParams<'a>>);
+pub struct CountersFunction<'a>(Function<CountersFunctionName, CountersFunctionParams<'a>>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
+++ b/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
@@ -7,7 +7,7 @@ function_set!(pub struct DynamicRangeLimitMixFunctionName "dynamic-range-limit-m
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct DynamicRangeLimitMixFunction<'a>(
-	Function<'a, DynamicRangeLimitMixFunctionName, CommaSeparated<'a, DynamicRangeLimitMixFunctionParams>>,
+	Function<DynamicRangeLimitMixFunctionName, CommaSeparated<'a, DynamicRangeLimitMixFunctionParams>>,
 );
 
 #[derive(Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/functions/easing_functions.rs
+++ b/crates/css_ast/src/functions/easing_functions.rs
@@ -68,8 +68,8 @@ pub enum EasingFunction<'a> {
 	StepStart(T![Ident]),
 	StepEnd(T![Ident]),
 	LinearFunction(LinearFunction<'a>),
-	CubicBezierFunction(CubicBezierFunction<'a>),
-	StepsFunction(StepsFunction<'a>),
+	CubicBezierFunction(CubicBezierFunction),
+	StepsFunction(StepsFunction),
 }
 
 impl<'a> Peek<'a> for EasingFunction<'a> {
@@ -109,7 +109,7 @@ function_set!(pub struct LinearFunctionName "linear");
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct LinearFunction<'a>(Function<'a, LinearFunctionName, CommaSeparated<'a, LinearFunctionParams>>);
+pub struct LinearFunction<'a>(Function<LinearFunctionName, CommaSeparated<'a, LinearFunctionParams>>);
 
 #[derive(Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -131,7 +131,7 @@ function_set!(pub struct CubicBezierFunctionName "cubic-bezier");
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct CubicBezierFunction<'a>(Function<'a, CubicBezierFunctionName, CubicBezierFunctionParams>);
+pub struct CubicBezierFunction(Function<CubicBezierFunctionName, CubicBezierFunctionParams>);
 
 #[derive(Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -160,7 +160,7 @@ impl<'a> Parse<'a> for CubicBezierFunctionParams {
 
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct StepsFunction<'a>(Function<'a, EasingFunctionName, StepsFunctionParams>);
+pub struct StepsFunction(Function<EasingFunctionName, StepsFunctionParams>);
 
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/functions/fit_content_function.rs
+++ b/crates/css_ast/src/functions/fit_content_function.rs
@@ -12,7 +12,7 @@ function_set!(pub struct FitContentFunctionName "fit-content");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[visit(self)]
-pub struct FitContentFunction<'a>(Function<'a, FitContentFunctionName, LengthPercentage>);
+pub struct FitContentFunction(Function<FitContentFunctionName, LengthPercentage>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/functions/gradient_functions.rs
+++ b/crates/css_ast/src/functions/gradient_functions.rs
@@ -26,7 +26,7 @@ function_set!(pub struct LinearGradientFunctionName "linear-gradient");
 /// ```
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct LinearGradientFunction<'a>(Function<'a, LinearGradientFunctionName, LinearGradientFunctionParams<'a>>);
+pub struct LinearGradientFunction<'a>(Function<LinearGradientFunctionName, LinearGradientFunctionParams<'a>>);
 
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -47,7 +47,7 @@ function_set!(pub struct RepeatingLinearGradientFunctionName "repeating-linear-g
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct RepeatingLinearGradientFunction<'a>(
-	Function<'a, RepeatingLinearGradientFunctionName, RepeatingLinearGradientFunctionParams<'a>>,
+	Function<RepeatingLinearGradientFunctionName, RepeatingLinearGradientFunctionParams<'a>>,
 );
 
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -70,7 +70,7 @@ function_set!(pub struct RadialGradientFunctionName "radial-gradient");
 /// ```
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct RadialGradientFunction<'a>(Function<'a, RadialGradientFunctionName, RadialGradientFunctionParams<'a>>);
+pub struct RadialGradientFunction<'a>(Function<RadialGradientFunctionName, RadialGradientFunctionParams<'a>>);
 
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -96,7 +96,7 @@ function_set!(pub struct RepeatingRadialGradientFunctionName "repeating-radial-g
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct RepeatingRadialGradientFunction<'a>(
-	Function<'a, RepeatingRadialGradientFunctionName, RepeatingRadialGradientFunctionParams<'a>>,
+	Function<RepeatingRadialGradientFunctionName, RepeatingRadialGradientFunctionParams<'a>>,
 );
 
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/functions/image_set_function.rs
+++ b/crates/css_ast/src/functions/image_set_function.rs
@@ -14,20 +14,20 @@ function_set!(pub struct TypeFunctionName "type");
 /// ```
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-pub struct ImageSetFunction<'a>(Function<'a, ImageSetFunctionName, CommaSeparated<'a, ImageSetParams<'a>>>);
+pub struct ImageSetFunction<'a>(Function<ImageSetFunctionName, CommaSeparated<'a, ImageSetParams<'a>>>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum ImageSetParams<'a> {
-	Image(Image<'a>, Option<ResolutionOrType<'a>>),
-	String(T![String], Option<ResolutionOrType<'a>>),
+	Image(Image<'a>, Option<ResolutionOrType>),
+	String(T![String], Option<ResolutionOrType>),
 }
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub enum ResolutionOrType<'a> {
+pub enum ResolutionOrType {
 	Resolution(Resolution),
-	Type(Function<'a, TypeFunctionName, T![String]>),
+	Type(Function<TypeFunctionName, T![String]>),
 }
 
 #[cfg(test)]

--- a/crates/css_ast/src/functions/leader_function.rs
+++ b/crates/css_ast/src/functions/leader_function.rs
@@ -11,7 +11,7 @@ function_set!(pub struct LeaderFunctionName "leader");
 /// ```
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct LeaderFunction<'a>(Function<'a, LeaderFunctionName, LeaderType>);
+pub struct LeaderFunction(Function<LeaderFunctionName, LeaderType>);
 
 keyword_set!(pub enum LeaderTypeKeywords { Dotted: "dotted", Solid: "solid", Space: "space" });
 

--- a/crates/css_ast/src/functions/param_function.rs
+++ b/crates/css_ast/src/functions/param_function.rs
@@ -10,7 +10,7 @@ function_set!(struct ParamFunctionName "param");
 /// ```
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-pub struct ParamFunction<'a>(Function<'a, ParamFunctionName, (T![DashedIdent], T![,], Option<ComponentValues<'a>>)>);
+pub struct ParamFunction<'a>(Function<ParamFunctionName, (T![DashedIdent], T![,], Option<ComponentValues<'a>>)>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/functions/snap_block_function.rs
+++ b/crates/css_ast/src/functions/snap_block_function.rs
@@ -9,7 +9,7 @@ function_set!(pub struct SnapBlockFunctionName "snap-block");
 // snap-block() = snap-block( <length> , [ start | end | near ]? )
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-pub struct SnapBlockFunction<'a>(Function<'a, SnapBlockFunctionName, SnapBlockFunctionParams>);
+pub struct SnapBlockFunction(Function<SnapBlockFunctionName, SnapBlockFunctionParams>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]

--- a/crates/css_ast/src/functions/snap_inline_function.rs
+++ b/crates/css_ast/src/functions/snap_inline_function.rs
@@ -12,7 +12,7 @@ function_set!(pub struct SnapInlineFunctionName "snap-inline");
 /// ```
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-pub struct SnapInlineFunction<'a>(Function<'a, SnapInlineFunctionName, SnapInlineFunctionParams>);
+pub struct SnapInlineFunction(Function<SnapInlineFunctionName, SnapInlineFunctionParams>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]

--- a/crates/css_ast/src/functions/string_function.rs
+++ b/crates/css_ast/src/functions/string_function.rs
@@ -10,7 +10,7 @@ function_set!(pub struct StringFunctionName "string");
 /// ```
 #[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct StringFunction<'a>(Function<'a, StringFunctionName, (T![Ident], Option<T![,]>, Option<StringKeywords>)>);
+pub struct StringFunction(Function<StringFunctionName, (T![Ident], Option<T![,]>, Option<StringKeywords>)>);
 
 keyword_set!(
 	pub enum StringKeywords {

--- a/crates/css_ast/src/functions/stripes_function.rs
+++ b/crates/css_ast/src/functions/stripes_function.rs
@@ -14,7 +14,7 @@ function_set!(pub struct StripesFunctionName "stripes");
 /// ```
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct StripesFunction<'a>(Function<'a, StripesFunctionName, CommaSeparated<'a, ColorStripe>>);
+pub struct StripesFunction<'a>(Function<StripesFunctionName, CommaSeparated<'a, ColorStripe>>);
 
 /// <https://drafts.csswg.org/css-images-4/#typedef-color-stripe>
 ///

--- a/crates/css_ast/src/functions/superellipse_function.rs
+++ b/crates/css_ast/src/functions/superellipse_function.rs
@@ -12,4 +12,4 @@ function_set!(pub struct SuperellipseFunctionName "superellipse");
 /// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-pub struct SuperellipseFunction<'a>(Function<'a, SuperellipseFunctionName, NumberOrInfinity>);
+pub struct SuperellipseFunction(Function<SuperellipseFunctionName, NumberOrInfinity>);

--- a/crates/css_ast/src/functions/symbols_function.rs
+++ b/crates/css_ast/src/functions/symbols_function.rs
@@ -13,7 +13,7 @@ function_set!(pub struct SymbolsFunctionName "symbols");
 /// ```
 #[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct SymbolsFunction<'a>(Function<'a, SymbolsFunctionName, (Option<SymbolsType>, Vec<'a, Symbol<'a>>)>);
+pub struct SymbolsFunction<'a>(Function<SymbolsFunctionName, (Option<SymbolsType>, Vec<'a, Symbol<'a>>)>);
 
 keyword_set!(
 	/// <https://drafts.csswg.org/css-counter-styles-3/#typedef-symbols-type>

--- a/crates/css_ast/src/functions/target_functions.rs
+++ b/crates/css_ast/src/functions/target_functions.rs
@@ -39,13 +39,13 @@ pub enum TargetCounterKind {
 pub enum Target<'a> {
 	// https://drafts.csswg.org/css-content-3/#target-counter
 	// target-counter() = target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )
-	TargetCounter(Function<'a, TargetFunctionNames, TargetCounterParams<'a>>),
+	TargetCounter(Function<TargetFunctionNames, TargetCounterParams<'a>>),
 	// https://drafts.csswg.org/css-content-3/#target-counters
 	// target-counters() = target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )
-	TargetCounters(Function<'a, TargetFunctionNames, TargetCountersParams<'a>>),
+	TargetCounters(Function<TargetFunctionNames, TargetCountersParams<'a>>),
 	// https://drafts.csswg.org/css-content-3/#target-text
 	// target-text() = target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )
-	TargetText(Function<'a, TargetFunctionNames, TargetTextParams>),
+	TargetText(Function<TargetFunctionNames, TargetTextParams>),
 }
 
 impl<'a> Peek<'a> for Target<'a> {
@@ -62,13 +62,13 @@ impl<'a> Parse<'a> for Target<'a> {
 		}
 		match TargetFunctionNames::build(p, c) {
 			TargetFunctionNames::Counter(_) => {
-				p.parse::<Function<'a, TargetFunctionNames, TargetCounterParams<'a>>>().map(Self::TargetCounter)
+				p.parse::<Function<TargetFunctionNames, TargetCounterParams<'a>>>().map(Self::TargetCounter)
 			}
 			TargetFunctionNames::Counters(_) => {
-				p.parse::<Function<'a, TargetFunctionNames, TargetCountersParams<'a>>>().map(Self::TargetCounters)
+				p.parse::<Function<TargetFunctionNames, TargetCountersParams<'a>>>().map(Self::TargetCounters)
 			}
 			TargetFunctionNames::Text(_) => {
-				p.parse::<Function<'a, TargetFunctionNames, TargetTextParams>>().map(Self::TargetText)
+				p.parse::<Function<TargetFunctionNames, TargetTextParams>>().map(Self::TargetText)
 			}
 		}
 	}

--- a/crates/css_ast/src/functions/transform_functions.rs
+++ b/crates/css_ast/src/functions/transform_functions.rs
@@ -6,28 +6,28 @@ use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[allow(clippy::large_enum_variant)] // TODO: matrix3d should probably be boxed
-pub enum TransformFunction<'a> {
-	Matrix(MatrixFunction<'a>),
-	Matrix3d(Matrix3dFunction<'a>),
-	Translate(TranslateFunction<'a>),
-	Translate3d(Translate3dFunction<'a>),
-	TranslateX(TranslatexFunction<'a>),
-	TranslateY(TranslateyFunction<'a>),
-	TranslateZ(TranslatezFunction<'a>),
-	Scale(ScaleFunction<'a>),
-	Scale3d(Scale3dFunction<'a>),
-	ScaleX(ScalexFunction<'a>),
-	ScaleY(ScaleyFunction<'a>),
-	ScaleZ(ScalexFunction<'a>),
-	Rotate(RotateFunction<'a>),
-	Rotate3d(Rotate3dFunction<'a>),
-	RotateX(RotatexFunction<'a>),
-	RotateY(RotateyFunction<'a>),
-	RotateZ(RotatezFunction<'a>),
-	Skew(SkewFunction<'a>),
-	SkewX(SkewxFunction<'a>),
-	SkewY(SkewyFunction<'a>),
-	Perspective(PerspectiveFunction<'a>),
+pub enum TransformFunction {
+	Matrix(MatrixFunction),
+	Matrix3d(Matrix3dFunction),
+	Translate(TranslateFunction),
+	Translate3d(Translate3dFunction),
+	TranslateX(TranslatexFunction),
+	TranslateY(TranslateyFunction),
+	TranslateZ(TranslatezFunction),
+	Scale(ScaleFunction),
+	Scale3d(Scale3dFunction),
+	ScaleX(ScalexFunction),
+	ScaleY(ScaleyFunction),
+	ScaleZ(ScalexFunction),
+	Rotate(RotateFunction),
+	Rotate3d(Rotate3dFunction),
+	RotateX(RotatexFunction),
+	RotateY(RotateyFunction),
+	RotateZ(RotatezFunction),
+	Skew(SkewFunction),
+	SkewX(SkewxFunction),
+	SkewY(SkewyFunction),
+	Perspective(PerspectiveFunction),
 }
 
 function_set!(pub struct MatrixFunctionName "matrix");
@@ -40,7 +40,7 @@ function_set!(pub struct MatrixFunctionName "matrix");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct MatrixFunction<'a>(pub Function<'a, MatrixFunctionName, MatrixFunctionParams>);
+pub struct MatrixFunction(pub Function<MatrixFunctionName, MatrixFunctionParams>);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -68,7 +68,7 @@ function_set!(pub struct Matrix3dFunctionName "matrix3d");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct Matrix3dFunction<'a>(pub Function<'a, Matrix3dFunctionName, Matrix3dFunctionParams>);
+pub struct Matrix3dFunction(pub Function<Matrix3dFunctionName, Matrix3dFunctionParams>);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -117,8 +117,8 @@ function_set!(pub struct TranslateFunctionName "translate");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct TranslateFunction<'a>(
-	pub Function<'a, TranslateFunctionName, (LengthPercentage, Option<T![,]>, Option<LengthPercentage>)>,
+pub struct TranslateFunction(
+	pub Function<TranslateFunctionName, (LengthPercentage, Option<T![,]>, Option<LengthPercentage>)>,
 );
 
 function_set!(pub struct Translate3dFunctionName "translate3d");
@@ -131,7 +131,7 @@ function_set!(pub struct Translate3dFunctionName "translate3d");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct Translate3dFunction<'a>(pub Function<'a, Translate3dFunctionName, Translate3dFunctionParams>);
+pub struct Translate3dFunction(pub Function<Translate3dFunctionName, Translate3dFunctionParams>);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -153,7 +153,7 @@ function_set!(pub struct TranslatexFunctionName "translatex");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct TranslatexFunction<'a>(pub Function<'a, TranslatexFunctionName, LengthPercentage>);
+pub struct TranslatexFunction(pub Function<TranslatexFunctionName, LengthPercentage>);
 
 function_set!(pub struct TranslateyFunctionName "translatey");
 
@@ -165,7 +165,7 @@ function_set!(pub struct TranslateyFunctionName "translatey");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct TranslateyFunction<'a>(pub Function<'a, TranslateyFunctionName, LengthPercentage>);
+pub struct TranslateyFunction(pub Function<TranslateyFunctionName, LengthPercentage>);
 
 function_set!(pub struct TranslatezFunctionName "translatez");
 
@@ -177,7 +177,7 @@ function_set!(pub struct TranslatezFunctionName "translatez");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct TranslatezFunction<'a>(pub Function<'a, TranslatezFunctionName, Length>);
+pub struct TranslatezFunction(pub Function<TranslatezFunctionName, Length>);
 
 function_set!(pub struct ScaleFunctionName "scale");
 
@@ -189,9 +189,7 @@ function_set!(pub struct ScaleFunctionName "scale");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct ScaleFunction<'a>(
-	pub Function<'a, ScaleFunctionName, (NumberOrPercentage, Option<T![,]>, Option<T![Number]>)>,
-);
+pub struct ScaleFunction(pub Function<ScaleFunctionName, (NumberOrPercentage, Option<T![,]>, Option<T![Number]>)>);
 
 function_set!(pub struct Scale3dFunctionName "scale3d");
 
@@ -203,7 +201,7 @@ function_set!(pub struct Scale3dFunctionName "scale3d");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct Scale3dFunction<'a>(pub Function<'a, Scale3dFunctionName, Scale3dFunctionParams>);
+pub struct Scale3dFunction(pub Function<Scale3dFunctionName, Scale3dFunctionParams>);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -225,7 +223,7 @@ function_set!(pub struct ScalexFunctionName "scalex");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct ScalexFunction<'a>(pub Function<'a, ScalexFunctionName, NumberOrPercentage>);
+pub struct ScalexFunction(pub Function<ScalexFunctionName, NumberOrPercentage>);
 
 function_set!(pub struct ScaleyFunctionName "scaley");
 
@@ -237,7 +235,7 @@ function_set!(pub struct ScaleyFunctionName "scaley");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct ScaleyFunction<'a>(pub Function<'a, ScaleyFunctionName, NumberOrPercentage>);
+pub struct ScaleyFunction(pub Function<ScaleyFunctionName, NumberOrPercentage>);
 
 function_set!(pub struct ScalezFunctionName "scalez");
 
@@ -249,7 +247,7 @@ function_set!(pub struct ScalezFunctionName "scalez");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct ScalezFunction<'a>(pub Function<'a, ScalezFunctionName, NumberOrPercentage>);
+pub struct ScalezFunction(pub Function<ScalezFunctionName, NumberOrPercentage>);
 
 function_set!(pub struct RotateFunctionName "rotate");
 
@@ -261,7 +259,7 @@ function_set!(pub struct RotateFunctionName "rotate");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct RotateFunction<'a>(pub Function<'a, RotateFunctionName, AngleOrZero>);
+pub struct RotateFunction(pub Function<RotateFunctionName, AngleOrZero>);
 
 function_set!(pub struct Rotate3dFunctionName "rotate3d");
 
@@ -273,7 +271,7 @@ function_set!(pub struct Rotate3dFunctionName "rotate3d");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct Rotate3dFunction<'a>(pub Function<'a, Rotate3dFunctionName, Rotate3dFunctionParams>);
+pub struct Rotate3dFunction(pub Function<Rotate3dFunctionName, Rotate3dFunctionParams>);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -297,7 +295,7 @@ function_set!(pub struct RotatexFunctionName "rotatex");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct RotatexFunction<'a>(pub Function<'a, RotatexFunctionName, AngleOrZero>);
+pub struct RotatexFunction(pub Function<RotatexFunctionName, AngleOrZero>);
 
 function_set!(pub struct RotateyFunctionName "rotatey");
 
@@ -309,7 +307,7 @@ function_set!(pub struct RotateyFunctionName "rotatey");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct RotateyFunction<'a>(pub Function<'a, RotateyFunctionName, AngleOrZero>);
+pub struct RotateyFunction(pub Function<RotateyFunctionName, AngleOrZero>);
 
 function_set!(pub struct RotatezFunctionName "rotatez");
 
@@ -321,7 +319,7 @@ function_set!(pub struct RotatezFunctionName "rotatez");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct RotatezFunction<'a>(pub Function<'a, RotatezFunctionName, AngleOrZero>);
+pub struct RotatezFunction(pub Function<RotatezFunctionName, AngleOrZero>);
 
 function_set!(pub struct SkewFunctionName "skew");
 
@@ -333,7 +331,7 @@ function_set!(pub struct SkewFunctionName "skew");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct SkewFunction<'a>(pub Function<'a, SkewFunctionName, (AngleOrZero, Option<T![,]>, Option<AngleOrZero>)>);
+pub struct SkewFunction(pub Function<SkewFunctionName, (AngleOrZero, Option<T![,]>, Option<AngleOrZero>)>);
 
 function_set!(pub struct SkewxFunctionName "skewx");
 
@@ -345,7 +343,7 @@ function_set!(pub struct SkewxFunctionName "skewx");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct SkewxFunction<'a>(pub Function<'a, SkewxFunctionName, AngleOrZero>);
+pub struct SkewxFunction(pub Function<SkewxFunctionName, AngleOrZero>);
 
 function_set!(pub struct SkewyFunctionName "skewy");
 
@@ -357,7 +355,7 @@ function_set!(pub struct SkewyFunctionName "skewy");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct SkewyFunction<'a>(pub Function<'a, SkewyFunctionName, AngleOrZero>);
+pub struct SkewyFunction(pub Function<SkewyFunctionName, AngleOrZero>);
 
 function_set!(pub struct PerspectiveFunctionName "perspective");
 
@@ -369,7 +367,7 @@ function_set!(pub struct PerspectiveFunctionName "perspective");
 #[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-pub struct PerspectiveFunction<'a>(pub Function<'a, PerspectiveFunctionName, LengthOrNone>);
+pub struct PerspectiveFunction(pub Function<PerspectiveFunctionName, LengthOrNone>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -34,14 +34,14 @@ pub enum ContentListItem<'a> {
 	Quote(Quote),
 	// https://drafts.csswg.org/css-content-3/#leader-function
 	// leader() = leader( <leader-type> )
-	LeaderFunction(LeaderFunction<'a>),
+	LeaderFunction(LeaderFunction),
 	Target(Target<'a>),
 	// https://drafts.csswg.org/css-content-3/#string-function
 	// string() = string( <custom-ident> , [ first | start | last | first-except ]? )
-	StringFunction(StringFunction<'a>),
+	StringFunction(StringFunction),
 	// https://drafts.csswg.org/css-content-3/#funcdef-content
 	// content() = content( [ text | before | after | first-letter | marker ]? )
-	ContentFunction(ContentFunction<'a>),
+	ContentFunction(ContentFunction),
 	Counter(Counter<'a>),
 }
 

--- a/crates/css_ast/src/types/corner_shape_value.rs
+++ b/crates/css_ast/src/types/corner_shape_value.rs
@@ -20,23 +20,23 @@ keyword_set!(pub enum CornerShapeKeyword {
 /// ```
 #[derive(ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-pub enum CornerShapeValue<'a> {
+pub enum CornerShapeValue {
 	Round(T![Ident]),
 	Scoop(T![Ident]),
 	Bevel(T![Ident]),
 	Notch(T![Ident]),
 	Square(T![Ident]),
 	Squircle(T![Ident]),
-	Superellipse(SuperellipseFunction<'a>),
+	Superellipse(SuperellipseFunction),
 }
 
-impl<'a> Peek<'a> for CornerShapeValue<'a> {
+impl<'a> Peek<'a> for CornerShapeValue {
 	fn peek(p: &css_parse::Parser<'a>, c: Cursor) -> bool {
 		CornerShapeKeyword::peek(p, c) || SuperellipseFunction::peek(p, c)
 	}
 }
 
-impl<'a> Parse<'a> for CornerShapeValue<'a> {
+impl<'a> Parse<'a> for CornerShapeValue {
 	fn parse(p: &mut css_parse::Parser<'a>) -> ParserResult<Self> {
 		if p.peek::<T![Ident]>() {
 			Ok(match p.parse::<CornerShapeKeyword>()? {

--- a/crates/css_ast/src/types/generic_family.rs
+++ b/crates/css_ast/src/types/generic_family.rs
@@ -13,8 +13,8 @@ function_set!(pub struct GenericScriptSpecificFunctionName "generic");
 /// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-pub enum GenericFamily<'a> {
-	ScriptSpecificFunction(GenericScriptSpecificFunction<'a>),
+pub enum GenericFamily {
+	ScriptSpecificFunction(GenericScriptSpecificFunction),
 	Complete(GenericComplete),
 	Incomplete(GenericIncomplete),
 }
@@ -26,9 +26,7 @@ pub enum GenericFamily<'a> {
 /// ```
 #[derive(Peek, Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
-pub struct GenericScriptSpecificFunction<'a>(
-	Function<'a, GenericScriptSpecificFunctionName, GenericScriptSpecificKeyword>,
-);
+pub struct GenericScriptSpecificFunction(Function<GenericScriptSpecificFunctionName, GenericScriptSpecificKeyword>);
 
 keyword_set!(
 	/// <https://drafts.csswg.org/css-fonts-4/#family-name-syntax>

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -7,7 +7,7 @@ use crate::TransformFunction;
 // <transform-list> = <transform-function>+
 #[derive(ToSpan, Peek, Parse, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct TransformList<'a>(pub Vec<'a, TransformFunction<'a>>);
+pub struct TransformList<'a>(pub Vec<'a, TransformFunction>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/values/borders/mod.rs
+++ b/crates/css_ast/src/values/borders/mod.rs
@@ -1361,7 +1361,7 @@ pub struct BorderEndEndRadiusStyleValue;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerShapeStyleValue<'a>;
+pub struct CornerShapeStyleValue;
 
 /// Represents the style value for `corner-top-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-left-shape).
 ///
@@ -1384,7 +1384,7 @@ pub struct CornerShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerTopLeftShapeStyleValue<'a>;
+pub struct CornerTopLeftShapeStyleValue;
 
 /// Represents the style value for `corner-top-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-right-shape).
 ///
@@ -1407,7 +1407,7 @@ pub struct CornerTopLeftShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerTopRightShapeStyleValue<'a>;
+pub struct CornerTopRightShapeStyleValue;
 
 /// Represents the style value for `corner-bottom-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-right-shape).
 ///
@@ -1430,7 +1430,7 @@ pub struct CornerTopRightShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerBottomRightShapeStyleValue<'a>;
+pub struct CornerBottomRightShapeStyleValue;
 
 /// Represents the style value for `corner-bottom-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-left-shape).
 ///
@@ -1453,7 +1453,7 @@ pub struct CornerBottomRightShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerBottomLeftShapeStyleValue<'a>;
+pub struct CornerBottomLeftShapeStyleValue;
 
 /// Represents the style value for `corner-start-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-start-shape).
 ///
@@ -1476,7 +1476,7 @@ pub struct CornerBottomLeftShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerStartStartShapeStyleValue<'a>;
+pub struct CornerStartStartShapeStyleValue;
 
 /// Represents the style value for `corner-start-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-end-shape).
 ///
@@ -1499,7 +1499,7 @@ pub struct CornerStartStartShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerStartEndShapeStyleValue<'a>;
+pub struct CornerStartEndShapeStyleValue;
 
 /// Represents the style value for `corner-end-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-start-shape).
 ///
@@ -1522,7 +1522,7 @@ pub struct CornerStartEndShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerEndStartShapeStyleValue<'a>;
+pub struct CornerEndStartShapeStyleValue;
 
 /// Represents the style value for `corner-end-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-end-shape).
 ///
@@ -1545,7 +1545,7 @@ pub struct CornerEndStartShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerEndEndShapeStyleValue<'a>;
+pub struct CornerEndEndShapeStyleValue;
 
 /// Represents the style value for `corner-top-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-shape).
 ///
@@ -1568,7 +1568,7 @@ pub struct CornerEndEndShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerTopShapeStyleValue<'a>;
+pub struct CornerTopShapeStyleValue;
 
 /// Represents the style value for `corner-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-right-shape).
 ///
@@ -1591,7 +1591,7 @@ pub struct CornerTopShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerRightShapeStyleValue<'a>;
+pub struct CornerRightShapeStyleValue;
 
 /// Represents the style value for `corner-bottom-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-shape).
 ///
@@ -1614,7 +1614,7 @@ pub struct CornerRightShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerBottomShapeStyleValue<'a>;
+pub struct CornerBottomShapeStyleValue;
 
 /// Represents the style value for `corner-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-left-shape).
 ///
@@ -1637,7 +1637,7 @@ pub struct CornerBottomShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerLeftShapeStyleValue<'a>;
+pub struct CornerLeftShapeStyleValue;
 
 /// Represents the style value for `corner-block-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-start-shape).
 ///
@@ -1660,7 +1660,7 @@ pub struct CornerLeftShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerBlockStartShapeStyleValue<'a>;
+pub struct CornerBlockStartShapeStyleValue;
 
 /// Represents the style value for `corner-block-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-end-shape).
 ///
@@ -1683,7 +1683,7 @@ pub struct CornerBlockStartShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerBlockEndShapeStyleValue<'a>;
+pub struct CornerBlockEndShapeStyleValue;
 
 /// Represents the style value for `corner-inline-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-start-shape).
 ///
@@ -1706,7 +1706,7 @@ pub struct CornerBlockEndShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerInlineStartShapeStyleValue<'a>;
+pub struct CornerInlineStartShapeStyleValue;
 
 /// Represents the style value for `corner-inline-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-end-shape).
 ///
@@ -1729,7 +1729,7 @@ pub struct CornerInlineStartShapeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct CornerInlineEndShapeStyleValue<'a>;
+pub struct CornerInlineEndShapeStyleValue;
 
 // /// Represents the style value for `border-limit` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-limit).
 // ///

--- a/crates/css_ast/src/values/flexbox/mod.rs
+++ b/crates/css_ast/src/values/flexbox/mod.rs
@@ -164,4 +164,4 @@ pub struct FlexShrinkStyleValue;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum FlexBasisStyleValue<'a> {}
+pub enum FlexBasisStyleValue {}

--- a/crates/css_ast/src/values/logical/mod.rs
+++ b/crates/css_ast/src/values/logical/mod.rs
@@ -26,7 +26,7 @@ use impls::*;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct BlockSizeStyleValue<'a>;
+pub struct BlockSizeStyleValue;
 
 /// Represents the style value for `inline-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#inline-size).
 ///
@@ -49,7 +49,7 @@ pub struct BlockSizeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct InlineSizeStyleValue<'a>;
+pub struct InlineSizeStyleValue;
 
 /// Represents the style value for `min-block-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#min-block-size).
 ///
@@ -72,7 +72,7 @@ pub struct InlineSizeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct MinBlockSizeStyleValue<'a>;
+pub struct MinBlockSizeStyleValue;
 
 /// Represents the style value for `min-inline-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#min-inline-size).
 ///
@@ -95,7 +95,7 @@ pub struct MinBlockSizeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct MinInlineSizeStyleValue<'a>;
+pub struct MinInlineSizeStyleValue;
 
 /// Represents the style value for `max-block-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#max-block-size).
 ///
@@ -118,7 +118,7 @@ pub struct MinInlineSizeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct MaxBlockSizeStyleValue<'a>;
+pub struct MaxBlockSizeStyleValue;
 
 /// Represents the style value for `max-inline-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#max-inline-size).
 ///
@@ -141,7 +141,7 @@ pub struct MaxBlockSizeStyleValue<'a>;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub struct MaxInlineSizeStyleValue<'a>;
+pub struct MaxInlineSizeStyleValue;
 
 /// Represents the style value for `margin-block-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block-start).
 ///

--- a/crates/css_ast/src/values/page_floats/mod.rs
+++ b/crates/css_ast/src/values/page_floats/mod.rs
@@ -51,7 +51,7 @@ pub enum FloatReferenceStyleValue {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum FloatStyleValue<'a> {}
+pub enum FloatStyleValue {}
 
 /// Represents the style value for `clear` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#clear).
 ///

--- a/crates/css_ast/src/values/sizing/mod.rs
+++ b/crates/css_ast/src/values/sizing/mod.rs
@@ -28,7 +28,7 @@ use impls::*;
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum WidthStyleValue<'a> {}
+pub enum WidthStyleValue {}
 
 /// Represents the style value for `height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#height).
 ///
@@ -53,7 +53,7 @@ pub enum WidthStyleValue<'a> {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum HeightStyleValue<'a> {}
+pub enum HeightStyleValue {}
 
 /// Represents the style value for `min-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-width).
 ///
@@ -78,7 +78,7 @@ pub enum HeightStyleValue<'a> {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum MinWidthStyleValue<'a> {}
+pub enum MinWidthStyleValue {}
 
 /// Represents the style value for `min-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-height).
 ///
@@ -103,7 +103,7 @@ pub enum MinWidthStyleValue<'a> {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum MinHeightStyleValue<'a> {}
+pub enum MinHeightStyleValue {}
 
 /// Represents the style value for `max-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#max-width).
 ///
@@ -128,7 +128,7 @@ pub enum MinHeightStyleValue<'a> {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum MaxWidthStyleValue<'a> {}
+pub enum MaxWidthStyleValue {}
 
 /// Represents the style value for `max-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#max-height).
 ///
@@ -153,7 +153,7 @@ pub enum MaxWidthStyleValue<'a> {}
 #[caniuse(Unknown)]
 #[baseline(Unknown)]
 #[versions(Unknown)]
-pub enum MaxHeightStyleValue<'a> {}
+pub enum MaxHeightStyleValue {}
 
 /// Represents the style value for `box-sizing` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#box-sizing).
 ///

--- a/crates/css_parse/src/syntax/function_block.rs
+++ b/crates/css_parse/src/syntax/function_block.rs
@@ -3,7 +3,7 @@ use csskit_derives::ToSpan;
 
 #[derive(ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct FunctionBlock<'a>(Function<'a, token_macros::Function, ComponentValues<'a>>);
+pub struct FunctionBlock<'a>(Function<token_macros::Function, ComponentValues<'a>>);
 
 // https://drafts.csswg.org/css-syntax-3/#consume-function
 impl<'a> Parse<'a> for FunctionBlock<'a> {

--- a/crates/csskit_proc_macro/src/def.rs
+++ b/crates/csskit_proc_macro/src/def.rs
@@ -94,7 +94,7 @@ pub(crate) enum DefType {
 	Url,
 	DashedIdent,
 	CustomIdent,
-	Custom(DefIdent, bool),
+	Custom(DefIdent),
 }
 
 impl Parse for Def {
@@ -261,8 +261,8 @@ impl Def {
 						Def::Type(DefType::LengthPercentageOrAuto(r.clone()))
 					}
 					// "<length-percentage> | <flex>" can be simplified to "<length-percentage-or-flex>"
-					(Def::Type(DefType::Custom(ident, _)), Def::Type(DefType::LengthPercentage(r)))
-					| (Def::Type(DefType::LengthPercentage(r)), Def::Type(DefType::Custom(ident, _)))
+					(Def::Type(DefType::Custom(ident)), Def::Type(DefType::LengthPercentage(r)))
+					| (Def::Type(DefType::LengthPercentage(r)), Def::Type(DefType::Custom(ident)))
 						if ident.to_string() == "Flex" =>
 					{
 						Def::Type(DefType::LengthPercentageOrFlex(r.clone()))
@@ -397,7 +397,6 @@ impl Parse for DefType {
 			"custom-ident" => Self::CustomIdent,
 			str => {
 				let mut str = str.to_pascal_case().to_owned();
-				let mut life = false;
 				if input.peek(token::Paren) {
 					let content;
 					parenthesized!(content in input);
@@ -405,9 +404,8 @@ impl Parse for DefType {
 						Err(Error::new(input.span(), "disallowed content inside deftype function"))?
 					}
 					str.push_str("Function");
-					life = true;
 				}
-				Self::Custom(DefIdent(str), life)
+				Self::Custom(DefIdent(str))
 			}
 		};
 		input.parse::<Token![>]>()?;

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -17,19 +17,19 @@ expression: pretty
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
-enum Foo<'a> {
+enum Foo {
     None(::css_parse::T![Ident]),
-    CalcSizeFunction(crate::CalcSizeFunction<'a>),
+    CalcSizeFunction(crate::CalcSizeFunction),
 }
 #[automatically_derived]
-impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
+impl<'a> ::css_parse::Peek<'a> for Foo {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
         use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::CalcSizeFunction<'a>>::peek(p, c)
+        <::css_parse::T![Ident]>::peek(p, c) || <crate::CalcSizeFunction>::peek(p, c)
     }
 }
 #[automatically_derived]
-impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
+impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
         match p.parse_if_peek::<FooKeywords>()? {
@@ -38,6 +38,6 @@ impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
             }
             None => {}
         };
-        Ok(Self::CalcSizeFunction(p.parse::<crate::CalcSizeFunction<'a>>()?))
+        Ok(Self::CalcSizeFunction(p.parse::<crate::CalcSizeFunction>()?))
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -19,14 +19,13 @@ expression: pretty
 #[visit(self)]
 enum Foo<'a> {
     FitContent(::css_parse::T![Ident]),
-    FitContentFunction(crate::FitContentFunction<'a>),
+    FitContentFunction(crate::FitContentFunction),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
         use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c)
-            || <crate::FitContentFunction<'a>>::peek(p, c)
+        <::css_parse::T![Ident]>::peek(p, c) || <crate::FitContentFunction>::peek(p, c)
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -19,13 +19,13 @@ expression: pretty
 #[visit(self)]
 enum Foo<'a> {
     Normal(::css_parse::T![Ident]),
-    StylesetFunction(crate::StylesetFunction<'a>),
+    StylesetFunction(crate::StylesetFunction),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
         use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c) || <crate::StylesetFunction<'a>>::peek(p, c)
+        <::css_parse::T![Ident]>::peek(p, c) || <crate::StylesetFunction>::peek(p, c)
     }
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -33,7 +33,7 @@ fn test_def_builds_type() {
 fn test_def_builds_quoted_type() {
 	assert_eq!(
 		::syn::parse2::<StrWrapped<Def>>(quote! { "<'some-prop'>" }).unwrap().0,
-		Def::Type(DefType::Custom(DefIdent("SomePropStyleValue".into()), false))
+		Def::Type(DefType::Custom(DefIdent("SomePropStyleValue".into())))
 	)
 }
 
@@ -64,7 +64,7 @@ fn test_def_builds_quoted_custom_type_with_count() {
 	assert_eq!(
 		::syn::parse2::<StrWrapped<Def>>(quote! { "<'animation-delay'>{1,}" }).unwrap().0,
 		Def::Multiplier(
-			Box::new(Def::Type(DefType::Custom(DefIdent("AnimationDelayStyleValue".into()), false),)),
+			Box::new(Def::Type(DefType::Custom(DefIdent("AnimationDelayStyleValue".into())),)),
 			DefMultiplierSeparator::None,
 			DefRange::RangeFrom(1.)
 		)
@@ -524,7 +524,7 @@ fn custom_type_with_checks() {
 #[test]
 fn custom_function_type() {
 	let syntax = to_valuedef!(" none | <calc-size()> ");
-	let data = to_deriveinput! { enum Foo<'a> {} };
+	let data = to_deriveinput! { enum Foo {} };
 	assert_snapshot!(syntax, data, "custom_function_type");
 }
 

--- a/tasks/generate-values/mod.ts
+++ b/tasks/generate-values/mod.ts
@@ -521,7 +521,6 @@ const snake = (name: string) => name.replace(/([_-\s]\w)/g, (n) => `_${n.slice(1
 // so it's easier just to hardcode these as a list...
 const requiresAllocatorLifetime = new Map([
 	["anchor-position", new Set([])],
-	["color-hdr", new Set(["dynamic-range-limit"])],
 	["ui", new Set(["outline"])],
 	["borders", new Set(["border-inline-color", "border-block-color"])],
 	["conditional", new Set(["container-name"])],
@@ -801,7 +800,8 @@ async function getSpec(name: string, index: Record<string, number[]>) {
 			.replace(/<[^>]+>/g, "")
 			.replace(/\[[^\[\]]*\]/g, "")
 			.trim();
-		const isCombinedType = /^<(length|time|number|percentage)(?:[^\|]+) \| <(length|time|number|percentage)(?:[^\|]+)>$/.test(table.value);
+		const isCombinedType =
+			/^<(length|time|number|percentage)(?:[^\|]+) \| <(length|time|number|percentage)(?:[^\|]+)>$/.test(table.value);
 		console.log(table.value, isCombinedType);
 		const isTypeOrAuto = /^auto \| <(length|time|number)(?:[^\|]+)$|^<(length|time|number)(?:[^\|]+)> \| auto$/.test(
 			table.value,
@@ -833,13 +833,10 @@ async function getSpec(name: string, index: Record<string, number[]>) {
 			table.value.includes("<content-list>") ||
 			table.value.includes("<image-1D>") ||
 			table.value.includes("<transform-list>") ||
-			table.value.includes("<corner-shape-value>") ||
-			table.value.includes("<'width'>") ||
-			table.value.includes("<'min-width'>") ||
-			table.value.includes("<'max-width'>") ||
+			table.value.includes("<dynamic-range-limit-mix()>") ||
+			table.value.includes("<param()>") ||
 			table.value.includes("]+") ||
 			table.value.includes("]#") ||
-			table.value.includes("()>") ||
 			/#(:?$|[^\{])/.test(table.value);
 		if (lifetimes?.has(table.name) && mustRequireLifetime) {
 			throw new Error(


### PR DESCRIPTION
The Function dynamic type was a little hastily built, and as a consequence the struct definition ended up requiring all
of the common traits, plus the `'a` lifetime used for the bump allocator. It didn't need this (evident by the fact is
was stuffed into PhantomData).

This change drops the trait requirements (requiring them only when needed) and as a consequence drops the `'a` lifetime.
This also has a rather large fanout effect because there aren't many functions that actually _needed_ the lifetime, but
the assumption was baked in all the way to generate.rs...

So this change not only drops the lifetime from all structs, but also tweaks generate.rs to only supply the lifetime to
the functions that need it (via the usual routes).
