### PR TITLE
css_ast: tidy up build files using prettyplease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,8 @@ dependencies = [
  "insta",
  "miette",
  "pprof",
+ "prettyplease",
+ "proc-macro2",
  "quote",
  "serde",
  "serde_json",

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -33,9 +33,11 @@ bitmask-enum = { workspace = true }
 
 [build-dependencies]
 csskit_source_finder = { workspace = true }
+heck = { workspace = true }
+prettyplease = { workspace = true }
+proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
-heck = { workspace = true }
 
 [dev-dependencies]
 css_parse = { workspace = true, features = ["testing"] }

--- a/crates/css_ast/build.rs
+++ b/crates/css_ast/build.rs
@@ -1,13 +1,15 @@
 use csskit_source_finder::find_visitable_nodes;
 use heck::{ToKebabCase, ToSnakeCase};
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::{
 	collections::HashSet,
 	env,
 	fs::write,
+	io::Error,
 	path::{Path, PathBuf},
 };
-use syn::{Ident, PathArguments, Type, TypePath};
+use syn::{AngleBracketedGenericArguments, GenericArgument, Ident, PathArguments, Type, TypePath};
 
 trait GetIdent {
 	fn get_ident(&self) -> Option<Ident>;
@@ -29,7 +31,51 @@ trait GetArguments {
 impl GetArguments for Type {
 	fn get_arguments(&self) -> Option<PathArguments> {
 		match self {
-			Self::Path(TypePath { path, .. }) => path.segments.last().map(|seg| seg.arguments.clone()),
+			Self::Path(TypePath { path, .. }) => path.segments.last().map(|seg| {
+				// Strip trait bounds from generic arguments
+				match &seg.arguments {
+					PathArguments::AngleBracketed(args) => {
+						// For each generic argument, strip the bounds
+						let stripped_args: Vec<GenericArgument> = args
+							.args
+							.iter()
+							.filter_map(|arg| {
+								match arg {
+									GenericArgument::Type(Type::Path(TypePath { path, .. })) => {
+										// Extract just the identifier, no bounds
+										path.segments.last().map(|seg| {
+											GenericArgument::Type(Type::Path(TypePath {
+												qself: None,
+												path: syn::Path {
+													leading_colon: None,
+													segments: std::iter::once(syn::PathSegment {
+														ident: seg.ident.clone(),
+														arguments: PathArguments::None,
+													})
+													.collect(),
+												},
+											}))
+										})
+									}
+									_ => Some(arg.clone()),
+								}
+							})
+							.collect();
+
+						if stripped_args.is_empty() {
+							PathArguments::None
+						} else {
+							PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+								colon2_token: None,
+								lt_token: args.lt_token,
+								args: stripped_args.into_iter().collect(),
+								gt_token: args.gt_token,
+							})
+						}
+					}
+					other => other.clone(),
+				}
+			}),
 			_ => None,
 		}
 	}
@@ -37,6 +83,71 @@ impl GetArguments for Type {
 
 fn ident_to_snake_case(ident: Ident) -> Ident {
 	format_ident!("{}", ident.to_string().to_snake_case())
+}
+
+// Strip trait bounds from a type, keeping only the type name and generic parameter names
+fn strip_bounds_from_type(ty: &Type) -> Option<Type> {
+	match ty {
+		Type::Path(TypePath { path, .. }) => {
+			let last_segment = path.segments.last()?;
+			let ident = last_segment.ident.clone();
+
+			// Get arguments without bounds
+			let args = match &last_segment.arguments {
+				PathArguments::AngleBracketed(args) => {
+					let stripped_args: Vec<GenericArgument> = args
+						.args
+						.iter()
+						.filter_map(|arg| match arg {
+							GenericArgument::Type(Type::Path(TypePath { path, .. })) => {
+								path.segments.last().map(|seg| {
+									GenericArgument::Type(Type::Path(TypePath {
+										qself: None,
+										path: syn::Path {
+											leading_colon: None,
+											segments: std::iter::once(syn::PathSegment {
+												ident: seg.ident.clone(),
+												arguments: PathArguments::None,
+											})
+											.collect(),
+										},
+									}))
+								})
+							}
+							_ => Some(arg.clone()),
+						})
+						.collect();
+
+					if stripped_args.is_empty() {
+						PathArguments::None
+					} else {
+						PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+							colon2_token: None,
+							lt_token: args.lt_token,
+							args: stripped_args.into_iter().collect(),
+							gt_token: args.gt_token,
+						})
+					}
+				}
+				other => other.clone(),
+			};
+
+			Some(Type::Path(TypePath {
+				qself: None,
+				path: syn::Path {
+					leading_colon: None,
+					segments: std::iter::once(syn::PathSegment { ident, arguments: args }).collect(),
+				},
+			}))
+		}
+		_ => None,
+	}
+}
+
+fn write_tokens(file: &str, source: TokenStream) -> Result<(), Error> {
+	let contents = syn::parse_file(&source.to_string()).map_err(|e| Error::other(e.to_string()))?;
+	let contents = prettyplease::unparse(&contents);
+	write(Path::new(&env::var("OUT_DIR").unwrap()).join(file), contents)
 }
 
 fn main() {
@@ -48,7 +159,6 @@ fn main() {
 		println!("cargo::rerun-if-changed={}", path.display());
 	});
 
-	println!("cargo::warning=Constructring css_node_kind.rs");
 	{
 		let variants =
 			matches.iter().filter_map(|type_str| syn::parse_str::<Type>(type_str).ok().and_then(|ty| ty.get_ident()));
@@ -59,17 +169,18 @@ fn main() {
 					#(#variants),*
 				}
 		};
-		write(Path::new(&env::var("OUT_DIR").unwrap()).join("css_node_kind.rs"), source.to_string()).unwrap();
+		write_tokens("css_node_kind.rs", source).unwrap()
 	}
 
