### PR TITLE
css_ast: derive(Parse) on more types

### DIFF
--- a/crates/css_ast/src/selector/class.rs
+++ b/crates/css_ast/src/selector/class.rs
@@ -1,7 +1,7 @@
-use css_parse::{Cursor, Kind, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{ToCursors, ToSpan, Visitable};
+use css_parse::{Cursor, Kind, Parser, Peek, T};
+use csskit_derives::{Parse, ToCursors, ToSpan, Visitable};
 
-#[derive(ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(tag = "type"))]
 #[visit(self)]
 pub struct Class {
@@ -12,13 +12,5 @@ pub struct Class {
 impl<'a> Peek<'a> for Class {
 	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
 		c == Kind::Delim && c == '.' && p.peek_n(2) == Kind::Ident
-	}
-}
-
-impl<'a> Parse<'a> for Class {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let dot = p.parse::<T![.]>()?;
-		let name = p.parse::<T![Ident]>()?;
-		Ok(Self { dot, name })
 	}
 }

--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -1,8 +1,8 @@
-use css_parse::{Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{ToCursors, ToSpan, Visitable};
+use css_parse::T;
+use csskit_derives::{Parse, ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/selectors/#combinators
-#[derive(ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(rename_all = "kebab-case"))]
 #[visit(self)]
 pub enum Combinator {
@@ -12,24 +12,6 @@ pub enum Combinator {
 	Column(T![||]),
 	Nesting(T![&]),
 	Descendant(T![' ']),
-}
-
-impl<'a> Parse<'a> for Combinator {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		if p.peek::<T![>]>() {
-			Ok(Self::Child(p.parse::<T![>]>()?))
-		} else if p.peek::<T![+]>() {
-			Ok(Self::NextSibling(p.parse::<T![+]>()?))
-		} else if p.peek::<T![~]>() {
-			Ok(Self::SubsequentSibling(p.parse::<T![~]>()?))
-		} else if p.peek::<T![&]>() {
-			Ok(Self::Nesting(p.parse::<T![&]>()?))
-		} else if p.peek::<T![||]>() {
-			Ok(Self::Column(p.parse::<T![||]>()?))
-		} else {
-			Ok(Self::Descendant(p.parse::<T![' ']>()?))
-		}
-	}
 }
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/ratio.rs
+++ b/crates/css_ast/src/types/ratio.rs
@@ -1,24 +1,15 @@
 use crate::units::CSSInt;
-use css_parse::{Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{Peek, ToCursors, ToSpan, Visitable};
+use css_parse::T;
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 
 // https://drafts.csswg.org/css-values-4/#ratios
-#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit(self)]
 pub struct Ratio {
 	pub numerator: CSSInt,
 	pub slash: Option<T![/]>,
 	pub denominator: Option<CSSInt>,
-}
-
-impl<'a> Parse<'a> for Ratio {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let numerator = p.parse::<CSSInt>()?;
-		let slash = p.parse_if_peek::<T![/]>()?;
-		let denominator = if slash.is_some() { Some(p.parse::<CSSInt>()?) } else { None };
-		Ok(Self { numerator, slash, denominator })
-	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
These types can trivially use derive(Parse), so they should!
