### PR TITLE
Tidy up diagnostics, split them into respective crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "similar",
  "smallvec",
  "syn",
+ "thiserror 2.0.16",
 ]
 
 [[package]]

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -21,6 +21,7 @@ chromashift = { workspace = true, optional = true }
 
 bumpalo = { workspace = true, features = ["collections", "boxed"] }
 miette = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
 smallvec = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 

--- a/crates/css_ast/src/diagnostics.rs
+++ b/crates/css_ast/src/diagnostics.rs
@@ -1,0 +1,366 @@
+use css_parse::{Cursor, Kind, Span};
+use miette::Diagnostic;
+use thiserror::Error;
+
+pub use css_parse::diagnostics::*;
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This cannot yet be parsed by the parser :(")]
+#[diagnostic(code(css_parse::Unimplemented))]
+#[help("This feature needs to be implemented within csskit. This file won't parse without it.")]
+pub struct Unimplemented(#[label("Didn't recognise this bit")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This at-rule mut not have a 'prelude'.")]
+#[diagnostic(code(css_parse::DisllowedAtRulePrelude))]
+#[help("The 'prelude' is the bit between the @keyword and the {{")]
+pub struct DisallowedAtRulePrelude(#[label("Remove this part")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This at-rule must not have a 'block'.")]
+#[diagnostic(code(css_parse::DisllowedAtRuleBlock))]
+#[help("The 'block' is the bit between the {{ and }}")]
+pub struct DisallowedAtRuleBlock(#[label("Remove this part")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This at-rule must have a 'prelude'.")]
+#[diagnostic(code(css_parse::MissingAtRulePrelude))]
+#[help("The 'prelude' is the bit between the @ and the {{")]
+pub struct MissingAtRulePrelude(#[label("Add content here")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This at-rule must have a 'block'.")]
+#[diagnostic(code(css_parse::MissingAtRuleBlock))]
+#[help("The 'block' is the bit between the {{ and }}")]
+pub struct MissingAtRuleBlock(#[label("Add {{}} here")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected charset '{0}'. '{0}' isn't allowed here. This must be a valid IANA language code.")]
+#[diagnostic(code(css_parse::UnexpectedCharset))]
+#[help("Consider removing the rule or setting this to 'utf-8'")]
+pub struct UnexpectedCharset(pub String, #[label("This charset code is not allowed here")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected literal '{0}'")]
+#[diagnostic(code(css_parse::UnexpectedLiteral))]
+#[help("Try removing the word here.")]
+pub struct UnexpectedLiteral(pub String, #[label("??")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected identifier '{0}'. '{0}' isn't allowed here, but '{1}' is.")]
+#[diagnostic(code(css_parse::UnexpectedIdentSuggest))]
+#[help("Try changing this to '{1}'")]
+pub struct UnexpectedIdentSuggest(pub String, pub String, #[label("This keyword is not allowed here")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected duplicate '{0}'")]
+#[diagnostic(code(css_parse::UnexpectedDuplicateIdent))]
+#[help("Try removing the word here.")]
+pub struct UnexpectedDuplicateIdent(pub String, #[label("Remove this duplicate")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected pseudo selector ':{0}'")]
+#[diagnostic(code(css_parse::UnexpectedPseudo))]
+#[help("This isn't a valid psuedo selector for this rule.")]
+pub struct UnexpectedPseudoClass(pub String, #[label("This psuedo selector")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected pseudo selector ':{0}'()")]
+#[diagnostic(code(css_parse::UnexpectedPseudoClassFunction))]
+#[help("This isn't a valid psuedo selector for this rule.")]
+pub struct UnexpectedPseudoClassFunction(pub String, #[label("This psuedo selector")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected pseudo element '::{0}'")]
+#[diagnostic(code(css_parse::UnexpectedPseudoElement))]
+#[help("This isn't a valid psuedo selector for this rule.")]
+pub struct UnexpectedPseudoElement(pub String, #[label("This psuedo selector")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected pseudo element '::{0}'")]
+#[diagnostic(code(css_parse::UnexpectedPseudoElementFunction))]
+#[help("This isn't a valid psuedo selector for this rule.")]
+pub struct UnexpectedPseudoElementFunction(pub String, #[label("This psuedo selector")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("The dimension '{0}' wasn't recognised for this value type")]
+#[diagnostic(code(css_parse::UnexpectedDimension))]
+#[help(
+	"This isn't a recognisable dimension for this value type. If it's a valid dimension, it might be that it cannot be used for this rule or in this position."
+)]
+pub struct UnexpectedDimension(pub String, #[label("This isn't recognised")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected at rule '@{0}'")]
+#[diagnostic(code(css_parse::UnexpectedAtRule))]
+#[help("This isn't a recognisable at-rule here. If the rule is valid, it might not be allowed here.")]
+pub struct UnexpectedAtRule(pub String, #[label("This isn't recognised")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unexpected function '{0}'()")]
+#[diagnostic(code(css_parse::UnexpectedFunction))]
+#[help("A function with this name wasn't expected in this position.")]
+pub struct UnexpectedFunction(pub String, #[label("Here")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unknown Rule")]
+#[diagnostic(code(css_parse::UnknownRule))]
+#[help("This might be a mistake in the parser, please file an issue!")]
+pub struct UnknownRule(#[label("Don't know how to interpret this")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unknown Value")]
+#[diagnostic(code(css_parse::UnknownValue))]
+#[help("This might be a mistake in the parser, please file an issue!")]
+pub struct UnknownValue(#[label("Don't know how to interpret this")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unknown named color '{0}'")]
+#[diagnostic(code(css_parse::UnknownColor))]
+#[help("Replace this unknown color with a known named color or a valid color value.")]
+pub struct UnknownColor(pub String, #[label("This isn't a known color")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected `{}` but found `{}`", self.0, Kind::from(self.1))]
+#[diagnostic(code(css_parse::ExpectedToken))]
+#[help("This is not correct CSS syntax.")]
+pub struct ExpectedKind(pub Kind, #[label("`{}` expected", self.0)] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected a dimension but found `{}`", Kind::from(self.0))]
+#[diagnostic(code(css_parse::ExpectedDimension))]
+#[help("This is not correct CSS syntax.")]
+pub struct ExpectedDimension(#[label("dimension expected")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected a function but found `{0}`")]
+#[diagnostic(code(css_parse::ExpectedFunction))]
+#[help("This is not correct CSS syntax.")]
+pub struct ExpectedFunction(pub Kind, #[label("This token")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected to see {0}() but saw {1}()")]
+#[diagnostic(code(css_parse::ExpectedFunctionOf))]
+#[help("Try changing the {1}() to {0}()")]
+pub struct ExpectedFunctionOf(pub String, pub String, #[label("This function")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected an @ keyword but saw `{0}`")]
+#[diagnostic(code(css_parse::ExpectedAtKeyword))]
+#[help("This is not correct CSS syntax.")]
+pub struct ExpectedAtKeyword(pub Kind, #[label("This at-keyword")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected to see @{0} but saw @{1}")]
+#[diagnostic(code(css_parse::ExpectedAtKeywordOf))]
+#[help("Try changing the @{1} to @{0}")]
+pub struct ExpectedAtKeywordOf(pub String, pub String, #[label("This at-keyword")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected to see {0} but saw {1}")]
+#[diagnostic(code(css_parse::ExpectedDelimOf))]
+#[help("Try changing the {1} to {0}")]
+pub struct ExpectedDelimOf(pub char, pub char, #[label("This delimiter")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Invalid hexidecimal value for color: '{0}'")]
+#[diagnostic(code(css_parse::BadHexColor))]
+#[help("Hex colours must be 3, 4, 6 or 8 digits long.")]
+pub struct BadHexColor(pub String, #[label("This is the wrong format")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This block uses an invalid selector, so the whole block would be discarded.")]
+#[diagnostic(code(css_parse::NoSelector))]
+#[help("Try adding a selector to this style rule")]
+pub struct NoSelector(#[label("This selector isn't valid")] pub Span, pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This selector has two combinators next to each other, which is disallowed.")]
+#[diagnostic(code(css_parse::AdjacentSelectorCombinators))]
+#[help("Try removing one of the combinators or add a selector in between them")]
+pub struct AdjacentSelectorCombinators(
+	#[label("...because this combinator is right next to the previous one")] pub Span,
+	#[label("This selector is invalid...")] pub Span,
+);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This selector has two types next to each other, which is disallowed.")]
+#[diagnostic(code(css_parse::AdjacentSelectorTypes))]
+#[help("Try removing one of the types or add a space inbetween")]
+pub struct AdjacentSelectorTypes(
+	#[label("...because this type is right next to the previous one.")] pub Span,
+	#[label("This selector is invalid...")] pub Span,
+);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This value isn't allowed to be a raw number, it has to have a dimension.")]
+#[diagnostic(code(css_parse::DisallowedValueWithoutDimension))]
+#[help("Try adding a dimension, like '{0}'")]
+pub struct DisallowedValueWithoutDimension(pub String, #[label("This value")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("A math function isn't valid here.")]
+#[diagnostic(code(css_parse::DisallowedMathFunction))]
+#[help("var() and env() can be used but math functions like {0}() cannot.")]
+pub struct DisallowedMathFunction(pub String, #[label("This value")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected an opening curly brace but saw `{}`", Kind::from(self.0))]
+#[diagnostic(code(css_parse::ExpectedOpenCurly))]
+#[help("This is not correct CSS syntax.")]
+pub struct ExpectedOpenCurly(#[label("This value")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected a number but saw `{0}`")]
+#[diagnostic(code(css_parse::ExpectedNumber))]
+#[help("This is not correct CSS syntax.")]
+pub struct ExpectedNumber(pub Kind, #[label("This value")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected a signed number but saw `{0}`")]
+#[diagnostic(code(css_parse::ExpectedSign))]
+#[help("This number needs a + or a -.")]
+pub struct ExpectedSign(pub f32, #[label("Add a + here")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Expected an unsigned number but saw `{}`", self.0.token().value())]
+#[diagnostic(code(css_parse::ExpectedUnsigned))]
+#[help("This number cannot have a + or a -.")]
+pub struct ExpectedUnsigned(#[label("This should be {}", self.0.token().value().abs())] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This number is out of bounds.")]
+#[diagnostic(code(css_parse::NumberOutOfBounds))]
+#[help("This needs to be a number between {1}.")]
+pub struct NumberOutOfBounds(pub f32, pub String, #[label("This value")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This number cannot be negative.")]
+#[diagnostic(code(css_parse::NumberNotNegative))]
+#[help("This needs to be greater or equal to 0")]
+pub struct NumberNotNegative(pub f32, #[label("This value")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This number is too small.")]
+#[diagnostic(code(css_parse::NumberTooSmall))]
+#[help("This needs to be larger than {0}")]
+pub struct NumberTooSmall(pub f32, #[label("This value")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This number is too large.")]
+#[diagnostic(code(css_parse::NumberTooLarge))]
+#[help("This needs to be smaller than {0}")]
+pub struct NumberTooLarge(pub f32, #[label("This value")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This value isn't allowed to have a fraction, it must be a whole number (integer).")]
+#[diagnostic(code(css_parse::ExpectedInt))]
+#[help("Try using {} instead", self.0.token().value().round())]
+pub struct ExpectedInt(#[label("This value")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This value must have a fraction, it must be float.")]
+#[diagnostic(code(css_parse::ExpectedFloat))]
+#[help("Try using {} instead", self.0.token().value())]
+pub struct ExpectedFloat(#[label("This value")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This number must be 0, got {} instead.", self.0.token().value())]
+#[diagnostic(code(css_parse::ExpectedZero))]
+#[help("Try replacing it with the literal 0 instead")]
+pub struct ExpectedZero(#[label("This value")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This number must not be 0.")]
+#[diagnostic(code(css_parse::ExpectedZero))]
+#[help("Try replacing it with a positive or negative number")]
+pub struct UnexpectedZero(#[label("This value")] pub Cursor);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This media query tries to compare itself equal to two different numbers.")]
+#[diagnostic(code(css_parse::UnexpectedMediaRangeComparisonEqualsTwice))]
+#[help("Try deleting one.")]
+pub struct UnexpectedMediaRangeComparisonEqualsTwice(#[label("This comparison")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Display 'list-item' can only be combined with 'flow' or 'flow-root'")]
+#[diagnostic(code(css_parse::DisplayHasInvalidListItemCombo))]
+#[help("{0} is not valid in combination with list-item, try changing it to 'flow' or 'flow-root'")]
+pub struct DisplayHasInvalidListItemCombo(pub String, pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("hwb and hsl colors must have a hue as their first argument.")]
+#[diagnostic(code(css_parse::ColorMustStartWithHue))]
+#[help("Try adding a % to the first color component.")]
+pub struct ColorMustStartWithHue(#[label("This component")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Only hwb and hsl colors have a hue as their first argument.")]
+#[diagnostic(code(css_parse::ColorMustNotStartWithHue))]
+#[help("Try removing the %")]
+pub struct ColorMustNotStartWithHue(#[label("This component")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Colors should not use a hue as the middle color component")]
+#[diagnostic(code(css_parse::ColorMustNotStartWithHue))]
+#[help("Try removing the %")]
+pub struct ColorMustNotHaveHueInMiddle(#[label("This component")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Colors using the legacy syntax must have commas between the components")]
+#[diagnostic(code(css_parse::ColorLegacyMustIncludeComma))]
+#[help("Try using the non-legacy syntax, without commas")]
+pub struct ColorLegacyMustIncludeComma(#[label("Put a commma here")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Colors using the legacy syntax must not use percentages, but absolute numbers")]
+#[diagnostic(code(css_parse::ColorLegacyMustNotUsePercent))]
+#[help("Try removing the %, or use the non-legacy syntax")]
+pub struct ColorLegacyMustNotUsePercent(#[label("This should not be a percentage")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Hex colors can be 3, 4, 6, or 8 characters in length. This one is {0}")]
+#[diagnostic(code(css_parse::ColorLegacyMustNotUsePercent))]
+#[help("Try rewriting this to be 3, 4, 6 or 8 characters")]
+pub struct ColorHexWrongLength(pub usize, #[label("This is not the right number of characters")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("{0} cannot be used as a keyframe name, as it's a reserved word.")]
+#[diagnostic(code(css_parse::ReservedKeyframeName))]
+#[help("")]
+pub struct ReservedKeyframeName(pub String, #[label("Rename it, or try wrapping it in quotes")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("An @layer {{}} (block) rule cannot have multiple names.")]
+#[diagnostic(code(css_parse::DisallowedLayerBlockWithMultipleNames))]
+#[help("")]
+pub struct DisallowedLayerBlockWithMultipleNames(#[label("Remove most (or all) of these names.")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("!important cannot be used for this property")]
+#[diagnostic(code(css_parse::DisallowedImportant))]
+#[help("")]
+pub struct DisallowedImportant(#[label("Remove this.")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("{0} requires at least {1} arguments, but saw {2}")]
+#[diagnostic(code(css_parse::DisallowedImportant))]
+#[help("")]
+pub struct NotEnoughArguments(
+	pub String,
+	pub usize,
+	pub usize,
+	#[label("Add another argument to this function.")] pub Span,
+);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("'{0}' not a valid <counter-name>")]
+#[diagnostic(code(css_parse::Unexpected))]
+#[help("")]
+pub struct InvalidCounterName(pub String, #[label("This value")] pub Span);
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("This attr(name) is invalid.")]
+#[diagnostic(code(css_parse::Unexpected))]
+#[help("Try adding a | between each name.")]
+pub struct InvalidAttrName(#[label("This value")] pub Span);

--- a/crates/css_ast/src/functions/attr_function.rs
+++ b/crates/css_ast/src/functions/attr_function.rs
@@ -1,10 +1,8 @@
+use crate::{Syntax, diagnostics};
 use css_parse::{
-	ComponentValues, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set,
-	keyword_set,
+	ComponentValues, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
-
-use crate::types::Syntax;
 
 function_set!(pub struct AttrFunctionName "attr");
 
@@ -48,9 +46,7 @@ impl<'a> Parse<'a> for AttrName {
 		}
 
 		if a.is_none() && b.is_none() {
-			let any = p.parse::<T![Any]>()?;
-			let c: Cursor = any.into();
-			Err(diagnostics::ExpectedIdent(c.into(), c.into()))?
+			Err(diagnostics::ExpectedIdent(p.next()))?
 		}
 
 		debug_assert!(a.is_some() && b.is_some());

--- a/crates/css_ast/src/functions/easing_functions.rs
+++ b/crates/css_ast/src/functions/easing_functions.rs
@@ -1,6 +1,6 @@
+use crate::diagnostics;
 use css_parse::{
-	Build, CommaSeparated, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, function_set,
-	keyword_set,
+	Build, CommaSeparated, Cursor, Function, Parse, Parser, Peek, Result as ParserResult, T, function_set, keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
@@ -107,7 +107,7 @@ impl<'a> Parse<'a> for EasingFunction<'a> {
 			Some(EasingFunctionName::Linear(_)) => p.parse::<LinearFunction>().map(Self::LinearFunction),
 			Some(EasingFunctionName::CubicBezier(_)) => p.parse::<CubicBezierFunction>().map(Self::CubicBezierFunction),
 			Some(EasingFunctionName::Steps(_)) => p.parse::<StepsFunction>().map(Self::StepsFunction),
-			None => Err(diagnostics::Unexpected(c.into(), c.into()))?,
+			None => Err(diagnostics::Unexpected(p.next()))?,
 		}
 	}
 }

--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+mod diagnostics;
 mod functions;
 mod properties;
 mod rules;
@@ -26,9 +27,7 @@ pub use units::*;
 pub use values::*;
 pub use visit::*;
 
-use css_parse::{
-	Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan, diagnostics,
-};
+use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan};
 
 pub use css_parse::{Declaration, DeclarationValue};
 
@@ -49,7 +48,7 @@ impl<'a> Peek<'a> for Todo {
 
 impl<'a> Parse<'a> for Todo {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		Err(diagnostics::Unimplemented(Span::new(p.offset(), p.offset())))?
+		Err(diagnostics::Unimplemented(p.next()))?
 	}
 }
 

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -1,4 +1,5 @@
-use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, diagnostics};
+use crate::diagnostics;
+use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-syntax-3/#charset-rule
@@ -22,7 +23,7 @@ impl<'a> Parse<'a> for CharsetRule {
 		// CharsetRule MUST be all lowercase, alt cases such as CHARSET or charSet aren't
 		// valid here, compares to other at-rules which are case insensitive.
 		if !p.eq_ignore_ascii_case(c, "charset") {
-			Err(diagnostics::UnexpectedAtRule(p.parse_str(c).into(), c.into()))?;
+			Err(diagnostics::UnexpectedAtRule(p.parse_str(c).into(), c))?;
 		}
 		// Charsets MUST have a space between the at keyword and the string. This
 		// isn't necessary in other at rules where an at keyword can align with other

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -1,8 +1,8 @@
-use crate::{Visit, VisitMut, Visitable as VisitableTrait, VisitableMut, stylesheet::Rule};
+use crate::{Rule, Visit, VisitMut, Visitable as VisitableTrait, VisitableMut, diagnostics};
 use bumpalo::collections::Vec;
 use css_parse::{
 	AtRule, Build, ConditionKeyword, Cursor, FeatureConditionList, Kind, Parse, Parser, Peek, PreludeList,
-	Result as ParserResult, RuleList, T, atkeyword_set, diagnostics, keyword_set,
+	Result as ParserResult, RuleList, T, atkeyword_set, keyword_set,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 use csskit_proc_macro::visit;
@@ -184,7 +184,8 @@ impl<'a> Parse<'a> for ContainerFeature<'a> {
 							},)+
 						}
 					} else {
-						Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
+						let source_cursor = p.to_source_cursor(c);
+						Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), c))?
 					}
 				}
 			}

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -1,7 +1,7 @@
-use crate::StyleValue;
+use crate::{StyleValue, diagnostics};
 use css_parse::{
 	AtRule, CommaSeparated, Cursor, NoBlockAllowed, Parse, Parser, Peek, QualifiedRule, Result as ParserResult,
-	RuleList, T, ToSpan, atkeyword_set, diagnostics, keyword_set,
+	RuleList, T, ToSpan, atkeyword_set, keyword_set,
 };
 use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
 

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -168,8 +168,7 @@ impl<'a> Parse<'a> for SupportsFeature<'a> {
 			let close = p.parse_if_peek::<T![')']>()?;
 			Ok(Self::Property(open, property, close))
 		} else {
-			let c = p.peek_n(1);
-			Err(diagnostics::Unexpected(c.into(), c.into()))?
+			Err(diagnostics::Unexpected(p.next()))?
 		}
 	}
 }

--- a/crates/css_ast/src/selector/moz.rs
+++ b/crates/css_ast/src/selector/moz.rs
@@ -1,10 +1,9 @@
+use crate::{DirValue, diagnostics};
 use css_parse::{
-	Build, Cursor, Parse, Parser, Result as ParserResult, T, diagnostics, function_set, pseudo_class, pseudo_element,
+	Build, Cursor, Parse, Parser, Result as ParserResult, T, function_set, pseudo_class, pseudo_element,
 	syntax::CommaSeparated,
 };
 use csskit_derives::{ToCursors, Visitable};
-
-use super::functional_pseudo_class::DirValue;
 
 pseudo_element!(
 	/// https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#pseudo-elements_and_pseudo-classes
@@ -190,7 +189,7 @@ impl<'a> Parse<'a> for MozFunctionalPseudoClass {
 			let close = p.parse_if_peek::<T![')']>()?;
 			Ok(Self::LocaleDir(MozLocaleDirFunctionalPseudoClass { colon, function, value, close }))
 		} else {
-			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c.into()))?
+			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c))?
 		}
 	}
 }

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -1,10 +1,9 @@
+use crate::{CSSInt, diagnostics};
 use css_parse::{
 	Cursor, CursorSink, Kind, KindSet, Parse, Parser, Peek, Result as ParserResult, Span, T, ToCursors, ToSpan,
-	diagnostics, keyword_set,
+	keyword_set,
 };
 use csskit_derives::Visitable;
-
-use crate::units::CSSInt;
 
 keyword_set!(pub enum NthKeyword {
 	Odd: "odd",
@@ -55,10 +54,10 @@ impl<'a> Parse<'a> for Nth {
 			cursors[1] = c;
 		}
 		if !matches!(c.token().kind(), Kind::Number | Kind::Dimension | Kind::Ident) {
-			Err(diagnostics::Unexpected(c.into(), c.into()))?
+			Err(diagnostics::Unexpected(c))?
 		}
 		if c.token().is_float() {
-			Err(diagnostics::ExpectedInt(c.token().value(), c.into()))?
+			Err(diagnostics::ExpectedInt(c))?
 		}
 
 		match p.parse_str_lower(c) {
@@ -78,12 +77,12 @@ impl<'a> Parse<'a> for Nth {
 					1
 				};
 				if !matches!(char, Some('n') | Some('N')) {
-					Err(diagnostics::Unexpected(c.into(), c.into()))?
+					Err(diagnostics::Unexpected(c))?
 				}
 				if let Ok(b) = chars.as_str().parse::<i32>() {
 					return Ok(Self::Anb(a, b, cursors));
 				} else if !chars.as_str().is_empty() {
-					Err(diagnostics::Unexpected(c.into(), c.into()))?
+					Err(diagnostics::Unexpected(c))?
 				}
 			}
 		}
@@ -107,10 +106,10 @@ impl<'a> Parse<'a> for Nth {
 			debug_assert!(cursors[3] == Cursor::EMPTY);
 			cursors[3] = c;
 			if c.token().is_float() {
-				Err(diagnostics::ExpectedInt(c.token().value(), c.into()))?
+				Err(diagnostics::ExpectedInt(c))?
 			}
 			if c.token().has_sign() && b_sign != 0 {
-				Err(diagnostics::ExpectedUnsigned(c.token().value(), c.into()))?
+				Err(diagnostics::ExpectedUnsigned(c))?
 			}
 			if b_sign == 0 {
 				b_sign = 1;

--- a/crates/css_ast/src/selector/pseudo_class.rs
+++ b/crates/css_ast/src/selector/pseudo_class.rs
@@ -1,4 +1,5 @@
-use css_parse::{Build, Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set};
+use crate::diagnostics;
+use css_parse::{Build, Parse, Parser, Result as ParserResult, T, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 use super::{moz::MozPseudoClass, ms::MsPseudoClass, o::OPseudoClass, webkit::WebkitPseudoClass};
@@ -122,7 +123,7 @@ impl<'a> Parse<'a> for PseudoClass {
 						if let Ok(psuedo) = p.try_parse::<OPseudoClass>() {
 							return Ok(Self::O(psuedo));
 						}
-						Err(diagnostics::UnexpectedPseudoClass(p.parse_str(c).into(), c.into()))?
+						Err(diagnostics::UnexpectedPseudoClass(p.parse_str(c).into(), c))?
 					}
 				}
 			};

--- a/crates/css_ast/src/selector/pseudo_element.rs
+++ b/crates/css_ast/src/selector/pseudo_element.rs
@@ -1,7 +1,6 @@
-use css_parse::{Build, KindSet, Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set, pseudo_class};
+use crate::{MozPseudoElement, MsPseudoElement, OPseudoElement, WebkitPseudoElement, diagnostics};
+use css_parse::{Build, KindSet, Parse, Parser, Result as ParserResult, T, keyword_set, pseudo_class};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
-
-use super::{moz::MozPseudoElement, ms::MsPseudoElement, o::OPseudoElement, webkit::WebkitPseudoElement};
 
 macro_rules! apply_pseudo_element {
 	($macro: ident) => {
@@ -83,7 +82,7 @@ impl<'a> Parse<'a> for PseudoElement {
 						if let Ok(psuedo) = p.try_parse::<OPseudoElement>() {
 							return Ok(Self::O(psuedo));
 						}
-						Err(diagnostics::UnexpectedPseudoElement(p.parse_str(c).into(), c.into()))?
+						Err(diagnostics::UnexpectedPseudoElement(p.to_source_cursor(c).to_string(), c))?
 					}
 				}
 			}

--- a/crates/css_ast/src/selector/webkit.rs
+++ b/crates/css_ast/src/selector/webkit.rs
@@ -1,7 +1,6 @@
-use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, diagnostics, pseudo_class, pseudo_element};
+use crate::{CompoundSelector, diagnostics};
+use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, pseudo_class, pseudo_element};
 use csskit_derives::{ToCursors, Visitable};
-
-use super::CompoundSelector;
 
 pseudo_element!(
 	/// <https://searchfox.org/wubkat/source/Source/WebCore/css/CSSPseudoSelectors.json>
@@ -91,7 +90,7 @@ impl<'a> Parse<'a> for WebkitFunctionalPseudoElement<'a> {
 			let close = p.parse_if_peek::<T![')']>()?;
 			Ok(Self::Distributed(WebkitDistrubutedFunctionalPseudoElement { colons, function, value, close }))
 		} else {
-			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c.into()))?
+			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c))?
 		}
 	}
 }
@@ -126,7 +125,7 @@ impl<'a> Parse<'a> for WebkitFunctionalPseudoClass<'a> {
 			let close = p.parse_if_peek::<T![')']>()?;
 			Ok(Self::Any(WebkitAnyFunctionalPseudoClass { colon, function, value, close }))
 		} else {
-			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c.into()))?
+			Err(diagnostics::UnexpectedFunction(p.parse_str(c).into(), c))?
 		}
 	}
 }

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -110,7 +110,7 @@ apply_rules!(define_atkeyword_set);
 impl<'a> RuleVariants<'a> for Rule<'a> {
 	fn parse_at_rule(p: &mut Parser<'a>, c: Cursor) -> ParserResult<Self> {
 		if !AtRuleKeywords::peek(p, c) {
-			Err(diagnostics::Unexpected(c.into(), c.into()))?;
+			Err(diagnostics::Unexpected(p.next()))?;
 		}
 		let kw = AtRuleKeywords::build(p, c);
 		macro_rules! parse_rule {

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -1,8 +1,8 @@
 mod named;
 mod system;
 
-use crate::ColorFunction;
-use css_parse::{Build, Cursor, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
+use crate::{ColorFunction, diagnostics};
+use css_parse::{Build, Cursor, Parse, Parser, Peek, Result as ParserResult, T, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 pub use named::*;
@@ -101,7 +101,7 @@ impl<'a> Parse<'a> for Color {
 		} else if p.peek::<ColorFunction>() {
 			p.parse::<ColorFunction>().map(Color::Function)
 		} else {
-			Err(diagnostics::Unimplemented(p.peek_n(1).into()))?
+			Err(diagnostics::Unimplemented(p.peek_n(1)))?
 		}
 	}
 }

--- a/crates/css_ast/src/types/grid_line.rs
+++ b/crates/css_ast/src/types/grid_line.rs
@@ -1,7 +1,6 @@
-use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, diagnostics, keyword_set, parse_optionals};
+use crate::{PositiveNonZeroInt, Visitable, diagnostics};
+use css_parse::{Cursor, Parse, Parser, Result as ParserResult, T, keyword_set, parse_optionals};
 use csskit_derives::{Peek, ToCursors, ToSpan};
-
-use crate::{PositiveNonZeroInt, Visitable};
 
 keyword_set!(pub enum GridLineKeywords { Auto: "auto", Span: "span" });
 
@@ -37,10 +36,10 @@ impl<'a> Parse<'a> for GridLine {
 		{
 			let c: Cursor = num.into();
 			if !num.is_int() {
-				Err(diagnostics::ExpectedInt(num.into(), c.into()))?
+				Err(diagnostics::ExpectedInt(c))?
 			}
 			if num.value() == 0.0 {
-				Err(diagnostics::UnexpectedZero(c.into()))?
+				Err(diagnostics::UnexpectedZero(c))?
 			}
 		}
 

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -1,7 +1,6 @@
-use css_parse::{Build, Cursor, Kind, Parse, Parser, Peek, Result as ParserResult, T, Token, diagnostics, keyword_set};
+use crate::{LengthPercentage, diagnostics};
+use css_parse::{Build, Cursor, Kind, Parse, Parser, Peek, Result as ParserResult, T, Token, keyword_set};
 use csskit_derives::{IntoCursor, ToCursors, ToSpan, Visitable};
-
-use crate::units::LengthPercentage;
 
 // https://drafts.csswg.org/css-values-4/#position
 // <position> = [
@@ -48,8 +47,7 @@ impl<'a> Parse<'a> for Position {
 				if let Some(vertical) = first.to_vertical() {
 					return Ok(Self::TwoValue(horizontal, vertical));
 				} else {
-					let cursor: Cursor = second.into();
-					Err(diagnostics::Unexpected(cursor.into(), cursor.into()))?
+					Err(diagnostics::Unexpected(second.into()))?
 				}
 			}
 		}
@@ -57,13 +55,12 @@ impl<'a> Parse<'a> for Position {
 		if matches!(first, PositionSingleValue::Center(_) | PositionSingleValue::LengthPercentage(_))
 			|| !matches!(&second, PositionSingleValue::LengthPercentage(_))
 		{
-			let cursor: Cursor = second.into();
-			Err(diagnostics::Unexpected(cursor.into(), cursor.into()))?
+			Err(diagnostics::Unexpected(second.into()))?
 		}
 		let third = p.parse::<PositionSingleValue>()?;
 		if third.to_horizontal_keyword().is_none() && third.to_vertical_keyword().is_none() {
 			let cursor: Cursor = third.into();
-			Err(diagnostics::UnexpectedIdent(p.parse_str(cursor).into(), cursor.into()))?
+			Err(diagnostics::UnexpectedIdent(p.parse_str(cursor).into(), cursor))?
 		}
 		let fourth = p.parse::<LengthPercentage>()?;
 		if let PositionSingleValue::LengthPercentage(second) = second {
@@ -71,23 +68,19 @@ impl<'a> Parse<'a> for Position {
 				if let Some(vertical) = third.to_vertical_keyword() {
 					Ok(Self::FourValue(horizontal, second, vertical, fourth))
 				} else {
-					let cursor: Cursor = third.into();
-					Err(diagnostics::Unexpected(cursor.into(), cursor.into()))?
+					Err(diagnostics::Unexpected(third.into()))?
 				}
 			} else if let Some(horizontal) = third.to_horizontal_keyword() {
 				if let Some(vertical) = first.to_vertical_keyword() {
 					Ok(Self::FourValue(horizontal, fourth, vertical, second))
 				} else {
-					let cursor: Cursor = third.into();
-					Err(diagnostics::Unexpected(cursor.into(), cursor.into()))?
+					Err(diagnostics::Unexpected(third.into()))?
 				}
 			} else {
-				let cursor: Cursor = third.into();
-				Err(diagnostics::Unexpected(cursor.into(), cursor.into()))?
+				Err(diagnostics::Unexpected(third.into()))?
 			}
 		} else {
-			let cursor: Cursor = second.into();
-			Err(diagnostics::Unexpected(cursor.into(), cursor.into()))?
+			Err(diagnostics::Unexpected(second.into()))?
 		}
 	}
 }

--- a/crates/css_ast/src/types/position_area.rs
+++ b/crates/css_ast/src/types/position_area.rs
@@ -1,4 +1,5 @@
-use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
+use crate::diagnostics;
+use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-anchor-position-1/#typedef-position-area
@@ -71,8 +72,7 @@ impl<'a> Parse<'a> for PositionArea {
 		} else if let Some(vertical) = p.parse_if_peek::<PositionAreaPhsyicalVertical>()? {
 			Ok(Self::Physical(p.parse_if_peek::<PositionAreaPhsyicalHorizontal>()?, Some(vertical)))
 		} else {
-			let c: Cursor = p.parse::<T![Any]>()?.into();
-			Err(diagnostics::Unexpected(c.into(), c.into()))?
+			Err(diagnostics::Unexpected(p.next()))?
 		}
 	}
 }

--- a/crates/css_ast/src/types/positive_non_zero_int.rs
+++ b/crates/css_ast/src/types/positive_non_zero_int.rs
@@ -1,5 +1,5 @@
-use crate::CSSInt;
-use css_parse::{Parse, Parser, Result as ParserResult, ToSpan, diagnostics};
+use crate::{CSSInt, diagnostics};
+use css_parse::{Parse, Parser, Result as ParserResult, ToSpan};
 use csskit_derives::{Peek, ToCursors, ToSpan};
 
 #[derive(ToSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/types/repeat_style.rs
+++ b/crates/css_ast/src/types/repeat_style.rs
@@ -1,4 +1,5 @@
-use css_parse::{Build, Cursor, Parse, Parser, Peek, Result as ParserResult, T, diagnostics, keyword_set};
+use crate::diagnostics;
+use css_parse::{Build, Cursor, Parse, Parser, Peek, Result as ParserResult, T, keyword_set};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 /// <https://drafts.csswg.org/css-backgrounds-4/#background-repeat>
@@ -33,7 +34,10 @@ impl<'a> Parse<'a> for RepeatStyle {
 				let second = p.parse_if_peek::<Repetition>()?;
 				Ok(Self::Repetition(first, second))
 			}
-			_ => Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?,
+			_ => {
+				let source_cursor = p.to_source_cursor(c);
+				Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), c))?
+			}
 		}
 	}
 }

--- a/crates/css_ast/src/types/shadow.rs
+++ b/crates/css_ast/src/types/shadow.rs
@@ -1,6 +1,5 @@
-use crate::types::Color;
-use crate::units::Length;
-use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, T, ToSpan, diagnostics};
+use crate::{Color, Length, diagnostics};
+use css_parse::{Cursor, Parse, Parser, Peek, Result as ParserResult, T, ToSpan};
 use csskit_derives::{ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-backgrounds-3/#typedef-shadow
@@ -33,7 +32,7 @@ impl<'a> Parse<'a> for Shadow {
 		let blur_radius = p.parse_if_peek::<Length>()?;
 		if let Some(blur) = blur_radius {
 			if 0.0f32 > blur.into() {
-				Err(diagnostics::NumberTooSmall(0.0, blur.to_span()))?
+				Err(diagnostics::NumberTooSmall(0.0f32, blur.to_span()))?
 			}
 		}
 
@@ -43,7 +42,8 @@ impl<'a> Parse<'a> for Shadow {
 		if let Some(ident) = inset {
 			if !p.eq_ignore_ascii_case(ident.into(), "inset") {
 				let c: Cursor = x.into();
-				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
+				let source_cursor = p.to_source_cursor(c);
+				Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), c))?
 			}
 		}
 

--- a/crates/css_ast/src/values/writing_modes/impls.rs
+++ b/crates/css_ast/src/values/writing_modes/impls.rs
@@ -32,8 +32,7 @@ impl<'a> Parse<'a> for GlyphOrientationVerticalStyleValue {
 						_ => {}
 					}
 				}
-				let c: ::css_parse::Cursor = p.parse::<::css_parse::token_macros::Any>()?.into();
-				Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+				Err(crate::diagnostics::Unexpected(p.next()))?
 			}
 		}
 	}

--- a/crates/css_lexer/src/cursor.rs
+++ b/crates/css_lexer/src/cursor.rs
@@ -466,6 +466,14 @@ impl PartialEq<DimensionUnit> for &Cursor {
 	}
 }
 
+#[cfg(feature = "miette")]
+impl From<Cursor> for miette::SourceSpan {
+	fn from(val: Cursor) -> Self {
+		let span = val.span();
+		span.into()
+	}
+}
+
 #[cfg(feature = "serde")]
 impl serde::ser::Serialize for Cursor {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/css_parse/src/comparison.rs
+++ b/crates/css_parse/src/comparison.rs
@@ -44,8 +44,8 @@ impl<'a> Parse<'a> for Comparison {
 					p.parse::<T![<]>().map(Comparison::LessThan)
 				}
 			}
-			Some(char) => Err(diagnostics::UnexpectedDelim(char, c.into()))?,
-			_ => Err(diagnostics::Unexpected(c.into(), c.into()))?,
+			Some(char) => Err(diagnostics::UnexpectedDelim(char, p.next()))?,
+			_ => Err(diagnostics::Unexpected(p.next()))?,
 		}
 	}
 }

--- a/crates/css_parse/src/diagnostics.rs
+++ b/crates/css_parse/src/diagnostics.rs
@@ -1,406 +1,81 @@
 use crate::{Cursor, Kind, Span};
-use miette::{self, Diagnostic};
-use thiserror::{self, Error};
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("The token at {0} cannot yet be parsed by the parser :(")]
-#[diagnostic(
-	help("This feature needs to be implemented within csskit. This file won't parse without it."),
-	code(css_parse::Unimplemented)
-)]
-pub struct Unimplemented(#[label("Didn't recognise this bit")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This at-rule mut not have a 'prelude'.")]
-#[diagnostic(help("The 'prelude' is the bit between the @keyword and the {{"), code(css_parse::DisllowedAtRulePrelude))]
-pub struct DisallowedAtRulePrelude(#[label("Remove this part")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This at-rule must not have a 'block'.")]
-#[diagnostic(help("The 'block' is the bit between the {{ and }}"), code(css_parse::DisllowedAtRuleBlock))]
-pub struct DisallowedAtRuleBlock(#[label("Remove this part")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This at-rule must have a 'prelude'.")]
-#[diagnostic(help("The 'prelude' is the bit between the @ and the {{"), code(css_parse::MissingAtRulePrelude))]
-pub struct MissingAtRulePrelude(#[label("Add content here")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This at-rule must have a 'block'.")]
-#[diagnostic(help("The 'block' is the bit between the {{ and }}"), code(css_parse::MissingAtRuleBlock))]
-pub struct MissingAtRuleBlock(#[label("Add {{}} here")] pub Span);
+use miette::Diagnostic;
+use thiserror::Error;
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("This declaration wasn't understood, and so was disregarded.")]
-#[diagnostic(help("The declaration contains invalid syntax, and will be ignored."), code(css_parse::BadDeclaration))]
+#[diagnostic(code(css_parse::BadDeclaration))]
+#[help("The declaration contains invalid syntax, and will be ignored.")]
 pub struct BadDeclaration(#[label("This is not valid syntax for a declaration.")] pub Span);
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected `{0}`")]
-#[diagnostic(help("This is not correct CSS syntax."), code(css_parse::Unexpected))]
-pub struct Unexpected(pub Kind, #[label("This wasn't expected here")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected charset '{0}'. '{0}' isn't allowed here. This must be a valid IANA language code.")]
-#[diagnostic(help("Consider removing the rule or setting this to 'utf-8'"), code(css_parse::UnexpectedCharset))]
-pub struct UnexpectedCharset(pub String, #[label("This charset code is not allowed here")] pub Span);
+#[error("Unexpected `{}`", Kind::from(self.0))]
+#[diagnostic(code(css_parse::Unexpected))]
+#[help("This is not correct CSS syntax.")]
+pub struct Unexpected(#[label("This wasn't expected here")] pub Cursor);
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Unexpected identifier '{0}'")]
-#[diagnostic(help("Try removing the word here."), code(css_parse::UnexpectedIdent))]
-pub struct UnexpectedIdent(pub String, #[label("??")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected literal '{0}'")]
-#[diagnostic(help("Try removing the word here."), code(css_parse::UnexpectedLiteral))]
-pub struct UnexpectedLiteral(pub String, #[label("??")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected identifier '{0}'. '{0}' isn't allowed here, but '{1}' is.")]
-#[diagnostic(help("Try changing this to '{1}'"), code(css_parse::UnexpectedIdentSuggest))]
-pub struct UnexpectedIdentSuggest(pub String, pub String, #[label("This keyword is not allowed here")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected duplicate '{0}'")]
-#[diagnostic(help("Try removing the word here."), code(css_parse::UnexpectedDuplicateIdent))]
-pub struct UnexpectedDuplicateIdent(pub String, #[label("Remove this duplicate")] pub Span);
+#[diagnostic(code(css_parse::UnexpectedIdent))]
+#[help("There is an extra word which shouldn't be in this position.")]
+pub struct UnexpectedIdent(pub String, #[label("Try removing the word here.")] pub Cursor);
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Unexpected delimeter '{0}'")]
-#[diagnostic(help("Try removing the the character."), code(css_parse::UnexpectedDelim))]
-pub struct UnexpectedDelim(pub char, #[label("This character wasn't understood")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected pseudo selector ':{0}'")]
-#[diagnostic(help("This isn't a valid psuedo selector for this rule."), code(css_parse::UnexpectedPseudo))]
-pub struct UnexpectedPseudoClass(pub String, #[label("This psuedo selector")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected pseudo selector ':{0}'()")]
-#[diagnostic(help("This isn't a valid psuedo selector for this rule."), code(css_parse::UnexpectedPseudoClassFunction))]
-pub struct UnexpectedPseudoClassFunction(pub String, #[label("This psuedo selector")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected pseudo element '::{0}'")]
-#[diagnostic(help("This isn't a valid psuedo selector for this rule."), code(css_parse::UnexpectedPseudoElement))]
-pub struct UnexpectedPseudoElement(pub String, #[label("This psuedo selector")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected pseudo element '::{0}'")]
-#[diagnostic(
-	help("This isn't a valid psuedo selector for this rule."),
-	code(css_parse::UnexpectedPseudoElementFunction)
-)]
-pub struct UnexpectedPseudoElementFunction(pub String, #[label("This psuedo selector")] pub Span);
+#[diagnostic(code(css_parse::UnexpectedDelim))]
+#[help("Try removing the the character.")]
+pub struct UnexpectedDelim(pub char, #[label("This character wasn't understood")] pub Cursor);
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Unexpected tag name ':{0}'")]
-#[diagnostic(help("This isn't a valid tag name."), code(css_parse::UnexpectedTag))]
-pub struct UnexpectedTag(pub String, #[label("This tag")] pub Span);
+#[diagnostic(code(css_parse::UnexpectedTag))]
+#[help("This isn't a valid tag name.")]
+pub struct UnexpectedTag(pub String, #[label("This tag")] pub Cursor);
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Unexpected ID selector ':{0}'")]
-#[diagnostic(help("This isn't a valid ID."), code(css_parse::UnexpectedId))]
-pub struct UnexpectedId(pub String, #[label("This ID")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("The dimension '{0}' wasn't recognised for this value type")]
-#[diagnostic(
-	help(
-		"This isn't a recognisable dimension for this value type. If it's a valid dimension, it might be that it cannot be used for this rule or in this position."
-	),
-	code(css_parse::UnexpectedDimension)
-)]
-pub struct UnexpectedDimension(pub String, #[label("This isn't recognised")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected at rule '@{0}'")]
-#[diagnostic(
-	help("This isn't a recognisable at-rule here. If the rule is valid, it might not be allowed here."),
-	code(css_parse::UnexpectedAtRule)
-)]
-pub struct UnexpectedAtRule(pub String, #[label("This isn't recognised")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unexpected function '{0}'()")]
-#[diagnostic(help("This function wasn't expected in this position."), code(css_parse::UnexpectedFunction))]
-pub struct UnexpectedFunction(pub String, #[label("??")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unknown Rule")]
-#[diagnostic(help("This might be a mistake in the parser, please file an issue!"), code(css_parse::UnknownRule))]
-pub struct UnknownRule(#[label("Don't know how to interpret this")] pub Span);
+#[diagnostic(code(css_parse::UnexpectedId))]
+#[help("This isn't a valid ID.")]
+pub struct UnexpectedId(pub String, #[label("This ID")] pub Cursor);
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Ignored property due to parse error.")]
-#[diagnostic(
-	help("This property is going to be ignored because it doesn't look valid. If it is valid, please file an issue!"),
-	code(css_parse::UnknownDeclaration)
-)]
+#[diagnostic(code(css_parse::UnknownDeclaration))]
+#[help("This property is going to be ignored because it doesn't look valid. If it is valid, please file an issue!")]
 pub struct UnknownDeclaration(#[label("This property was ignored.")] pub Span);
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("Unknown Value")]
-#[diagnostic(help("This might be a mistake in the parser, please file an issue!"), code(css_parse::UnknownValue))]
-pub struct UnknownValue(#[label("Don't know how to interpret this")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Unknown named color '{0}'")]
-#[diagnostic(
-	help("Replace this unknown color with a known named color or a valid color value."),
-	code(css_parse::UnknownColor)
-)]
-pub struct UnknownColor(pub String, #[label("This isn't a known color")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
 #[error("Expected this to be the end of the file, but there was more content.")]
-#[diagnostic(
-	help("This is likely a problem with the parser. Please submit a bug report!"),
-	code(css_parse::ExpectedEnd)
-)]
+#[diagnostic(code(css_parse::ExpectedEnd))]
+#[help("This is likely a problem with the parser. Please submit a bug report!")]
 pub struct ExpectedEnd(#[label("All of this extra content was ignored.")] pub Span);
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Expected more content but reached the end of the file.")]
-#[diagnostic(help("Perhaps this file isn't finished yet?"), code(css_parse::UnexpectedEnd))]
+#[diagnostic(code(css_parse::UnexpectedEnd))]
+#[help("Perhaps this file isn't finished yet?")]
 pub struct UnexpectedEnd();
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Expected more content before this curly brace.")]
-#[diagnostic(help("This needed more content here"), code(css_parse::UnexpectedCloseCurly))]
-pub struct UnexpectedCloseCurly(pub Span);
+#[diagnostic(code(css_parse::UnexpectedCloseCurly))]
+#[help("This needed more content here")]
+pub struct UnexpectedCloseCurly(pub Cursor);
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("Expected `{0}` but found `{1}` {2}")]
-#[diagnostic(help("This is not correct CSS syntax."), code(css_parse::ExpectedToken))]
-pub struct ExpectedKind(pub Kind, pub Kind, #[label("`{0}` expected")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected a dimension but found `{1}`")]
-#[diagnostic(help("This is not correct CSS syntax."), code(css_parse::ExpectedDimension))]
-pub struct ExpectedDimension(pub Cursor, #[label("dimension expected")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected an identifier but found `{0}`")]
-#[diagnostic(help("This is not correct CSS syntax."), code(css_parse::ExpectedIdent))]
-pub struct ExpectedIdent(pub Kind, #[label("This should be `{0}`")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected an identifier but not `{0}`")]
-#[diagnostic(help("This is wrong. Maybe it is misspelled?"), code(css_parse::ExpectedOtherIdent))]
-pub struct ExpectedOtherIdent(pub String, #[label("This cannot be `{0}`")] pub Span);
+#[error("Expected an identifier but found `{}`", Kind::from(self.0))]
+#[diagnostic(code(css_parse::ExpectedIdent))]
+#[help("This is not correct CSS syntax.")]
+pub struct ExpectedIdent(#[label("This should be an identifier")] pub Cursor);
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Expected the identifier `{0}` but found `{1}`")]
-#[diagnostic(help("Try changing `{1}` to `{0}`."), code(css_parse::ExpectedIdentOf))]
-pub struct ExpectedIdentOf(pub &'static str, pub String, #[label("This should be `{0}`")] pub Span);
+#[diagnostic(code(css_parse::ExpectedIdentOf))]
+#[help("Try changing `{1}` to `{0}`.")]
+pub struct ExpectedIdentOf(pub &'static str, pub String, #[label("This should be `{0}`")] pub Cursor);
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("Expected a function but found `{0}`")]
-#[diagnostic(help("This is not correct CSS syntax."), code(css_parse::ExpectedFunction))]
-pub struct ExpectedFunction(pub Kind, #[label("This token")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected to see {0}() but saw {1}()")]
-#[diagnostic(help("Try changing the {1}() to {0}()"), code(css_parse::ExpectedFunctionOf))]
-pub struct ExpectedFunctionOf(pub String, pub String, #[label("This function")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected an @ keyword but saw `{0}`")]
-#[diagnostic(help("This is not correct CSS syntax."), code(css_parse::ExpectedAtKeyword))]
-pub struct ExpectedAtKeyword(pub Kind, #[label("This at-keyword")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected to see @{0} but saw @{1}")]
-#[diagnostic(help("Try changing the @{1} to @{0}"), code(css_parse::ExpectedAtKeywordOf))]
-pub struct ExpectedAtKeywordOf(pub String, pub String, #[label("This at-keyword")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected a delimiter but saw `{0}`")]
-#[diagnostic(help("This is not correct CSS syntax."), code(css_parse::ExpectedDelim))]
-pub struct ExpectedDelim(pub Kind, #[label("This at-keyword")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected to see {0} but saw {1}")]
-#[diagnostic(help("Try changing the {1} to {0}"), code(css_parse::ExpectedDelimOf))]
-pub struct ExpectedDelimOf(pub char, pub char, #[label("This delimiter")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Invalid hexidecimal value for color: '{0}'")]
-#[diagnostic(help("Hex colours must be 3, 4, 6 or 8 digits long."), code(css_parse::BadHexColor))]
-pub struct BadHexColor(pub String, #[label("This is the wrong format")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This block uses an invalid selector, so the whole block would be discarded.")]
-#[diagnostic(help("Try adding a selector to this style rule"), code(css_parse::NoSelector))]
-pub struct NoSelector(#[label("This selector isn't valid")] pub Span, pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This selector has two combinators next to each other, which is disallowed.")]
-#[diagnostic(
-	help("Try removing one of the combinators or add a selector in between them"),
-	code(css_parse::AdjacentSelectorCombinators)
-)]
-pub struct AdjacentSelectorCombinators(
-	#[label("...because this combinator is right next to the previous one")] pub Span,
-	#[label("This selector is invalid...")] pub Span,
-);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This selector has two types next to each other, which is disallowed.")]
-#[diagnostic(help("Try removing one of the types or add a space inbetween"), code(css_parse::AdjacentSelectorTypes))]
-pub struct AdjacentSelectorTypes(
-	#[label("...because this type is right next to the previous one.")] pub Span,
-	#[label("This selector is invalid...")] pub Span,
-);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This value isn't allowed to be a raw number, it has to have a dimension.")]
-#[diagnostic(help("Try adding a dimension, like '{0}'"), code(css_parse::DisallowedValueWithoutDimension))]
-pub struct DisallowedValueWithoutDimension(pub String, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("A math function isn't valid here.")]
-#[diagnostic(
-	help("var() and env() can be used but math functions like {0}() cannot."),
-	code(css_parse::DisallowedMathFunction)
-)]
-pub struct DisallowedMathFunction(pub String, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected an opening curly brace but saw `{0}`")]
-#[diagnostic(help("This is not correct CSS syntax."), code(css_parse::ExpectedOpenCurly))]
-pub struct ExpectedOpenCurly(pub Kind, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected a number but saw `{0}`")]
-#[diagnostic(help("This is not correct CSS syntax."), code(css_parse::ExpectedNumber))]
-pub struct ExpectedNumber(pub Kind, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected a signed number but saw `{0}`")]
-#[diagnostic(help("This number needs a + or a -."), code(css_parse::ExpectedSign))]
-pub struct ExpectedSign(pub f32, #[label("Add a + here")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Expected an unsigned number but saw `{0}`")]
-#[diagnostic(help("This number cannot have a + or a -."), code(css_parse::ExpectedUnsigned))]
-pub struct ExpectedUnsigned(pub f32, #[label("Remove the sign")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number is out of bounds.")]
-#[diagnostic(help("This needs to be a number between {1}."), code(css_parse::NumberOutOfBounds))]
-pub struct NumberOutOfBounds(pub f32, pub String, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number cannot be negative.")]
-#[diagnostic(help("This needs to be greater or equal to 0"), code(css_parse::NumberNotNegative))]
-pub struct NumberNotNegative(pub f32, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number is too small.")]
-#[diagnostic(help("This needs to be larger than {0}"), code(css_parse::NumberTooSmall))]
-pub struct NumberTooSmall(pub f32, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number is too large.")]
-#[diagnostic(help("This needs to be smaller than {0}"), code(css_parse::NumberTooLarge))]
-pub struct NumberTooLarge(pub f32, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This value isn't allowed to have a fraction, it must be a whole number (integer).")]
-#[diagnostic(help("Try using {0} instead"), code(css_parse::ExpectedInt))]
-pub struct ExpectedInt(pub f32, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This value must have a fraction, it must be float.")]
-#[diagnostic(help("Try using {0} instead"), code(css_parse::ExpectedFloat))]
-pub struct ExpectedFloat(pub f32, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number must be 0, got {0} instead.")]
-#[diagnostic(help("Try replacing it with the literal 0 instead"), code(css_parse::ExpectedZero))]
-pub struct ExpectedZero(pub f32, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This number must not be 0.")]
-#[diagnostic(help("Try replacing it with a positive or negative number"), code(css_parse::ExpectedZero))]
-pub struct UnexpectedZero(#[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This media query tries to compare itself equal to two different numbers.")]
-#[diagnostic(help("Try deleting one."), code(css_parse::UnexpectedMediaRangeComparisonEqualsTwice))]
-pub struct UnexpectedMediaRangeComparisonEqualsTwice(#[label("This comparison")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Display 'list-item' can only be combined with 'flow' or 'flow-root'")]
-#[diagnostic(
-	help("{0} is not valid in combination with list-item, try changing it to 'flow' or 'flow-root'"),
-	code(css_parse::DisplayHasInvalidListItemCombo)
-)]
-pub struct DisplayHasInvalidListItemCombo(pub String, pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("hwb and hsl colors must have a hue as their first argument.")]
-#[diagnostic(help("Try adding a % to the first color component."), code(css_parse::ColorMustStartWithHue))]
-pub struct ColorMustStartWithHue(#[label("This component")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Only hwb and hsl colors have a hue as their first argument.")]
-#[diagnostic(help("Try removing the %"), code(css_parse::ColorMustNotStartWithHue))]
-pub struct ColorMustNotStartWithHue(#[label("This component")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Colors should not use a hue as the middle color component")]
-#[diagnostic(help("Try removing the %"), code(css_parse::ColorMustNotStartWithHue))]
-pub struct ColorMustNotHaveHueInMiddle(#[label("This component")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Colors using the legacy syntax must have commas between the components")]
-#[diagnostic(help("Try using the non-legacy syntax, without commas"), code(css_parse::ColorLegacyMustIncludeComma))]
-pub struct ColorLegacyMustIncludeComma(#[label("Put a commma here")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Colors using the legacy syntax must not use percentages, but absolute numbers")]
-#[diagnostic(help("Try removing the %, or use the non-legacy syntax"), code(css_parse::ColorLegacyMustNotUsePercent))]
-pub struct ColorLegacyMustNotUsePercent(#[label("This should not be a percentage")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("Hex colors can be 3, 4, 6, or 8 characters in length. This one is {0}")]
-#[diagnostic(help("Try rewriting this to be 3, 4, 6 or 8 characters"), code(css_parse::ColorLegacyMustNotUsePercent))]
-pub struct ColorHexWrongLength(pub usize, #[label("This is not the right number of characters")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("{0} cannot be used as a keyframe name, as it's a reserved word.")]
-#[diagnostic(help(""), code(css_parse::ReservedKeyframeName))]
-pub struct ReservedKeyframeName(pub String, #[label("Rename it, or try wrapping it in quotes")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("An @layer {{}} (block) rule cannot have multiple names.")]
-#[diagnostic(help(""), code(css_parse::DisallowedLayerBlockWithMultipleNames))]
-pub struct DisallowedLayerBlockWithMultipleNames(#[label("Remove most (or all) of these names.")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("!important cannot be used for this property")]
-#[diagnostic(help(""), code(css_parse::DisallowedImportant))]
-pub struct DisallowedImportant(#[label("Remove this.")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("{0} requires at least {1} arguments, but saw {2}")]
-#[diagnostic(help(""), code(css_parse::DisallowedImportant))]
-pub struct NotEnoughArguments(
-	pub String,
-	pub usize,
-	pub usize,
-	#[label("Add another argument to this function.")] pub Span,
-);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("'{0}' not a valid <counter-name>")]
-#[diagnostic(help(""), code(css_parse::Unexpected))]
-pub struct InvalidCounterName(pub String, #[label("This value")] pub Span);
-
-#[derive(Debug, Error, Diagnostic)]
-#[error("This attr(name) is invalid.")]
-#[diagnostic(help("Try adding a | between each name."), code(css_parse::Unexpected))]
-pub struct InvalidAttrName(#[label("This value")] pub Span);
+#[error("Expected a delimiter but saw `{}`", Kind::from(self.0))]
+#[diagnostic(code(css_parse::ExpectedDelim))]
+#[help("This is not correct CSS syntax.")]
+pub struct ExpectedDelim(#[label("Here")] pub Cursor);

--- a/crates/css_parse/src/macros/optionals.rs
+++ b/crates/css_parse/src/macros/optionals.rs
@@ -80,9 +80,7 @@ macro_rules! parse_optionals {
 			}
 
 			if $($name.is_none())&&+ {
-				use $crate::{diagnostics, T};
-				let c: $crate::Cursor = $p.parse::<T![Any]>()?.into();
-				Err(diagnostics::Unexpected(c.into(), c.into()))?
+				Err($crate::diagnostics::Unexpected($p.next()))?
 			}
 
 			(($($name),+))

--- a/crates/css_parse/src/macros/pseudo_class.rs
+++ b/crates/css_parse/src/macros/pseudo_class.rs
@@ -64,7 +64,7 @@ macro_rules! pseudo_class {
 					}
 				} else {
 					use $crate::ToSpan;
-					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.to_span()))?
+					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.into()))?
 				}
 			}
 		}

--- a/crates/css_parse/src/macros/pseudo_element.rs
+++ b/crates/css_parse/src/macros/pseudo_element.rs
@@ -62,7 +62,7 @@ macro_rules! pseudo_element {
 					}
 				} else {
 					use $crate::ToSpan;
-					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.to_span()))?
+					Err($crate::diagnostics::UnexpectedIdent(p.parse_str(ident.into()).into(), ident.into()))?
 				}
 			}
 		}

--- a/crates/css_parse/src/parser.rs
+++ b/crates/css_parse/src/parser.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use bitmask_enum::bitmask;
 use bumpalo::Bump;
-use css_lexer::Lexer;
+use css_lexer::{Lexer, SourceCursor};
 use miette::Error;
 use std::mem::take;
 
@@ -246,6 +246,10 @@ impl<'a> Parser<'a> {
 				}
 			}
 		}
+	}
+
+	pub fn to_source_cursor(&self, cursor: Cursor) -> SourceCursor<'a> {
+		SourceCursor::from(cursor, cursor.str_slice(self.source_text))
 	}
 
 	pub fn consume_trivia(&mut self) {

--- a/crates/css_parse/src/syntax/bang_important.rs
+++ b/crates/css_parse/src/syntax/bang_important.rs
@@ -41,7 +41,8 @@ impl<'a> Parse<'a> for BangImportant {
 		let bang = p.parse::<T![!]>()?;
 		let important = p.parse::<T![Ident]>()?;
 		if !p.eq_ignore_ascii_case(important.into(), "important") {
-			Err(diagnostics::ExpectedIdentOf("important", p.parse_str(important.into()).into(), important.to_span()))?
+			let source_cursor = p.to_source_cursor(important.into());
+			Err(diagnostics::ExpectedIdentOf("important", source_cursor.to_string(), important.into()))?
 		}
 		Ok(Self { bang, important })
 	}

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -93,8 +93,7 @@ impl<'a> Parse<'a> for ComponentValue<'a> {
 		} else if p.peek::<T![,]>() {
 			p.parse::<T![,]>().map(Self::Comma)
 		} else {
-			let c = p.next();
-			Err(diagnostics::Unexpected(c.into(), c.into()))?
+			Err(diagnostics::Unexpected(p.next()))?
 		}
 	}
 }

--- a/crates/css_parse/src/syntax/declaration_rule_list.rs
+++ b/crates/css_parse/src/syntax/declaration_rule_list.rs
@@ -68,8 +68,7 @@ where
 				let rule = p.parse::<Declaration<'a, D>>()?;
 				declarations.push(rule);
 			} else {
-				let c = p.peek_n(1);
-				Err(diagnostics::Unexpected(c.into(), c.into()))?;
+				Err(diagnostics::Unexpected(p.next()))?;
 			}
 		}
 	}

--- a/crates/css_parse/src/syntax/no_block_allowed.rs
+++ b/crates/css_parse/src/syntax/no_block_allowed.rs
@@ -16,8 +16,7 @@ impl<'a> Parse<'a> for NoBlockAllowed {
 		} else if let Some(semicolon) = p.parse_if_peek::<T![;]>()? {
 			Ok(Self(Some(semicolon)))
 		} else {
-			let c = p.peek_next();
-			Err(diagnostics::Unexpected(c.into(), c.into()))?
+			Err(diagnostics::Unexpected(p.next()))?
 		}
 	}
 }

--- a/crates/css_parse/src/syntax/no_prelude_allowed.rs
+++ b/crates/css_parse/src/syntax/no_prelude_allowed.rs
@@ -14,8 +14,7 @@ impl<'a> Parse<'a> for NoPreludeAllowed {
 		if p.peek::<T![LeftCurly]>() || p.peek::<T![;]>() {
 			Ok(Self {})
 		} else {
-			let c = p.peek_next();
-			Err(diagnostics::Unexpected(c.into(), c.into()))?
+			Err(diagnostics::Unexpected(p.next()))?
 		}
 	}
 }

--- a/crates/css_parse/src/syntax/qualified_rule.rs
+++ b/crates/css_parse/src/syntax/qualified_rule.rs
@@ -47,7 +47,7 @@ where
 		// <}-token>
 		//   This is a parse error. If nested is true, return nothing. Otherwise, consume a token and append the result to rule’s prelude.
 		if p.is(State::Nested) && p.peek::<T!['}']>() {
-			Err(diagnostics::UnexpectedCloseCurly(p.peek_n(1).into()))?;
+			Err(diagnostics::UnexpectedCloseCurly(p.peek_n(1)))?;
 		}
 
 		// <{-token>
@@ -59,8 +59,8 @@ where
 				// If nested is true, consume the remnants of a bad declaration from input, with nested set to true, and return nothing.
 				if p.is(State::Nested) {
 					p.rewind(checkpoint);
-					p.parse::<BadDeclaration>()?;
-					Err(diagnostics::BadDeclaration(checkpoint.to_span()))?
+					let span = p.parse::<BadDeclaration>()?.to_span();
+					Err(diagnostics::BadDeclaration(span))?
 				// If nested is false, consume a block from input, and return nothing.
 				} else {
 					// QualifiedRules must be able to consume a block from their input when encountering

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -333,7 +333,7 @@ macro_rules! custom_double_delim {
 				let first = p.parse::<$crate::T![Delim]>()?;
 				if first != $first {
 					let c: Cursor = first.into();
-					Err($crate::diagnostics::ExpectedDelim(c.into(), c.into()))?;
+					Err($crate::diagnostics::ExpectedDelim(c))?;
 				}
 				let skip = p.set_skip(KindSet::NONE);
 				let second = p.parse::<$crate::T![Delim]>();
@@ -341,7 +341,7 @@ macro_rules! custom_double_delim {
 				let second = second?;
 				if second != $second {
 					let c:Cursor = second.into();
-					Err($crate::diagnostics::ExpectedDelim(c.into(), c.into()))?;
+					Err($crate::diagnostics::ExpectedDelim(c))?;
 				}
 				Ok(Self(first, second))
 			}
@@ -915,7 +915,7 @@ impl<'a> Parse<'a> for Whitespace {
 		let c = p.next();
 		p.set_skip(skip);
 		if c != Kind::Whitespace {
-			Err(diagnostics::Unexpected(c.into(), c.into()))?
+			Err(diagnostics::Unexpected(c))?
 		}
 		Ok(Self(c))
 	}

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -54,7 +54,7 @@ pub trait BooleanFeature<'a>: Sized {
 		let ident = p.parse::<T![Ident]>()?;
 		let c: Cursor = ident.into();
 		if !p.eq_ignore_ascii_case(c, name) {
-			Err(diagnostics::ExpectedIdentOf(name, p.parse_str(c).into(), c.into()))?
+			Err(diagnostics::ExpectedIdentOf(name, p.parse_str(c).into(), c))?
 		}
 		if p.peek::<T![:]>() {
 			let colon = p.parse::<T![:]>()?;

--- a/crates/css_parse/src/traits/declaration_value.rs
+++ b/crates/css_parse/src/traits/declaration_value.rs
@@ -80,7 +80,7 @@ pub trait DeclarationValue<'a>: Sized {
 	/// The default implementation of this method is to return an Unexpected Err.
 	fn parse_custom_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c.into(), c.into()))?
+		Err(diagnostics::Unexpected(c))?
 	}
 
 	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called before verifying that
@@ -91,7 +91,7 @@ pub trait DeclarationValue<'a>: Sized {
 	/// The default implementation of this method is to return an Unexpected Err.
 	fn parse_computed_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c.into(), c.into()))?
+		Err(diagnostics::Unexpected(c))?
 	}
 
 	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called on values that are
@@ -104,7 +104,7 @@ pub trait DeclarationValue<'a>: Sized {
 	/// The default implementation of this method is to return an Unexpected Err.
 	fn parse_specified_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c.into(), c.into()))?
+		Err(diagnostics::Unexpected(c))?
 	}
 
 	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called on values that are
@@ -114,7 +114,7 @@ pub trait DeclarationValue<'a>: Sized {
 	/// The default implementation of this method is to return an Unexpected Err.
 	fn parse_unknown_declaration_value(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c.into(), c.into()))?
+		Err(diagnostics::Unexpected(c))?
 	}
 
 	// Like `parse()` but with the additional context of the `name` [Cursor] - the same [Cursor]

--- a/crates/css_parse/src/traits/discrete_feature.rs
+++ b/crates/css_parse/src/traits/discrete_feature.rs
@@ -56,7 +56,7 @@ pub trait DiscreteFeature<'a>: Sized {
 		let ident = p.parse::<T![Ident]>()?;
 		let c: Cursor = ident.into();
 		if !p.eq_ignore_ascii_case(c, name) {
-			Err(diagnostics::ExpectedIdentOf(name, p.parse_str(c).into(), c.into()))?
+			Err(diagnostics::ExpectedIdentOf(name, p.parse_str(c).into(), c))?
 		}
 		if p.peek::<T![:]>() {
 			let colon = p.parse::<T![:]>()?;

--- a/crates/css_parse/src/traits/lists/feature_condition_list.rs
+++ b/crates/css_parse/src/traits/lists/feature_condition_list.rs
@@ -94,7 +94,8 @@ where
 			if matches!(keyword, ConditionKeyword::Not(_)) {
 				return Ok(Self::build_is(p.parse::<Self::FeatureCondition>()?));
 			}
-			Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
+			let source_cursor = p.to_source_cursor(c);
+			Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), c))?
 		}
 		let mut feature = p.parse::<Self::FeatureCondition>()?;
 		let keyword = p.parse_if_peek::<ConditionKeyword>()?;

--- a/crates/css_parse/src/traits/parse.rs
+++ b/crates/css_parse/src/traits/parse.rs
@@ -34,8 +34,7 @@ where
 			let c = p.next();
 			Ok(Self::build(p, c))
 		} else {
-			let c = p.next();
-			Err(diagnostics::Unexpected(c.into(), c.into()))?
+			Err(diagnostics::Unexpected(p.next()))?
 		}
 	}
 }

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -130,7 +130,8 @@ pub trait RangedFeature<'a>: Sized {
 				let close = p.parse::<T![')']>()?;
 				return Self::new_legacy(open, name, colon, value, close);
 			} else if name.is_legacy() {
-				Err(diagnostics::UnexpectedIdent(p.parse_str(c).into(), c.into()))?
+				let source_cursor = p.to_source_cursor(c);
+				Err(diagnostics::UnexpectedIdent(source_cursor.to_string(), c))?
 			}
 			let comparison = p.parse::<Comparison>()?;
 			let value = p.parse::<Self::Value>()?;
@@ -143,7 +144,7 @@ pub trait RangedFeature<'a>: Sized {
 		let c = p.peek_next();
 		let name = p.parse::<Self::FeatureName>()?;
 		if name.is_legacy() {
-			Err(diagnostics::Unexpected(c.into(), c.into()))?
+			Err(diagnostics::Unexpected(c))?
 		}
 		if !p.peek::<T![Delim]>() {
 			let close = p.parse::<T![')']>()?;

--- a/crates/css_parse/src/traits/rule_variants.rs
+++ b/crates/css_parse/src/traits/rule_variants.rs
@@ -11,7 +11,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 	/// The default implementation of this method is to return an Unexpected [Err].
 	fn parse_at_rule(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c.into(), c.into()))?
+		Err(diagnostics::Unexpected(c))?
 	}
 
 	/// Like [crate::Parse::parse()] but with the additional context of the `name` [Cursor]. This cursor is known to be
@@ -21,7 +21,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 	/// The default implementation of this method is to return an Unexpected [Err].
 	fn parse_unknown_at_rule(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c.into(), c.into()))?
+		Err(diagnostics::Unexpected(c))?
 	}
 
 	/// Like [crate::Parse::parse()] but with the additional context that the next cursor is _not_ an
@@ -31,7 +31,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 	/// The default implementation of this method is to return an Unexpected [Err].
 	fn parse_qualified_rule(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c.into(), c.into()))?
+		Err(diagnostics::Unexpected(c))?
 	}
 
 	/// Like [crate::Parse::parse()] but with the additional context that the next cursor is _not_ an
@@ -41,7 +41,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 	/// The default implementation of this method is to return an Unexpected [Err].
 	fn parse_unknown_qualified_rule(p: &mut Parser<'a>, _name: Cursor) -> Result<Self> {
 		let c = p.peek_n(1);
-		Err(diagnostics::Unexpected(c.into(), c.into()))?
+		Err(diagnostics::Unexpected(c))?
 	}
 
 	/// If all of the parse steps have failed, including parsing the Unknown Qualified Rule, we may want to consume a bad
@@ -78,7 +78,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 					if let Some(s) = Self::bad_declaration(declaration?) {
 						Ok(s)
 					} else {
-						Err(diagnostics::Unexpected(c.into(), c.into()))?
+						Err(diagnostics::Unexpected(c))?
 					}
 				})
 		}

--- a/crates/css_parse/src/traits/selectors.rs
+++ b/crates/css_parse/src/traits/selectors.rs
@@ -67,7 +67,7 @@ pub trait SelectorComponent<'a>: Sized {
 					if Self::Type::peek(p, c) {
 						Ok(Self::build_type(Self::Type::build(p, c)))
 					} else {
-						Err(diagnostics::UnexpectedTag(p.parse_str_lower(c).to_owned(), c.into()))?
+						Err(diagnostics::UnexpectedTag(p.parse_str_lower(c).to_owned(), c))?
 					}
 				}
 			},
@@ -77,7 +77,7 @@ pub trait SelectorComponent<'a>: Sized {
 				if Self::Id::peek(p, c) {
 					Ok(Self::build_id(Self::Id::build(p, c)))
 				} else {
-					Err(diagnostics::UnexpectedId(p.parse_str_lower(c).to_owned(), c.into()))?
+					Err(diagnostics::UnexpectedId(p.parse_str_lower(c).to_owned(), c))?
 				}
 			}
 			Kind::LeftSquare => {
@@ -90,7 +90,7 @@ pub trait SelectorComponent<'a>: Sized {
 					p.set_skip(skip);
 					match c.token().kind() {
 						Kind::Ident => p.parse::<Self::Class>().map(Self::build_class),
-						k => Err(diagnostics::ExpectedIdent(k, c.into()))?,
+						_ => Err(diagnostics::ExpectedIdent(c))?,
 					}
 				}
 				'*' => {
@@ -119,7 +119,7 @@ pub trait SelectorComponent<'a>: Sized {
 							Kind::Function => {
 								p.parse::<Self::FunctionalPseudoElement>().map(Self::build_functional_pseudo_element)
 							}
-							_ => Err(diagnostics::Unexpected(c3.into(), c3.into()))?,
+							_ => Err(diagnostics::Unexpected(c3))?,
 						}
 					}
 					Kind::Ident => {
@@ -134,7 +134,7 @@ pub trait SelectorComponent<'a>: Sized {
 						p.set_skip(skip);
 						p.parse::<Self::FunctionalPseudoClass>().map(Self::build_functional_pseudo_class)
 					}
-					_ => Err(diagnostics::Unexpected(t.kind(), c2.into()))?,
+					_ => Err(diagnostics::Unexpected(c2))?,
 				}
 			}
 			_ => {

--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -197,10 +197,10 @@ fn generate_keyword_parsing(
 								p.next();
 								ident
 							} else {
-								return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+								return Err(crate::diagnostics::Unexpected(c))?;
 							}
 						} else {
-							return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+							return Err(crate::diagnostics::Unexpected(c))?;
 						}
 				  };
 				}
