### PR TITLE
csskit_derives: Add support for parsing as keyword

### DIFF
--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -1,62 +1,16 @@
+use crate::err;
 use itertools::{Itertools, Position};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use syn::{
-	Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, ExprRange, Fields, Meta, Token, Type, TypePath,
-	parse::Parse, parse_quote,
+	Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, ExprPath, ExprRange, Fields, Meta, Token, Type,
+	TypePath, parse::Parse, parse_quote,
 };
 
-use crate::err;
-
-/// Generate range validation code for a field based on the in_range attribute
-fn generate_range_validation(field_ident: &Ident, range_expr: &ExprRange) -> TokenStream {
-	let start = &range_expr.start;
-	let end = &range_expr.end;
-	match (start, end) {
-		// 1..=10 (inclusive end)
-		(Some(start), Some(end)) => {
-			quote! {
-				if let Ok(i) = std::convert::TryInto::<f32>::try_into(#field_ident) {
-					if !(#start..=#end).contains(&i) {
-						use ::css_parse::ToSpan;
-						Err(::css_parse::diagnostics::NumberOutOfBounds(
-							#field_ident.into(),
-							format!("{}..={}", #start, #end),
-							#field_ident.to_span()
-						))?
-					}
-				}
-			}
-		}
-		(Some(start), None) => {
-			quote! {
-				if let Ok(i) = std::convert::TryInto::<f32>::try_into(#field_ident) {
-					if #start > i {
-						use ::css_parse::ToSpan;
-						Err(::css_parse::diagnostics::NumberTooSmall(
-							#start,
-							#field_ident.to_span()
-						))?
-					}
-				}
-			}
-		}
-		(None, Some(end)) => {
-			quote! {
-				if let Ok(i) = std::convert::TryInto::<f32>::try_into(#field_ident) {
-					if #end < i {
-						use ::css_parse::ToSpan;
-						Err(::css_parse::diagnostics::NumberTooLarge(
-							#end,
-							#field_ident.to_span()
-						))?
-					}
-				}
-			}
-		}
-		// .. (full range) - no validation needed
-		(None, None) => quote! {},
-	}
+#[derive(Debug, Clone, Copy)]
+enum FieldParseMode {
+	Sequential,
+	AllMustOccur,
 }
 
 trait ToVarsAndTypes {
@@ -82,17 +36,19 @@ impl ToVarsAndTypes for Fields {
 	}
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq)]
+#[derive(Debug, Default)]
 struct ParseArg {
 	pub state: Option<Ident>,
 	pub stop: Option<(Ident, Ident)>,
 	pub in_range: Option<ExprRange>,
 	pub all_must_occur: bool,
+	pub keyword_variant: Option<ExprPath>, // Store the specific keyword variant like FooKeywords::Auto
 }
 
 impl Parse for ParseArg {
 	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-		let (mut state, mut stop, mut in_range, mut all_must_occur) = (None, None, None, false);
+		let (mut state, mut stop, mut in_range, mut all_must_occur, mut keyword_variant) =
+			(None, None, None, false, None);
 		while !input.is_empty() {
 			match input.parse::<Ident>()? {
 				i if i == "state" => {
@@ -126,7 +82,12 @@ impl Parse for ParseArg {
 						Err(Error::new(i.span(), "redefinition of 'in_range'".to_string()))?;
 					}
 					input.parse::<Token![=]>()?;
-					let range = input.parse::<ExprRange>()?;
+					let range = input.parse::<syn::Expr>()?;
+					let range = if let syn::Expr::Range(range_expr) = range {
+						range_expr
+					} else {
+						return Err(Error::new_spanned(range, "Expected range expression"));
+					};
 					in_range = Some(range);
 				}
 				i if i == "all_must_occur" => {
@@ -135,6 +96,13 @@ impl Parse for ParseArg {
 					}
 					all_must_occur = true;
 				}
+				i if i == "keyword" => {
+					if keyword_variant.is_some() {
+						Err(Error::new(i.span(), "redefinition of 'keyword'".to_string()))?;
+					}
+					input.parse::<Token![=]>()?;
+					keyword_variant = Some(input.parse::<ExprPath>()?);
+				}
 				ident => Err(Error::new(ident.span(), format!("Unrecognized Value arg {ident:?}")))?,
 			}
 
@@ -142,7 +110,7 @@ impl Parse for ParseArg {
 				input.parse::<Token![,]>()?;
 			}
 		}
-		Ok(Self { state, stop, in_range, all_must_occur })
+		Ok(Self { state, stop, in_range, all_must_occur, keyword_variant })
 	}
 }
 
@@ -156,6 +124,229 @@ impl From<&Vec<Attribute>> for ParseArg {
 		} else {
 			Self::default()
 		}
