### PR TITLE
css_parse: Avoid having to manually flush Cursor Sinks by emitting Eof.

### DIFF
--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -34,7 +34,7 @@ mod tests {
 		// Descendent combinator
 		assert_parse!(CssAtomSet::ATOMS, Combinator, "     ");
 		assert_parse!(CssAtomSet::ATOMS, Combinator, "     ");
-		// assert_parse!(CssAtomSet::ATOMS, Combinator, "  /**/   /**/   /**/ ");
+		assert_parse!(CssAtomSet::ATOMS, Combinator, "  /**/   /**/   /**/ ");
 		// Column
 		assert_parse!(CssAtomSet::ATOMS, Combinator, "||");
 	}

--- a/crates/css_parse/src/cursor_interleave_sink.rs
+++ b/crates/css_parse/src/cursor_interleave_sink.rs
@@ -1,4 +1,4 @@
-use crate::{Cursor, CursorSink};
+use crate::{Cursor, CursorSink, Kind};
 
 /// This is a [CursorSink] that wraps a Sink (`impl CursorSink`) and a slice of [Cursor]s to interleave. On each
 /// [CursorSink::append()] call, will append to the delegate sink, while also interleaving any of the Cursors from the
@@ -9,16 +9,32 @@ pub struct CursorInterleaveSink<'a, S> {
 	sink: &'a mut S,
 	interleave: &'a [(bumpalo::collections::Vec<'a, Cursor>, Cursor)],
 	current_index: usize,
+	#[cfg(debug_assertions)]
+	seen_eof: bool,
 }
 
 impl<'a, S: CursorSink> CursorInterleaveSink<'a, S> {
 	pub fn new(sink: &'a mut S, interleave: &'a [(bumpalo::collections::Vec<'a, Cursor>, Cursor)]) -> Self {
-		Self { sink, interleave, current_index: 0 }
+		Self {
+			sink,
+			interleave,
+			current_index: 0,
+			#[cfg(debug_assertions)]
+			seen_eof: false,
+		}
 	}
 }
 
 impl<'a, S: CursorSink> CursorSink for CursorInterleaveSink<'a, S> {
 	fn append(&mut self, c: Cursor) {
+		#[cfg(debug_assertions)]
+		{
+			debug_assert!(!self.seen_eof, "Received cursor after EOF: {:?}", c);
+			if c == Kind::Eof {
+				self.seen_eof = true;
+			}
+		}
+
 		// Check if this content cursor has associated trivia
 		while self.current_index < self.interleave.len() {
 			let (trivia, associated_cursor) = &self.interleave[self.current_index];
@@ -34,6 +50,18 @@ impl<'a, S: CursorSink> CursorSink for CursorInterleaveSink<'a, S> {
 			}
 			self.current_index += 1;
 		}
+
+		// If this is EOF, flush any remaining trivia before emitting EOF
+		if c == Kind::Eof {
+			while self.current_index < self.interleave.len() {
+				let (trivia, _) = &self.interleave[self.current_index];
+				for cursor in trivia {
+					self.sink.append(*cursor);
+				}
+				self.current_index += 1;
+			}
+		}
+
 		self.sink.append(c);
 	}
 }

--- a/crates/css_parse/src/parser_return.rs
+++ b/crates/css_parse/src/parser_return.rs
@@ -32,11 +32,16 @@ impl<'a, T: ToCursors> ParserReturn<'a, T> {
 impl<T: ToCursors> ToCursors for ParserReturn<'_, T> {
 	fn to_cursors(&self, s: &mut impl CursorSink) {
 		if let Some(output) = &self.output {
+			let eof_offset = css_lexer::SourceOffset(self.source_text.len() as u32);
+			let eof_cursor = crate::Cursor::new(eof_offset, css_lexer::Token::EOF);
+
 			if self.with_trivia {
 				let mut sink = CursorInterleaveSink::new(s, &self.trivia);
 				ToCursors::to_cursors(output, &mut sink);
+				sink.append(eof_cursor);
 			} else {
 				ToCursors::to_cursors(output, s);
+				s.append(eof_cursor);
 			}
 		}
 	}

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -40,7 +40,6 @@ macro_rules! assert_parse {
 			let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
 			use $crate::ToCursors;
 			result.to_cursors(&mut ordered_sink);
-			ordered_sink.flush();
 		}
 		if source_text.trim() != actual.trim() {
 			panic!("\n\nParse failed: did not match expected format:\n\n   parser input: {:?}\n  parser output: {:?}\n", source_text, actual);
@@ -88,7 +87,6 @@ macro_rules! assert_parse_error {
 					let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
 					use $crate::ToCursors;
 					result.to_cursors(&mut ordered_sink);
-					ordered_sink.flush();
 				}
 				panic!("\n\nExpected errors but it passed without error.\n\n   parser input: {:?}\n  parser output: {:?}\n       expected: (Error)", source_text, actual);
 			}


### PR DESCRIPTION
We had a bug whereby trailing Trivia was not being correctly emitted due to the need to flush various CursorSinks. The
problem is the sinks can be combined in arbitrary orders and may need to be flushed in different orders. Rather than
this being the responsibility of callsites, we can instead emit an Eof token in ToCursors which can act as a sentinel
value for the sinks to flush.

So this change implements that: ParserReturn ToCursors emits an Eof, and both CursorOrderedSink and
CursorInterleaveSink will flush their respective buffers based on this signal. CursorOverlaySink needs some small
changes to ensure that it doesn't emit Eof from Overlays, as an Eof effectively closes the sink and should only be
emitted once. Consequently some debug asserts have been added to ensure sinks only see one Eof.
