### PR TITLE
csskit_proc_macro: Improve support for AllMustOccur with checks

### DIFF
--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -292,6 +292,10 @@ impl Def {
 			Def::DimensionLiteral(f, _) if derives_parse => {
 				quote! { #[parse(in_range = #f..=#f)] }
 			}
+			Def::Optional(def) => match def.deref() {
+				Def::Type(deftype) if derives_parse => deftype.generate_in_range_attr(),
+				_ => quote! {},
+			},
 			Def::Type(deftype) if derives_parse => deftype.generate_in_range_attr(),
 			_ => quote! {},
 		};
@@ -883,6 +887,14 @@ impl GenerateDefinition for Def {
 							} else {
 								def.to_type()
 							};
+							let attrs = def.type_attributes(derives_parse, derives_visitable);
+							quote! { #attrs pub #ty }
+						});
+						quote! { ( #(#types),* ); }
+					}
+					Self::Combinator(defs, DefCombinatorStyle::AllMustOccur) => {
+						let types = defs.iter().map(|def| {
+							let ty = def.to_type();
 							let attrs = def.type_attributes(derives_parse, derives_visitable);
 							quote! { #attrs pub #ty }
 						});

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__all_must_occur_struct_with_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__all_must_occur_struct_with_range.snap
@@ -1,0 +1,10 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+#[derive(Parse)]
+struct Foo(
+    pub ::css_parse::T![Ident],
+    #[parse(in_range = 0f32..= 100f32)]
+    pub ::css_parse::T![Dimension:: %],
+);

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_and_length_with_range.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__auto_and_length_with_range.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-struct Foo<'a>(pub ::css_parse::T![Ident], crate::Length);
+struct Foo<'a>(pub ::css_parse::T![Ident], pub crate::Length);
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_combinator_with_checks_derives_parse.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__ordered_combinator_with_checks_derives_parse.snap
@@ -1,0 +1,18 @@
+---
+source: crates/csskit_proc_macro/src/test.rs
+expression: pretty
+---
+::css_parse::keyword_set!(
+    #[derive(::csskit_derives::Visitable)] #[visit(skip)] pub enum FooKeywords { Bar :
+    "bar", }
+);
+#[derive(Parse)]
+enum Foo {
+    #[parse(keyword = FooKeywords::Bar)]
+    Bar(::css_parse::T![Ident]),
+    Foo(
+        ::css_parse::T![Ident],
+        #[parse(in_range = -90f32..= 90f32)]
+        Option<crate::Angle>,
+    ),
+}

--- a/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__simple_optionals.snap
+++ b/crates/csskit_proc_macro/src/snapshots/csskit_proc_macro__test__simple_optionals.snap
@@ -2,7 +2,7 @@
 source: crates/csskit_proc_macro/src/test.rs
 expression: pretty
 ---
-struct Foo<'a>(pub crate::Length, ::css_parse::T![Ident]);
+struct Foo<'a>(pub crate::Length, pub ::css_parse::T![Ident]);
 #[automatically_derived]
 impl<'a> ::css_parse::Parse<'a> for Foo<'a> {
     fn parse(p: &mut ::css_parse::Parser<'a>) -> ::css_parse::Result<Self> {

--- a/crates/csskit_proc_macro/src/test.rs
+++ b/crates/csskit_proc_macro/src/test.rs
@@ -814,6 +814,20 @@ fn auto_or_type_with_checks_derive_parse() {
 }
 
 #[test]
+fn ordered_combinator_with_checks_derives_parse() {
+	let syntax = to_valuedef!( bar | foo <angle [-90deg,90deg]>? );
+	let data = to_deriveinput! { #[derive(Parse)] enum Foo {} };
+	assert_snapshot!(syntax, data, "ordered_combinator_with_checks_derives_parse");
+}
+
+#[test]
+fn all_must_occur_struct_with_range() {
+	let syntax = to_valuedef!(" auto && <percentage [0,100]> ");
+	let data = to_deriveinput! { #[derive(Parse)] struct Foo; };
+	assert_snapshot!(syntax, data, "all_must_occur_struct_with_range");
+}
+
+#[test]
 fn auto_or_type() {
 	let syntax = to_valuedef!( auto | <custom-ident> );
 	let data = to_deriveinput! { struct Foo; };


### PR DESCRIPTION
Checks & visibility were not working correctly for AllMustOccur types. This change fixes that.
