### PR TITLE
css_parse: drop peek_next/peek_including_white_space

### DIFF
--- a/crates/css_parse/src/comparison.rs
+++ b/crates/css_parse/src/comparison.rs
@@ -27,7 +27,7 @@ pub enum Comparison {
 
 impl<'a> Parse<'a> for Comparison {
 	fn parse(p: &mut Parser<'a>) -> Result<Comparison> {
-		let c = p.peek_next();
+		let c = p.peek_n(1);
 		match c.token().char() {
 			Some('=') => p.parse::<T![=]>().map(Comparison::Equal),
 			Some('>') => {

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -79,7 +79,7 @@ impl<'a> Parse<'a> for ComponentValue<'a> {
 			p.parse::<T![Delim]>().map(|delim| {
 				// Carefully handle Whitespace rules to ensure whitespace isn't lost when re-serializing
 				let mut rules = AssociatedWhitespaceRules::none();
-				if p.peek_next_including_whitespace() == Kind::Whitespace {
+				if p.peek_n_with_skip(1, KindSet::COMMENTS) == Kind::Whitespace {
 					rules |= AssociatedWhitespaceRules::EnforceAfter;
 				} else {
 					rules |= AssociatedWhitespaceRules::BanAfter;

--- a/crates/css_parse/src/syntax/qualified_rule.rs
+++ b/crates/css_parse/src/syntax/qualified_rule.rs
@@ -41,7 +41,7 @@ where
 		// stop token (if passed)
 		//   This is a parse error. Return nothing.
 		if p.at_end() {
-			Err(Diagnostic::new(p.peek_next(), Diagnostic::unexpected_end))?
+			Err(Diagnostic::new(p.peek_n(1), Diagnostic::unexpected_end))?
 		}
 
 		// <}-token>

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -382,7 +382,7 @@ cursor_wrapped!(Whitespace);
 impl<'a> Peek<'a> for Whitespace {
 	fn peek(p: &Parser<'a>, _: Cursor) -> bool {
 		// Whitespace needs to peek its own cursor because it was likely given one that skipped Whitespace.
-		let c = p.peek_next_including_whitespace();
+		let c = p.peek_n_with_skip(1, KindSet::COMMENTS);
 		c == Kind::Whitespace
 	}
 }

--- a/crates/css_parse/src/traits/lists/feature_condition_list.rs
+++ b/crates/css_parse/src/traits/lists/feature_condition_list.rs
@@ -65,12 +65,12 @@ where
 	fn build_or(features: Vec<'a, (Self::FeatureCondition, Option<Ident>)>) -> Self;
 
 	fn parse_condition(p: &mut Parser<'a>) -> Result<Self> {
-		let c = p.peek_next();
+		let c = p.peek_n(1);
 		if Ident::peek(p, c) && Self::keyword_is_not(p, c) {
 			return Ok(Self::build_not(p.parse::<Ident>()?, p.parse::<Self::FeatureCondition>()?));
 		}
 		let mut feature = p.parse::<Self::FeatureCondition>()?;
-		let c = p.peek_next();
+		let c = p.peek_n(1);
 		if Ident::peek(p, c) {
 			if Self::keyword_is_and(p, c) {
 				let mut features = Vec::new_in(p.bump());
@@ -78,7 +78,7 @@ where
 				loop {
 					features.push((feature, Some(keyword)));
 					feature = p.parse::<Self::FeatureCondition>()?;
-					let c = p.peek_next();
+					let c = p.peek_n(1);
 					if !(Ident::peek(p, c) && Self::keyword_is_and(p, c)) {
 						features.push((feature, None));
 						return Ok(Self::build_and(features));
@@ -91,7 +91,7 @@ where
 				loop {
 					features.push((feature, Some(keyword)));
 					feature = p.parse::<Self::FeatureCondition>()?;
-					let c = p.peek_next();
+					let c = p.peek_n(1);
 					if !(Ident::peek(p, c) && Self::keyword_is_or(p, c)) {
 						features.push((feature, None));
 						return Ok(Self::build_or(features));

--- a/crates/css_parse/src/traits/lists/prelude_list.rs
+++ b/crates/css_parse/src/traits/lists/prelude_list.rs
@@ -9,7 +9,7 @@ pub trait PreludeList<'a>: Sized + Parse<'a> {
 		let mut items = Vec::new_in(p.bump());
 		loop {
 			items.push(p.parse::<Self::PreludeItem>()?);
-			if p.peek_next() == Self::STOP_TOKENS {
+			if p.peek_n(1) == Self::STOP_TOKENS {
 				return Ok(items);
 			}
 		}

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -140,7 +140,7 @@ pub trait RangedFeature<'a>: Sized {
 		max: Option<&A>,
 	) -> ParserResult<Self> {
 		let open = p.parse::<T!['(']>()?;
-		let c = p.peek_next();
+		let c = p.peek_n(1);
 		if <T![Ident]>::peek(p, c) {
 			let atom = p.to_atom::<A>(c);
 			let ident = p.parse::<T![Ident]>()?;
@@ -169,7 +169,7 @@ pub trait RangedFeature<'a>: Sized {
 
 		let left = p.parse::<Self::Value>()?;
 		let left_comparison = p.parse::<Comparison>()?;
-		let c = p.peek_next();
+		let c = p.peek_n(1);
 		let ident = p.parse::<T![Ident]>()?;
 		if &p.to_atom::<A>(ident.into()) != name {
 			Err(Diagnostic::new(c, Diagnostic::unexpected))?

--- a/crates/css_parse/src/traits/rule_variants.rs
+++ b/crates/css_parse/src/traits/rule_variants.rs
@@ -58,7 +58,7 @@ pub trait RuleVariants<'a>: Sized + ToCursors + ToSpan {
 
 	fn parse_rule_variants(p: &mut Parser<'a>) -> Result<Self> {
 		let checkpoint = p.checkpoint();
-		let c: Cursor = p.peek_next();
+		let c: Cursor = p.peek_n(1);
 		if <T![AtKeyword]>::peek(p, c) {
 			Self::parse_at_rule(p, c).or_else(|_| {
 				p.rewind(checkpoint);

--- a/crates/css_parse/src/traits/style_sheet.rs
+++ b/crates/css_parse/src/traits/style_sheet.rs
@@ -34,7 +34,7 @@ pub trait StyleSheet<'a>: Sized + Parse<'a> {
 			}
 
 			// need to peek as last tokens may be whitespace.
-			if p.at_end() || p.peek_next() == Kind::Eof {
+			if p.at_end() || p.peek_n(1) == Kind::Eof {
 				return Ok(rules);
 			}
 			rules.push(p.parse::<Self::Rule>()?);


### PR DESCRIPTION
This change drops `peek_next()`, which was an optimisation over peen_n(1), but didn't add much (the perf impact was
likely negligible).

This change also drops `peek_including_white_space()` which was over specialised, instead introducing a new method
called `peek_n_with_skip()`. `peek_n()` now delegates to `peek_n_with_skip()`, by supplying `self.skip`.