+	}
+}
+
+fn generate_field_parsing(var: &Ident, ty: &Type, arg: &ParseArg, parse_mode: FieldParseMode) -> TokenStream {
+	if let Some(keyword_variant) = &arg.keyword_variant {
+		generate_keyword_parsing(var, keyword_variant, arg, parse_mode)
+	} else {
+		generate_normal_parsing(var, ty, arg, parse_mode)
+	}
+}
+
+fn generate_keyword_parsing(
+	var: &Ident,
+	keyword_variant: &syn::ExprPath,
+	arg: &ParseArg,
+	parse_mode: FieldParseMode,
+) -> TokenStream {
+	let range_validation = arg.in_range.as_ref().map(|r| generate_range_validation(&format_ident!("ident"), r));
+
+	if keyword_variant.path.segments.len() == 1 {
+		// Handle single type like #[parse(keyword = Auto)]
+		let keyword_type = &keyword_variant.path.segments.first().unwrap().ident;
+		match parse_mode {
+			FieldParseMode::Sequential if range_validation.is_some() => {
+				quote! {
+				  let #var = {
+					let ident = p.parse::<#keyword_type>()?;
+					#range_validation
+					ident
+				  };
+				}
+			}
+			FieldParseMode::Sequential => quote! { let #var = p.parse::<#keyword_type>()?; },
+			FieldParseMode::AllMustOccur => {
+				quote! {
+				  if #var.is_none() && <#keyword_type>::peek(p, c) {
+					let ident = p.parse::<#keyword_type>()?;
+					#range_validation
+					#var = Some(ident);
+					continue;
+				  }
+				}
+			}
+		}
+	} else {
+		// Handle enum variant like #[parse(keyword = FooKeywords::Auto)]
+		let keyword_type = keyword_variant
+			.path
+			.segments
+			.first()
+			.expect("keyword variant path should have at least one segment")
+			.ident
+			.clone();
+
+		match parse_mode {
+			FieldParseMode::Sequential => {
+				quote! {
+				  let #var = {
+					let c = p.peek_n(1);
+					if <#keyword_type>::peek(p, c) {
+					  let keyword = <#keyword_type>::build(p, c);
+					  if let #keyword_variant(ident) = keyword {
+						#range_validation
+						p.next();
+						ident
+					  } else {
+						return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+					  }
+					} else {
+					  return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+					}
+				  };
+				}
+			}
+			FieldParseMode::AllMustOccur => {
+				quote! {
+				  if #var.is_none() && <#keyword_type>::peek(p, c) {
+					let keyword = <#keyword_type>::build(p, c);
+					if let #keyword_variant(ident) = keyword {
+					  #range_validation
+					  p.next();
+					  #var = Some(ident);
+					  continue;
+					}
+				  }
+				}
+			}
+		}
+	}
+}
+
+fn generate_normal_parsing(var: &Ident, ty: &Type, arg: &ParseArg, parse_mode: FieldParseMode) -> TokenStream {
+	match parse_mode {
+		FieldParseMode::Sequential => {
+			let parse_step = quote! { let #var = p.parse::<#ty>()?; };
+			let check_step = arg.in_range.as_ref().map(|r| generate_range_validation(var, r));
+			quote! { #parse_step #check_step }
+		}
+		FieldParseMode::AllMustOccur => {
+			let inner = if let Some(r) = &arg.in_range {
+				let inner = format_ident!("val");
+				let range_check = generate_range_validation(&inner, r);
+				quote! {
+				  let #inner = p.parse::<#ty>()?;
+				  #range_check
+				  #var = Some(#inner);
+				}
+			} else {
+				quote! { #var = Some(p.parse::<#ty>()?); }
+			};
+			quote! {
+			  if #var.is_none() && <#ty>::peek(p, c) {
+				#inner
+				continue;
+			  }
+			}
+		}
+	}
+}
+
+fn generate_all_must_occur_parsing(
+	split_fields: &[(Ident, Type, ParseArg)],
+	members: Vec<TokenStream>,
+	post_parse_steps: TokenStream,
+) -> TokenStream {
+	let bindings: Vec<TokenStream> = split_fields
+		.iter()
+		.map(|(var, ty, _)| {
+			quote! { let mut #var: Option<#ty> = None; }
+		})
+		.collect();
+
+	let parse_steps: Vec<TokenStream> = split_fields
+		.iter()
+		.map(|(var, ty, arg)| generate_field_parsing(var, ty, arg, FieldParseMode::AllMustOccur))
+		.collect();
+
+	let vars = split_fields.iter().map(|(var, _, _)| var);
+	let checks: Vec<TokenStream> = vars.clone().map(|var| quote! { #var.is_none() }).collect();
+	let unwraps = vars.map(|var| quote! { #var.unwrap() });
+
+	quote! {
+	  #(#bindings)*
+	  loop {
+		let c = p.peek_n(1);
+		#(#parse_steps)*
+		break;
+	  }
+	  #post_parse_steps
+	  if #(#checks)||* {
+		let c = p.peek_n(1);
+		Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+	  }
+	  Ok(Self { #(#members: #unwraps),* })
+	}
+}
+
+fn generate_sequential_parsing(
+	split_fields: &[(Ident, Type, ParseArg)],
+	members: Vec<TokenStream>,
+	post_parse_steps: TokenStream,
+) -> TokenStream {
+	let parse_steps: Vec<TokenStream> = split_fields
+		.iter()
+		.map(|(var, ty, arg)| generate_field_parsing(var, ty, arg, FieldParseMode::Sequential))
+		.collect();
+
+	let vars = split_fields.iter().map(|(var, _, _)| var);
+
+	quote! {
+	  #( #parse_steps )*
+	  #post_parse_steps
+	  Ok(Self { #(#members: #vars),* })
+	}
+}
+
+fn generate_range_validation(field_ident: &Ident, range_expr: &ExprRange) -> TokenStream {
+	let start = &range_expr.start;
+	let end = &range_expr.end;
+	match (start, end) {
+		// 1..=10 (inclusive end)
+		(Some(start), Some(end)) => {
+			quote! {
+			  if let Ok(i) = std::convert::TryInto::<f32>::try_into(#field_ident) {
+				if !(#start..=#end).contains(&i) {
+				  use ::css_parse::ToSpan;
+				  Err(::css_parse::diagnostics::NumberOutOfBounds(
+					#field_ident.into(),
+					format!("{}..={}", #start, #end),
+					#field_ident.to_span()
+				  ))?
+				}
+			  }
+			}
+		}
+		(Some(start), None) => {
+			quote! {
+			  if let Ok(i) = std::convert::TryInto::<f32>::try_into(#field_ident) {
+				if #start > i {
+				  use ::css_parse::ToSpan;
+				  Err(::css_parse::diagnostics::NumberTooSmall(
+					#start,
+					#field_ident.to_span()
+				  ))?
+				}
+			  }
+			}
+		}
+		(None, Some(end)) => {
+			quote! {
+			  if let Ok(i) = std::convert::TryInto::<f32>::try_into(#field_ident) {
+				if #end < i {
+				  use ::css_parse::ToSpan;
+				  Err(::css_parse::diagnostics::NumberTooLarge(
+					#end,
+					#field_ident.to_span()
+				  ))?
+				}
+			  }
+			}
+		}
+		// .. (full range) - no validation needed
+		(None, None) => quote! {},
 	}
 }
 
@@ -176,199 +367,166 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	let ParseArg { state, stop, all_must_occur, .. } = (&input.attrs).into();
 	if let Some(ident) = state {
 		pre_parse_steps = quote! {
-			let state = p.set_state(State::#ident);
-			#pre_parse_steps
+		  let state = p.set_state(State::#ident);
+		  #pre_parse_steps
 		};
 		post_parse_steps = quote! {
-			#post_parse_steps
-			p.set_state(state);
+		  #post_parse_steps
+		  p.set_state(state);
 		};
 	}
 	if let Some((kind_or_kindset, ident)) = stop {
 		pre_parse_steps = if kind_or_kindset == "Kind" {
 			quote! {
-				let stop = p.set_stop(KindSet::new(&[Kind::#ident]));
-				#pre_parse_steps
+			  let stop = p.set_stop(KindSet::new(&[Kind::#ident]));
+			  #pre_parse_steps
 			}
 		} else {
 			quote! {
-				let stop = p.set_stop(KindSet::#ident);
-				#pre_parse_steps
+			  let stop = p.set_stop(KindSet::#ident);
+			  #pre_parse_steps
 			}
 		};
 		post_parse_steps = quote! {
-			#post_parse_steps
-			p.set_stop(stop);
+		  #post_parse_steps
+		  p.set_stop(stop);
 		};
 	}
 
 	let body = match input.data {
-		Data::Union(_) => err(ident.span(), "Cannot derive Parse on a Union"),
+    Data::Union(_) => err(ident.span(), "Cannot derive Parse on a Union"),
 
-		Data::Struct(DataStruct { fields, .. }) => {
-			let members = fields.members();
-			let split_fields = fields.to_vars_and_types();
-			let vars = split_fields.iter().map(|(var, _, _)| var);
+    Data::Struct(DataStruct { fields, .. }) => {
+      let members = fields.members();
+      let split_fields = fields.to_vars_and_types();
+      let _vars: Vec<_> = split_fields.iter().map(|(var, _, _)| quote! { #var }).collect();
 
-			if all_must_occur {
-				let bindings: Vec<TokenStream> = split_fields
-					.iter()
-					.map(|(var, ty, _)| {
-						quote! { let mut #var: Option<#ty> = None; }
-					})
-					.collect();
+      let members: Vec<TokenStream> = members.into_iter().map(|m| quote! { #m }).collect();
+      if all_must_occur {
+        generate_all_must_occur_parsing(&split_fields, members, post_parse_steps.clone())
+      } else {
+        generate_sequential_parsing(&split_fields, members, post_parse_steps.clone())
+      }
+    }
 
-				let parse_steps: Vec<TokenStream> = split_fields
-					.iter()
-					.map(|(var, ty, arg)| {
-						let inner = if let Some(r) = &arg.in_range {
-							let inner = format_ident!("val");
-							let range_check = generate_range_validation(&inner, r);
-							quote! {
-								let #inner = p.parse::<#ty>()?;
-								#range_check
-								#var = Some(#inner);
-							}
-						} else {
-							quote! { #var = Some(p.parse::<#ty>()?); }
-						};
-						quote! {
-							if #var.is_none() && <#ty>::peek(p, c) {
-								#inner
-								continue;
-							}
-						}
-					})
-					.collect();
-				let checks: Vec<TokenStream> = vars.clone().map(|var| quote! { #var.is_none() }).collect();
-				let unwraps = vars.clone().map(|var| quote! { #var.unwrap() });
-				quote! {
-					#(#bindings)*
-					loop {
-						let c = p.peek_n(1);
-						#(#parse_steps)*
-						break;
-					}
-					#post_parse_steps
-					if #(#checks)||* {
-						let c = p.peek_n(1);
-						Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
-					}
-					Ok(Self { #(#members: #unwraps),* })
-				}
-			} else {
-				// Generate sequential parsing logic (existing behavior)
-				let parse_steps: Vec<TokenStream> = split_fields
-					.iter()
-					.map(|(var, ty, arg)| {
-						let parse_step = quote! { let #var = p.parse::<#ty>()?; };
-						let check_step = arg.in_range.as_ref().map(|r| generate_range_validation(var, r));
-						quote! { #parse_step #check_step }
-					})
-					.collect();
+    Data::Enum(DataEnum { variants, .. }) => variants
+      .iter()
+      .sorted_by(|a, b| {
+        let a = {
+          let ParseArg { keyword_variant, .. } = (&a.attrs).into();
+          keyword_variant.map_or(1, |_| 0)
+        };
+        let b = {
+          let ParseArg { keyword_variant, .. } = (&b.attrs).into();
+          keyword_variant.map_or(1, |_| 0)
+        };
+        a.cmp(&b)
+      })
+      .with_position()
+      .map(|(position, variant)| {
+        let variant_ident = &variant.ident;
+        let ParseArg { all_must_occur, keyword_variant, .. } = (&variant.attrs).into();
+        let members = variant.fields.members();
+        let split_fields = variant.fields.to_vars_and_types();
+        let first_type =
+          split_fields.first().map(|(_, ty, _)| ty).expect("Field has to have at least one type!");
 
-				quote! {
-					#( #parse_steps )*
-					#post_parse_steps
-					Ok(Self { #(#members: #vars),* })
-				}
-			}
-		}
+        let members: Vec<TokenStream> = members.into_iter().map(|m| quote! { #m }).collect();
+        let step = if all_must_occur {
+          // AllMustOccur parsing for enum variant (using helper logic)
+          let bindings: Vec<TokenStream> = split_fields
+            .iter()
+            .map(|(var, ty, _)| {
+              quote! { let mut #var: Option<#ty> = None; }
+            })
+            .collect();
 
-		Data::Enum(DataEnum { variants, .. }) => variants
-			.iter()
-			.with_position()
-			.map(|(position, variant)| {
-				let variant_ident = &variant.ident;
-				let ParseArg { all_must_occur, .. } = (&variant.attrs).into();
-				let members = variant.fields.members();
-				let split_fields = variant.fields.to_vars_and_types();
-				let first_type = split_fields.first().map(|(_, ty, _)| ty);
-				let vars = split_fields.iter().map(|(var, _, _)| var);
+          let parse_steps: Vec<TokenStream> = split_fields
+            .iter()
+            .map(|(var, ty, arg)| generate_field_parsing(var, ty, arg, FieldParseMode::AllMustOccur))
+            .collect();
+          let vars = split_fields.iter().map(|(var, _, _)| var);
+          let checks: Vec<TokenStream> = vars.clone().map(|var| quote! { #var.is_none() }).collect();
+          let unwraps = vars.map(|var| quote! { #var.unwrap() });
 
-				let step = if all_must_occur {
-					// Generate AllMustOccur parsing logic for this variant
-					let bindings: Vec<TokenStream> = split_fields
-						.iter()
-						.map(|(var, ty, _)| {
-							quote! { let mut #var: Option<#ty> = None; }
-						})
-						.collect();
+          quote! {
+            #(#bindings)*
+            loop {
+              let c = p.peek_n(1);
+              #(#parse_steps)*
+              break;
+            }
+            #post_parse_steps
+            if #(#checks)||* {
+              let c = p.peek_n(1);
+              Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            }
+            Ok(Self::#variant_ident { #(#members: #unwraps),* })
+          }
+        } else {
+          let parse_steps: Vec<TokenStream> = split_fields
+            .iter()
+            .map(|(var, ty, arg)| generate_field_parsing(var, ty, arg, FieldParseMode::Sequential))
+            .collect();
+          let vars = split_fields.iter().map(|(var, _, _)| var);
 
-					let parse_steps: Vec<TokenStream> = split_fields
-						.iter()
-						.map(|(var, ty, arg)| {
-							let inner = if let Some(r) = &arg.in_range {
-								let inner = format_ident!("val");
-								let range_check = generate_range_validation(&inner, r);
-								quote! {
-									let #inner = p.parse::<#ty>()?;
-									#range_check
-									#var = Some(#inner);
-								}
-							} else {
-								quote! { #var = Some(p.parse::<#ty>()?); }
-							};
-							quote! {
-								if #var.is_none() && <#ty>::peek(p, c) {
-									#inner
-									continue;
-								}
-							}
-						})
-						.collect();
-					let checks: Vec<TokenStream> = vars.clone().map(|var| quote! { #var.is_none() }).collect();
-					let unwraps = vars.clone().map(|var| quote! { #var.unwrap() });
+          quote! {
+            #( #parse_steps )*
+            #post_parse_steps
+            Ok(Self::#variant_ident { #(#members: #vars),* })
+          }
+        };
 
-					quote! {
-						#(#bindings)*
-						loop {
-							let c = p.peek_n(1);
-							#(#parse_steps)*
-							break;
-						}
-						#post_parse_steps
-						if #(#checks)||* {
-							let c = p.peek_n(1);
-							Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
-						}
-						Ok(Self::#variant_ident { #(#members: #unwraps),* })
-					}
-				} else {
-					// Generate sequential parsing logic (existing behavior)
-					let parse_steps: Vec<TokenStream> = split_fields
-						.iter()
-						.map(|(var, ty, arg)| {
-							let parse_step = quote! { let #var = p.parse::<#ty>()?; };
-							let check_step = arg.in_range.as_ref().map(|r| generate_range_validation(var, r));
-							quote! { #parse_step #check_step }
-						})
-						.collect();
+        let condition = if let Some(keyword_variant) = &keyword_variant {
+          // Single type like #[parse(keyword = Auto)]
+          if keyword_variant.path.segments.len() == 1 {
+            let keyword_type = &keyword_variant.path.segments.first().unwrap().ident;
+            quote! { <#keyword_type>::peek(p, c) }
+          } else {
+            // Enum variant like #[parse(keyword = FooKeywords::Auto)]
+            let keyword_type = keyword_variant
+              .path
+              .segments
+              .first()
+              .expect("keyword variant path should have at least one segment")
+              .ident
+              .clone();
+            let keyword_parse = quote! { let c = p.peek_n(1); let keywords = if #keyword_type::peek(p, c) { Some(<#keyword_type>::build(p, c)) } else { None }; };
+            let desired = quote! { #keyword_variant };
+            return match position {
+              Position::First => quote! { #keyword_parse; if let Some(#desired(ident)) = keywords { #step } },
+              Position::Last => quote! {
+                  else if let Some(#desired(ident)) = keywords {
+                      #step
+                  } else {
+                      return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+                  }
+              },
+              Position::Only => quote! { #step },
+              Position::Middle => quote! { else if let Some(#desired(ident)) = keywords { #step } },
+            };
+          }
+        } else {
+          quote! { p.peek::<#first_type>() }
+        };
 
-					quote! {
-						#( #parse_steps )*
-						#post_parse_steps
-						Ok(Self::#variant_ident { #(#members: #vars),* })
-					}
-				};
-
-				match position {
-					Position::First => quote! { if p.peek::<#first_type>() { #step } },
-					Position::Last => quote! { else { #step } },
-					Position::Only => step,
-					Position::Middle => quote! { else if p.peek::<#first_type>() { #step } },
-				}
-			})
-			.collect(),
-	};
+        match position {
+          Position::First => quote! { if #condition { #step } },
+          Position::Last => quote! { else { #step } },
+          Position::Only => quote! { #step },
+          Position::Middle => quote! { else if #condition { #step } },
+        }
+      })
+      .collect(),
+  };
 	quote! {
-		#[automatically_derived]
-		impl #impl_generics ::css_parse::Parse<'a> for #ident #type_generics #where_clause {
-			fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-				use css_parse::{Parse};
-				#pre_parse_steps
-				#body
-			}
+	  #[automatically_derived]
+	  impl #impl_generics ::css_parse::Parse<'a> for #ident #type_generics #where_clause {
+		fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+		  use css_parse::{Parse, Build};
+		  #pre_parse_steps
+		  #body
 		}
+	  }
 	}
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for FlexValue {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<AutoKeyword>() {
             let f0 = p.parse::<AutoKeyword>()?;
             Ok(Self::Auto { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a, T> ::css_parse::Parse<'a> for Container<T> {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<T>() {
             let f0 = p.parse::<T>()?;
             Ok(Self::Single { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_and_tuple_mixed.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_and_tuple_mixed.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for FlexValue {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<Ident>() {
             let f0 = p.parse::<Ident>()?;
             Ok(Self::Auto { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Transform {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<Number>() {
             let x = p.parse::<Number>()?;
             if let Ok(i) = std::convert::TryInto::<f32>::try_into(x) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
@@ -1,0 +1,51 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for AllMustOccurEnum {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::{Parse, Build};
+        if p.peek::<String>() {
+            let f0 = p.parse::<String>()?;
+            Ok(Self::Simple { 0: f0 })
+        } else {
+            let mut auto_field: Option<AutoValue> = None;
+            let mut none_field: Option<NoneValue> = None;
+            let mut length: Option<Length> = None;
+            loop {
+                let c = p.peek_n(1);
+                if auto_field.is_none() && <FooKeywords>::peek(p, c) {
+                    let keyword = <FooKeywords>::build(p, c);
+                    if let FooKeywords::Auto(ident) = keyword {
+                        p.next();
+                        auto_field = Some(ident);
+                        continue;
+                    }
+                }
+                if none_field.is_none() && <FooKeywords>::peek(p, c) {
+                    let keyword = <FooKeywords>::build(p, c);
+                    if let FooKeywords::None(ident) = keyword {
+                        p.next();
+                        none_field = Some(ident);
+                        continue;
+                    }
+                }
+                if length.is_none() && <Length>::peek(p, c) {
+                    length = Some(p.parse::<Length>()?);
+                    continue;
+                }
+                break;
+            }
+            if auto_field.is_none() || none_field.is_none() || length.is_none() {
+                let c = p.peek_n(1);
+                Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            }
+            Ok(Self::Complex {
+                auto_field: auto_field.unwrap(),
+                none_field: none_field.unwrap(),
+                length: length.unwrap(),
+            })
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<String>() {
             let f0 = p.parse::<String>()?;
             Ok(Self::Normal { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<AutoKeyword>() {
             let mut auto: Option<AutoKeyword> = None;
             let mut percentage: Option<Number> = None;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
@@ -1,0 +1,38 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for TestEnum {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::{Parse, Build};
+        if p.peek::<String>() {
+            let f0 = p.parse::<String>()?;
+            Ok(Self::Normal { 0: f0 })
+        } else {
+            let none_value = {
+                let c = p.peek_n(1);
+                if <FooKeywords>::peek(p, c) {
+                    let keyword = <FooKeywords>::build(p, c);
+                    if let FooKeywords::None(ident) = keyword {
+                        p.next();
+                        ident
+                    } else {
+                        return Err(
+                            ::css_parse::diagnostics::Unexpected(c.into(), c.into()),
+                        )?;
+                    }
+                } else {
+                    return Err(
+                        ::css_parse::diagnostics::Unexpected(c.into(), c.into()),
+                    )?;
+                }
+            };
+            let other_field = p.parse::<Length>()?;
+            Ok(Self::WithKeyword {
+                none_value: none_value,
+                other_field: other_field,
+            })
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
@@ -1,0 +1,25 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::{Parse, Build};
+        let c = p.peek_n(1);
+        let keywords = if Keyword::peek(p, c) {
+            Some(<Keyword>::build(p, c))
+        } else {
+            None
+        };
+        if let Some(Keyword::Foo(ident)) = keywords {
+            let f0 = p.parse::<Ident>()?;
+            Ok(Self::Foo { 0: f0 })
+        } else if let Some(Keyword::Bar(ident)) = keywords {
+            let f0 = p.parse::<Ident>()?;
+            Ok(Self::Bar { 0: f0 })
+        } else {
+            return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants_or_type.snap
@@ -1,0 +1,26 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::{Parse, Build};
+        let c = p.peek_n(1);
+        let keywords = if Keyword::peek(p, c) {
+            Some(<Keyword>::build(p, c))
+        } else {
+            None
+        };
+        if let Some(Keyword::Foo(ident)) = keywords {
+            let f0 = p.parse::<Ident>()?;
+            Ok(Self::Foo { 0: f0 })
+        } else if let Some(Keyword::Bar(ident)) = keywords {
+            let f0 = p.parse::<Ident>()?;
+            Ok(Self::Bar { 0: f0 })
+        } else {
+            let f0 = p.parse::<Length>()?;
+            Ok(Self::Length { 0: f0 })
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_newtype_keyword.snap
@@ -1,0 +1,21 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::Parse;
+        if p.peek::<String>() {
+            let f0 = p.parse::<String>()?;
+            Ok(Self::Simple { 0: f0 })
+        } else {
+            let auto_value = p.parse::<Auto>()?;
+            let other = p.parse::<Length>()?;
+            Ok(Self::WithNewtype {
+                auto_value: auto_value,
+                other: other,
+            })
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_fields.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<String>() {
             let f0 = p.parse::<String>()?;
             Ok(Self::Keyword { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_lifetime.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for CssValue<'a> {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<String>() {
             let f0 = p.parse::<String>()?;
             Ok(Self::Keyword { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<Number>() {
             let f0 = p.parse::<Number>()?;
             if let Ok(i) = std::convert::TryInto::<f32>::try_into(f0) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_struct_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_struct_variants.snap
@@ -5,9 +5,10 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for BorderStyle {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
-        if p.peek() {
-            Ok(Self::Solid {})
+        use css_parse::{Parse, Build};
+        if p.peek::<Ident>() {
+            let f0 = p.parse::<Ident>()?;
+            Ok(Self::Solid { 0: f0 })
         } else if p.peek::<Length>() {
             let width = p.parse::<Length>()?;
             Ok(Self::Dashed { width: width })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_enum.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_enum.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Display {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         if p.peek::<Ident>() {
             let f0 = p.parse::<Ident>()?;
             Ok(Self::Block { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_simple_struct.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         Ok(Self {})
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_single_field_tuple_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_single_field_tuple_struct.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Opacity {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let f0 = p.parse::<Number>()?;
         Ok(Self { 0: f0 })
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
@@ -3,16 +3,22 @@ source: crates/csskit_derives/src/test/test_parse.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Parse<'a> for AutoAndLengthInState {
+impl<'a> ::css_parse::Parse<'a> for AllMustOccurNewtypeTest {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
-        let state = p.set_state(State::InValue);
-        let mut auto: Option<AutoKeyword> = None;
+        let mut auto_value: Option<Auto> = None;
+        let mut none_value: Option<None> = None;
         let mut length: Option<Length> = None;
         loop {
             let c = p.peek_n(1);
-            if auto.is_none() && <AutoKeyword>::peek(p, c) {
-                auto = Some(p.parse::<AutoKeyword>()?);
+            if auto_value.is_none() && <Auto>::peek(p, c) {
+                let ident = p.parse::<Auto>()?;
+                auto_value = Some(ident);
+                continue;
+            }
+            if none_value.is_none() && <None>::peek(p, c) {
+                let ident = p.parse::<None>()?;
+                none_value = Some(ident);
                 continue;
             }
             if length.is_none() && <Length>::peek(p, c) {
@@ -21,13 +27,13 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLengthInState {
             }
             break;
         }
-        p.set_state(state);
-        if auto.is_none() || length.is_none() {
+        if auto_value.is_none() || none_value.is_none() || length.is_none() {
             let c = p.peek_n(1);
             Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
         }
         Ok(Self {
-            auto: auto.unwrap(),
+            auto_value: auto_value.unwrap(),
+            none_value: none_value.unwrap(),
             length: length.unwrap(),
         })
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_existing_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_existing_lifetime.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Token<'a> {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let span = p.parse::<str>()?;
         Ok(Self { span: span })
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
@@ -1,0 +1,31 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for RegularKeywordTest {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::{Parse, Build};
+        let auto_value = {
+            let c = p.peek_n(1);
+            if <FooKeywords>::peek(p, c) {
+                let keyword = <FooKeywords>::build(p, c);
+                if let FooKeywords::Auto(ident) = keyword {
+                    p.next();
+                    ident
+                } else {
+                    return Err(
+                        ::css_parse::diagnostics::Unexpected(c.into(), c.into()),
+                    )?;
+                }
+            } else {
+                return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+            }
+        };
+        let length = p.parse::<Length>()?;
+        Ok(Self {
+            auto_value: auto_value,
+            length: length,
+        })
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for AutoAndLength {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let mut auto: Option<AutoKeyword> = None;
         let mut length: Option<Length> = None;
         loop {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
@@ -1,0 +1,46 @@
+---
+source: crates/csskit_derives/src/test/test_parse.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Parse<'a> for SpecificKeywordTest {
+    fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
+        use css_parse::{Parse, Build};
+        let mut auto_field: Option<AutoValue> = None;
+        let mut none_field: Option<NoneValue> = None;
+        let mut length: Option<Length> = None;
+        loop {
+            let c = p.peek_n(1);
+            if auto_field.is_none() && <FooKeywords>::peek(p, c) {
+                let keyword = <FooKeywords>::build(p, c);
+                if let FooKeywords::Auto(ident) = keyword {
+                    p.next();
+                    auto_field = Some(ident);
+                    continue;
+                }
+            }
+            if none_field.is_none() && <FooKeywords>::peek(p, c) {
+                let keyword = <FooKeywords>::build(p, c);
+                if let FooKeywords::None(ident) = keyword {
+                    p.next();
+                    none_field = Some(ident);
+                    continue;
+                }
+            }
+            if length.is_none() && <Length>::peek(p, c) {
+                length = Some(p.parse::<Length>()?);
+                continue;
+            }
+            break;
+        }
+        if auto_field.is_none() || none_field.is_none() || length.is_none() {
+            let c = p.peek_n(1);
+            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+        }
+        Ok(Self {
+            auto_field: auto_field.unwrap(),
+            none_field: none_field.unwrap(),
+            length: length.unwrap(),
+        })
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
@@ -3,19 +3,23 @@ source: crates/csskit_derives/src/test/test_parse.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Parse<'a> for AutoAndLengthWithRange {
+impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
-        let mut auto: Option<AutoKeyword> = None;
-        let mut length: Option<Length> = None;
+        let mut auto_value: Option<AutoValue> = None;
+        let mut percentage: Option<Number> = None;
         loop {
             let c = p.peek_n(1);
-            if auto.is_none() && <AutoKeyword>::peek(p, c) {
-                auto = Some(p.parse::<AutoKeyword>()?);
-                continue;
+            if auto_value.is_none() && <FooKeywords>::peek(p, c) {
+                let keyword = <FooKeywords>::build(p, c);
+                if let FooKeywords::Auto(ident) = keyword {
+                    p.next();
+                    auto_value = Some(ident);
+                    continue;
+                }
             }
-            if length.is_none() && <Length>::peek(p, c) {
-                let val = p.parse::<Length>()?;
+            if percentage.is_none() && <Number>::peek(p, c) {
+                let val = p.parse::<Number>()?;
                 if let Ok(i) = std::convert::TryInto::<f32>::try_into(val) {
                     if !(0..=100).contains(&i) {
                         use ::css_parse::ToSpan;
@@ -28,18 +32,18 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLengthWithRange {
                         )?
                     }
                 }
-                length = Some(val);
+                percentage = Some(val);
                 continue;
             }
             break;
         }
-        if auto.is_none() || length.is_none() {
+        if auto_value.is_none() || percentage.is_none() {
             let c = p.peek_n(1);
             Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
         }
         Ok(Self {
-            auto: auto.unwrap(),
-            length: length.unwrap(),
+            auto_value: auto_value.unwrap(),
+            percentage: percentage.unwrap(),
         })
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_lifetime.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_lifetime.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Value<'a> {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let content = p.parse::<Ident>()?;
         Ok(Self { content: content })
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_many_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_many_fields.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Transform {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let rotate_x = p.parse::<Angle>()?;
         let rotate_y = p.parse::<Angle>()?;
         let rotate_z = p.parse::<Angle>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Color {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let red = p.parse::<CSSInt>()?;
         if let Ok(i) = std::convert::TryInto::<f32>::try_into(red) {
             if !(0..=255).contains(&i) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_newtype_keyword.snap
@@ -3,16 +3,14 @@ source: crates/csskit_derives/src/test/test_parse.rs
 expression: pretty
 ---
 #[automatically_derived]
-impl<'a> ::css_parse::Parse<'a> for Color {
+impl<'a> ::css_parse::Parse<'a> for NewtypeKeywordTest {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
-        let red = p.parse::<CSSInt>()?;
-        let green = p.parse::<CSSInt>()?;
-        let blue = p.parse::<CSSInt>()?;
+        let auto_value = p.parse::<Auto>()?;
+        let length = p.parse::<Length>()?;
         Ok(Self {
-            red: red,
-            green: green,
-            blue: blue,
+            auto_value: auto_value,
+            length: length,
         })
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Volume {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let level = p.parse::<Number>()?;
         if let Ok(i) = std::convert::TryInto::<f32>::try_into(level) {
             if !(0.0f32..=100.0f32).contains(&i) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for PositiveValue {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let value = p.parse::<CSSInt>()?;
         if let Ok(i) = std::convert::TryInto::<f32>::try_into(value) {
             if 1.0f32 > i {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Probability {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let value = p.parse::<Number>()?;
         if let Ok(i) = std::convert::TryInto::<f32>::try_into(value) {
             if 1.0f32 < i {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Length {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let f0 = p.parse::<Number>()?;
         let f1 = p.parse::<Unit>()?;
         Ok(Self { 0: f0, 1: f1 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Scale {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let f0 = p.parse::<Number>()?;
         if let Ok(i) = std::convert::TryInto::<f32>::try_into(f0) {
             if !(0.1..=10.0).contains(&i) {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_unit_struct.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_unit_struct.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Auto {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         Ok(Self {})
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_both_state_and_stop.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_both_state_and_stop.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for RuleContent {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let stop = p.set_stop(KindSet::new(&[Kind::RightBrace]));
         let state = p.set_state(State::InRule);
         let declarations = p.parse::<Vec<String>>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_multiple_state_stop_combinations.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_multiple_state_stop_combinations.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Declaration {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let stop = p.set_stop(KindSet::DeclarationEnd);
         let state = p.set_state(State::InDeclaration);
         let property = p.parse::<Ident>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_state_attribute.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_state_attribute.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for ValueInState {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let state = p.set_state(State::InValue);
         let content = p.parse::<String>()?;
         p.set_state(state);

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kind_attribute.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kind_attribute.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for StopOnSemicolon {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let stop = p.set_stop(KindSet::new(&[Kind::Semicolon]));
         let items = p.parse::<Vec<String>>()?;
         p.set_stop(stop);

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kindset_attribute.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_with_stop_kindset_attribute.snap
@@ -5,7 +5,7 @@ expression: pretty
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for StopOnBlockEnd {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
-        use css_parse::Parse;
+        use css_parse::{Parse, Build};
         let stop = p.set_stop(KindSet::BlockEnd);
         let declarations = p.parse::<Vec<String>>()?;
         p.set_stop(stop);

--- a/crates/csskit_derives/src/test/test_parse.rs
+++ b/crates/csskit_derives/src/test/test_parse.rs
@@ -74,7 +74,7 @@ fn parse_enum_with_fields() {
 fn parse_enum_with_struct_variants() {
 	let data = to_deriveinput! {
 		enum BorderStyle {
-			Solid,
+			Solid(Ident),
 			Dashed { width: Length },
 			Dotted { radius: Length },
 		}
@@ -392,4 +392,140 @@ fn parse_enum_mixed_variants() {
 		}
 	};
 	assert_parse_snapshot!(data, "parse_enum_mixed_variants");
+}
+
+#[test]
+fn parse_struct_with_keyword_pattern_and_range() {
+	let data = to_deriveinput! {
+		#[parse(all_must_occur)]
+		struct KeywordWithRange {
+			#[parse(keyword = FooKeywords::Auto)]
+			auto_value: AutoValue,
+			#[parse(in_range = 0..=100)]
+			percentage: Number,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_keyword_pattern_and_range");
+}
+
+#[test]
+fn parse_struct_with_different_keyword_variants() {
+	// This test verifies that specific variants are matched, not just any variant of the keyword enum
+	let data = to_deriveinput! {
+		#[parse(all_must_occur)]
+		struct SpecificKeywordTest {
+			#[parse(keyword = FooKeywords::Auto)]
+			auto_field: AutoValue,
+			#[parse(keyword = FooKeywords::None)]
+			none_field: NoneValue,
+			length: Length,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_different_keyword_variants");
+}
+
+#[test]
+fn parse_struct_regular_with_keyword_pattern() {
+	// Test keyword parsing in regular (non-all_must_occur) structs
+	let data = to_deriveinput! {
+		struct RegularKeywordTest {
+			#[parse(keyword = FooKeywords::Auto)]
+			auto_value: AutoValue,
+			length: Length,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_regular_with_keyword_pattern");
+}
+
+#[test]
+fn parse_enum_variant_with_keyword_pattern() {
+	// Test keyword parsing in enum variants
+	let data = to_deriveinput! {
+		enum TestEnum {
+			Normal(String),
+			WithKeyword {
+				#[parse(keyword = FooKeywords::None)]
+				none_value: NoneValue,
+				other_field: Length,
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_variant_with_keyword_pattern");
+}
+
+#[test]
+fn parse_enum_variant_all_must_occur_with_keyword() {
+	// Test keyword parsing in all_must_occur enum variants
+	let data = to_deriveinput! {
+		enum AllMustOccurEnum {
+			Simple(String),
+			#[parse(all_must_occur)]
+			Complex {
+				#[parse(keyword = FooKeywords::Auto)]
+				auto_field: AutoValue,
+				#[parse(keyword = FooKeywords::None)]
+				none_field: NoneValue,
+				length: Length,
+			},
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_variant_all_must_occur_with_keyword");
+}
+
+#[test]
+fn parse_struct_with_newtype_keyword() {
+	// Test newtype struct keyword parsing like #[parse(keyword = Auto)]
+	let data = to_deriveinput! {
+		struct NewtypeKeywordTest {
+			#[parse(keyword = Auto)]
+			auto_value: Auto,
+			length: Length,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_with_newtype_keyword");
+}
+
+#[test]
+fn parse_struct_all_must_occur_with_newtype_keyword() {
+	// Test newtype struct keyword in all_must_occur scenario
+	let data = to_deriveinput! {
+		#[parse(all_must_occur)]
+		struct AllMustOccurNewtypeTest {
+			#[parse(keyword = Auto)]
+			auto_value: Auto,
+			#[parse(keyword = None)]
+			none_value: None,
+			length: Length,
+		}
+	};
+	assert_parse_snapshot!(data, "parse_struct_all_must_occur_with_newtype_keyword");
+}
+
+#[test]
+fn parse_enum_variant_with_keyword_variants() {
+	// Test newtype struct keyword in enum variant
+	let data = to_deriveinput! {
+		enum NewtypeEnum {
+			#[parse(keyword = Keyword::Foo)]
+			Foo(Ident),
+			#[parse(keyword = Keyword::Bar)]
+			Bar(Ident),
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_variant_with_keyword_variants");
+}
+
+#[test]
+fn parse_enum_variant_with_keyword_variants_or_type() {
+	// Test newtype struct keyword in enum variant
+	let data = to_deriveinput! {
+		enum NewtypeEnum {
+			Length(Length),
+			#[parse(keyword = Keyword::Foo)]
+			Foo(Ident),
+			#[parse(keyword = Keyword::Bar)]
+			Bar(Ident),
+		}
+	};
+	assert_parse_snapshot!(data, "parse_enum_variant_with_keyword_variants_or_type");
 }


### PR DESCRIPTION
csskit_derives would always parse an Ident as an Ident. This is different to generate.rs which would use a Keywords
struct/enum.

This change adds a new #[parse(keyword = ...)] syntax which allows the struct to lean on that type to parse & get an
Ident back, which negates the need to pack that keyword into the struct.
