### PR TITLE
css_ast: Clean up a few nodes by using derive(Parse/Peek)

### DIFF
--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use bumpalo::collections::Vec;
 use css_parse::{
-	Cursor, Declaration, FeatureConditionList, Parse, Parser, Peek, Result as ParserResult, T, discrete_feature,
+	Cursor, Declaration, FeatureConditionList, Parse, Parser, Result as ParserResult, T, discrete_feature,
 	ranged_feature,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
@@ -221,7 +221,7 @@ impl<'a> VisitableMut for ScrollStateQuery<'a> {
 	}
 }
 
-#[derive(ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub enum ScrollStateFeature {
@@ -230,37 +230,8 @@ pub enum ScrollStateFeature {
 	Stuck(StuckScrollStateFeature),
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
-pub enum ScrollStateFeatureKeyword {
-	#[atom(CssAtomSet::Scrollable)]
-	Scrollable(T![Ident]),
-	#[atom(CssAtomSet::Snapped)]
-	Snapped(T![Ident]),
-	#[atom(CssAtomSet::Stuck)]
-	Stuck(T![Ident]),
-}
-
-impl<'a> Peek<'a> for ScrollStateFeature {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		ScrollStateFeatureKeyword::peek(p, c)
-	}
-}
-
-impl<'a> Parse<'a> for ScrollStateFeature {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		let keyword = p.parse::<ScrollStateFeatureKeyword>()?;
-		match keyword {
-			ScrollStateFeatureKeyword::Scrollable(_) => p.parse::<ScrollableScrollStateFeature>().map(Self::Scrollable),
-			ScrollStateFeatureKeyword::Snapped(_) => p.parse::<SnappedScrollStateFeature>().map(Self::Snapped),
-			ScrollStateFeatureKeyword::Stuck(_) => p.parse::<StuckScrollStateFeature>().map(Self::Stuck),
-		}
-	}
-}
-
 discrete_feature!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum ScrollableScrollStateFeature<CssAtomSet::Scrollable, ScrollableScrollStateFeatureKeyword>
@@ -301,7 +272,7 @@ pub enum ScrollableScrollStateFeatureKeyword {
 }
 
 discrete_feature!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum SnappedScrollStateFeature<CssAtomSet::Snapped, SnappedScrollStateFeatureKeyword>
@@ -328,7 +299,7 @@ pub enum SnappedScrollStateFeatureKeyword {
 }
 
 discrete_feature!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[visit(self)]
 	pub enum StuckScrollStateFeature<CssAtomSet::Stuck, StuckScrollStateFeatureKeyword>

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -139,17 +139,6 @@ pub enum SupportsFeature<'a> {
 	Property(T!['('], Declaration<'a, StyleValue<'a>>, Option<T![')']>),
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub enum SupportsFeatureKeyword {
-	#[atom(CssAtomSet::FontTech)]
-	FontTech(T![Function]),
-	#[atom(CssAtomSet::FontFormat)]
-	FontFormat(T![Function]),
-	#[atom(CssAtomSet::Selector)]
-	Selector(T![Function]),
-}
-
 impl<'a> Parse<'a> for SupportsFeature<'a> {
 	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
 		let open = p.parse_if_peek::<T!['(']>()?;

--- a/crates/css_ast/src/selector/tag.rs
+++ b/crates/css_ast/src/selector/tag.rs
@@ -7,8 +7,8 @@ use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
 #[visit]
 pub enum Tag {
 	Html(HtmlTag),
-	HtmlNonConforming(HtmlNonConformingTag),
 	HtmlNonStandard(HtmlNonStandardTag),
+	HtmlNonConforming(HtmlNonConformingTag),
 	Svg(SvgTag),
 	Mathml(MathmlTag),
 	CustomElement(CustomElementTag),

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -72,16 +72,6 @@ impl ToChromashift for Color {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
-pub enum ColorKeyword {
-	#[atom(CssAtomSet::Currentcolor)]
-	Currentcolor(T![Ident]),
-	#[atom(CssAtomSet::Transparent)]
-	Transparent(T![Ident]),
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/css_ast/src/units/line_width.rs
+++ b/crates/css_ast/src/units/line_width.rs
@@ -2,49 +2,20 @@ use super::prelude::*;
 
 use super::Length;
 
-#[derive(Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
-pub enum LineWidthKeyword {
-	#[atom(CssAtomSet::Thin)]
-	Thin(T![Ident]),
-	#[atom(CssAtomSet::Medium)]
-	Medium(T![Ident]),
-	#[atom(CssAtomSet::Thick)]
-	Thick(T![Ident]),
-}
-
-#[derive(IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[visit]
 pub enum LineWidth {
 	#[visit(skip)]
+	#[atom(CssAtomSet::Thin)]
 	Thin(T![Ident]),
 	#[visit(skip)]
+	#[atom(CssAtomSet::Medium)]
 	Medium(T![Ident]),
 	#[visit(skip)]
+	#[atom(CssAtomSet::Thick)]
 	Thick(T![Ident]),
 	Length(Length),
-}
-
-impl<'a> Peek<'a> for LineWidth {
-	fn peek(p: &Parser<'a>, c: Cursor) -> bool {
-		Length::peek(p, c) || LineWidthKeyword::peek(p, c)
-	}
-}
-
-impl<'a> Parse<'a> for LineWidth {
-	fn parse(p: &mut Parser<'a>) -> ParserResult<Self> {
-		if p.peek::<Length>() {
-			p.parse::<Length>().map(Self::Length)
-		} else {
-			match p.parse::<LineWidthKeyword>()? {
-				LineWidthKeyword::Medium(ident) => Ok(Self::Medium(ident)),
-				LineWidthKeyword::Thin(ident) => Ok(Self::Thin(ident)),
-				LineWidthKeyword::Thick(ident) => Ok(Self::Thick(ident)),
-			}
-		}
-	}
 }
 
 // impl From<LineWidth> for Length {


### PR DESCRIPTION
This minimised the amount of manual implementations.
