### PR TITLE
css_lexer: Eagerly parse hex values & encode them in Token data

### DIFF
--- a/crates/css_lexer/src/private.rs
+++ b/crates/css_lexer/src/private.rs
@@ -848,9 +848,21 @@ impl<'a> CharsConsumer for Chars<'a> {
 
 	fn consume_hash_token(&mut self) -> Token {
 		self.next();
+		let hex_reader = self.clone();
 		let first_is_ascii = is_ident(self.peek_nth(0));
 		let (len, contains_non_lower_ascii, _, contains_escape) = self.consume_ident_sequence();
-		Token::new_hash(contains_non_lower_ascii, first_is_ascii, contains_escape, len + 1)
+		let mut hex_value = 0;
+		if len <= 8 {
+			for c in hex_reader.take(len as usize) {
+				if let Some(d) = c.to_digit(16) {
+					hex_value = (hex_value << 4) | d;
+				} else {
+					hex_value = 0;
+					break;
+				}
+			}
+		}
+		Token::new_hash(contains_non_lower_ascii, first_is_ascii, contains_escape, len + 1, hex_value)
 	}
 
 	fn consume_ident_sequence_finding_url_keyword(&mut self) -> (u32, bool, bool, bool, bool) {

--- a/crates/css_lexer/tests/tests.rs
+++ b/crates/css_lexer/tests/tests.rs
@@ -329,6 +329,7 @@ fn tokenizes_returning_correct_str_inner_value() {
 		assert_eq!(token, Kind::Hash);
 		assert_eq!(token.with_cursor(SourceOffset(5)).str_slice(source), "#foo");
 		assert_eq!(token.with_cursor(SourceOffset(5)).parse_str(source, &allocator), "foo");
+		assert_eq!(token.hex_value(), 0);
 		assert_eq!(lexer.offset(), 9);
 	}
 	assert_eq!(lexer.advance(), Kind::Whitespace);
@@ -417,6 +418,7 @@ fn tokenizes_returning_correct_str_escaped_value() {
 		assert_eq!(token, Kind::Hash);
 		assert_eq!(token.with_cursor(SourceOffset(7)).str_slice(source), "#f\\6fo");
 		assert_eq!(token.with_cursor(SourceOffset(7)).parse_str(source, &allocator), "foo");
+		assert_eq!(token.hex_value(), 0);
 		assert_eq!(lexer.offset(), 13);
 	}
 	assert_eq!(lexer.advance(), Kind::Whitespace);
@@ -1169,4 +1171,20 @@ fn tokenizes_weird_url_function_names() {
 	assert_eq!(lexer.advance(), Kind::Ident);
 	assert_eq!(lexer.advance(), Kind::RightParen);
 	assert_eq!(lexer.advance(), Kind::Eof);
+}
+
+#[test]
+fn tokenizes_hex_values_correctly() {
+	let mut lexer = Lexer::new("#ff0");
+	let token = lexer.advance();
+	assert_eq!(token.hex_value(), 0xFF0);
+	let mut lexer = Lexer::new("#ffg");
+	let token = lexer.advance();
+	assert_eq!(token.hex_value(), 0);
+	let mut lexer = Lexer::new("#CAFEBABE");
+	let token = lexer.advance();
+	assert_eq!(token.hex_value(), 0xCAFEBABE);
+	let mut lexer = Lexer::new("#CAFE BABE");
+	let token = lexer.advance();
+	assert_eq!(token.hex_value(), 0xCAFE);
 }


### PR DESCRIPTION
An 8 character hexadecimal colour value is quite cheap to parse during tokenisation, and it just so happens that a Token - being comprised of 2 u32s - has just enough space to squeeze a hex into, if we accept the limitation of the hash
length going from a max of 2,147,483,647 down to 16,777,215.

In reality, a 16 million character long ID aught to be enough for anybody.
