### PR TITLE
Introduce ToNumberValue to aid in number checking code

### DIFF
--- a/crates/css_ast/src/types/auto_or.rs
+++ b/crates/css_ast/src/types/auto_or.rs
@@ -1,6 +1,7 @@
 use crate::{Visit, VisitMut, Visitable, VisitableMut};
 use css_parse::{
-	Cursor, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan, keyword_set, token_macros::Ident,
+	Cursor, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToNumberValue, ToSpan, keyword_set,
+	token_macros::Ident,
 };
 
 keyword_set!(pub struct AutoKeyword "auto");
@@ -76,15 +77,11 @@ where
 	}
 }
 
-impl<T> TryFrom<AutoOr<T>> for f32
-where
-	f32: TryFrom<T>,
-{
-	type Error = ();
-	fn try_from(value: AutoOr<T>) -> Result<Self, Self::Error> {
-		match value {
-			AutoOr::Auto(_) => Err(()),
-			AutoOr::Some(t) => t.try_into().map_err(|_| ()),
+impl<T: ToNumberValue> ToNumberValue for AutoOr<T> {
+	fn to_number_value(&self) -> Option<f32> {
+		match self {
+			Self::Auto(_) => None,
+			Self::Some(t) => t.to_number_value(),
 		}
 	}
 }
@@ -122,18 +119,15 @@ mod tests {
 	}
 
 	#[test]
-	fn test_try_from() {
+	fn test_to_number_value() {
 		let bump = Bump::default();
 		let num = parse!(in bump "47" as AutoOrNumber).output.unwrap();
-		let f: f32 = num.try_into().unwrap();
-		assert_eq!(f, 47.0);
+		assert_eq!(num.to_number_value(), Some(47.0));
 
-		let num = parse!(in bump "12px" as AutoOrLength).output.unwrap();
-		let f: f32 = num.try_into().unwrap();
-		assert_eq!(f, 12.0);
+		let num = parse!(in bump "47px" as AutoOrLength).output.unwrap();
+		assert_eq!(num.to_number_value(), Some(47.0));
 
-		let num = parse!(in bump "auto" as AutoOrNumber).output.unwrap();
-		let f: Result<f32, _> = num.try_into();
-		assert!(f.is_err());
+		let num = parse!(in bump "auto" as AutoOrLength).output.unwrap();
+		assert_eq!(num.to_number_value(), None);
 	}
 }

--- a/crates/css_ast/src/types/autonone_or.rs
+++ b/crates/css_ast/src/types/autonone_or.rs
@@ -1,6 +1,7 @@
 use crate::{Visit, VisitMut, Visitable, VisitableMut};
 use css_parse::{
-	Cursor, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan, keyword_set, token_macros::Ident,
+	Cursor, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToNumberValue, ToSpan, keyword_set,
+	token_macros::Ident,
 };
 
 keyword_set!(pub enum AutoOrNoneKeywords {
@@ -82,16 +83,12 @@ where
 	}
 }
 
-impl<T> TryFrom<AutoNoneOr<T>> for f32
-where
-	f32: TryFrom<T>,
-{
-	type Error = ();
-	fn try_from(value: AutoNoneOr<T>) -> Result<Self, Self::Error> {
-		match value {
-			AutoNoneOr::Auto(_) => Err(()),
-			AutoNoneOr::None(_) => Err(()),
-			AutoNoneOr::Some(t) => t.try_into().map_err(|_| ()),
+impl<T: ToNumberValue> ToNumberValue for AutoNoneOr<T> {
+	fn to_number_value(&self) -> Option<f32> {
+		match self {
+			Self::None(_) => None,
+			Self::Auto(_) => None,
+			Self::Some(t) => t.to_number_value(),
 		}
 	}
 }
@@ -131,22 +128,15 @@ mod tests {
 	}
 
 	#[test]
-	fn test_try_from() {
+	fn test_to_number_value() {
 		let bump = Bump::default();
 		let num = parse!(in bump "47" as AutoNoneOrNumber).output.unwrap();
-		let f: f32 = num.try_into().unwrap();
-		assert_eq!(f, 47.0);
+		assert_eq!(num.to_number_value(), Some(47.0));
 
-		let num = parse!(in bump "12px" as AutoNoneOrLength).output.unwrap();
-		let f: f32 = num.try_into().unwrap();
-		assert_eq!(f, 12.0);
+		let num = parse!(in bump "47px" as AutoNoneOrLength).output.unwrap();
+		assert_eq!(num.to_number_value(), Some(47.0));
 
-		let num = parse!(in bump "auto" as AutoNoneOrNumber).output.unwrap();
-		let f: Result<f32, _> = num.try_into();
-		assert!(f.is_err());
-
-		let num = parse!(in bump "none" as AutoNoneOrNumber).output.unwrap();
-		let f: Result<f32, _> = num.try_into();
-		assert!(f.is_err());
+		let num = parse!(in bump "auto" as AutoNoneOrLength).output.unwrap();
+		assert_eq!(num.to_number_value(), None);
 	}
 }

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -1,4 +1,4 @@
-use css_parse::{Build, Cursor, DimensionUnit, Parser, T};
+use css_parse::{Build, Cursor, DimensionUnit, Parser, T, ToNumberValue};
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 
 // const DEG_GRAD: f32 = 0.9;
@@ -24,6 +24,12 @@ impl From<Angle> for f32 {
 			Angle::Turn(f) => f.into(),
 			Angle::Deg(f) => f.into(),
 		}
+	}
+}
+
+impl ToNumberValue for Angle {
+	fn to_number_value(&self) -> Option<f32> {
+		Some((*self).into())
 	}
 }
 

--- a/crates/css_ast/src/units/flex.rs
+++ b/crates/css_ast/src/units/flex.rs
@@ -1,4 +1,4 @@
-use css_parse::{Build, Cursor, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T, ToNumberValue};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 // https://www.w3.org/TR/css-grid-2/#typedef-flex
@@ -10,6 +10,12 @@ pub struct Flex(T![Dimension::Fr]);
 impl From<Flex> for f32 {
 	fn from(flex: Flex) -> Self {
 		flex.0.into()
+	}
+}
+
+impl ToNumberValue for Flex {
+	fn to_number_value(&self) -> Option<f32> {
+		Some((*self).into())
 	}
 }
 

--- a/crates/css_ast/src/units/int.rs
+++ b/crates/css_ast/src/units/int.rs
@@ -1,4 +1,4 @@
-use css_parse::{Build, Cursor, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T, ToNumberValue};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 #[derive(IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -20,6 +20,12 @@ impl From<CSSInt> for i32 {
 impl From<CSSInt> for f32 {
 	fn from(value: CSSInt) -> Self {
 		value.0.into()
+	}
+}
+
+impl ToNumberValue for CSSInt {
+	fn to_number_value(&self) -> Option<f32> {
+		Some(self.0.into())
 	}
 }
 

--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -1,4 +1,4 @@
-use css_parse::{Build, Cursor, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T, ToNumberValue};
 use csskit_derives::{IntoCursor, Peek, ToCursors, Visitable};
 
 use super::Flex;
@@ -107,6 +107,12 @@ impl PartialEq<f32> for Length {
 	}
 }
 
+impl ToNumberValue for Length {
+	fn to_number_value(&self) -> Option<f32> {
+		Some((*self).into())
+	}
+}
+
 impl<'a> Peek<'a> for Length {
 	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
 		macro_rules! is_checks {
@@ -161,6 +167,12 @@ impl From<LengthPercentage> for f32 {
 			}
 		}
 		apply_lengths!(match_length)
+	}
+}
+
+impl ToNumberValue for LengthPercentage {
+	fn to_number_value(&self) -> Option<f32> {
+		Some((*self).into())
 	}
 }
 
@@ -232,6 +244,12 @@ impl From<NumberLength> for f32 {
 	}
 }
 
+impl ToNumberValue for NumberLength {
+	fn to_number_value(&self) -> Option<f32> {
+		Some((*self).into())
+	}
+}
+
 impl<'a> Build<'a> for NumberLength {
 	fn build(p: &Parser<'a>, c: Cursor) -> Self {
 		debug_assert!(Self::peek(p, c));
@@ -253,6 +271,12 @@ impl From<NumberPercentage> for f32 {
 			NumberPercentage::Number(n) => n.into(),
 			NumberPercentage::Percentage(n) => n.into(),
 		}
+	}
+}
+
+impl ToNumberValue for NumberPercentage {
+	fn to_number_value(&self) -> Option<f32> {
+		Some((*self).into())
 	}
 }
 

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -1,4 +1,4 @@
-use css_parse::{Build, Cursor, Parser, Peek, T};
+use css_parse::{Build, Cursor, Parser, Peek, T, ToNumberValue};
 use csskit_derives::{IntoCursor, ToCursors, Visitable};
 
 // https://drafts.csswg.org/css-values/#resolution
@@ -18,6 +18,12 @@ impl From<Time> for f32 {
 			Time::Ms(f) => f.into(),
 			Time::S(f) => f.into(),
 		}
+	}
+}
+
+impl ToNumberValue for Time {
+	fn to_number_value(&self) -> Option<f32> {
+		Some((*self).into())
 	}
 }
 

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -1,5 +1,6 @@
 use crate::{
-	Build, Cursor, CursorSink, DimensionUnit, Kind, KindSet, Parse, Parser, Peek, Result, Span, Token, diagnostics,
+	Build, Cursor, CursorSink, DimensionUnit, Kind, KindSet, Parse, Parser, Peek, Result, Span, ToNumberValue, Token,
+	diagnostics,
 };
 
 macro_rules! cursor_wrapped {
@@ -248,6 +249,12 @@ macro_rules! custom_dimension {
 		impl PartialEq<f32> for $ident {
 			fn eq(&self, other: &f32) -> bool {
 				self.value() == *other
+			}
+		}
+
+		impl $crate::ToNumberValue for $ident {
+			fn to_number_value(&self) -> Option<f32> {
+				Some(self.value())
 			}
 		}
 
@@ -955,6 +962,12 @@ impl From<Dimension> for f32 {
 	}
 }
 
+impl ToNumberValue for Dimension {
+	fn to_number_value(&self) -> Option<f32> {
+		Some(self.0.token().value())
+	}
+}
+
 impl From<Dimension> for (f32, DimensionUnit) {
 	fn from(val: Dimension) -> Self {
 		let value = val.0.token().value();
@@ -1003,6 +1016,7 @@ cursor_wrapped!(Number);
 
 impl Number {
 	pub const NUMBER_ZERO: Number = Number(Cursor::dummy(Token::NUMBER_ZERO));
+	pub const ZERO: Number = Number(Cursor::dummy(Token::NUMBER_ZERO));
 
 	/// Returns the [f32] representation of the number's value.
 	pub fn value(&self) -> f32 {
@@ -1022,10 +1036,6 @@ impl Number {
 	}
 }
 
-impl Number {
-	pub const ZERO: Number = Number(Cursor::dummy(Token::NUMBER_ZERO));
-}
-
 impl<'a> Peek<'a> for Number {
 	fn peek(_: &Parser<'a>, c: Cursor) -> bool {
 		c == Kind::Number
@@ -1040,19 +1050,25 @@ impl<'a> Build<'a> for Number {
 
 impl From<Number> for f32 {
 	fn from(value: Number) -> Self {
-		value.0.token().value()
+		value.value()
 	}
 }
 
 impl From<Number> for i32 {
 	fn from(value: Number) -> Self {
-		value.0.token().value() as i32
+		value.value() as i32
 	}
 }
 
 impl PartialEq<f32> for Number {
 	fn eq(&self, other: &f32) -> bool {
-		self.0.token().value() == *other
+		self.value() == *other
+	}
+}
+
+impl ToNumberValue for Number {
+	fn to_number_value(&self) -> Option<f32> {
+		Some(self.value())
 	}
 }
 

--- a/crates/css_parse/src/traits/mod.rs
+++ b/crates/css_parse/src/traits/mod.rs
@@ -12,6 +12,7 @@ mod rule_variants;
 mod selectors;
 mod style_sheet;
 mod to_cursors;
+mod to_number_value;
 
 pub use boolean_feature::*;
 pub use build::*;
@@ -27,3 +28,4 @@ pub use rule_variants::*;
 pub use selectors::*;
 pub use style_sheet::*;
 pub use to_cursors::*;
+pub use to_number_value::*;

--- a/crates/css_parse/src/traits/to_number_value.rs
+++ b/crates/css_parse/src/traits/to_number_value.rs
@@ -1,0 +1,13 @@
+pub trait ToNumberValue {
+	fn to_number_value(&self) -> Option<f32>;
+
+	fn to_int_value(&self) -> Option<i32> {
+		self.to_number_value().map(|f| f as i32)
+	}
+}
+
+impl<T: ToNumberValue> ToNumberValue for Option<T> {
+	fn to_number_value(&self) -> Option<f32> {
+		self.as_ref().and_then(|t| t.to_number_value())
+	}
+}

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -307,41 +307,41 @@ fn generate_range_validation(field_ident: &Ident, range_expr: &ExprRange) -> Tok
 		// 1..=10 (inclusive end)
 		(Some(start), Some(end)) => {
 			quote! {
-			  if let Ok(i) = std::convert::TryInto::<f32>::try_into(#field_ident) {
-				if !(#start..=#end).contains(&i) {
-				  use ::css_parse::ToSpan;
-				  Err(::css_parse::diagnostics::NumberOutOfBounds(
-					#field_ident.into(),
-					format!("{}..={}", #start, #end),
-					#field_ident.to_span()
-				  ))?
-				}
+			  if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&#field_ident) {
+					if !(#start..=#end).contains(&i) {
+						use ::css_parse::ToSpan;
+						Err(::css_parse::diagnostics::NumberOutOfBounds(
+							i,
+							format!("{}..={}", #start, #end),
+							#field_ident.to_span()
+						))?
+					}
 			  }
 			}
 		}
 		(Some(start), None) => {
 			quote! {
-			  if let Ok(i) = std::convert::TryInto::<f32>::try_into(#field_ident) {
-				if #start > i {
-				  use ::css_parse::ToSpan;
-				  Err(::css_parse::diagnostics::NumberTooSmall(
-					#start,
-					#field_ident.to_span()
-				  ))?
-				}
+			  if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&#field_ident) {
+					if #start > i {
+						use ::css_parse::ToSpan;
+						Err(::css_parse::diagnostics::NumberTooSmall(
+							#start,
+							#field_ident.to_span()
+						))?
+					}
 			  }
 			}
 		}
 		(None, Some(end)) => {
 			quote! {
-			  if let Ok(i) = std::convert::TryInto::<f32>::try_into(#field_ident) {
-				if #end < i {
-				  use ::css_parse::ToSpan;
-				  Err(::css_parse::diagnostics::NumberTooLarge(
-					#end,
-					#field_ident.to_span()
-				  ))?
-				}
+			  if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&#field_ident) {
+					if #end < i {
+						use ::css_parse::ToSpan;
+						Err(::css_parse::diagnostics::NumberTooLarge(
+							#end,
+							#field_ident.to_span()
+						))?
+					}
 			  }
 			}
 		}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
@@ -20,7 +20,7 @@ impl<'a> ::css_parse::Parse<'a> for FlexValue {
                 }
                 if max.is_none() && <Length>::peek(p, c) {
                     let val = p.parse::<Length>()?;
-                    if let Ok(i) = std::convert::TryInto::<f32>::try_into(val) {
+                    if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&val) {
                         if 0 > i {
                             use ::css_parse::ToSpan;
                             Err(

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
@@ -8,14 +8,14 @@ impl<'a> ::css_parse::Parse<'a> for Transform {
         use css_parse::{Parse, Build};
         if p.peek::<Number>() {
             let x = p.parse::<Number>()?;
-            if let Ok(i) = std::convert::TryInto::<f32>::try_into(x) {
+            if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&x) {
                 if 0 > i {
                     use ::css_parse::ToSpan;
                     Err(::css_parse::diagnostics::NumberTooSmall(0, x.to_span()))?
                 }
             }
             let y = p.parse::<Number>()?;
-            if let Ok(i) = std::convert::TryInto::<f32>::try_into(y) {
+            if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&y) {
                 if 0 > i {
                     use ::css_parse::ToSpan;
                     Err(::css_parse::diagnostics::NumberTooSmall(0, y.to_span()))?
@@ -24,12 +24,12 @@ impl<'a> ::css_parse::Parse<'a> for Transform {
             Ok(Self::Scale { x: x, y: y })
         } else if p.peek::<Number>() {
             let angle = p.parse::<Number>()?;
-            if let Ok(i) = std::convert::TryInto::<f32>::try_into(angle) {
+            if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&angle) {
                 if !(-360..=360).contains(&i) {
                     use ::css_parse::ToSpan;
                     Err(
                         ::css_parse::diagnostics::NumberOutOfBounds(
-                            angle.into(),
+                            i,
                             format!("{}..={}", - 360, 360),
                             angle.to_span(),
                         ),
@@ -40,12 +40,12 @@ impl<'a> ::css_parse::Parse<'a> for Transform {
         } else {
             let x = p.parse::<Length>()?;
             let y = p.parse::<Percentage>()?;
-            if let Ok(i) = std::convert::TryInto::<f32>::try_into(y) {
+            if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&y) {
                 if !(-100..=100).contains(&i) {
                     use ::css_parse::ToSpan;
                     Err(
                         ::css_parse::diagnostics::NumberOutOfBounds(
-                            y.into(),
+                            i,
                             format!("{}..={}", - 100, 100),
                             y.to_span(),
                         ),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
@@ -17,12 +17,12 @@ impl<'a> ::css_parse::Parse<'a> for Value {
                 }
                 if percentage.is_none() && <Number>::peek(p, c) {
                     let val = p.parse::<Number>()?;
-                    if let Ok(i) = std::convert::TryInto::<f32>::try_into(val) {
+                    if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&val) {
                         if !(0..=100).contains(&i) {
                             use ::css_parse::ToSpan;
                             Err(
                                 ::css_parse::diagnostics::NumberOutOfBounds(
-                                    val.into(),
+                                    i,
                                     format!("{}..={}", 0, 100),
                                     val.to_span(),
                                 ),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
@@ -8,12 +8,12 @@ impl<'a> ::css_parse::Parse<'a> for Value {
         use css_parse::{Parse, Build};
         if p.peek::<Number>() {
             let f0 = p.parse::<Number>()?;
-            if let Ok(i) = std::convert::TryInto::<f32>::try_into(f0) {
+            if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&f0) {
                 if !(0..=100).contains(&i) {
                     use ::css_parse::ToSpan;
                     Err(
                         ::css_parse::diagnostics::NumberOutOfBounds(
-                            f0.into(),
+                            i,
                             format!("{}..={}", 0, 100),
                             f0.to_span(),
                         ),
@@ -23,7 +23,7 @@ impl<'a> ::css_parse::Parse<'a> for Value {
             Ok(Self::Percentage { 0: f0 })
         } else {
             let f0 = p.parse::<Number>()?;
-            if let Ok(i) = std::convert::TryInto::<f32>::try_into(f0) {
+            if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&f0) {
                 if 0.1 > i {
                     use ::css_parse::ToSpan;
                     Err(::css_parse::diagnostics::NumberTooSmall(0.1, f0.to_span()))?

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
@@ -16,12 +16,12 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLengthWithRange {
             }
             if length.is_none() && <Length>::peek(p, c) {
                 let val = p.parse::<Length>()?;
-                if let Ok(i) = std::convert::TryInto::<f32>::try_into(val) {
+                if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&val) {
                     if !(0..=100).contains(&i) {
                         use ::css_parse::ToSpan;
                         Err(
                             ::css_parse::diagnostics::NumberOutOfBounds(
-                                val.into(),
+                                i,
                                 format!("{}..={}", 0, 100),
                                 val.to_span(),
                             ),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
@@ -20,12 +20,12 @@ impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
             }
             if percentage.is_none() && <Number>::peek(p, c) {
                 let val = p.parse::<Number>()?;
-                if let Ok(i) = std::convert::TryInto::<f32>::try_into(val) {
+                if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&val) {
                     if !(0..=100).contains(&i) {
                         use ::css_parse::ToSpan;
                         Err(
                             ::css_parse::diagnostics::NumberOutOfBounds(
-                                val.into(),
+                                i,
                                 format!("{}..={}", 0, 100),
                                 val.to_span(),
                             ),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
@@ -7,12 +7,12 @@ impl<'a> ::css_parse::Parse<'a> for Color {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
         let red = p.parse::<CSSInt>()?;
-        if let Ok(i) = std::convert::TryInto::<f32>::try_into(red) {
+        if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&red) {
             if !(0..=255).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
                     ::css_parse::diagnostics::NumberOutOfBounds(
-                        red.into(),
+                        i,
                         format!("{}..={}", 0, 255),
                         red.to_span(),
                     ),
@@ -20,12 +20,12 @@ impl<'a> ::css_parse::Parse<'a> for Color {
             }
         }
         let green = p.parse::<CSSInt>()?;
-        if let Ok(i) = std::convert::TryInto::<f32>::try_into(green) {
+        if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&green) {
             if !(0..=255).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
                     ::css_parse::diagnostics::NumberOutOfBounds(
-                        green.into(),
+                        i,
                         format!("{}..={}", 0, 255),
                         green.to_span(),
                     ),
@@ -33,12 +33,12 @@ impl<'a> ::css_parse::Parse<'a> for Color {
             }
         }
         let blue = p.parse::<CSSInt>()?;
-        if let Ok(i) = std::convert::TryInto::<f32>::try_into(blue) {
+        if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&blue) {
             if !(0..=255).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
                     ::css_parse::diagnostics::NumberOutOfBounds(
-                        blue.into(),
+                        i,
                         format!("{}..={}", 0, 255),
                         blue.to_span(),
                     ),
@@ -46,12 +46,12 @@ impl<'a> ::css_parse::Parse<'a> for Color {
             }
         }
         let alpha = p.parse::<Number>()?;
-        if let Ok(i) = std::convert::TryInto::<f32>::try_into(alpha) {
+        if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&alpha) {
             if !(0..=1).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
                     ::css_parse::diagnostics::NumberOutOfBounds(
-                        alpha.into(),
+                        i,
                         format!("{}..={}", 0, 1),
                         alpha.to_span(),
                     ),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
@@ -7,12 +7,12 @@ impl<'a> ::css_parse::Parse<'a> for Volume {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
         let level = p.parse::<Number>()?;
-        if let Ok(i) = std::convert::TryInto::<f32>::try_into(level) {
+        if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&level) {
             if !(0.0f32..=100.0f32).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
                     ::css_parse::diagnostics::NumberOutOfBounds(
-                        level.into(),
+                        i,
                         format!("{}..={}", 0.0f32, 100.0f32),
                         level.to_span(),
                     ),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
@@ -7,7 +7,7 @@ impl<'a> ::css_parse::Parse<'a> for PositiveValue {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
         let value = p.parse::<CSSInt>()?;
-        if let Ok(i) = std::convert::TryInto::<f32>::try_into(value) {
+        if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&value) {
             if 1.0f32 > i {
                 use ::css_parse::ToSpan;
                 Err(::css_parse::diagnostics::NumberTooSmall(1.0f32, value.to_span()))?

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
@@ -7,7 +7,7 @@ impl<'a> ::css_parse::Parse<'a> for Probability {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
         let value = p.parse::<Number>()?;
-        if let Ok(i) = std::convert::TryInto::<f32>::try_into(value) {
+        if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&value) {
             if 1.0f32 < i {
                 use ::css_parse::ToSpan;
                 Err(::css_parse::diagnostics::NumberTooLarge(1.0f32, value.to_span()))?

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
@@ -7,12 +7,12 @@ impl<'a> ::css_parse::Parse<'a> for Scale {
     fn parse(p: &mut css_parse::Parser<'a>) -> css_parse::Result<Self> {
         use css_parse::{Parse, Build};
         let f0 = p.parse::<Number>()?;
-        if let Ok(i) = std::convert::TryInto::<f32>::try_into(f0) {
+        if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&f0) {
             if !(0.1..=10.0).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
                     ::css_parse::diagnostics::NumberOutOfBounds(
-                        f0.into(),
+                        i,
                         format!("{}..={}", 0.1, 10.0),
                         f0.to_span(),
                     ),


### PR DESCRIPTION
A few attempts at getting a generic way of checking numbers have occurred - most recently
https://github.com/csskit/csskit/pull/364. These all try to leverage a std trait such as Into, TryInto, etc.

This change hopes to solve this problem more completely by introducing a new ToNumberValue trait which CSS number like
tokens (Numbers, Ints, Dimensions) can leverage, and the upper-types (such as AutoOr<T>) can also use. ToNumberValue
makes life simpler vs something like TryInto for 2 reasons:

- &self means no move semantics or borrow checker issues
- Option<f32> allows us to grab a value without sentinel values, and without Err(())
