### PR TITLE
CI: increment version in release/dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Get version and set TAG_NAME
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version | split(".") | "\(.[0]).\(.[1]).\(.[2] | tonumber + 1)"')
           TAG_NAME="${VERSION}-canary.${GITHUB_SHA}"
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
       - name: Setup
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Get version and set TAG_NAME
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version | split(".") | "\(.[0]).\(.[1]).\(.[2] | tonumber + 1)"')
           TAG_NAME="${VERSION}-canary.${GITHUB_SHA}"
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
           echo "TAG_NAME=$TAG_NAME"; echo "DIST_TAG=$DIST_TAG"
@@ -178,7 +178,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Get version and set TAG_NAME
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version | split(".") | "\(.[0]).\(.[1]).\(.[2] | tonumber + 1)"')
           TAG_NAME="${VERSION}-canary.${GITHUB_SHA}"
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
           echo "TAG_NAME=$TAG_NAME"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Get version and set TAG_NAME
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version | split(".") | "\(.[0]).\(.[1]).\(.[2] | tonumber + 1)"')
           TAG_NAME="${VERSION}-canary.${GITHUB_SHA}"
           echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
       - name: Setup


### PR DESCRIPTION
cargo publish will fail without bumping the version as it won't allow downgrading the pre-release version.