@@ -296,7 +296,7 @@ fn generate_must_occur_parsing(
 	  #post_parse_steps
 	  if #occurance_cond {
 			let c = p.peek_n(1);
-			Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+			Err(crate::diagnostics::Unexpected(c))?
 	  }
 	  Ok(#constructor { #(#members: #assignments),* })
 	}
@@ -331,7 +331,7 @@ fn generate_range_validation(field_ident: &Ident, range_expr: &ExprRange) -> Tok
 			  if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&#field_ident) {
 					if !(#start..=#end).contains(&i) {
 						use ::css_parse::ToSpan;
-						Err(::css_parse::diagnostics::NumberOutOfBounds(
+						Err(crate::diagnostics::NumberOutOfBounds(
 							i,
 							format!("{}..={}", #start, #end),
 							#field_ident.to_span()
@@ -345,7 +345,7 @@ fn generate_range_validation(field_ident: &Ident, range_expr: &ExprRange) -> Tok
 			  if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&#field_ident) {
 					if #start > i {
 						use ::css_parse::ToSpan;
-						Err(::css_parse::diagnostics::NumberTooSmall(
+						Err(crate::diagnostics::NumberTooSmall(
 							#start,
 							#field_ident.to_span()
 						))?
@@ -358,7 +358,7 @@ fn generate_range_validation(field_ident: &Ident, range_expr: &ExprRange) -> Tok
 			  if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&#field_ident) {
 					if #end < i {
 						use ::css_parse::ToSpan;
-						Err(::css_parse::diagnostics::NumberTooLarge(
+						Err(crate::diagnostics::NumberTooLarge(
 							#end,
 							#field_ident.to_span()
 						))?
@@ -492,7 +492,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
                   else if let Some(#desired(ident)) = keywords {
                       #step
                   } else {
-                      return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+                      return Err(crate::diagnostics::Unexpected(c))?;
                   }
               },
               Position::Only => quote! { #step },

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_mixed_variants.snap
@@ -23,9 +23,7 @@ impl<'a> ::css_parse::Parse<'a> for FlexValue {
                     if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&val) {
                         if 0 > i {
                             use ::css_parse::ToSpan;
-                            Err(
-                                ::css_parse::diagnostics::NumberTooSmall(0, val.to_span()),
-                            )?
+                            Err(crate::diagnostics::NumberTooSmall(0, val.to_span()))?
                         }
                     }
                     max = Some(val);
@@ -35,7 +33,7 @@ impl<'a> ::css_parse::Parse<'a> for FlexValue {
             }
             if min.is_none() || max.is_none() {
                 let c = p.peek_n(1);
-                Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+                Err(crate::diagnostics::Unexpected(c))?
             }
             Ok(Self::MinMax {
                 min: min.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_struct_variants_with_ranges.snap
@@ -11,14 +11,14 @@ impl<'a> ::css_parse::Parse<'a> for Transform {
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&x) {
                 if 0 > i {
                     use ::css_parse::ToSpan;
-                    Err(::css_parse::diagnostics::NumberTooSmall(0, x.to_span()))?
+                    Err(crate::diagnostics::NumberTooSmall(0, x.to_span()))?
                 }
             }
             let y = p.parse::<Number>()?;
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&y) {
                 if 0 > i {
                     use ::css_parse::ToSpan;
-                    Err(::css_parse::diagnostics::NumberTooSmall(0, y.to_span()))?
+                    Err(crate::diagnostics::NumberTooSmall(0, y.to_span()))?
                 }
             }
             Ok(Self::Scale { x: x, y: y })
@@ -28,7 +28,7 @@ impl<'a> ::css_parse::Parse<'a> for Transform {
                 if !(-360..=360).contains(&i) {
                     use ::css_parse::ToSpan;
                     Err(
-                        ::css_parse::diagnostics::NumberOutOfBounds(
+                        crate::diagnostics::NumberOutOfBounds(
                             i,
                             format!("{}..={}", - 360, 360),
                             angle.to_span(),
@@ -44,7 +44,7 @@ impl<'a> ::css_parse::Parse<'a> for Transform {
                 if !(-100..=100).contains(&i) {
                     use ::css_parse::ToSpan;
                     Err(
-                        ::css_parse::diagnostics::NumberOutOfBounds(
+                        crate::diagnostics::NumberOutOfBounds(
                             i,
                             format!("{}..={}", - 100, 100),
                             y.to_span(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_all_must_occur_with_keyword.snap
@@ -39,7 +39,7 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurEnum {
             }
             if auto_field.is_none() || none_field.is_none() || length.is_none() {
                 let c = p.peek_n(1);
-                Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+                Err(crate::diagnostics::Unexpected(c))?
             }
             Ok(Self::Complex {
                 auto_field: auto_field.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur.snap
@@ -26,7 +26,7 @@ impl<'a> ::css_parse::Parse<'a> for Value {
             }
             if auto.is_none() || length.is_none() {
                 let c = p.peek_n(1);
-                Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+                Err(crate::diagnostics::Unexpected(c))?
             }
             Ok(Self::Complex {
                 auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_all_must_occur_and_range.snap
@@ -21,7 +21,7 @@ impl<'a> ::css_parse::Parse<'a> for Value {
                         if !(0..=100).contains(&i) {
                             use ::css_parse::ToSpan;
                             Err(
-                                ::css_parse::diagnostics::NumberOutOfBounds(
+                                crate::diagnostics::NumberOutOfBounds(
                                     i,
                                     format!("{}..={}", 0, 100),
                                     val.to_span(),
@@ -36,7 +36,7 @@ impl<'a> ::css_parse::Parse<'a> for Value {
             }
             if auto.is_none() || percentage.is_none() {
                 let c = p.peek_n(1);
-                Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+                Err(crate::diagnostics::Unexpected(c))?
             }
             Ok(Self::WithRange {
                 auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_pattern.snap
@@ -18,14 +18,10 @@ impl<'a> ::css_parse::Parse<'a> for TestEnum {
                         p.next();
                         ident
                     } else {
-                        return Err(
-                            ::css_parse::diagnostics::Unexpected(c.into(), c.into()),
-                        )?;
+                        return Err(crate::diagnostics::Unexpected(c))?;
                     }
                 } else {
-                    return Err(
-                        ::css_parse::diagnostics::Unexpected(c.into(), c.into()),
-                    )?;
+                    return Err(crate::diagnostics::Unexpected(c))?;
                 }
             };
             let other_field = p.parse::<Length>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_variant_with_keyword_variants.snap
@@ -19,7 +19,7 @@ impl<'a> ::css_parse::Parse<'a> for NewtypeEnum {
             let f0 = p.parse::<Ident>()?;
             Ok(Self::Bar { 0: f0 })
         } else {
-            return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+            return Err(crate::diagnostics::Unexpected(c))?;
         }
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_with_range_validation.snap
@@ -12,7 +12,7 @@ impl<'a> ::css_parse::Parse<'a> for Value {
                 if !(0..=100).contains(&i) {
                     use ::css_parse::ToSpan;
                     Err(
-                        ::css_parse::diagnostics::NumberOutOfBounds(
+                        crate::diagnostics::NumberOutOfBounds(
                             i,
                             format!("{}..={}", 0, 100),
                             f0.to_span(),
@@ -26,7 +26,7 @@ impl<'a> ::css_parse::Parse<'a> for Value {
             if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&f0) {
                 if 0.1 > i {
                     use ::css_parse::ToSpan;
-                    Err(::css_parse::diagnostics::NumberTooSmall(0.1, f0.to_span()))?
+                    Err(crate::diagnostics::NumberTooSmall(0.1, f0.to_span()))?
                 }
             }
             Ok(Self::Scale { 0: f0 })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_all_must_occur_with_newtype_keyword.snap
@@ -29,7 +29,7 @@ impl<'a> ::css_parse::Parse<'a> for AllMustOccurNewtypeTest {
         }
         if auto_value.is_none() || none_value.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            Err(crate::diagnostics::Unexpected(c))?
         }
         Ok(Self {
             auto_value: auto_value.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_one_must_occur_with_optionals.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_one_must_occur_with_optionals.snap
@@ -22,7 +22,7 @@ impl<'a> ::css_parse::Parse<'a> for OneMustOccurTest {
         }
         if foo.is_none() && bar.is_none() {
             let c = p.peek_n(1);
-            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            Err(crate::diagnostics::Unexpected(c))?
         }
         Ok(Self { foo: foo, bar: bar })
     }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_regular_with_keyword_pattern.snap
@@ -14,12 +14,10 @@ impl<'a> ::css_parse::Parse<'a> for RegularKeywordTest {
                     p.next();
                     ident
                 } else {
-                    return Err(
-                        ::css_parse::diagnostics::Unexpected(c.into(), c.into()),
-                    )?;
+                    return Err(crate::diagnostics::Unexpected(c))?;
                 }
             } else {
-                return Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?;
+                return Err(crate::diagnostics::Unexpected(c))?;
             }
         };
         let length = p.parse::<Length>()?;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur.snap
@@ -22,7 +22,7 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLength {
         }
         if auto.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            Err(crate::diagnostics::Unexpected(c))?
         }
         Ok(Self {
             auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_range.snap
@@ -20,7 +20,7 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLengthWithRange {
                     if !(0..=100).contains(&i) {
                         use ::css_parse::ToSpan;
                         Err(
-                            ::css_parse::diagnostics::NumberOutOfBounds(
+                            crate::diagnostics::NumberOutOfBounds(
                                 i,
                                 format!("{}..={}", 0, 100),
                                 val.to_span(),
@@ -35,7 +35,7 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLengthWithRange {
         }
         if auto.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            Err(crate::diagnostics::Unexpected(c))?
         }
         Ok(Self {
             auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_all_must_occur_and_state.snap
@@ -24,7 +24,7 @@ impl<'a> ::css_parse::Parse<'a> for AutoAndLengthInState {
         p.set_state(state);
         if auto.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            Err(crate::diagnostics::Unexpected(c))?
         }
         Ok(Self {
             auto: auto.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_different_keyword_variants.snap
@@ -35,7 +35,7 @@ impl<'a> ::css_parse::Parse<'a> for SpecificKeywordTest {
         }
         if auto_field.is_none() || none_field.is_none() || length.is_none() {
             let c = p.peek_n(1);
-            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            Err(crate::diagnostics::Unexpected(c))?
         }
         Ok(Self {
             auto_field: auto_field.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_keyword_pattern_and_range.snap
@@ -24,7 +24,7 @@ impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
                     if !(0..=100).contains(&i) {
                         use ::css_parse::ToSpan;
                         Err(
-                            ::css_parse::diagnostics::NumberOutOfBounds(
+                            crate::diagnostics::NumberOutOfBounds(
                                 i,
                                 format!("{}..={}", 0, 100),
                                 val.to_span(),
@@ -39,7 +39,7 @@ impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
         }
         if auto_value.is_none() || percentage.is_none() {
             let c = p.peek_n(1);
-            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            Err(crate::diagnostics::Unexpected(c))?
         }
         Ok(Self {
             auto_value: auto_value.unwrap(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_range_fields.snap
@@ -11,7 +11,7 @@ impl<'a> ::css_parse::Parse<'a> for Color {
             if !(0..=255).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
-                    ::css_parse::diagnostics::NumberOutOfBounds(
+                    crate::diagnostics::NumberOutOfBounds(
                         i,
                         format!("{}..={}", 0, 255),
                         red.to_span(),
@@ -24,7 +24,7 @@ impl<'a> ::css_parse::Parse<'a> for Color {
             if !(0..=255).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
-                    ::css_parse::diagnostics::NumberOutOfBounds(
+                    crate::diagnostics::NumberOutOfBounds(
                         i,
                         format!("{}..={}", 0, 255),
                         green.to_span(),
@@ -37,7 +37,7 @@ impl<'a> ::css_parse::Parse<'a> for Color {
             if !(0..=255).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
-                    ::css_parse::diagnostics::NumberOutOfBounds(
+                    crate::diagnostics::NumberOutOfBounds(
                         i,
                         format!("{}..={}", 0, 255),
                         blue.to_span(),
@@ -50,7 +50,7 @@ impl<'a> ::css_parse::Parse<'a> for Color {
             if !(0..=1).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
-                    ::css_parse::diagnostics::NumberOutOfBounds(
+                    crate::diagnostics::NumberOutOfBounds(
                         i,
                         format!("{}..={}", 0, 1),
                         alpha.to_span(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_optional_keywords.snap
@@ -30,7 +30,7 @@ impl<'a> ::css_parse::Parse<'a> for KeywordWithRange {
         }
         if auto_value.is_none() && none_value.is_none() {
             let c = p.peek_n(1);
-            Err(::css_parse::diagnostics::Unexpected(c.into(), c.into()))?
+            Err(crate::diagnostics::Unexpected(c))?
         }
         Ok(Self {
             auto_value: auto_value,

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range.snap
@@ -11,7 +11,7 @@ impl<'a> ::css_parse::Parse<'a> for Volume {
             if !(0.0f32..=100.0f32).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
-                    ::css_parse::diagnostics::NumberOutOfBounds(
+                    crate::diagnostics::NumberOutOfBounds(
                         i,
                         format!("{}..={}", 0.0f32, 100.0f32),
                         level.to_span(),

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_from.snap
@@ -10,7 +10,7 @@ impl<'a> ::css_parse::Parse<'a> for PositiveValue {
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&value) {
             if 1.0f32 > i {
                 use ::css_parse::ToSpan;
-                Err(::css_parse::diagnostics::NumberTooSmall(1.0f32, value.to_span()))?
+                Err(crate::diagnostics::NumberTooSmall(1.0f32, value.to_span()))?
             }
         }
         Ok(Self { value: value })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_range_to.snap
@@ -10,7 +10,7 @@ impl<'a> ::css_parse::Parse<'a> for Probability {
         if let Some(i) = ::css_parse::ToNumberValue::to_number_value(&value) {
             if 1.0f32 < i {
                 use ::css_parse::ToSpan;
-                Err(::css_parse::diagnostics::NumberTooLarge(1.0f32, value.to_span()))?
+                Err(crate::diagnostics::NumberTooLarge(1.0f32, value.to_span()))?
             }
         }
         Ok(Self { value: value })

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_range.snap
@@ -11,7 +11,7 @@ impl<'a> ::css_parse::Parse<'a> for Scale {
             if !(0.1..=10.0).contains(&i) {
                 use ::css_parse::ToSpan;
                 Err(
-                    ::css_parse::diagnostics::NumberOutOfBounds(
+                    crate::diagnostics::NumberOutOfBounds(
                         i,
                         format!("{}..={}", 0.1, 10.0),
                         f0.to_span(),


### PR DESCRIPTION
The css_parse::diagnostics module had diagnostics for all kinds of errors, even those found in css_ast. This wasn't
right, so this change splits them out into css_parse::diagnostics and css_ast::diagnostics modules.

While here, it also became evident we're passing the same cursor data twice for many structs, e.g. a struct might take
`(Kind, Span)`, where it could just take a `(Cursor)`, if css_lexer had From<Cursor> for miette::SourceSpan.

So this change also introduces From<Cursor> for miette::SourceSpan in css_lexer, and changes a bunch of structs to use
Cursors instead of Spans. We should try to do this as much as possible in the future because it'll allow for richer
errors which can provide more information, not just span data.