-	println!("cargo::warning=Constructring css_apply_visit_methods.rs");
 	{
 		let methods = matches.iter().filter_map(|type_str| {
 			syn::parse_str::<Type>(type_str).ok().and_then(|ty| {
-				ty.get_ident().map(|ident| {
+				ty.get_ident().and_then(|ident| {
 					let method_name = format_ident!("visit_{}", ident_to_snake_case(ident));
 					let life = ty.get_arguments();
-					quote! { #method_name #life (#ty) }
+					// Strip bounds from the type for use in the macro
+					let ty_stripped = strip_bounds_from_type(&ty)?;
+					Some(quote! { #method_name #life (#ty_stripped) })
 				})
 			})
 		});
@@ -83,10 +194,9 @@ fn main() {
 				}
 			}
 		};
-		write(Path::new(&env::var("OUT_DIR").unwrap()).join("css_apply_visit_methods.rs"), source.to_string()).unwrap();
+		write_tokens("css_apply_visit_methods.rs", source).unwrap();
 	}
 
-	println!("cargo::warning=Constructring css_apply_properties.rs");
 	{
 		let variants = matches.iter().filter_map(|type_str| {
 			syn::parse_str::<Type>(type_str).ok().and_then(|ty| {
@@ -96,11 +206,12 @@ fn main() {
 							return None;
 						}
 						let variant_name = format_ident!("{}", name);
-						let mut variant_str = variant_name.to_string().to_kebab_case();
-						if variant_str.starts_with("webkit-") || variant_str.starts_with("moz-") {
-							variant_str = format!("-{variant_str}");
+						let mut variant_atom = variant_name.clone();
+						let kebab = variant_atom.to_string().to_kebab_case();
+						if matches!(kebab.split("-").next().unwrap_or_default(), "Webkit" | "Moz" | "Ms" | "O") {
+							variant_atom = format_ident!("_{variant_atom}");
 						}
-						Some(quote! { #variant_name: #ty = #variant_str })
+						Some(quote! { #variant_name: #ty = #variant_atom })
 					})
 				})
 			})
@@ -114,9 +225,9 @@ fn main() {
 				}
 			}
 		};
-		write(Path::new(&env::var("OUT_DIR").unwrap()).join("css_apply_properties.rs"), source.to_string()).unwrap();
+		write_tokens("css_apply_properties.rs", source).unwrap();
 	}
 
 	let elapsed = now.elapsed();
-	println!("cargo::warning=Built in {:.?}", &elapsed);
+	println!("cargo::warning=Took {:.0?} to generate build files", &elapsed);
 }

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -150,9 +150,9 @@ impl<'a> DeclarationValue<'a> for StyleValue<'a> {
 			}
 		}
 		macro_rules! parse_declaration_value {
-			( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $str: tt,)+ ) => {
+			( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $atom: ident,)+ ) => {
 				match p.to_atom::<CssAtomSet>(name) {
-					$(CssAtomSet::$name => p.parse::<values::$ty>().map(Self::$name),)+
+					$(CssAtomSet::$atom => p.parse::<values::$ty>().map(Self::$name),)+
 					_ => Err(Diagnostic::new(name, Diagnostic::unexpected))?,
 				}
 			}


### PR DESCRIPTION
When build errors occurred where Rust would point to these generated files, it usually resulted in a lot of console spam
due to these generated files being one gigantic line. This change tries to tidy the built code using prettyplease to
"format" it, such that large blocks are spread over multiple lines eliminating severe console spam.
