### PR TITLE
csskit_proc_macro: Visit sub-types of StyleValues

### DIFF
--- a/crates/csskit_derives/src/visitable.rs
+++ b/crates/csskit_derives/src/visitable.rs
@@ -80,17 +80,14 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 					.iter()
 					.map(|variant| {
 						let variant_ident = &variant.ident;
-						if Into::<VisitStyle>::into(&variant.attrs) == VisitStyle::Skip {
-							return quote! {
-								Self::#variant_ident(_) => {},
-							};
-						}
 						let (members, steps): (Vec<_>, Vec<_>) = variant
 							.fields
 							.iter()
 							.enumerate()
 							.map(|(i, field)| {
-								if Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip {
+								if Into::<VisitStyle>::into(&field.attrs) == VisitStyle::Skip
+									|| Into::<VisitStyle>::into(&variant.attrs) == VisitStyle::Skip
+								{
 									(format_ident!("_"), quote! {})
 								} else {
 									let ident = format_ident!("v{}", i);

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bound_range_multiplier_with_keyword.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Auto : "auto", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Auto :
+    "auto", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,9 +19,9 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
     Length(crate::Length, Option<crate::Length>),
+    #[visit(skip)]
     Auto(::css_parse::T![Ident]),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_multiplier_of_keywords.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { None : "none", Some : "some", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { None :
+    "none", Some : "some", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,12 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
-struct Foo<'a>(pub css_parse::T![Ident], pub Option<css_parse::T![Ident]>);
+struct Foo<'a>(
+    #[visit(skip)]
+    pub css_parse::T![Ident],
+    #[visit(skip)]
+    pub Option<css_parse::T![Ident]>,
+);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo(
     pub crate::AnimateableFeature,
     pub Option<crate::AnimateableFeature>,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo<'a>(
     pub crate::BorderTopColorStyleValue<'a>,
     pub Option<crate::BorderTopColorStyleValue<'a>>,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional2_keyword.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Foo : "foo", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,10 +19,15 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
-    Bar(Option<crate::Color>, Option<crate::Color>, ::css_parse::T![Ident]),
+    Bar(
+        Option<crate::Color>,
+        Option<crate::Color>,
+        #[visit(skip)]
+        ::css_parse::T![Ident],
+    ),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_all_keywords.snap
@@ -3,7 +3,8 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 ::css_parse::keyword_set!(
-    pub enum FooKeywords { Foo : "foo", Bar : "bar", Baz : "baz", }
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", Bar : "bar", Baz : "baz", }
 );
 #[derive(
     ::csskit_derives::ToSpan,
@@ -18,10 +19,12 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo {
+    #[visit(skip)]
     pub foo: Option<::css_parse::T![Ident]>,
+    #[visit(skip)]
     pub bar: Option<::css_parse::T![Ident]>,
+    #[visit(skip)]
     pub baz: Option<::css_parse::T![Ident]>,
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keyword.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Foo : "foo", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,10 +19,10 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
-    Bar(Option<crate::Color>, ::css_parse::T![Ident]),
+    Bar(Option<crate::Color>, #[visit(skip)] ::css_parse::T![Ident]),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_keywords_and_types.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Foo : "foo", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,8 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo {
+    #[visit(skip)]
     pub foo: Option<::css_parse::T![Ident]>,
     pub bar: Option<crate::Bar>,
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__combinator_optional_last_keyword.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Foo : "foo", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,10 +19,10 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
-    Bar(::css_parse::T![Ident], Option<crate::Color>),
+    Bar(#[visit(skip)] ::css_parse::T![Ident], Option<crate::Color>),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_all_optionals.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo {
     pub caret_color: Option<crate::CaretColorStyleValue>,
     pub caret_animation: Option<crate::CaretAnimationStyleValue>,

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_type.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { None : "none", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { None :
+    "none", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,8 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     None(::css_parse::T![Ident]),
     CalcSizeFunction(crate::CalcSizeFunction),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_args.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { FitContent : "fit-content", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords {
+    FitContent : "fit-content", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,8 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo<'a> {
+    #[visit(skip)]
     FitContent(::css_parse::T![Ident]),
     FitContentFunction(crate::FitContentFunction),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_function_variant_with_multiplier_args.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Normal : "normal", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Normal :
+    "normal", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,8 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo<'a> {
+    #[visit(skip)]
     Normal(::css_parse::T![Ident]),
     StylesetFunction(crate::StylesetFunction),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__custom_type_with_checks.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { None : "none", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { None :
+    "none", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,8 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     None(::css_parse::T![Ident]),
     LengthPercentage(crate::LengthPercentage),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_type_with_lifetime.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo<'a> {
     Color(crate::Color),
     Image(crate::Image1D<'a>),

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__enum_with_variable_count_type.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Auto : "auto", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Auto :
+    "auto", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,8 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo<'a> {
+    #[visit(skip)]
     Auto(::css_parse::T![Ident]),
     AnimateableFeatures(::css_parse::CommaSeparated<'a, crate::AnimateableFeature>),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__group_with_optional_leader.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Normal : "normal", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Normal :
+    "normal", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,8 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     Normal(::css_parse::T![Ident]),
     SelfPosition(Option<crate::OverflowPosition>, crate::SelfPosition),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__just_optional.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo(pub Option<crate::Color>, pub Option<crate::Color>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_bounded_type.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Foo : "foo", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,10 +19,10 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
-    Oblique(::css_parse::T![Ident], Option<crate::Angle>),
+    Oblique(#[visit(skip)] ::css_parse::T![Ident], Option<crate::Angle>),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Keyword : "keyword", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Keyword
+    : "keyword", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,9 +19,10 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     Keyword(::css_parse::T![Ident]),
+    #[visit(skip)]
     Literal2(crate::CSSInt),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_int_literal_dimension_literal.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Keyword : "keyword", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Keyword
+    : "keyword", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,10 +19,12 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     Keyword(::css_parse::T![Ident]),
+    #[visit(skip)]
     Literal1(crate::CSSInt),
+    #[visit(skip)]
     Literal1deg(::css_parse::T![Dimension]),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__keyword_or_type.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { None : "none", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { None :
+    "none", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,16 +19,16 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     None(::css_parse::T![Ident]),
-    CustomIdent(::css_parse::T![Ident]),
+    CustomIdent(crate::CustomIdent),
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
         use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c)
+        <::css_parse::T![Ident]>::peek(p, c) || <crate::CustomIdent>::peek(p, c)
     }
 }
 #[automatically_derived]
@@ -37,7 +40,7 @@ impl<'a> ::css_parse::Parse<'a> for Foo {
                 return Ok(Self::None(ident));
             }
             None => {
-                return Ok(Self::CustomIdent(p.parse::<::css_parse::T![Ident]>()?));
+                return Ok(Self::CustomIdent(p.parse::<crate::CustomIdent>()?));
             }
         }
     }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiple_keywords.snap
@@ -3,8 +3,8 @@ source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
 ::css_parse::keyword_set!(
-    pub enum FooKeywords { Black : "black", White : "white", LineThrough :
-    "line-through", Pink : "pink", }
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Black :
+    "black", White : "white", LineThrough : "line-through", Pink : "pink", }
 );
 #[derive(
     ::csskit_derives::ToSpan,
@@ -19,11 +19,14 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     Black(::css_parse::T![Ident]),
+    #[visit(skip)]
     White(::css_parse::T![Ident]),
+    #[visit(skip)]
     LineThrough(::css_parse::T![Ident]),
+    #[visit(skip)]
     Pink(::css_parse::T![Ident]),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_keywords.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Outset : "outset", Inset : "inset", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Outset :
+    "outset", Inset : "inset", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,7 +19,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::FooKeywords>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_comma_separated_types.snap
@@ -2,10 +2,14 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Foo : "foo", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
+    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -15,7 +19,9 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[visit(children)]
 enum SingleFoo {
+    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     Bar(crate::Bar),
 }
@@ -52,7 +58,6 @@ impl<'a> ::css_parse::Parse<'a> for SingleFoo {
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::SingleFoo>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__multiplier_with_just_keywords.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Outset : "outset", Inset : "inset", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Outset :
+    "outset", Inset : "inset", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,7 +19,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo<'a>(pub ::bumpalo::collections::Vec<'a, crate::FooKeywords>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_custom_function_last_option.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo(pub crate::CaretColorStyleValue, pub Option<crate::CaretAnimationStyleValue>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_one_or_more_commas.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_one_or_more_commas.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::AnimateableFeature>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__struct_with_variable_count_type.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::AnimateableFeature>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_auto_color2_optimized.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Auto : "auto", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Auto :
+    "auto", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,8 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
+    #[visit(skip)]
     Auto(::css_parse::T![Ident]),
     Color(crate::Color, crate::Color),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_fixed_range_color2_optimized.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo(pub crate::Color, pub crate::Color);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_group_type_keyword.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { LineThrough : "line-through", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords {
+    LineThrough : "line-through", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,9 +19,9 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo {
     Length(crate::Length),
+    #[visit(skip)]
     LineThrough(::css_parse::T![Ident]),
 }
 #[automatically_derived]

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_custom_type.snap
@@ -15,19 +15,18 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
-struct Foo(pub ::css_parse::T![Ident]);
+struct Foo(pub crate::CustomIdent);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {
     fn peek(p: &::css_parse::Parser<'a>, c: ::css_lexer::Cursor) -> bool {
         use ::css_parse::Peek;
-        <::css_parse::T![Ident]>::peek(p, c)
+        <crate::CustomIdent>::peek(p, c)
     }
 }
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {
         use ::css_parse::{Parse, Peek};
-        Ok(Self(p.parse::<::css_parse::T![Ident]>()?))
+        Ok(Self(p.parse::<crate::CustomIdent>()?))
     }
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo(pub crate::CSSInt);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_lone_type_with_lifetime.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo<'a>(pub crate::Image<'a>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_vec_type_with_lifetime.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::Image<'a>>);
 #[automatically_derived]
 impl<'a> ::css_parse::Peek<'a> for Foo<'a> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_oneormore.snap
@@ -2,7 +2,10 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-::css_parse::keyword_set!(pub enum FooKeywords { Foo : "foo", });
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Foo :
+    "foo", }
+);
 #[derive(
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
@@ -16,8 +19,8 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 enum Foo<'a> {
+    #[visit(skip)]
     Foo(::css_parse::T![Ident]),
     Lengths(::bumpalo::collections::Vec<'a, crate::Length>),
 }

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__value_with_multiplier_range.snap
@@ -15,7 +15,6 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
 struct Foo(
     pub crate::Length,
     pub crate::Length,

--- a/crates/csskit_proc_macro/src/value.rs
+++ b/crates/csskit_proc_macro/src/value.rs
@@ -47,7 +47,6 @@ pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 		#(#attrs)*
 		#[derive(::csskit_derives::ToSpan, ::csskit_derives::ToCursors, ::csskit_derives::Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-		#[visit(self)]
 		#def
 		#peek_impl
 		#parse_impl


### PR DESCRIPTION
When generating StyleValues in https://github.com/csskit/csskit/pull/318, the easy choice was to make them
`#[visit(self)]`, but of course that's a stop gap, as we want to be able to visit individual types, such as functions or
units. https://github.com/csskit/csskit/pull/321 added sufficient Visitable capability to all the necessary types, such
that now we can drop `#[visit(self)]` on StyleValues and instead use `#[visit]`, with an occasional smattering of
`#[visit(skip)]` on the sub-types.
