### PR TITLE
css_parse: Allow CursorPrettyWriteSink/CursorCompactWriteSink to push to other sinks.

### DIFF
--- a/crates/css_parse/src/traits/cursor_sink.rs
+++ b/crates/css_parse/src/traits/cursor_sink.rs
@@ -1,4 +1,4 @@
-use crate::{Cursor, Span, ToSpan, Token};
+use crate::{Cursor, SourceOffset, Span, ToSpan, Token};
 use bumpalo::collections::Vec;
 use std::fmt::{Result, Write};
 
@@ -22,8 +22,12 @@ impl<'a> ToSpan for SourceCursor<'a> {
 }
 
 impl<'a> SourceCursor<'a> {
+	pub const SPACE: SourceCursor<'static> = SourceCursor::from(Cursor::new(SourceOffset(0), Token::SPACE), " ");
+	pub const TAB: SourceCursor<'static> = SourceCursor::from(Cursor::new(SourceOffset(0), Token::TAB), "\t");
+	pub const NEWLINE: SourceCursor<'static> = SourceCursor::from(Cursor::new(SourceOffset(0), Token::NEWLINE), "\n");
+
 	#[inline(always)]
-	pub fn from(cursor: Cursor, source: &'a str) -> SourceCursor<'a> {
+	pub const fn from(cursor: Cursor, source: &'a str) -> SourceCursor<'a> {
 		Self { cursor, source }
 	}
 


### PR DESCRIPTION
Rather than these sinks pushing to a fmt::Write, they can be more flexible by pushing their tokens to another
SourceCursorSink. We already have an implementation of SourceCursorSink for String, so most of the use of these is
already handled for free, but it means we get to wrap them in more interesting ways.
