### PR TITLE
csskit_proc_macro: use #[parse] attrs for literal int/dimension types when derive(Parse)

### DIFF
--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__literal_with_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__literal_with_derive_parse.snap
@@ -1,0 +1,9 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+#[derive(Parse)]
+enum Foo {
+    Literal0deg(#[parse(in_range = 0f32..= 0f32)] ::css_parse::T![Dimension]),
+    Literal90deg(#[parse(in_range = 90f32..= 90f32)] ::css_parse::T![Dimension]),
+}

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -688,6 +688,13 @@ fn keyword_int_literal_dimension_literal() {
 }
 
 #[test]
+fn literal_with_derive_parse() {
+	let syntax = to_valuedef!(" 0deg | 90deg ");
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "literal_with_derive_parse");
+}
+
+#[test]
 fn combinator_optional_keyword() {
 	let syntax = to_valuedef! { foo | <color>? bar };
 	let data = to_deriveinput! { #[derive(Visitable)] enum Foo {} };


### PR DESCRIPTION
The IntLiteral & DimensionLiteral types need bounds checking, but these checks aren't in place when the struct derives
Parse - this change ensures the checks remain by adding the requisite #[parse] attributes to the struct definition.
