### PR TITLE
css_ast: Gate Visit behind a feature flag

### DIFF
--- a/.mise-tasks/generate-values/mod.ts
+++ b/.mise-tasks/generate-values/mod.ts
@@ -889,7 +889,6 @@ async function getSpec(name: string, index: Record<string, number[]>, descriptio
 			"ToSpan",
 			"ToCursors",
 			"StyleValue",
-			"Visitable",
 			"Debug",
 			"Clone",
 			"PartialEq",
@@ -925,7 +924,7 @@ ${l}	animation_type = "${table.animation_type?.replace(/\n/g, " ").toLowerCase()
 ${l})]
 ${l}#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 ${l}#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("${featureName}"))]
-${l}#[visit]
+${l}#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 ${l}pub ${dataType} ${table.name == "--*" ? "Custom" : pascal(table.name)}StyleValue${generics}${trail}`;
 	});
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,18 +876,18 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "grep-matcher"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a3141a10a43acfedc7c98a60a834d7ba00dfe7bec9071cbfc19b55b292ac02"
+checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "grep-regex"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edd147c7e3296e7a26bd3a81345ce849557d5a8e48ed88f736074e760f91f7e"
+checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
 dependencies = [
  "bstr",
  "grep-matcher",
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "grep-searcher"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b6c14b3fc2e0a107d6604d3231dec0509e691e62447104bc385a46a7892cda"
+checksum = "5f3fee5d08eb17c47cbca241967c66154f934515b4974be48380be2dbb019586"
 dependencies = [
  "bstr",
  "encoding_rs",

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -55,6 +55,7 @@ pprof = { workspace = true, features = ["flamegraph", "criterion"] }
 
 [features]
 default = []
+visitable = []
 serde = ["dep:serde", "dep:serde_json", "css_parse/serde", "smallvec/serde"]
 miette = ["css_parse/miette"]
 fancy = ["miette", "miette/fancy-no-backtrace"]

--- a/crates/css_ast/src/functions/attr_function.rs
+++ b/crates/css_ast/src/functions/attr_function.rs
@@ -8,9 +8,9 @@ use css_parse::ComponentValues;
 /// attr() = attr( <attr-name> <attr-type>? , <declaration-value>?)
 /// <attr-type> = type( <syntax> ) | raw-string | <attr-unit>
 /// ```
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct AttrFunction<'a> {
 	#[atom(CssAtomSet::Attr)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/calc_size_function.rs
+++ b/crates/css_ast/src/functions/calc_size_function.rs
@@ -9,9 +9,9 @@ use super::prelude::*;
 ///
 /// The `<size-keyword>` production matches any sizing keywords allowed in the context.
 /// For example, in width, it matches auto, min-content, stretch, etc.
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct CalcSizeFunction {
 	#[atom(CssAtomSet::CalcSize)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/color_function.rs
+++ b/crates/css_ast/src/functions/color_function.rs
@@ -1,9 +1,9 @@
 use super::prelude::*;
 use crate::{AngleOrNumber, NoneOr, NumberOrPercentage};
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum ColorSpace {
 	#[atom(CssAtomSet::Srgb)]
 	Srgb(T![Ident]),
@@ -25,9 +25,9 @@ pub enum ColorSpace {
 	XyzD65(T![Ident]),
 }
 
-#[derive(IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct CommaOrSlash(Cursor);
 
 impl<'a> Peek<'a> for CommaOrSlash {
@@ -46,9 +46,9 @@ impl<'a> Parse<'a> for CommaOrSlash {
 }
 
 /// <https://drafts.csswg.org/css-color/#typedef-color-function>
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum ColorFunction {
 	Color(ColorFunctionColor),
 	Rgb(RgbFunction),
@@ -90,9 +90,9 @@ impl crate::ToChromashift for ColorFunction {
 /// <xyz-params> = <xyz-space> [ <number> | <percentage> | none ]{3}
 /// <xyz-space> = xyz | xyz-d50 | xyz-d65
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ColorFunctionColor {
 	#[atom(CssAtomSet::Color)]
 	pub name: T![Function],
@@ -107,9 +107,9 @@ impl crate::ToChromashift for ColorFunctionColor {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ColorFunctionColorParams(
 	pub ColorSpace,
 	pub NoneOr<NumberOrPercentage>,
@@ -135,9 +135,9 @@ pub struct ColorFunctionColorParams(
 ///   [ <number> | <percentage> | none]{3}
 ///   [ / [<alpha-value> | none] ]?  )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RgbFunction {
 	#[atom(CssAtomSet::Rgb)]
 	pub name: T![Function],
@@ -152,9 +152,9 @@ impl crate::ToChromashift for RgbFunction {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RgbaFunction {
 	#[atom(CssAtomSet::Rgba)]
 	pub name: T![Function],
@@ -169,9 +169,9 @@ impl crate::ToChromashift for RgbaFunction {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RgbFunctionParams(
 	pub NoneOr<NumberOrPercentage>,
 	pub Option<T![,]>,
@@ -236,9 +236,9 @@ impl crate::ToChromashift for RgbFunctionParams {
 /// <legacy-hsl-syntax> = hsl( <hue>, <percentage>, <percentage>, <alpha-value>? )
 /// <legacy-hsla-syntax> = hsla( <hue>, <percentage>, <percentage>, <alpha-value>? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct HslFunction {
 	#[atom(CssAtomSet::Hsl)]
 	pub name: T![Function],
@@ -253,9 +253,9 @@ impl crate::ToChromashift for HslFunction {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct HslaFunction {
 	#[atom(CssAtomSet::Hsla)]
 	pub name: T![Function],
@@ -270,9 +270,9 @@ impl crate::ToChromashift for HslaFunction {
 	}
 }
 
-#[derive(Parse, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct HslFunctionParams(
 	pub NoneOr<AngleOrNumber>,
 	pub Option<T![,]>,
@@ -325,9 +325,9 @@ impl crate::ToChromashift for HslFunctionParams {
 //  [<percentage> | <number> | none]
 //  [<percentage> | <number> | none]
 //  [ / [<alpha-value> | none] ]? )
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct HwbFunction {
 	#[atom(CssAtomSet::Hwb)]
 	pub name: T![Function],
@@ -371,9 +371,9 @@ impl crate::ToChromashift for HwbFunction {
 	}
 }
 
-#[derive(Parse, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct HwbFunctionParams(
 	pub NoneOr<AngleOrNumber>,
 	pub NoneOr<NumberOrPercentage>,
@@ -390,9 +390,9 @@ pub struct HwbFunctionParams(
 ///  [ <percentage> | <number> | none]
 ///  [ / [<alpha-value> | none] ]? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LabFunction {
 	#[atom(CssAtomSet::Lab)]
 	pub name: T![Function],
@@ -436,9 +436,9 @@ impl crate::ToChromashift for LabFunction {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LabFunctionParams(
 	pub NoneOr<NumberOrPercentage>,
 	pub NoneOr<NumberOrPercentage>,
@@ -455,9 +455,9 @@ pub struct LabFunctionParams(
 ///  [ <hue> | none]
 ///  [ / [<alpha-value> | none] ]? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LchFunction {
 	#[atom(CssAtomSet::Lch)]
 	pub name: T![Function],
@@ -501,9 +501,9 @@ impl crate::ToChromashift for LchFunction {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LchFunctionParams(
 	pub NoneOr<NumberOrPercentage>,
 	pub NoneOr<NumberOrPercentage>,
@@ -520,9 +520,9 @@ pub struct LchFunctionParams(
 ///  [ <percentage> | <number> | none]
 ///  [ / [<alpha-value> | none] ]? )
 ///  ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct OklabFunction {
 	#[atom(CssAtomSet::Oklab)]
 	pub name: T![Function],
@@ -574,9 +574,9 @@ impl crate::ToChromashift for OklabFunction {
 ///  [ <percentage> | <number> | none]
 ///  [ / [<alpha-value> | none] ]? )
 ///  ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct OklchFunction {
 	#[atom(CssAtomSet::Oklch)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/content_function.rs
+++ b/crates/css_ast/src/functions/content_function.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// content() = content( [ text | before | after | first-letter | marker ]? )
 /// ```
-#[derive(Peek, Parse, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ContentFunction {
 	#[atom(CssAtomSet::Content)]
 	pub name: T![Function],
@@ -15,9 +15,9 @@ pub struct ContentFunction {
 	pub close: T![')'],
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum ContentKeyword {
 	#[atom(CssAtomSet::Text)]
 	Text(T![Ident]),

--- a/crates/css_ast/src/functions/counter_functions.rs
+++ b/crates/css_ast/src/functions/counter_functions.rs
@@ -6,9 +6,9 @@ use crate::types::CounterStyle;
 /// ```text,ignore
 /// <counter()>  =  counter( <counter-name>, <counter-style>? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct CounterFunction<'a> {
 	#[atom(CssAtomSet::Counter)]
 	pub name: T![Function],
@@ -25,9 +25,9 @@ pub struct CounterFunctionParams<'a>(T![Ident], Option<T![,]>, Option<CounterSty
 /// ```text,ignore
 /// <counters()> = counters( <counter-name>, <string>, <counter-style>? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct CountersFunction<'a> {
 	#[atom(CssAtomSet::Counters)]
 	pub name: T![Function],
@@ -41,9 +41,9 @@ pub struct CountersFunctionParams<'a>(T![Ident], Option<T![,]>, T![String], Opti
 
 // https://drafts.csswg.org/css-lists-3/#counter-functions
 // <counter> = <counter()> | <counters()>
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub enum Counter<'a> {
 	Counter(CounterFunction<'a>),
 	Counters(CountersFunction<'a>),

--- a/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
+++ b/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// dynamic-range-limit-mix() = dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct DynamicRangeLimitMixFunction<'a> {
 	#[atom(CssAtomSet::DynamicRangeLimitMix)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/easing_functions.rs
+++ b/crates/css_ast/src/functions/easing_functions.rs
@@ -20,29 +20,29 @@ use crate::Percentage;
 // steps() = steps( <integer>, <step-position>?)
 //
 // <step-position> = jump-start | jump-end | jump-none | jump-both | start | end
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum EasingFunction<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Linear)]
 	Linear(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Ease)]
 	Ease(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::EaseIn)]
 	EaseIn(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::EaseOut)]
 	EaseOut(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::EaseInOut)]
 	EaseInOut(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::StepStart)]
 	StepStart(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::StepEnd)]
 	StepEnd(T![Ident]),
 	#[atom(CssAtomSet::Linear)]
@@ -53,9 +53,9 @@ pub enum EasingFunction<'a> {
 	StepsFunction(StepsFunction),
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LinearFunction<'a> {
 	#[atom(CssAtomSet::Linear)]
 	pub name: T![Function],
@@ -63,9 +63,9 @@ pub struct LinearFunction<'a> {
 	pub close: T![')'],
 }
 
-#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LinearFunctionParams(T![Number], Option<Percentage>, Option<Percentage>);
 
 impl<'a> Parse<'a> for LinearFunctionParams {
@@ -80,9 +80,9 @@ impl<'a> Parse<'a> for LinearFunctionParams {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct CubicBezierFunction {
 	#[atom(CssAtomSet::CubicBezier)]
 	pub name: T![Function],
@@ -102,9 +102,9 @@ pub struct CubicBezierFunctionParams {
 	y2: T![Number],
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct StepsFunction {
 	#[atom(CssAtomSet::Steps)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/fit_content_function.rs
+++ b/crates/css_ast/src/functions/fit_content_function.rs
@@ -6,9 +6,9 @@ use crate::LengthPercentage;
 /// ```text
 /// fit-content( <length-percentage> )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct FitContentFunction {
 	#[atom(CssAtomSet::FitContent)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/gradient_functions.rs
+++ b/crates/css_ast/src/functions/gradient_functions.rs
@@ -5,9 +5,9 @@ use crate::{Length, LengthPercentage};
 /// ```text-ignore,
 /// <gradient> = <linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()>
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum Gradient<'a> {
 	#[atom(CssAtomSet::LinearGradient)]
 	LinearGradientFunction(LinearGradientFunction<'a>),
@@ -25,9 +25,9 @@ pub enum Gradient<'a> {
 /// <linear-gradient-syntax> = [ <angle> | <zero> | to <side-or-corner> ]? , <color-stop-list>
 /// <side-or-corner> = [left | right] || [top | bottom]
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LinearGradientFunction<'a> {
 	#[atom(CssAtomSet::LinearGradient)]
 	pub name: T![Function],
@@ -49,9 +49,9 @@ pub struct LinearGradientFunctionParams<'a>(
 /// <linear-gradient-syntax> = [ <angle> | <zero> | to <side-or-corner> ]? , <color-stop-list>
 /// <side-or-corner> = [left | right] || [top | bottom]
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RepeatingLinearGradientFunction<'a> {
 	#[atom(CssAtomSet::RepeatingLinearGradient)]
 	pub name: T![Function],
@@ -75,9 +75,9 @@ pub struct RepeatingLinearGradientFunctionParams<'a>(
 /// <radial-extent> = closest-corner | closest-side | farthest-corner | farthest-side
 /// <radial-shape> = circle | ellipse
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RadialGradientFunction<'a> {
 	#[atom(CssAtomSet::RadialGradient)]
 	pub name: T![Function],
@@ -104,9 +104,9 @@ pub struct RadialGradientFunctionParams<'a>(
 /// <radial-extent> = closest-corner | closest-side | farthest-corner | farthest-side
 /// <radial-shape> = circle | ellipse
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RepeatingRadialGradientFunction<'a> {
 	#[atom(CssAtomSet::RepeatingRadialGradient)]
 	pub name: T![Function],
@@ -125,9 +125,10 @@ pub struct RepeatingRadialGradientFunctionParams<'a>(
 	CommaSeparated<'a, ColorStopOrHint>,
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", visit(skip))]
 pub enum NamedDirection {
 	#[atom(CssAtomSet::Bottom)]
 	Bottom(T![Ident]),
@@ -165,9 +166,10 @@ pub enum RadialSize {
 /// ```text,ignore
 /// <radial-extent> = closest-corner | closest-side | farthest-corner | farthest-side
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", visit(skip))]
 pub enum RadialExtent {
 	#[atom(CssAtomSet::ClosestCorner)]
 	ClosestCorner(T![Ident]),
@@ -205,9 +207,10 @@ impl<'a> Parse<'a> for RadialSize {
 /// ```text,ignore
 /// <radial-shape> = circle | ellipse
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", visit(skip))]
 pub enum RadialShape {
 	#[atom(CssAtomSet::Circle)]
 	Circle(T![Ident]),

--- a/crates/css_ast/src/functions/image_set_function.rs
+++ b/crates/css_ast/src/functions/image_set_function.rs
@@ -7,9 +7,9 @@ use crate::{Image, Resolution};
 /// <image-set()> = image-set( <image-set-option># )
 /// <image-set-option> = [ <image> | <string> ] [ <resolution> || type(<string>) ]?
 /// ```
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ImageSetFunction<'a> {
 	#[atom(CssAtomSet::ImageSet)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/leader_function.rs
+++ b/crates/css_ast/src/functions/leader_function.rs
@@ -6,9 +6,9 @@ use super::prelude::*;
 /// leader() = leader( <leader-type> )
 /// <leader-type> = dotted | solid | space | <string>
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LeaderFunction {
 	#[atom(CssAtomSet::Leader)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/mod.rs
+++ b/crates/css_ast/src/functions/mod.rs
@@ -45,7 +45,7 @@ pub use transform_functions::*;
 pub use url::*;
 
 mod prelude {
-	pub(crate) use crate::{Angle, CSSInt, Color, CssAtomSet, CssDiagnostic, Position, Todo, Visitable};
+	pub(crate) use crate::{Angle, CSSInt, Color, CssAtomSet, CssDiagnostic, Position, Todo};
 	pub(crate) use bumpalo::collections::Vec;
 	pub(crate) use css_parse::{CommaSeparated, Cursor, Diagnostic, Parse, Parser, Peek, Result as ParserResult, T};
 	pub(crate) use csskit_derives::*;

--- a/crates/css_ast/src/functions/param_function.rs
+++ b/crates/css_ast/src/functions/param_function.rs
@@ -6,9 +6,9 @@ use css_parse::ComponentValues;
 /// ```text,ignore
 /// <param()> = param( <dashed-ident> , <declaration-value>? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ParamFunction<'a> {
 	#[atom(CssAtomSet::Param)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/repeat_function.rs
+++ b/crates/css_ast/src/functions/repeat_function.rs
@@ -7,9 +7,9 @@ use crate::{AutoOr, LineWidth, PositiveNonZeroInt};
 /// <repeat-line-width>        = repeat( [ <integer [1,∞]> ] , [ <line-width> ]+ )
 /// <auto-repeat-line-width>   = repeat( auto , [ <line-width> ]+ )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RepeatFunction<'a> {
 	#[atom(CssAtomSet::Repeat)]
 	pub name: T![Function],
@@ -17,12 +17,13 @@ pub struct RepeatFunction<'a> {
 	pub close: T![')'],
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub struct RepeatFunctionParams<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub count: AutoOr<PositiveNonZeroInt>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub comma: Option<T![,]>,
 	pub tracks: Vec<'a, LineWidth>,
 }

--- a/crates/css_ast/src/functions/snap_block_function.rs
+++ b/crates/css_ast/src/functions/snap_block_function.rs
@@ -3,9 +3,9 @@ use crate::units::LengthPercentage;
 
 // https://drafts.csswg.org/css-page-floats-3/#funcdef-float-snap-block
 // snap-block() = snap-block( <length> , [ start | end | near ]? )
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct SnapBlockFunction {
 	#[atom(CssAtomSet::SnapBlock)]
 	pub name: T![Function],
@@ -17,9 +17,9 @@ pub struct SnapBlockFunction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SnapBlockFunctionParams(LengthPercentage, Option<T![,]>, Option<SnapBlockKeyword>, Option<T![,]>);
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum SnapBlockKeyword {
 	#[atom(CssAtomSet::Start)]
 	Start(T![Ident]),

--- a/crates/css_ast/src/functions/snap_inline_function.rs
+++ b/crates/css_ast/src/functions/snap_inline_function.rs
@@ -6,9 +6,9 @@ use crate::units::LengthPercentage;
 /// ```text,ignore
 /// snap-inline() = snap-inline( <length> , [ left | right | near ]? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct SnapInlineFunction {
 	#[atom(CssAtomSet::SnapInline)]
 	pub name: T![Function],
@@ -20,9 +20,9 @@ pub struct SnapInlineFunction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SnapInlineFunctionParams(LengthPercentage, Option<T![,]>, Option<SnapInlineKeyword>, Option<T![,]>);
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum SnapInlineKeyword {
 	#[atom(CssAtomSet::Left)]
 	Left(T![Ident]),

--- a/crates/css_ast/src/functions/string_function.rs
+++ b/crates/css_ast/src/functions/string_function.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// string() = string( <custom-ident> , [ first | start | last | first-except ]? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct StringFunction {
 	#[atom(CssAtomSet::String)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/stripes_function.rs
+++ b/crates/css_ast/src/functions/stripes_function.rs
@@ -7,15 +7,15 @@ use crate::{types::Color, units::LengthPercentageOrFlex};
 /// <stripes()> = stripes( <color-stripe># )
 /// <color-stripe> = <color> && [ <length-percentage> | <flex> ]?
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct StripesFunction<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Stripes)]
 	pub name: T![Function],
 	pub params: CommaSeparated<'a, ColorStripe>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: T![')'],
 }
 
@@ -24,9 +24,9 @@ pub struct StripesFunction<'a> {
 /// ```text,ignore
 /// <color-stripe> = <color> && [ <length-percentage> | <flex> ]?
 /// ```
-#[derive(ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub struct ColorStripe {
 	pub color: Color,
 	pub thickness: Option<LengthPercentageOrFlex>,

--- a/crates/css_ast/src/functions/superellipse_function.rs
+++ b/crates/css_ast/src/functions/superellipse_function.rs
@@ -6,9 +6,9 @@ use crate::NumberOrInfinity;
 /// ```text,ignore
 /// superellipse() = superellipse(<number [-∞,∞]> | infinity | -infinity)
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct SuperellipseFunction {
 	#[atom(CssAtomSet::Superellipse)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/symbols_function.rs
+++ b/crates/css_ast/src/functions/symbols_function.rs
@@ -6,9 +6,9 @@ use crate::{CssAtomSet, types::Image};
 /// ```text,ignore
 /// symbols() = symbols( <symbols-type>? [ <string> | <image> ]+ )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct SymbolsFunction<'a> {
 	#[atom(CssAtomSet::Symbols)]
 	pub name: T![Function],
@@ -16,9 +16,9 @@ pub struct SymbolsFunction<'a> {
 	pub close: T![')'],
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct SymbolsFunctionParams<'a> {
 	pub symbols_type: Option<SymbolsType>,
 	pub symbols: Vec<'a, Symbol<'a>>,
@@ -29,9 +29,9 @@ pub struct SymbolsFunctionParams<'a> {
 /// ```text,ignore
 /// <symbols-type> = cyclic | numeric | alphabetic | symbolic | fixed
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum SymbolsType {
 	#[atom(CssAtomSet::Cyclic)]
 	Cyclic(T![Ident]),
@@ -52,12 +52,12 @@ pub enum SymbolsType {
 /// ```text,ignore
 /// <string> | <image>
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 #[allow(clippy::large_enum_variant)] // TODO: Box or shrink Image
-#[visit(children)]
 pub enum Symbol<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	String(T![String]),
 	Image(Image<'a>),
 }

--- a/crates/css_ast/src/functions/target_functions.rs
+++ b/crates/css_ast/src/functions/target_functions.rs
@@ -1,9 +1,9 @@
 use super::prelude::*;
 use crate::{CssAtomSet, types::CounterStyle};
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum TextFunctionContent {
 	#[atom(CssAtomSet::Content)]
 	Content(T![Ident]),
@@ -27,9 +27,9 @@ pub enum TargetCounterKind {
 /// ```text,ignore
 /// <target> = <target-counter()> | <target-counters()> | <target-text()>
 /// ```
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum Target<'a> {
 	// https://drafts.csswg.org/css-content-3/#target-counter
 	// target-counter() = target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )
@@ -42,9 +42,9 @@ pub enum Target<'a> {
 	TargetText(TargetTextFunction),
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct TargetCounterFunction<'a> {
 	#[atom(CssAtomSet::TargetCounter)]
 	pub name: T![Function],
@@ -62,9 +62,9 @@ pub struct TargetCounterParams<'a>(
 	Option<CounterStyle<'a>>,
 );
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct TargetCountersFunction<'a> {
 	#[atom(CssAtomSet::TargetCounters)]
 	pub name: T![Function],
@@ -84,9 +84,9 @@ pub struct TargetCountersParams<'a>(
 	Option<CounterStyle<'a>>,
 );
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct TargetTextFunction {
 	#[atom(CssAtomSet::TargetText)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/transform_functions.rs
+++ b/crates/css_ast/src/functions/transform_functions.rs
@@ -2,10 +2,10 @@ use super::prelude::*;
 use crate::{AngleOrZero, Length, LengthPercentage, NoneOr, NumberOrPercentage};
 
 // https://drafts.csswg.org/css-transforms-1/#two-d-transform-functions
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[allow(clippy::large_enum_variant)] // TODO: matrix3d should probably be boxed
-#[visit]
 pub enum TransformFunction {
 	Matrix(MatrixFunction),
 	Matrix3d(Matrix3dFunction),
@@ -35,9 +35,9 @@ pub enum TransformFunction {
 /// ```text,ignore
 /// matrix() = matrix( <number>#{6} )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct MatrixFunction {
 	#[atom(CssAtomSet::Matrix)]
 	pub name: T![Function],
@@ -66,9 +66,9 @@ pub struct MatrixFunctionParams(
 /// ```text,ignore
 /// matrix3d() = matrix3d( <number>#{16} )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Matrix3dFunction {
 	#[atom(CssAtomSet::Matrix3d)]
 	pub name: T![Function],
@@ -118,9 +118,9 @@ pub struct Matrix3dFunctionParams(
 /// ```text,ignore
 /// translate() = translate( <length-percentage> , <length-percentage>? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct TranslateFunction {
 	#[atom(CssAtomSet::Translate)]
 	pub name: T![Function],
@@ -135,9 +135,9 @@ pub struct TranslateFunction {
 /// ```text,ignore
 /// translate3d() = translate3d( <length-percentage> , <length-percentage> , <length> )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Translate3dFunction {
 	#[atom(CssAtomSet::Translate3d)]
 	pub name: T![Function],
@@ -160,9 +160,9 @@ pub struct Translate3dFunctionParams(
 /// ```text,ignore
 /// translateX() = translateX( <length-percentage> )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct TranslatexFunction {
 	#[atom(CssAtomSet::Translatex)]
 	pub name: T![Function],
@@ -175,9 +175,9 @@ pub struct TranslatexFunction {
 /// ```text,ignore
 /// translateY() = translateY( <length-percentage> )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct TranslateyFunction {
 	#[atom(CssAtomSet::Translatey)]
 	pub name: T![Function],
@@ -190,9 +190,9 @@ pub struct TranslateyFunction {
 /// ```text,ignore
 /// translateZ() = translateZ( <length> )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct TranslatezFunction {
 	#[atom(CssAtomSet::Translatez)]
 	pub name: T![Function],
@@ -205,9 +205,9 @@ pub struct TranslatezFunction {
 /// ```text,ignore
 /// scale() = scale( [ <number> | <percentage> ]#{1,2} )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ScaleFunction {
 	#[atom(CssAtomSet::Scale)]
 	pub name: T![Function],
@@ -220,9 +220,9 @@ pub struct ScaleFunction {
 /// ```text,ignore
 /// scale3d() = scale3d( [ <number> | <percentage> ]#{3} )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Scale3dFunction {
 	#[atom(CssAtomSet::Scale3d)]
 	pub name: T![Function],
@@ -245,9 +245,9 @@ pub struct Scale3dFunctionParams(
 /// ```text,ignore
 /// scaleX() = scaleX( <number> | <percentage> )
 /// ````
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ScalexFunction {
 	#[atom(CssAtomSet::Scalex)]
 	pub name: T![Function],
@@ -260,9 +260,9 @@ pub struct ScalexFunction {
 /// ```text,ignore
 /// scaleY() = scaleY( <number> | <percentage> )
 /// ````
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ScaleyFunction {
 	#[atom(CssAtomSet::Scaley)]
 	pub name: T![Function],
@@ -275,9 +275,9 @@ pub struct ScaleyFunction {
 /// ```text,ignore
 /// scaleZ() = scaleZ( <number> | <percentage> )
 /// ````
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ScalezFunction {
 	#[atom(CssAtomSet::Scalez)]
 	pub name: T![Function],
@@ -290,9 +290,9 @@ pub struct ScalezFunction {
 /// ```text,ignore
 /// rotate() = rotate( [ <angle> | <zero> ] )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RotateFunction {
 	#[atom(CssAtomSet::Rotate)]
 	pub name: T![Function],
@@ -305,9 +305,9 @@ pub struct RotateFunction {
 /// ```text,ignore
 /// rotate3d() = rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Rotate3dFunction {
 	#[atom(CssAtomSet::Rotate3d)]
 	pub name: T![Function],
@@ -332,9 +332,9 @@ pub struct Rotate3dFunctionParams(
 /// ```text,ignore
 /// rotateX() = rotateX( [ <angle> | <zero> ] )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RotatexFunction {
 	#[atom(CssAtomSet::Rotatex)]
 	pub name: T![Function],
@@ -347,9 +347,9 @@ pub struct RotatexFunction {
 /// ```text,ignore
 /// rotateY() = rotateY( [ <angle> | <zero> ] )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RotateyFunction {
 	#[atom(CssAtomSet::Rotatey)]
 	pub name: T![Function],
@@ -362,9 +362,9 @@ pub struct RotateyFunction {
 /// ```text,ignore
 /// rotateZ() = rotateZ( [ <angle> | <zero> ] )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct RotatezFunction {
 	#[atom(CssAtomSet::Rotatez)]
 	pub name: T![Function],
@@ -377,9 +377,9 @@ pub struct RotatezFunction {
 /// ```text,ignore
 /// skew() = skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct SkewFunction {
 	#[atom(CssAtomSet::Skew)]
 	pub name: T![Function],
@@ -392,9 +392,9 @@ pub struct SkewFunction {
 /// ```text,ignore
 /// skewX() = skewX( [ <angle> | <zero> ] )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct SkewxFunction {
 	#[atom(CssAtomSet::Skewx)]
 	pub name: T![Function],
@@ -407,9 +407,9 @@ pub struct SkewxFunction {
 /// ```text,ignore
 /// skewY() = skewY( [ <angle> | <zero> ] )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct SkewyFunction {
 	#[atom(CssAtomSet::Skewy)]
 	pub name: T![Function],
@@ -422,9 +422,9 @@ pub struct SkewyFunction {
 /// ```text,ignore
 /// perspective() = perspective( [ <length [0,∞]> | none ] )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct PerspectiveFunction {
 	#[atom(CssAtomSet::Perspective)]
 	pub name: T![Function],

--- a/crates/css_ast/src/functions/url.rs
+++ b/crates/css_ast/src/functions/url.rs
@@ -7,9 +7,9 @@ use super::prelude::*;
 /// <url()> = url( <string> <url-modifier>* ) | <url-token>
 /// <src()> = src( <string> <url-modifier>* )
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum Url {
 	Url(T![Url]),
 	#[atom(CssAtomSet::Url)]

--- a/crates/css_ast/src/lib.rs
+++ b/crates/css_ast/src/lib.rs
@@ -14,6 +14,7 @@ mod traits;
 mod types;
 mod units;
 mod values;
+#[cfg(feature = "visitable")]
 pub mod visit;
 
 pub use css_atom_set::*;
@@ -27,17 +28,17 @@ pub use stylesheet::*;
 pub use types::*;
 pub use units::*;
 pub use values::*;
+#[cfg(feature = "visitable")]
 pub use visit::*;
 
 use crate::diagnostics::CssDiagnostic;
 
 use css_parse::{Cursor, CursorSink, Parse, Parser, Peek, Result as ParserResult, Span, ToCursors, ToSpan};
-use csskit_derives::Visitable;
 
 // TODO! - delete this when we're done ;)
-#[derive(Visitable, Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum Todo {
 	#[default]
 	Todo,

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -3,18 +3,20 @@ use css_lexer::Kind;
 use css_parse::{
 	ComponentValues, Cursor, DeclarationValue, Diagnostic, KindSet, Parser, Peek, Result as ParserResult, State, T,
 };
-use csskit_derives::{Parse, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, ToCursors, ToSpan};
 use std::{fmt::Debug, hash::Hash};
 
 // The build.rs generates a list of CSS properties from the value mods
 include!(concat!(env!("OUT_DIR"), "/css_apply_properties.rs"));
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[parse(state = State::Nested, stop = KindSet::RIGHT_CURLY_OR_SEMICOLON)]
 pub struct Custom<'a>(pub ComponentValues<'a>);
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[parse(state = State::Nested, stop = KindSet::RIGHT_CURLY_OR_SEMICOLON)]
 pub struct Computed<'a>(pub ComponentValues<'a>);
@@ -49,26 +51,27 @@ impl<'a> Peek<'a> for Computed<'a> {
 	}
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[parse(state = State::Nested, stop = KindSet::RIGHT_CURLY_OR_SEMICOLON)]
 pub struct Unknown<'a>(pub ComponentValues<'a>);
 
 macro_rules! style_value {
 	( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $str: tt,)+ ) => {
-		#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-		#[visit]
+		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 		pub enum StyleValue<'a> {
-			#[visit(skip)]
+			#[cfg_attr(feature = "visitable", visit(skip))]
 			Initial(T![Ident]),
-			#[visit(skip)]
+			#[cfg_attr(feature = "visitable", visit(skip))]
 			Inherit(T![Ident]),
-			#[visit(skip)]
+			#[cfg_attr(feature = "visitable", visit(skip))]
 			Unset(T![Ident]),
-			#[visit(skip)]
+			#[cfg_attr(feature = "visitable", visit(skip))]
 			Revert(T![Ident]),
-			#[visit(skip)]
+			#[cfg_attr(feature = "visitable", visit(skip))]
 			RevertLayer(T![Ident]),
 			#[cfg_attr(feature = "serde", serde(untagged))]
 			Custom(Custom<'a>),

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -1,10 +1,10 @@
 use super::prelude::*;
 
 // https://drafts.csswg.org/css-syntax-3/#charset-rule
-#[derive(ToSpan, ToCursors, Visitable, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.charset"))]
-#[visit(self)]
 pub struct CharsetRule {
 	at_keyword: T![AtKeyword],
 	space: T![' '],

--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -1,52 +1,53 @@
-use crate::{
-	CssAtomSet, StyleValue, Visit, VisitMut, Visitable as VisitableTrait, VisitableMut, types::Ratio, units::Length,
-};
+use crate::{CssAtomSet, StyleValue, types::Ratio, units::Length};
+#[cfg(feature = "visitable")]
+use crate::{Visit, VisitMut, Visitable as VisitableTrait, VisitableMut};
 use bumpalo::collections::Vec;
 use css_parse::{
 	Cursor, Declaration, FeatureConditionList, Parse, Parser, Result as ParserResult, T, discrete_feature,
 	ranged_feature,
 };
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
+#[cfg(feature = "visitable")]
 use csskit_proc_macro::visit;
 
 ranged_feature!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
-	pub enum WidthContainerFeature<CssAtomSet::Width, Length>
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	pub enum WidthContainerFeature{CssAtomSet::Width, Length}
 );
 
 ranged_feature!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
-	pub enum HeightContainerFeature<CssAtomSet::Height, Length>
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	pub enum HeightContainerFeature{CssAtomSet::Height, Length}
 );
 
 ranged_feature!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
-	pub enum InlineSizeContainerFeature<CssAtomSet::InlineSize, Length>
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	pub enum InlineSizeContainerFeature{CssAtomSet::InlineSize, Length}
 );
 
 ranged_feature!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
-	pub enum BlockSizeContainerFeature<CssAtomSet::BlockSize, Length>
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	pub enum BlockSizeContainerFeature{CssAtomSet::BlockSize, Length}
 );
 
 ranged_feature!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
-	pub enum AspectRatioContainerFeature<CssAtomSet::AspectRatio, Ratio>
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	pub enum AspectRatioContainerFeature{CssAtomSet::AspectRatio, Ratio}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum OrientationContainerFeatureKeyword {
 	#[atom(CssAtomSet::Portrait)]
 	Portrait(T![Ident]),
@@ -55,15 +56,15 @@ pub enum OrientationContainerFeatureKeyword {
 }
 
 discrete_feature!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
-	pub enum OrientationContainerFeature<CssAtomSet::Orientation, OrientationContainerFeatureKeyword>
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	pub enum OrientationContainerFeature{CssAtomSet::Orientation, OrientationContainerFeatureKeyword}
 );
 
 #[derive(ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", visit)]
 pub enum StyleQuery<'a> {
 	Is(Declaration<'a, StyleValue<'a>>),
 	Not(T![Ident], Declaration<'a, StyleValue<'a>>),
@@ -102,6 +103,7 @@ impl<'a> Parse<'a> for StyleQuery<'a> {
 	}
 }
 
+#[cfg(feature = "visitable")]
 impl<'a> VisitableTrait for StyleQuery<'a> {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		v.visit_style_query(self);
@@ -122,6 +124,7 @@ impl<'a> VisitableTrait for StyleQuery<'a> {
 	}
 }
 
+#[cfg(feature = "visitable")]
 impl<'a> VisitableMut for StyleQuery<'a> {
 	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
 		v.visit_style_query(self);
@@ -144,7 +147,7 @@ impl<'a> VisitableMut for StyleQuery<'a> {
 
 #[derive(ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", visit)]
 pub enum ScrollStateQuery<'a> {
 	Is(ScrollStateFeature),
 	Not(T![Ident], ScrollStateFeature),
@@ -183,6 +186,7 @@ impl<'a> Parse<'a> for ScrollStateQuery<'a> {
 	}
 }
 
+#[cfg(feature = "visitable")]
 impl<'a> VisitableTrait for ScrollStateQuery<'a> {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		match self {
@@ -202,6 +206,7 @@ impl<'a> VisitableTrait for ScrollStateQuery<'a> {
 	}
 }
 
+#[cfg(feature = "visitable")]
 impl<'a> VisitableMut for ScrollStateQuery<'a> {
 	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
 		match self {
@@ -221,9 +226,9 @@ impl<'a> VisitableMut for ScrollStateQuery<'a> {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum ScrollStateFeature {
 	Scrollable(ScrollableScrollStateFeature),
 	Snapped(SnappedScrollStateFeature),
@@ -231,15 +236,15 @@ pub enum ScrollStateFeature {
 }
 
 discrete_feature!(
-	#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
-	pub enum ScrollableScrollStateFeature<CssAtomSet::Scrollable, ScrollableScrollStateFeatureKeyword>
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	pub enum ScrollableScrollStateFeature{CssAtomSet::Scrollable, ScrollableScrollStateFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum ScrollableScrollStateFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),
@@ -272,15 +277,15 @@ pub enum ScrollableScrollStateFeatureKeyword {
 }
 
 discrete_feature!(
-	#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
-	pub enum SnappedScrollStateFeature<CssAtomSet::Snapped, SnappedScrollStateFeatureKeyword>
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	pub enum SnappedScrollStateFeature{CssAtomSet::Snapped, SnappedScrollStateFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum SnappedScrollStateFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),
@@ -299,15 +304,15 @@ pub enum SnappedScrollStateFeatureKeyword {
 }
 
 discrete_feature!(
-	#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
-	pub enum StuckScrollStateFeature<CssAtomSet::Stuck, StuckScrollStateFeatureKeyword>
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	pub enum StuckScrollStateFeature{CssAtomSet::Stuck, StuckScrollStateFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum StuckScrollStateFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -1,24 +1,25 @@
 use super::prelude::*;
 
 // https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct DocumentRule<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Document)]
 	pub name: T![AtKeyword],
 	pub prelude: DocumentMatcherList<'a>,
 	pub block: DocumentRuleBlock<'a>,
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub struct DocumentMatcherList<'a>(pub CommaSeparated<'a, DocumentMatcher>);
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum DocumentMatcher {
 	Url(T![Url]),
 	#[atom(CssAtomSet::Url)]
@@ -33,8 +34,9 @@ pub enum DocumentMatcher {
 	Regexp(T![Function], T![String], T![')']),
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub struct DocumentRuleBlock<'a>(RuleList<'a, Rule<'a>>);
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -2,25 +2,25 @@ use super::prelude::*;
 use crate::Computed;
 
 // https://drafts.csswg.org/css-fonts/#font-face-rule
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.font-face"))]
-#[visit]
 pub struct FontFaceRule<'a> {
 	#[atom(CssAtomSet::FontFace)]
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub name: T![AtKeyword],
 	pub block: FontFaceRuleBlock<'a>,
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub struct FontFaceRuleBlock<'a>(DeclarationList<'a, FontFaceRuleStyleValue<'a>>);
 
-#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 struct FontFaceRuleStyleValue<'a>(StyleValue<'a>);
 
 impl<'a> DeclarationValue<'a> for FontFaceRuleStyleValue<'a> {

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -3,21 +3,21 @@ use crate::Percentage;
 use css_parse::NoBlockAllowed;
 
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
-#[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.keyframes"))]
-#[visit]
 pub struct KeyframesRule<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Keyframes)]
 	pub name: T![AtKeyword],
 	pub prelude: KeyframesName,
 	pub block: KeyframesRuleBlock<'a>,
 }
 
-#[derive(Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum KeyframesName {
 	Ident(T![Ident]),
 	String(T![String]),
@@ -43,24 +43,24 @@ impl<'a> Parse<'a> for KeyframesName {
 	}
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct KeyframesRuleBlock<'a>(RuleList<'a, Keyframe<'a>>);
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct Keyframe<'a>(QualifiedRule<'a, KeyframeSelectors<'a>, StyleValue<'a>, NoBlockAllowed>);
 
-#[derive(Peek, Parse, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub struct KeyframeSelectors<'a>(pub CommaSeparated<'a, KeyframeSelector>);
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum KeyframeSelector {
 	#[atom(CssAtomSet::From)]
 	From(T![Ident]),

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -1,27 +1,28 @@
 use super::prelude::*;
 
 // https://drafts.csswg.org/css-cascade-5/#layering
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.layer"))]
-#[visit]
 pub struct LayerRule<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Layer)]
 	pub name: T![AtKeyword],
 	pub prelude: LayerNameList<'a>,
 	pub block: Option<LayerRuleBlock<'a>>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub semicolon: Option<T![;]>,
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LayerNameList<'a>(pub CommaSeparated<'a, LayerName<'a>>);
 
-#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LayerName<'a>(T![Ident], Vec<'a, (T![.], T![Ident])>);
 
 impl<'a> Parse<'a> for LayerName<'a> {
@@ -40,7 +41,8 @@ impl<'a> Parse<'a> for LayerName<'a> {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LayerRuleBlock<'a>(RuleList<'a, Rule<'a>>);
 

--- a/crates/css_ast/src/rules/media/features/any_hover.rs
+++ b/crates/css_ast/src/rules/media/features/any_hover.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum AnyHoverMediaFeature<CssAtomSet::AnyHover, AnyHoverMediaFeatureKeyword>
+	pub enum AnyHoverMediaFeature{CssAtomSet::AnyHover, AnyHoverMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum AnyHoverMediaFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/any_pointer.rs
+++ b/crates/css_ast/src/rules/media/features/any_pointer.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum AnyPointerMediaFeature<CssAtomSet::AnyPointer, AnyPointerMediaFeatureKeyword>
+	pub enum AnyPointerMediaFeature{CssAtomSet::AnyPointer, AnyPointerMediaFeatureKeyword}
 );
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/rules/media/features/color.rs
+++ b/crates/css_ast/src/rules/media/features/color.rs
@@ -4,7 +4,7 @@ use crate::units::CSSInt;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum ColorMediaFeature<CssAtomSet::Color | CssAtomSet::MinColor | CssAtomSet::MaxColor, CSSInt>
+	pub enum ColorMediaFeature{CssAtomSet::Color | CssAtomSet::MinColor | CssAtomSet::MaxColor, CSSInt}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/features/color_gamut.rs
+++ b/crates/css_ast/src/rules/media/features/color_gamut.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum ColorGamutMediaFeature<CssAtomSet::ColorGamut, ColorGamutMediaFeatureKeyword>
+	pub enum ColorGamutMediaFeature{CssAtomSet::ColorGamut, ColorGamutMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum ColorGamutMediaFeatureKeyword {
 	#[atom(CssAtomSet::Srgb)]
 	Srgb(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/color_index.rs
+++ b/crates/css_ast/src/rules/media/features/color_index.rs
@@ -4,7 +4,7 @@ use crate::units::CSSInt;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum ColorIndexMediaFeature<CssAtomSet::ColorIndex | CssAtomSet::MaxColorIndex | CssAtomSet::MinColorIndex, CSSInt>
+	pub enum ColorIndexMediaFeature{CssAtomSet::ColorIndex | CssAtomSet::MaxColorIndex | CssAtomSet::MinColorIndex, CSSInt}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/features/device_height.rs
+++ b/crates/css_ast/src/rules/media/features/device_height.rs
@@ -4,7 +4,7 @@ use crate::units::Length;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum DeviceHeightMediaFeature<CssAtomSet::DeviceHeight | CssAtomSet::MinDeviceHeight | CssAtomSet::MaxDeviceHeight, Length>
+	pub enum DeviceHeightMediaFeature{CssAtomSet::DeviceHeight | CssAtomSet::MinDeviceHeight | CssAtomSet::MaxDeviceHeight, Length}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/features/device_width.rs
+++ b/crates/css_ast/src/rules/media/features/device_width.rs
@@ -4,7 +4,7 @@ use crate::units::Length;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum DeviceWidthMediaFeature<CssAtomSet::DeviceWidth | CssAtomSet::MinDeviceWidth | CssAtomSet::MaxDeviceWidth, Length>
+	pub enum DeviceWidthMediaFeature{CssAtomSet::DeviceWidth | CssAtomSet::MinDeviceWidth | CssAtomSet::MaxDeviceWidth, Length}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/features/display_mode.rs
+++ b/crates/css_ast/src/rules/media/features/display_mode.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum DisplayModeMediaFeature<CssAtomSet::DisplayMode, DisplayModeMediaFeatureKeyword>
+	pub enum DisplayModeMediaFeature{CssAtomSet::DisplayMode, DisplayModeMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DisplayModeMediaFeatureKeyword {
 	#[atom(CssAtomSet::Fullscreen)]
 	Fullscreen(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/dynamic_range.rs
+++ b/crates/css_ast/src/rules/media/features/dynamic_range.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum DynamicRangeMediaFeature<CssAtomSet::DynamicRange, DynamicRangeMediaFeatureKeyword>
+	pub enum DynamicRangeMediaFeature{CssAtomSet::DynamicRange, DynamicRangeMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DynamicRangeMediaFeatureKeyword {
 	#[atom(CssAtomSet::Standard)]
 	Standard(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/environment_blending.rs
+++ b/crates/css_ast/src/rules/media/features/environment_blending.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum EnvironmentBlendingMediaFeature<CssAtomSet::EnvironmentBlending, EnvironmentBlendingMediaFeatureKeyword>
+	pub enum EnvironmentBlendingMediaFeature{CssAtomSet::EnvironmentBlending, EnvironmentBlendingMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum EnvironmentBlendingMediaFeatureKeyword {
 	#[atom(CssAtomSet::Opaque)]
 	Opaque(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/forced_colors.rs
+++ b/crates/css_ast/src/rules/media/features/forced_colors.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum ForcedColorsMediaFeature<CssAtomSet::ForcedColors, ForcedColorsMediaFeatureKeyword>
+	pub enum ForcedColorsMediaFeature{CssAtomSet::ForcedColors, ForcedColorsMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum ForcedColorsMediaFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/grid.rs
+++ b/crates/css_ast/src/rules/media/features/grid.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 boolean_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum GridMediaFeature<CssAtomSet::Grid>
+	pub enum GridMediaFeature{CssAtomSet::Grid}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/features/height.rs
+++ b/crates/css_ast/src/rules/media/features/height.rs
@@ -4,7 +4,7 @@ use crate::units::Length;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum HeightMediaFeature<CssAtomSet::Height | CssAtomSet::MinHeight | CssAtomSet::MaxHeight, Length>
+	pub enum HeightMediaFeature{CssAtomSet::Height | CssAtomSet::MinHeight | CssAtomSet::MaxHeight, Length}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/features/horizontal_viewport_segments.rs
+++ b/crates/css_ast/src/rules/media/features/horizontal_viewport_segments.rs
@@ -4,7 +4,7 @@ use crate::units::CSSInt;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum HorizontalViewportSegmentsMediaFeature<CssAtomSet::HorizontalViewportSegments | CssAtomSet::MinHorizontalViewportSegments | CssAtomSet::MaxHorizontalViewportSegments, CSSInt>
+	pub enum HorizontalViewportSegmentsMediaFeature{CssAtomSet::HorizontalViewportSegments | CssAtomSet::MinHorizontalViewportSegments | CssAtomSet::MaxHorizontalViewportSegments, CSSInt}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/features/hover.rs
+++ b/crates/css_ast/src/rules/media/features/hover.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum HoverMediaFeature<CssAtomSet::Hover, HoverMediaFeatureKeyword>
+	pub enum HoverMediaFeature{CssAtomSet::Hover, HoverMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum HoverMediaFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/inverted_colors.rs
+++ b/crates/css_ast/src/rules/media/features/inverted_colors.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum InvertedColorsMediaFeature<CssAtomSet::InvertedColors, InvertedColorsMediaFeatureKeyword>
+	pub enum InvertedColorsMediaFeature{CssAtomSet::InvertedColors, InvertedColorsMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum InvertedColorsMediaFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/mod.rs
+++ b/crates/css_ast/src/rules/media/features/mod.rs
@@ -87,5 +87,5 @@ pub use width::*;
 mod prelude {
 	pub(crate) use crate::CssAtomSet;
 	pub(crate) use css_parse::{T, boolean_feature, discrete_feature, ranged_feature};
-	pub(crate) use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+	pub(crate) use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 }

--- a/crates/css_ast/src/rules/media/features/monochrome.rs
+++ b/crates/css_ast/src/rules/media/features/monochrome.rs
@@ -4,7 +4,7 @@ use crate::units::CSSInt;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MonochromeMediaFeature<CssAtomSet::Monochrome | CssAtomSet::MinMonochrome | CssAtomSet::MaxMonochrome, CSSInt>
+	pub enum MonochromeMediaFeature{CssAtomSet::Monochrome | CssAtomSet::MinMonochrome | CssAtomSet::MaxMonochrome, CSSInt}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/features/moz.rs
+++ b/crates/css_ast/src/rules/media/features/moz.rs
@@ -6,7 +6,7 @@ use crate::units::CSSFloat;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MozDevicePixelRatioMediaFeature<CssAtomSet::_MozDevicePixelRatio | CssAtomSet::_MozMinDevicePixelRatio | CssAtomSet::_MozMaxDevicePixelRatio, CSSFloat>
+	pub enum MozDevicePixelRatioMediaFeature{CssAtomSet::_MozDevicePixelRatio | CssAtomSet::_MozMinDevicePixelRatio | CssAtomSet::_MozMaxDevicePixelRatio, CSSFloat}
 );
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -21,25 +21,25 @@ pub enum MozDeviceOrientationMediaFeatureKeyword {
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MozDeviceOrientationMediaFeature<CssAtomSet::_MozDeviceOrientation, MozDeviceOrientationMediaFeatureKeyword>
+	pub enum MozDeviceOrientationMediaFeature{CssAtomSet::_MozDeviceOrientation, MozDeviceOrientationMediaFeatureKeyword}
 );
 
 boolean_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MozMacGraphiteThemeMediaFeature<CssAtomSet::_MozMacGraphiteTheme>
+	pub enum MozMacGraphiteThemeMediaFeature{CssAtomSet::_MozMacGraphiteTheme}
 );
 
 boolean_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MozMaemoClassicMediaFeature<CssAtomSet::_MozMaemoClassicTheme>
+	pub enum MozMaemoClassicMediaFeature{CssAtomSet::_MozMaemoClassicTheme}
 );
 
 boolean_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MozImagesInMenusMediaFeature<CssAtomSet::_MozMaemoClassicTheme>
+	pub enum MozImagesInMenusMediaFeature{CssAtomSet::_MozMaemoClassicTheme}
 );
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -60,11 +60,11 @@ pub enum MozOsVersionMediaFeatureKeyword {
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MozOsVersionMediaFeature<CssAtomSet::_MozOsVersion, MozOsVersionMediaFeatureKeyword>
+	pub enum MozOsVersionMediaFeature{CssAtomSet::_MozOsVersion, MozOsVersionMediaFeatureKeyword}
 );
 
 boolean_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MozTouchEnabledMediaFeature<CssAtomSet::_MozTouchEnabled>
+	pub enum MozTouchEnabledMediaFeature{CssAtomSet::_MozTouchEnabled}
 );

--- a/crates/css_ast/src/rules/media/features/ms.rs
+++ b/crates/css_ast/src/rules/media/features/ms.rs
@@ -13,7 +13,7 @@ pub enum MsHighContrastMediaFeatureKeyword {
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MsHighContrastMediaFeature<CssAtomSet::_MsHighContrast, MsHighContrastMediaFeatureKeyword>
+	pub enum MsHighContrastMediaFeature{CssAtomSet::_MsHighContrast, MsHighContrastMediaFeatureKeyword}
 );
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -30,7 +30,7 @@ pub enum MsViewStateMediaFeatureKeyword {
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MsViewStateMediaFeature<CssAtomSet::_MsViewState, MsViewStateMediaFeatureKeyword>
+	pub enum MsViewStateMediaFeature{CssAtomSet::_MsViewState, MsViewStateMediaFeatureKeyword}
 );
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -40,17 +40,17 @@ pub struct MsImeAlignMediaFeatureKeyword(#[atom(CssAtomSet::Auto)] T![Ident]);
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MsImeAlignMediaFeature<CssAtomSet::_MsImeAlign, MsImeAlignMediaFeatureKeyword>
+	pub enum MsImeAlignMediaFeature{CssAtomSet::_MsImeAlign, MsImeAlignMediaFeatureKeyword}
 );
 
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MsDevicePixelRatioMediaFeature<CssAtomSet::_MsDevicePixelRatio | CssAtomSet::_MsMinDevicePixelRatio | CssAtomSet::_MsMaxDevicepixelRatio, CSSFloat>
+	pub enum MsDevicePixelRatioMediaFeature{CssAtomSet::_MsDevicePixelRatio | CssAtomSet::_MsMinDevicePixelRatio | CssAtomSet::_MsMaxDevicepixelRatio, CSSFloat}
 );
 
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum MsColumnCountMediaFeature<CssAtomSet::_MsColumnCount | CssAtomSet::_MsMinColumnCount | CssAtomSet::_MsMaxColumnCount, CSSInt>
+	pub enum MsColumnCountMediaFeature{CssAtomSet::_MsColumnCount | CssAtomSet::_MsMinColumnCount | CssAtomSet::_MsMaxColumnCount, CSSInt}
 );

--- a/crates/css_ast/src/rules/media/features/nav_controls.rs
+++ b/crates/css_ast/src/rules/media/features/nav_controls.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum NavControlsMediaFeature<CssAtomSet::NavControls, NavControlsMediaFeatureKeyword>
+	pub enum NavControlsMediaFeature{CssAtomSet::NavControls, NavControlsMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum NavControlsMediaFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/o.rs
+++ b/crates/css_ast/src/rules/media/features/o.rs
@@ -4,5 +4,5 @@ use crate::units::CSSFloat;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum ODevicePixelRatioMediaFeature<CssAtomSet::_ODevicePixelRatio | CssAtomSet::_OMinDevicePixelRatio | CssAtomSet::_OMaxDevicePixelRatio, CSSFloat>
+	pub enum ODevicePixelRatioMediaFeature{CssAtomSet::_ODevicePixelRatio | CssAtomSet::_OMinDevicePixelRatio | CssAtomSet::_OMaxDevicePixelRatio, CSSFloat}
 );

--- a/crates/css_ast/src/rules/media/features/orientation.rs
+++ b/crates/css_ast/src/rules/media/features/orientation.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum OrientationMediaFeature<CssAtomSet::Orientation, OrientationMediaFeatureKeyword>
+	pub enum OrientationMediaFeature{CssAtomSet::Orientation, OrientationMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum OrientationMediaFeatureKeyword {
 	#[atom(CssAtomSet::Portrait)]
 	Portrait(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/overflow_block.rs
+++ b/crates/css_ast/src/rules/media/features/overflow_block.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum OverflowBlockMediaFeature<CssAtomSet::OverflowBlock, OverflowBlockMediaFeatureKeyword>
+	pub enum OverflowBlockMediaFeature{CssAtomSet::OverflowBlock, OverflowBlockMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum OverflowBlockMediaFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/overflow_inline.rs
+++ b/crates/css_ast/src/rules/media/features/overflow_inline.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum OverflowInlineMediaFeature<CssAtomSet::OverflowInline, OverflowInlineMediaFeatureKeyword>
+	pub enum OverflowInlineMediaFeature{CssAtomSet::OverflowInline, OverflowInlineMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum OverflowInlineMediaFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/pointer.rs
+++ b/crates/css_ast/src/rules/media/features/pointer.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum PointerMediaFeature<CssAtomSet::Pointer, PointerMediaFeatureKeyword>
+	pub enum PointerMediaFeature{CssAtomSet::Pointer, PointerMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum PointerMediaFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/prefers_color_scheme.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_color_scheme.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum PrefersColorSchemeMediaFeature<CssAtomSet::PrefersColorScheme, PrefersColorSchemeMediaFeatureKeyword>
+	pub enum PrefersColorSchemeMediaFeature{CssAtomSet::PrefersColorScheme, PrefersColorSchemeMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum PrefersColorSchemeMediaFeatureKeyword {
 	#[atom(CssAtomSet::Light)]
 	Light(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/prefers_contrast.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_contrast.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum PrefersContrastMediaFeature<CssAtomSet::PrefersContrast, PrefersContrastMediaFeatureKeyword>
+	pub enum PrefersContrastMediaFeature{CssAtomSet::PrefersContrast, PrefersContrastMediaFeatureKeyword}
 );
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/rules/media/features/prefers_reduced_data.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_reduced_data.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum PrefersReducedDataMediaFeature<CssAtomSet::PrefersReducedData, PrefersReducedDataMediaFeatureKeyword>
+	pub enum PrefersReducedDataMediaFeature{CssAtomSet::PrefersReducedData, PrefersReducedDataMediaFeatureKeyword}
 );
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/rules/media/features/prefers_reduced_motion.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_reduced_motion.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum PrefersReducedMotionMediaFeature<CssAtomSet::PrefersReducedMotion, PrefersReducedMotionMediaFeatureKeyword>
+	pub enum PrefersReducedMotionMediaFeature{CssAtomSet::PrefersReducedMotion, PrefersReducedMotionMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum PrefersReducedMotionMediaFeatureKeyword {
 	#[atom(CssAtomSet::NoPreference)]
 	NoPreference(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/prefers_reduced_transparency.rs
+++ b/crates/css_ast/src/rules/media/features/prefers_reduced_transparency.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum PrefersReducedTransparencyMediaFeature<CssAtomSet::PrefersReducedTransparency, PrefersReducedTransparencyMediaFeatureKeyword>
+	pub enum PrefersReducedTransparencyMediaFeature{CssAtomSet::PrefersReducedTransparency, PrefersReducedTransparencyMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum PrefersReducedTransparencyMediaFeatureKeyword {
 	#[atom(CssAtomSet::NoPreference)]
 	NoPreference(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/scan.rs
+++ b/crates/css_ast/src/rules/media/features/scan.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum ScanMediaFeature<CssAtomSet::Scan, ScanMediaFeatureKeyword>
+	pub enum ScanMediaFeature{CssAtomSet::Scan, ScanMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum ScanMediaFeatureKeyword {
 	#[atom(CssAtomSet::Interlace)]
 	Interlace(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/scripting.rs
+++ b/crates/css_ast/src/rules/media/features/scripting.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum ScriptingMediaFeature<CssAtomSet::Scripting, ScriptingMediaFeatureKeyword>
+	pub enum ScriptingMediaFeature{CssAtomSet::Scripting, ScriptingMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum ScriptingMediaFeatureKeyword {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/vertical_viewport_segments.rs
+++ b/crates/css_ast/src/rules/media/features/vertical_viewport_segments.rs
@@ -4,7 +4,7 @@ use crate::units::CSSInt;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum VerticalViewportSegmentsMediaFeature<CssAtomSet::VerticalViewportSegments | CssAtomSet::MaxVerticalViewportSegments | CssAtomSet::MinVerticalViewportSegments, CSSInt>
+	pub enum VerticalViewportSegmentsMediaFeature{CssAtomSet::VerticalViewportSegments | CssAtomSet::MaxVerticalViewportSegments | CssAtomSet::MinVerticalViewportSegments, CSSInt}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/features/video_color_gamut.rs
+++ b/crates/css_ast/src/rules/media/features/video_color_gamut.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum VideoColorGamutMediaFeature<CssAtomSet::VideoColorGamut, VideoColorGamutMediaFeatureKeyword>
+	pub enum VideoColorGamutMediaFeature{CssAtomSet::VideoColorGamut, VideoColorGamutMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum VideoColorGamutMediaFeatureKeyword {
 	#[atom(CssAtomSet::Srgb)]
 	Srgb(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/video_dynamic_range.rs
+++ b/crates/css_ast/src/rules/media/features/video_dynamic_range.rs
@@ -3,12 +3,12 @@ use super::prelude::*;
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum VideoDynamicRangeMediaFeature<CssAtomSet::VideoDynamicRange, VideoDynamicRangeMediaFeatureKeyword>
+	pub enum VideoDynamicRangeMediaFeature{CssAtomSet::VideoDynamicRange, VideoDynamicRangeMediaFeatureKeyword}
 );
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum VideoDynamicRangeMediaFeatureKeyword {
 	#[atom(CssAtomSet::Standard)]
 	Standard(T![Ident]),

--- a/crates/css_ast/src/rules/media/features/webkit.rs
+++ b/crates/css_ast/src/rules/media/features/webkit.rs
@@ -13,34 +13,34 @@ pub enum BooleanKeyword {
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum WebkitAnimationMediaFeature<CssAtomSet::_WebkitAnimation, BooleanKeyword>
+	pub enum WebkitAnimationMediaFeature{CssAtomSet::_WebkitAnimation, BooleanKeyword}
 );
 
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum WebkitTransform2dMediaFeature<CssAtomSet::_WebkitTransform2d, BooleanKeyword>
+	pub enum WebkitTransform2dMediaFeature{CssAtomSet::_WebkitTransform2d, BooleanKeyword}
 );
 
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum WebkitTransform3dMediaFeature<CssAtomSet::_WebkitTransform3d, BooleanKeyword>
+	pub enum WebkitTransform3dMediaFeature{CssAtomSet::_WebkitTransform3d, BooleanKeyword}
 );
 
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum WebkitTransitionMediaFeature<CssAtomSet::_WebkitTransition, BooleanKeyword>
+	pub enum WebkitTransitionMediaFeature{CssAtomSet::_WebkitTransition, BooleanKeyword}
 );
 
 discrete_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum WebkitVideoPlayableInlineMediaFeature<CssAtomSet::_WebkitVideoPlayableInline, BooleanKeyword>);
+	pub enum WebkitVideoPlayableInlineMediaFeature{CssAtomSet::_WebkitVideoPlayableInline, BooleanKeyword});
 
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum WebkitDevicePixelRatioMediaFeature<CssAtomSet::_WebkitDevicePixelRatio | CssAtomSet::_WebkitMinDevicePixelRatio | CssAtomSet::_WebkitMaxDevicePixelRatio, CSSFloat>
+	pub enum WebkitDevicePixelRatioMediaFeature{CssAtomSet::_WebkitDevicePixelRatio | CssAtomSet::_WebkitMinDevicePixelRatio | CssAtomSet::_WebkitMaxDevicePixelRatio, CSSFloat}
 );

--- a/crates/css_ast/src/rules/media/features/width.rs
+++ b/crates/css_ast/src/rules/media/features/width.rs
@@ -4,7 +4,7 @@ use crate::units::Length;
 ranged_feature!(
 	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	pub enum WidthMediaFeature<CssAtomSet::Width | CssAtomSet::MinWidth | CssAtomSet::MaxWidth, Length>
+	pub enum WidthMediaFeature{CssAtomSet::Width | CssAtomSet::MinWidth | CssAtomSet::MaxWidth, Length}
 );
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -4,18 +4,18 @@ use css_parse::{
 	Block, Cursor, Diagnostic, FeatureConditionList, Kind, KindSet, Parse, Parser, Peek, PreludeList,
 	Result as ParserResult, T,
 };
-use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan};
 
 mod features;
 pub use features::*;
 
 // https://drafts.csswg.org/mediaqueries-4/
-#[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.media"))]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct MediaRule<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Media)]
 	pub name: T![AtKeyword],
 	pub prelude: MediaQueryList<'a>,

--- a/crates/css_ast/src/rules/mod.rs
+++ b/crates/css_ast/src/rules/mod.rs
@@ -41,14 +41,13 @@ pub use supports::*;
 pub use webkit::*;
 
 mod prelude {
-	pub(crate) use crate::{
-		CssAtomSet, CssDiagnostic, StyleValue, Visit, VisitMut, Visitable as VisitableTrait, VisitableMut,
-		stylesheet::Rule,
-	};
+	pub(crate) use crate::{CssAtomSet, CssDiagnostic, StyleValue, stylesheet::Rule};
+	#[cfg(feature = "visitable")]
+	pub(crate) use crate::{Visit, VisitMut, Visitable as VisitableTrait, VisitableMut};
 	pub(crate) use bumpalo::collections::Vec;
 	pub(crate) use css_parse::{
 		Block, CommaSeparated, ComponentValues, Cursor, Declaration, DeclarationList, DeclarationValue, Diagnostic,
 		FeatureConditionList, Kind, KindSet, Parse, Parser, Peek, QualifiedRule, Result as ParserResult, RuleList, T,
 	};
-	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
+	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan};
 }

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -1,11 +1,11 @@
 use super::prelude::*;
 use crate::{DocumentMatcherList, DocumentRuleBlock};
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct MozDocumentRule<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::_MozDocument)]
 	pub name: T![AtKeyword],
 	pub prelude: DocumentMatcherList<'a>,

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -3,25 +3,26 @@ use crate::specificity::{Specificity, ToSpecificity};
 
 // https://drafts.csswg.org/cssom-1/#csspagerule
 // https://drafts.csswg.org/css-page-3/#at-page-rule
-#[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.page"))]
-#[visit]
 pub struct PageRule<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Page)]
 	pub name: T![AtKeyword],
 	pub prelude: Option<PageSelectorList<'a>>,
 	pub block: PageRuleBlock<'a>,
 }
 
-#[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct PageSelectorList<'a>(pub CommaSeparated<'a, PageSelector<'a>>);
 
-#[derive(ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct PageSelector<'a> {
 	pub page_type: Option<T![Ident]>,
 	pub pseudos: Vec<'a, PagePseudoClass>,
@@ -76,48 +77,48 @@ impl ToSpecificity for PagePseudoClass {
 	}
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub struct PageRuleBlock<'a>(Block<'a, StyleValue<'a>, MarginRule<'a>>);
 
 // https://drafts.csswg.org/cssom-1/#cssmarginrule
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum MarginRule<'a> {
 	#[atom(CssAtomSet::TopLeftCorner)]
-	TopLeftCorner(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	TopLeftCorner(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::TopLeft)]
-	TopLeft(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	TopLeft(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::TopCenter)]
-	TopCenter(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	TopCenter(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::TopRight)]
-	TopRight(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	TopRight(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::TopRightCorner)]
-	TopRightCorner(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	TopRightCorner(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::RightTop)]
-	RightTop(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	RightTop(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::RightMiddle)]
-	RightMiddle(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	RightMiddle(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::RightBottom)]
-	RightBottom(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	RightBottom(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::BottomRightCorner)]
-	BottomRightCorner(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	BottomRightCorner(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::BottomRight)]
-	BottomRight(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	BottomRight(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::BottomCenter)]
-	BottomCenter(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	BottomCenter(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::BottomLeft)]
-	BottomLeft(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	BottomLeft(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::BottomLeftCorner)]
-	BottomLeftCorner(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	BottomLeftCorner(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::LeftBottom)]
-	LeftBottom(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	LeftBottom(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::LeftMiddle)]
-	LeftMiddle(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	LeftMiddle(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 	#[atom(CssAtomSet::LeftTop)]
-	LeftTop(#[visit(skip)] T![AtKeyword], MarginRuleBlock<'a>),
+	LeftTop(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),
 }
 
 impl<'a> MarginRule<'a> {
@@ -164,9 +165,9 @@ impl<'a> MarginRule<'a> {
 	}
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub struct MarginRuleBlock<'a>(DeclarationList<'a, StyleValue<'a>>);
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -3,30 +3,31 @@ use crate::Computed;
 
 // https://drafts.csswg.org/cssom-1/#csspagerule
 // https://drafts.csswg.org/css-page-3/#at-page-rule
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.property"))]
-#[visit]
 pub struct PropertyRule<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Property)]
 	pub name: T![AtKeyword],
 	pub prelude: PropertyPrelude,
 	pub block: PropertyRuleBlock<'a>,
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct PropertyPrelude(T![DashedIdent]);
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct PropertyRuleBlock<'a>(DeclarationList<'a, PropertyRuleValue<'a>>);
 
-#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub enum PropertyRuleValue<'a> {
 	InitialValue(ComponentValues<'a>),
 	Syntax(SyntaxValue),
@@ -34,9 +35,9 @@ pub enum PropertyRuleValue<'a> {
 	Unknown(ComponentValues<'a>),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum InheritsValue {
 	#[atom(CssAtomSet::True)]
 	True(T![Ident]),
@@ -44,9 +45,9 @@ pub enum InheritsValue {
 	False(T![Ident]),
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct SyntaxValue(T![String]);
 
 impl<'a> DeclarationValue<'a> for PropertyRuleValue<'a> {

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -32,19 +32,20 @@ use crate::selector::ComplexSelector;
 ///
 /// <https://drafts.csswg.org/css-conditional-3/#at-supports>
 /// <https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports>
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.property"))]
-#[visit]
 pub struct SupportsRule<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Supports)]
 	pub name: T![AtKeyword],
 	pub prelude: SupportsCondition<'a>,
 	pub block: SupportsRuleBlock<'a>,
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct SupportsRuleBlock<'a>(RuleList<'a, Rule<'a>>);
 
@@ -91,6 +92,7 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
 	}
 }
 
+#[cfg(feature = "visitable")]
 impl<'a> VisitableTrait for SupportsCondition<'a> {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		match self {
@@ -110,6 +112,7 @@ impl<'a> VisitableTrait for SupportsCondition<'a> {
 	}
 }
 
+#[cfg(feature = "visitable")]
 impl<'a> VisitableMut for SupportsCondition<'a> {
 	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
 		match self {
@@ -170,6 +173,7 @@ impl<'a> Parse<'a> for SupportsFeature<'a> {
 	}
 }
 
+#[cfg(feature = "visitable")]
 impl<'a> VisitableTrait for SupportsFeature<'a> {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		match self {
@@ -181,6 +185,7 @@ impl<'a> VisitableTrait for SupportsFeature<'a> {
 	}
 }
 
+#[cfg(feature = "visitable")]
 impl<'a> VisitableMut for SupportsFeature<'a> {
 	fn accept_mut<V: VisitMut>(&mut self, v: &mut V) {
 		match self {

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -2,11 +2,11 @@ use super::prelude::*;
 use crate::{KeyframesName, KeyframesRuleBlock};
 
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct WebkitKeyframesRule<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::_WebkitKeyframes)]
 	pub name: T![AtKeyword],
 	pub prelude: KeyframesName,

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -1,23 +1,23 @@
 use crate::CssAtomSet;
 use css_parse::{KindSet, Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan};
 
 use super::NamespacePrefix;
 
-#[derive(Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct Attribute {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub open: T!['['],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub namespace_prefix: Option<NamespacePrefix>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub attribute: T![Ident],
 	pub operator: Option<AttributeOperator>,
 	pub value: Option<AttributeValue>,
 	pub modifier: Option<AttributeModifier>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![']']>,
 }
 
@@ -45,9 +45,9 @@ impl<'a> Parse<'a> for Attribute {
 	}
 }
 
-#[derive(Parse, ToSpan, Peek, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, Peek, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum AttributeOperator {
 	Exact(T![=]),
 	SpaceList(T![~=]),
@@ -57,22 +57,22 @@ pub enum AttributeOperator {
 	Contains(T![*=]),
 }
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum AttributeValue {
 	String(T![String]),
 	Ident(T![Ident]),
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[cfg_attr(
 	feature = "css_feature_data",
 	derive(::csskit_derives::ToCSSFeature),
 	css_feature("css.selectors.attribute")
 )]
-#[visit(self)]
 pub enum AttributeModifier {
 	#[cfg_attr(feature = "css_feature_data", css_feature("css.selectors.attribute.case_sensitive_modifier"))]
 	#[atom(CssAtomSet::S)]

--- a/crates/css_ast/src/selector/class.rs
+++ b/crates/css_ast/src/selector/class.rs
@@ -1,9 +1,9 @@
 use css_parse::{Cursor, Kind, Parser, Peek, T};
-use csskit_derives::{Parse, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, ToCursors, ToSpan};
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Class {
 	pub dot: T![.],
 	pub name: T![Ident],

--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -1,10 +1,10 @@
 use css_parse::T;
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 // https://drafts.csswg.org/selectors/#combinators
-#[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum Combinator {
 	Child(T![>]),
 	NextSibling(T![+]),

--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -1,7 +1,7 @@
 use crate::CssAtomSet;
 use css_lexer::Kind;
 use css_parse::{CommaSeparated, Diagnostic, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 use super::{ForgivingSelector, Nth, RelativeSelector, SelectorList};
 
@@ -30,7 +30,8 @@ macro_rules! apply_functional_pseudo_class {
 
 macro_rules! define_functional_pseudo_class {
 	( $($ident: ident($ty: ty) $pat: pat $(,)*)+ ) => {
-		#[derive( ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+		#[derive( ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.selectors"))]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		pub enum FunctionalPseudoClass<'a> {
@@ -60,9 +61,9 @@ impl<'a> Parse<'a> for FunctionalPseudoClass<'a> {
 	}
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct DirPseudoFunction {
 	pub colon: T![:],
 	#[atom(CssAtomSet::Dir)]
@@ -71,9 +72,9 @@ pub struct DirPseudoFunction {
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DirValue {
 	#[atom(CssAtomSet::Rtl)]
 	Rtl(T![Ident]),
@@ -81,65 +82,65 @@ pub enum DirValue {
 	Ltr(T![Ident]),
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct HasPseudoFunction<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Has)]
 	pub function: T![Function],
 	pub value: RelativeSelector<'a>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct HostPseudoFunction<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Host)]
 	pub function: T![Function],
 	pub value: SelectorList<'a>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct HostContextPseudoFunction<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::HostContext)]
 	pub function: T![Function],
 	pub value: SelectorList<'a>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct IsPseudoFunction<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Is)]
 	pub function: T![Function],
 	pub value: ForgivingSelector<'a>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct LangPseudoFunction<'a> {
 	pub colon: T![:],
 	#[atom(CssAtomSet::Lang)]
@@ -159,121 +160,121 @@ pub enum LangValue {
 	String(T![String]),
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct NotPseudoFunction<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Not)]
 	pub function: T![Function],
 	pub value: SelectorList<'a>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct NthChildPseudoFunction {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthChild)]
 	pub function: T![Function],
 	pub value: Nth,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct NthColPseudoFunction {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthCol)]
 	pub function: T![Function],
 	pub value: Nth,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct NthLastChildPseudoFunction {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthLastChild)]
 	pub function: T![Function],
 	pub value: Nth,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct NthLastColPseudoFunction {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthLastCol)]
 	pub function: T![Function],
 	pub value: Nth,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct NthLastOfTypePseudoFunction {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthLastOfType)]
 	pub function: T![Function],
 	pub value: Nth,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct NthOfTypePseudoFunction {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthOfType)]
 	pub function: T![Function],
 	pub value: Nth,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct WherePseudoFunction<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colon: T![:],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Where)]
 	pub function: T![Function],
 	pub value: ForgivingSelector<'a>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct StatePseudoFunction {
 	pub colon: T![:],
 	#[atom(CssAtomSet::State)]
@@ -282,9 +283,9 @@ pub struct StatePseudoFunction {
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct HeadingPseudoFunction<'a> {
 	pub colon: T![:],
 	#[atom(CssAtomSet::Heading)]

--- a/crates/css_ast/src/selector/functional_pseudo_element.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_element.rs
@@ -2,14 +2,14 @@ use crate::{CssAtomSet, CssDiagnostic};
 use bumpalo::collections::Vec;
 use css_lexer::Kind;
 use css_parse::{Diagnostic, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{Parse, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, ToCursors, ToSpan};
 
 use super::CompoundSelector;
 
-#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.selectors"))]
-#[visit]
 pub enum FunctionalPseudoElement<'a> {
 	// https://drafts.csswg.org/css-highlight-api/#custom-highlight-pseudo
 	Highlight(HighlightPseudoElement),
@@ -56,9 +56,9 @@ impl<'a> Parse<'a> for FunctionalPseudoElement<'a> {
 	}
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct HighlightPseudoElement {
 	pub colons: T![::],
 	#[atom(CssAtomSet::Highlight)]
@@ -67,23 +67,23 @@ pub struct HighlightPseudoElement {
 	pub close: T![')'],
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct SlottedPseudoElement<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colons: T![::],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Slotted)]
 	pub function: T![Function],
 	pub value: CompoundSelector<'a>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct PartPseudoElement<'a> {
 	pub colons: T![::],
 	#[atom(CssAtomSet::Part)]
@@ -92,9 +92,9 @@ pub struct PartPseudoElement<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct PickerPseudoElement {
 	pub colons: T![::],
 	#[atom(CssAtomSet::Picker)]
@@ -103,9 +103,9 @@ pub struct PickerPseudoElement {
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ViewTransitionGroupPseudoElement<'a> {
 	pub colons: T![::],
 	#[atom(CssAtomSet::ViewTransitionGroup)]
@@ -114,9 +114,9 @@ pub struct ViewTransitionGroupPseudoElement<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ViewTransitionImagePairPseudoElement<'a> {
 	pub colons: T![::],
 	#[atom(CssAtomSet::ViewTransitionImagePair)]
@@ -125,9 +125,9 @@ pub struct ViewTransitionImagePairPseudoElement<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ViewTransitionNewPseudoElement<'a> {
 	pub colons: T![::],
 	#[atom(CssAtomSet::ViewTransitionNew)]
@@ -136,9 +136,9 @@ pub struct ViewTransitionNewPseudoElement<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct ViewTransitionOldPseudoElement<'a> {
 	pub colons: T![::],
 	#[atom(CssAtomSet::ViewTransitionOld)]
@@ -147,9 +147,9 @@ pub struct ViewTransitionOldPseudoElement<'a> {
 	pub close: Option<T![')']>,
 }
 
-#[derive(Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum PtNameAndClassSelector<'a> {
 	Wildcard(T![*]),
 	Named(T![Ident], Vec<'a, (T![.], T![Ident])>),

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -3,7 +3,7 @@ use css_parse::{
 	CompoundSelector as CompoundSelectorTrait, Parse, Parser, Result as ParserResult,
 	SelectorComponent as SelectorComponentTrait, T, syntax::CommaSeparated,
 };
-use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan};
 
 mod attribute;
 mod class;
@@ -43,14 +43,14 @@ pub use webkit::*;
 ///     │                       ╰───────╯ │
 ///     ╰─────────────────────────────────╯
 /// ```
-#[derive(Peek, Parse, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct SelectorList<'a>(pub CommaSeparated<'a, CompoundSelector<'a>>);
 
-#[derive(Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct CompoundSelector<'a>(pub Vec<'a, SelectorComponent<'a>>);
 
 impl<'a> CompoundSelectorTrait<'a> for CompoundSelector<'a> {
@@ -67,22 +67,22 @@ pub type ComplexSelector<'a> = SelectorList<'a>;
 pub type ForgivingSelector<'a> = SelectorList<'a>;
 pub type RelativeSelector<'a> = SelectorList<'a>;
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Id(T![Hash]);
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Wildcard(T![*]);
 
 // This encapsulates all `simple-selector` subtypes (e.g. `wq-name`,
 // `id-selector`) into one enum, as it makes parsing and visiting much more
 // practical.
-#[derive(Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub enum SelectorComponent<'a> {
 	Id(Id),
 	Class(Class),
@@ -171,7 +171,6 @@ impl<'a> SelectorComponentTrait<'a> for SelectorComponent<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use crate::assert_visits;
 	use css_parse::assert_parse;
 
 	#[test]
@@ -234,7 +233,9 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
+		use crate::assert_visits;
 		assert_visits!(".foo", CompoundSelector, Class);
 		assert_visits!("#bar", CompoundSelector, Id);
 		assert_visits!(".foo", SelectorList, CompoundSelector, Class);
@@ -249,7 +250,9 @@ mod tests {
 
 	#[test]
 	#[should_panic]
+	#[cfg(feature = "visitable")]
 	fn test_assert_visits_fails() {
+		use crate::assert_visits;
 		assert_visits!(".foo", CompoundSelector, visit_id<Id>);
 	}
 }

--- a/crates/css_ast/src/selector/moz.rs
+++ b/crates/css_ast/src/selector/moz.rs
@@ -2,13 +2,13 @@ use crate::{CssAtomSet, CssDiagnostic, DirValue};
 use css_parse::{
 	Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T, pseudo_class, pseudo_element, syntax::CommaSeparated,
 };
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 pseudo_element!(
 	/// https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#pseudo-elements_and_pseudo-classes
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 	pub enum MozPseudoElement {
 		AnonymousBlock: CssAtomSet::_MozAnonymousBlock,
 		AnonymousItem: CssAtomSet::_MozAnonymousItem,
@@ -87,9 +87,9 @@ pseudo_element!(
 	}
 );
 
-#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum MozFunctionalPseudoElement<'a> {
 	TreeCell(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
 	TreeCellText(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
@@ -102,9 +102,9 @@ pub enum MozFunctionalPseudoElement<'a> {
 	TreeTwisty(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
 }
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum MozFunctionalPseudoElementKeyword {
 	#[atom(CssAtomSet::_MozTreeCell)]
 	TreeCell(T![Function]),
@@ -154,9 +154,9 @@ impl<'a> Parse<'a> for MozFunctionalPseudoElement<'a> {
 
 pseudo_class!(
 	/// <https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#pseudo-elements_and_pseudo-classes>
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 	pub enum MozPseudoClass {
 		Any: CssAtomSet::_MozAny,
 		AnyLink: CssAtomSet::_MozAnyLink,
@@ -188,9 +188,9 @@ pseudo_class!(
 	}
 );
 
-#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum MozFunctionalPseudoClass {
 	LocaleDir(MozLocaleDirFunctionalPseudoClass),
 }
@@ -210,9 +210,9 @@ impl<'a> Parse<'a> for MozFunctionalPseudoClass {
 	}
 }
 
-#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct MozLocaleDirFunctionalPseudoClass {
 	pub colon: T![:],
 	pub function: T![Function],

--- a/crates/css_ast/src/selector/ms.rs
+++ b/crates/css_ast/src/selector/ms.rs
@@ -1,11 +1,11 @@
 use crate::CssAtomSet;
 use css_parse::{Diagnostic, pseudo_class, pseudo_element};
-use csskit_derives::{ToCursors, ToSpan, Visitable};
+use csskit_derives::{ToCursors, ToSpan};
 
 pseudo_element!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 	pub enum MsPseudoElement {
 		Backdrop: CssAtomSet::_MsBackdrop,
 		Browse: CssAtomSet::_MsBrowse,
@@ -29,9 +29,9 @@ pseudo_element!(
 );
 
 pseudo_class!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 	pub enum MsPseudoClass {
 		Fullscreen: CssAtomSet::_MsFullscreen,
 		InputPlaceholder: CssAtomSet::_MsInputPlaceholder

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,12 +1,12 @@
 use css_parse::{Diagnostic, KindSet, Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{IntoCursor, Peek, ToCursors, ToSpan};
 
 use super::Tag;
 
 // https://drafts.csswg.org/selectors/#combinators
-#[derive(Peek, ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Namespace {
 	pub prefix: Option<NamespacePrefix>,
 	pub tag: NamespaceTag,

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -3,11 +3,10 @@ use css_parse::{
 	Cursor, CursorSink, Diagnostic, Kind, KindSet, Parse, Parser, Peek, Result as ParserResult, Span, T, ToCursors,
 	ToSpan,
 };
-use csskit_derives::Visitable;
 
-#[derive(Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum Nth {
 	Odd(T![Ident]),
 	Even(T![Ident]),

--- a/crates/css_ast/src/selector/o.rs
+++ b/crates/css_ast/src/selector/o.rs
@@ -1,11 +1,11 @@
 use crate::CssAtomSet;
 use css_parse::{Diagnostic, pseudo_class, pseudo_element};
-use csskit_derives::{ToCursors, ToSpan, Visitable};
+use csskit_derives::{ToCursors, ToSpan};
 
 pseudo_element!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 	pub enum OPseudoElement {
 		InnerSpinButton: CssAtomSet::_OInnerSpinButton,
 		OuterSpinButton: CssAtomSet::_OOuterSpinButton,
@@ -19,9 +19,9 @@ pseudo_element!(
 );
 
 pseudo_class!(
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 	pub enum OPseudoClass {
 		Prefocus: CssAtomSet::_OPrefocus,
 	}

--- a/crates/css_ast/src/selector/pseudo_class.rs
+++ b/crates/css_ast/src/selector/pseudo_class.rs
@@ -1,6 +1,6 @@
 use crate::{CssAtomSet, CssDiagnostic};
 use css_parse::{Diagnostic, Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Peek, ToCursors, ToSpan};
 
 use super::{moz::MozPseudoClass, ms::MsPseudoClass, o::OPseudoClass, webkit::WebkitPseudoClass};
 
@@ -73,10 +73,10 @@ macro_rules! apply_pseudo_class {
 
 macro_rules! define_pseudo_class {
 	( $($(#[$meta:meta])* $ident: ident: $pat: pat $(,)*)+ ) => {
-		#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 		#[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.selectors"))]
-		#[visit(self)]
 		pub enum PseudoClass {
 			$($(#[$meta])* $ident(T![:], T![Ident]),)+
 			Webkit(WebkitPseudoClass),

--- a/crates/css_ast/src/selector/pseudo_element.rs
+++ b/crates/css_ast/src/selector/pseudo_element.rs
@@ -1,7 +1,7 @@
 use crate::{CssAtomSet, CssDiagnostic, MozPseudoElement, MsPseudoElement, OPseudoElement, WebkitPseudoElement};
 use css_lexer::Kind;
 use css_parse::{Diagnostic, KindSet, Parse, Parser, Peek, Result as ParserResult, T, pseudo_class};
-use csskit_derives::{ToCursors, ToSpan, Visitable};
+use csskit_derives::{ToCursors, ToSpan};
 
 macro_rules! apply_pseudo_element {
 	($macro: ident) => {
@@ -32,10 +32,10 @@ macro_rules! apply_pseudo_element {
 
 macro_rules! define_pseudo_element {
 	( $($(#[$meta:meta])* $ident: ident: $pat: pat $(,)*)+ ) => {
-		#[derive(ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		#[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.selectors"))]
-		#[visit(self)]
+		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 		pub enum PseudoElement {
 			$($(#[$meta])* $ident(T![::], T![Ident]),)+
 			Webkit(WebkitPseudoElement),
@@ -89,10 +89,10 @@ impl<'a> Parse<'a> for PseudoElement {
 }
 
 pseudo_class!(
-	#[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.selectors"))]
-	#[derive(ToSpan, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToSpan, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+	#[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.selectors"))]
 	pub enum LegacyPseudoElement {
 		After: CssAtomSet::After,
 		Before: CssAtomSet::Before,

--- a/crates/css_ast/src/selector/tag.rs
+++ b/crates/css_ast/src/selector/tag.rs
@@ -1,10 +1,10 @@
 use crate::CssAtomSet;
 use css_parse::{Cursor, Diagnostic, Parse, Parser, Peek, Result, T};
-use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
+use csskit_derives::{IntoCursor, Parse, Peek, ToCursors};
 
-#[derive(Parse, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum Tag {
 	Html(HtmlTag),
 	HtmlNonStandard(HtmlNonStandardTag),
@@ -21,9 +21,9 @@ impl<'a> Peek<'a> for Tag {
 	}
 }
 
-#[derive(ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct CustomElementTag(T![Ident]);
 
 impl CustomElementTag {
@@ -95,9 +95,9 @@ impl<'a> Parse<'a> for CustomElementTag {
 }
 
 /// <https://html.spec.whatwg.org/multipage/indices.html#elements-3>
-#[derive(Parse, Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum HtmlTag {
 	#[atom(CssAtomSet::A)]
 	A(T![Ident]),
@@ -326,9 +326,9 @@ pub enum HtmlTag {
 }
 
 /// <https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features>
-#[derive(Parse, Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum HtmlNonConformingTag {
 	#[atom(CssAtomSet::Acronym)]
 	Acronym(T![Ident]),
@@ -390,9 +390,9 @@ pub enum HtmlNonConformingTag {
 	Xmp(T![Ident]),
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum HtmlNonStandardTag {
 	// https://wicg.github.io/fenced-frame/#the-fencedframe-element
 	#[atom(CssAtomSet::Fencedframe)]
@@ -409,9 +409,9 @@ pub enum HtmlNonStandardTag {
 }
 
 /// <https://svgwg.org/svg2-draft/eltindex.html>
-#[derive(Parse, Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SvgTag {
 	#[atom(CssAtomSet::A)]
 	A(T![Ident]),
@@ -544,9 +544,9 @@ pub enum SvgTag {
 }
 
 /// <https://w3c.github.io/mathml/#mmlindex_elements>
-#[derive(Parse, Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum MathmlTag {
 	#[atom(CssAtomSet::Abs)]
 	Abs(T![Ident]),
@@ -866,9 +866,9 @@ pub enum MathmlTag {
 	Xo(T![Ident]),
 }
 
-#[derive(ToCursors, Parse, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Parse, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct UnknownTag(T![Ident]);
 
 impl<'a> Peek<'a> for UnknownTag {

--- a/crates/css_ast/src/selector/webkit.rs
+++ b/crates/css_ast/src/selector/webkit.rs
@@ -1,12 +1,12 @@
 use crate::{CompoundSelector, CssAtomSet, CssDiagnostic};
 use css_parse::{Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T, pseudo_class, pseudo_element};
-use csskit_derives::{ToCursors, ToSpan, Visitable};
+use csskit_derives::{ToCursors, ToSpan};
 
 pseudo_element!(
 	/// <https://searchfox.org/wubkat/source/Source/WebCore/css/CSSPseudoSelectors.json>
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 	pub enum WebkitPseudoElement {
 		CalendarDatePickerIndicator: CssAtomSet::_WebkitCalendarPickerIndicator,
 		CapsLockIndicator: CssAtomSet::_WebkitCapsLockIndicator,
@@ -74,9 +74,9 @@ pseudo_element!(
 	}
 );
 
-#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum WebkitFunctionalPseudoElement<'a> {
 	Distributed(WebkitDistrubutedFunctionalPseudoElement<'a>),
 }
@@ -96,22 +96,22 @@ impl<'a> Parse<'a> for WebkitFunctionalPseudoElement<'a> {
 	}
 }
 
-#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct WebkitDistrubutedFunctionalPseudoElement<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub colons: T![::],
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub function: T![Function],
 	pub value: CompoundSelector<'a>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: Option<T![')']>,
 }
 
-#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
 pub enum WebkitFunctionalPseudoClass<'a> {
 	Any(WebkitAnyFunctionalPseudoClass<'a>),
 }
@@ -131,9 +131,9 @@ impl<'a> Parse<'a> for WebkitFunctionalPseudoClass<'a> {
 	}
 }
 
-#[derive(ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct WebkitAnyFunctionalPseudoClass<'a> {
 	pub colon: T![:],
 	pub function: T![Function],
@@ -143,9 +143,9 @@ pub struct WebkitAnyFunctionalPseudoClass<'a> {
 
 pseudo_class!(
 	/// <https://searchfox.org/wubkat/source/Source/WebCore/css/CSSPseudoSelectors.json>
-	#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+	#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-	#[visit(self)]
+	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 	pub enum WebkitPseudoClass {
 		AnimatingFullScreenTransition: CssAtomSet::_WebkitAnimatingFullScreenTransition,
 		AnyLink: CssAtomSet::_WebkitAnyLink,  // Alias for :anyLink

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -2,7 +2,7 @@ use crate::{CssAtomSet, CssDiagnostic, SelectorList, StyleValue, UnknownAtRule, 
 use css_parse::{
 	BadDeclaration, Cursor, Diagnostic, Parse, Parser, QualifiedRule, Result as ParserResult, RuleVariants,
 };
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 /// Represents a "Style Rule", such as `body { width: 100% }`. See also the CSS-OM [CSSStyleRule][1] interface.
 ///
@@ -10,9 +10,9 @@ use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
 /// Each [Declaration][css_parse::Declaration] will have a [StyleValue], and each rule will be a [NestedGroupRule].
 ///
 /// [1]: https://drafts.csswg.org/cssom-1/#the-cssstylerule-interface
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct StyleRule<'a>(pub QualifiedRule<'a, SelectorList<'a>, StyleValue<'a>, NestedGroupRule<'a>>);
 
 // https://drafts.csswg.org/css-nesting/#conditionals
@@ -34,7 +34,8 @@ macro_rules! nested_group_rule {
     )+ ) => {
 		#[allow(clippy::large_enum_variant)] // TODO: Box?
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
-		#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 		pub enum NestedGroupRule<'a> {
 			$(

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -4,12 +4,12 @@ use css_parse::{
 	ComponentValues, Cursor, Diagnostic, Parse, Parser, QualifiedRule, Result as ParserResult, RuleVariants,
 	StyleSheet as StyleSheetTrait, T,
 };
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 // https://drafts.csswg.org/cssom-1/#the-cssstylesheet-interface
-#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct StyleSheet<'a> {
 	pub rules: Vec<'a, Rule<'a>>,
 }
@@ -61,18 +61,18 @@ macro_rules! apply_rules {
 	};
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct UnknownAtRule<'a> {
 	name: T![AtKeyword],
 	prelude: ComponentValues<'a>,
 	block: ComponentValues<'a>,
 }
 
-#[derive(Parse, Peek, ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct UnknownQualifiedRule<'a>(QualifiedRule<'a, ComponentValues<'a>, StyleValue<'a>, ComponentValues<'a>>);
 
 macro_rules! rule {
@@ -81,7 +81,8 @@ macro_rules! rule {
     )+ ) => {
 		#[allow(clippy::large_enum_variant)] // TODO: Box?
 		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
-		#[derive(ToSpan, ToCursors, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 		pub enum Rule<'a> {
 			$(

--- a/crates/css_ast/src/test_helpers.rs
+++ b/crates/css_ast/src/test_helpers.rs
@@ -1,32 +1,35 @@
-use crate::visit::apply_visit_methods;
-
+#[cfg(feature = "visitable")]
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct TestVisitor {
 	pub visits: Vec<&'static str>,
 }
 
-macro_rules! visit_mut_trait {
-	( $(
-		$name: ident$(<$life:lifetime>)?($obj: ident$(<$olife:lifetime>)?),
-	)+ ) => {
-		impl $crate::VisitMut for TestVisitor {
-			$(
-				fn $name$(<$life>)?(&mut self, _rule: &mut $crate::$obj$(<$olife>)?) {
-					self.handle_visit(stringify!($obj));
-				}
-			)+
-		}
-	}
-}
-apply_visit_methods!(visit_mut_trait);
-
+#[cfg(feature = "visitable")]
 impl TestVisitor {
 	fn handle_visit(&mut self, type_name: &'static str) {
 		self.visits.push(type_name);
 	}
 }
 
+#[cfg(feature = "visitable")]
+macro_rules! visit_mut_trait {
+	( $(
+		$name: ident$(<$($gen:tt),+>)?($obj: ident$(<$($ogen:tt),+>)?),
+	)+ ) => {
+		impl $crate::VisitMut for TestVisitor {
+			$(
+				fn $name$(<$($gen),+>)?(&mut self, _rule: &mut $crate::$obj$(<$($ogen),+>)?) {
+					self.handle_visit(stringify!($obj));
+				}
+			)+
+		}
+	}
+}
+#[cfg(feature = "visitable")]
+crate::visit::apply_visit_methods!(visit_mut_trait);
+
 #[macro_export]
+#[cfg(feature = "visitable")]
 macro_rules! assert_visits {
 	($source: expr, $parse_type: ty $(, $visit_type: ty)* $(,)?) => {{
 		use bumpalo::Bump;

--- a/crates/css_ast/src/types/absolute_size.rs
+++ b/crates/css_ast/src/types/absolute_size.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <absolute-size> = [ xx-small | x-small | small | medium | large | x-large | xx-large ]
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum AbsoluteSize {
 	#[atom(CssAtomSet::XxSmall)]
 	XxSmall(T![Ident]),

--- a/crates/css_ast/src/types/anchor_name.rs
+++ b/crates/css_ast/src/types/anchor_name.rs
@@ -6,16 +6,15 @@ use super::prelude::*;
 /// <anchor-name> = <dashed-ident>
 /// ```
 #[syntax("<dashed-ident>")]
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct AnchorName;
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use crate::assert_visits;
 	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
@@ -34,7 +33,9 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
+		use crate::assert_visits;
 		assert_visits!("--foo", AnchorName, DashedIdent);
 	}
 }

--- a/crates/css_ast/src/types/animateable_feature.rs
+++ b/crates/css_ast/src/types/animateable_feature.rs
@@ -2,9 +2,9 @@ use super::prelude::*;
 
 // https://drafts.csswg.org/css-will-change-1/#typedef-animateable-feature
 // <animateable-feature> = scroll-position | contents | <custom-ident>
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum AnimateableFeature {
 	#[atom(CssAtomSet::ScrollPosition)]
 	ScrollPosition(T![Ident]),

--- a/crates/css_ast/src/types/attachment.rs
+++ b/crates/css_ast/src/types/attachment.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <attachment> = scroll | fixed | local
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum Attachment {
 	#[atom(CssAtomSet::Scroll)]
 	Scroll(T![Ident]),

--- a/crates/css_ast/src/types/auto_line_width_list.rs
+++ b/crates/css_ast/src/types/auto_line_width_list.rs
@@ -6,9 +6,9 @@ use super::prelude::*;
 /// <auto-line-width-list> = [ <line-width-or-repeat> ]* <auto-repeat-line-width> [ <line-width-or-repeat> ]*
 /// ```
 #[syntax(" [ <line-width-or-repeat> ]* <repeat()> [ <line-width-or-repeat> ]* ")]
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct AutoLineWidthList<'a>;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/auto_or.rs
+++ b/crates/css_ast/src/types/auto_or.rs
@@ -1,10 +1,11 @@
 use super::prelude::*;
 use css_parse::token_macros::Ident;
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub enum AutoOr<T> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Auto)]
 	Auto(Ident),
 	Some(T),

--- a/crates/css_ast/src/types/autonone_or.rs
+++ b/crates/css_ast/src/types/autonone_or.rs
@@ -1,13 +1,14 @@
 use super::prelude::*;
 use css_parse::token_macros::Ident;
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub enum AutoNoneOr<T> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Auto)]
 	Auto(Ident),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::None)]
 	None(Ident),
 	Some(T),

--- a/crates/css_ast/src/types/baseline_position.rs
+++ b/crates/css_ast/src/types/baseline_position.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <baseline-position> = [ first | last ]? && baseline
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum BaselinePosition {
 	#[atom(CssAtomSet::First)]
 	First(T![Ident]),

--- a/crates/css_ast/src/types/bg_clip.rs
+++ b/crates/css_ast/src/types/bg_clip.rs
@@ -7,9 +7,9 @@ use super::prelude::*;
 /// <bg-clip> = <visual-box> | border-area | text
 /// <visual-box> = <visual-box> | margin-box
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum BgClip {
 	#[atom(CssAtomSet::ContentBox)]
 	ContentBox(T![Ident]),

--- a/crates/css_ast/src/types/bg_size.rs
+++ b/crates/css_ast/src/types/bg_size.rs
@@ -6,9 +6,9 @@ use super::prelude::*;
 /// <bg-size> = [ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain
 /// ```
 #[syntax(" [ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain ")]
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum BgSize {}
 
 #[cfg(test)]
@@ -32,6 +32,7 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
 		use crate::assert_visits;
 		assert_visits!("12%", BgSize, LengthPercentage);

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -3,25 +3,25 @@ mod system;
 
 use crate::{ColorFunction, CssAtomSet};
 use css_parse::T;
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
 pub use named::*;
 pub use system::*;
 
-#[derive(Peek, Parse, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum Color {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Currentcolor)]
 	Currentcolor(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Transparent)]
 	Transparent(T![Ident]),
 	System(SystemColor),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	Hex(T![Hash]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	Named(NamedColor),
 	Function(ColorFunction),
 	// TODO: need bumpalo::Box PartialEq, or bumpalo::Box serde
@@ -76,7 +76,7 @@ impl ToChromashift for Color {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{Parser, assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
 	fn size_test() {
@@ -130,6 +130,7 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
 		use crate::assert_visits;
 		assert_visits!("#fff", Color);
@@ -147,6 +148,7 @@ mod tests {
 		use crate::CssAtomSet;
 		use bumpalo::Bump;
 		use chromashift::{Hex, Named, Srgb};
+		use css_parse::Parser;
 		let bump = Bump::default();
 
 		let source_text = "red";

--- a/crates/css_ast/src/types/color/named.rs
+++ b/crates/css_ast/src/types/color/named.rs
@@ -1,10 +1,10 @@
 use crate::CssAtomSet;
 use css_parse::T;
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
-#[derive(Peek, Parse, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum NamedColor {
 	#[atom(CssAtomSet::Aliceblue)]
 	Aliceblue(T![Ident]),

--- a/crates/css_ast/src/types/color/system.rs
+++ b/crates/css_ast/src/types/color/system.rs
@@ -1,10 +1,10 @@
 use crate::CssAtomSet;
 use css_parse::T;
-use csskit_derives::{Parse, Peek, ToCursors, ToSpan, Visitable};
+use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
 
-#[derive(Peek, Parse, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SystemColor {
 	#[atom(CssAtomSet::Accentcolor)]
 	Accentcolor(T![Ident]),

--- a/crates/css_ast/src/types/compat_auto.rs
+++ b/crates/css_ast/src/types/compat_auto.rs
@@ -8,9 +8,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <compat-auto> = searchfield | textarea | checkbox | radio | menulist | listbox | meter | progress-bar | button
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum CompatAuto {
 	#[atom(CssAtomSet::Search)]
 	Searchfield(T![Ident]),

--- a/crates/css_ast/src/types/compat_special.rs
+++ b/crates/css_ast/src/types/compat_special.rs
@@ -9,9 +9,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <compat-special> = textfield | menulist-button
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum CompatSpecial {
 	#[atom(CssAtomSet::Textfield)]
 	Textfield(T![Ident]),

--- a/crates/css_ast/src/types/content_distribution.rs
+++ b/crates/css_ast/src/types/content_distribution.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <content-distribution> = space-between | space-around | space-evenly | stretch
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum ContentDistribution {
 	#[atom(CssAtomSet::SpaceBetween)]
 	SpaceBetween(T![Ident]),

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -6,9 +6,9 @@ use crate::{AttrFunction, ContentFunction, Counter, Image, LeaderFunction, Quote
 /// ```text,ignore
 /// <content-list> = [ <string> | <image> | <attr()> | contents | <quote> | <leader()> | <target> | <string()> | <content()> | <counter> ]+
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct ContentList<'a>(pub Vec<'a, ContentListItem<'a>>);
 
 /// <https://drafts.csswg.org/css-content-3/#content-values>
@@ -16,17 +16,17 @@ pub struct ContentList<'a>(pub Vec<'a, ContentListItem<'a>>);
 /// ```text,ignore
 /// <content-list> = [ <string> | <image> | <attr()> | contents | <quote> | <leader()> | <target> | <string()> | <content()> | <counter> ]+
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum ContentListItem<'a> {
 	String(T![String]),
 	Image(Image<'a>),
 	AttrFunction(AttrFunction<'a>),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Contents)]
 	Contents(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	Quote(Quote),
 	// https://drafts.csswg.org/css-content-3/#leader-function
 	// leader() = leader( <leader-type> )
@@ -45,7 +45,6 @@ pub enum ContentListItem<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use crate::assert_visits;
 	use css_parse::assert_parse;
 
 	#[test]
@@ -74,7 +73,9 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
+		use crate::assert_visits;
 		assert_visits!("'some string'", ContentList, ContentListItem);
 		assert_visits!("url(dot.gif)", ContentList, ContentListItem, Image, Url);
 		assert_visits!("counter(foo,decimal)", ContentList, ContentListItem, CounterFunction);

--- a/crates/css_ast/src/types/content_position.rs
+++ b/crates/css_ast/src/types/content_position.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <content-position> = center | start | end | flex-start | flex-end
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum ContentPosition {
 	#[atom(CssAtomSet::Center)]
 	Center(T![Ident]),

--- a/crates/css_ast/src/types/coord_box.rs
+++ b/crates/css_ast/src/types/coord_box.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <coord-box> = <paint-box> | view-box
 /// ```
-#[derive(Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum CoordBox {
 	#[atom(CssAtomSet::ContentBox)]
 	ContentBox(T![Ident]),

--- a/crates/css_ast/src/types/corner_shape_value.rs
+++ b/crates/css_ast/src/types/corner_shape_value.rs
@@ -6,9 +6,9 @@ use super::prelude::*;
 /// <corner-shape-value> = round | scoop | bevel | notch | square | squircle | <superellipse()>
 /// ```
 #[syntax(" round | scoop | bevel | notch | square | squircle | <superellipse()> ")]
-#[derive(Peek, Parse, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum CornerShapeValue {}
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/counter_style.rs
+++ b/crates/css_ast/src/types/counter_style.rs
@@ -2,13 +2,13 @@ use super::prelude::*;
 
 use crate::SymbolsFunction;
 
-#[derive(Parse, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum CounterStyle<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	Predefined(PredefinedCounter),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	Named(T![Ident]),
 	SymbolsFunction(SymbolsFunction<'a>),
 }

--- a/crates/css_ast/src/types/cursor_image.rs
+++ b/crates/css_ast/src/types/cursor_image.rs
@@ -8,12 +8,12 @@ use crate::{ImageSetFunction, Url};
 /// ```
 ///
 /// `<url-set>` is a limited version of image-set(), where the `<image>` sub-production is restricted to `<url>` only.
-#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum CursorImage<'a> {
-	Url(Url, #[visit(skip)] Option<(T![Number], T![Number])>),
-	UrlSet(ImageSetFunction<'a>, #[visit(skip)] Option<(T![Number], T![Number])>),
+	Url(Url, #[cfg_attr(feature = "visitable", visit(skip))] Option<(T![Number], T![Number])>),
+	UrlSet(ImageSetFunction<'a>, #[cfg_attr(feature = "visitable", visit(skip))] Option<(T![Number], T![Number])>),
 }
 
 impl<'a> Parse<'a> for CursorImage<'a> {
@@ -44,7 +44,6 @@ impl<'a> Parse<'a> for CursorImage<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use crate::assert_visits;
 	use css_parse::assert_parse;
 
 	#[test]
@@ -59,7 +58,9 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
+		use crate::assert_visits;
 		assert_visits!("url(hyper.cur)", CursorImage, Url);
 		assert_visits!("url(hyper.png) 2 3", CursorImage, Url);
 		assert_visits!("image-set(url('foo.jpg') 1x)", CursorImage, ImageSetFunction);

--- a/crates/css_ast/src/types/cursor_predefined.rs
+++ b/crates/css_ast/src/types/cursor_predefined.rs
@@ -6,9 +6,9 @@ use super::prelude::*;
 /// <cursor-predefined> = auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | grab | grabbing | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out
 /// ```
 ///
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum CursorPredefined {
 	#[atom(CssAtomSet::Auto)]
 	Auto(T![Ident]),

--- a/crates/css_ast/src/types/custom_ident.rs
+++ b/crates/css_ast/src/types/custom_ident.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 /// <https://drafts.csswg.org/css-values/#custom-idents>
 ///
 /// Wraps `T![Ident]`, but exists for the purposes of Visitable/VisitableMut.
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct CustomIdent(T![Ident]);

--- a/crates/css_ast/src/types/dashed_ident.rs
+++ b/crates/css_ast/src/types/dashed_ident.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 /// <https://drafts.csswg.org/css-values/#dashed-idents>
 ///
 /// Wraps `T![DashedIdent]`, but exists for the purposes of Visitable/VisitableMut.
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct DashedIdent(T![DashedIdent]);

--- a/crates/css_ast/src/types/display_inside.rs
+++ b/crates/css_ast/src/types/display_inside.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <display-inside> = flow | flow-root | table | flex | grid | ruby
 /// ```
-#[derive(Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DisplayInside {
 	#[atom(CssAtomSet::Flow)]
 	Flow(T![Ident]),

--- a/crates/css_ast/src/types/display_outside.rs
+++ b/crates/css_ast/src/types/display_outside.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <display-outside>  = block | inline | run-in
 /// ```
-#[derive(Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DisplayOutside {
 	#[atom(CssAtomSet::Block)]
 	Block(T![Ident]),

--- a/crates/css_ast/src/types/family_name.rs
+++ b/crates/css_ast/src/types/family_name.rs
@@ -6,16 +6,15 @@ use super::prelude::*;
 /// <family-name> = <string> | <custom-ident>+
 /// ```
 #[syntax(" <string> | <custom-ident>+ ")]
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum FamilyName<'a> {}
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use crate::assert_visits;
 	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
@@ -34,7 +33,9 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
+		use crate::assert_visits;
 		assert_visits!("'foo'", FamilyName);
 		assert_visits!("foo bar", FamilyName, CustomIdent, CustomIdent);
 	}

--- a/crates/css_ast/src/types/font_weight_absolute.rs
+++ b/crates/css_ast/src/types/font_weight_absolute.rs
@@ -6,9 +6,9 @@ use super::prelude::*;
 /// <font-weight-absolute> = [normal | bold | <number [1,1000]>]
 /// ```
 #[syntax(" normal | bold | <number [1,1000]> ")]
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum FontWeightAbsolute {}
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/generic_family.rs
+++ b/crates/css_ast/src/types/generic_family.rs
@@ -9,9 +9,9 @@ use super::prelude::*;
 /// <generic-incomplete> = ui-serif | ui-sans-serif | ui-monospace | ui-rounded
 /// ```
 #[syntax(" <generic-script-specific> | <generic-complete> | <generic-incomplete> ")]
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum GenericFamily {}
 
 /// <https://drafts.csswg.org/css-fonts-4/#family-name-syntax>

--- a/crates/css_ast/src/types/grid_line.rs
+++ b/crates/css_ast/src/types/grid_line.rs
@@ -4,9 +4,9 @@ use css_parse::parse_optionals;
 
 // https://drafts.csswg.org/css-grid-2/#typedef-grid-row-start-grid-line
 // <grid-line> = auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]
-#[derive(Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum GridLine {
 	Auto(T![Ident]),
 	Span(T![Ident], Option<PositiveNonZeroInt>, Option<T![Ident]>),

--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -7,9 +7,9 @@ use crate::{Gradient, Url};
 /// ```text
 /// <image> = <url> | <gradient>
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum Image<'a> {
 	Url(Url),
 	Gradient(Gradient<'a>),
@@ -19,7 +19,6 @@ pub enum Image<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use crate::assert_visits;
 	use css_parse::assert_parse;
 
 	#[test]
@@ -35,7 +34,9 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
+		use crate::assert_visits;
 		assert_visits!("url('foo')", Image, Url);
 		assert_visits!("linear-gradient(red, blue)", Image, Gradient, LinearGradientFunction);
 	}

--- a/crates/css_ast/src/types/image_1d.rs
+++ b/crates/css_ast/src/types/image_1d.rs
@@ -6,9 +6,9 @@ use crate::StripesFunction;
 // <image-1D> = <stripes()>
 // <stripes()> = stripes( <color-stripe># )
 // <color-stripe> = <color> && [ <length-percentage> | <flex> ]?
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct Image1D<'a>(StripesFunction<'a>);
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/layout_box.rs
+++ b/crates/css_ast/src/types/layout_box.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <layout-box> = <visual-box> | margin-box
 /// ```
-#[derive(Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum LayoutBox {
 	#[atom(CssAtomSet::ContentBox)]
 	ContentBox(T![Ident]),

--- a/crates/css_ast/src/types/line_style.rs
+++ b/crates/css_ast/src/types/line_style.rs
@@ -1,8 +1,8 @@
 use super::prelude::*;
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum LineStyle {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/types/line_width_list.rs
+++ b/crates/css_ast/src/types/line_width_list.rs
@@ -6,9 +6,9 @@ use super::prelude::*;
 /// <line-width-list> = [ <line-width-or-repeat> ]+
 /// ```
 #[syntax(" [ <line-width-or-repeat> ]+ ")]
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct LineWidthList<'a>;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/line_width_or_repeat.rs
+++ b/crates/css_ast/src/types/line_width_or_repeat.rs
@@ -6,9 +6,9 @@ use super::prelude::*;
 /// <line-width-or-repeat> = [ <line-width> | <repeat-line-width> ]
 /// ```
 #[syntax(" <line-width> | <repeat()> ")]
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum LineWidthOrRepeat<'a> {}
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/mod.rs
+++ b/crates/css_ast/src/types/mod.rs
@@ -162,6 +162,6 @@ mod prelude {
 	pub(crate) use css_parse::{
 		Cursor, Diagnostic, Kind, Parse, Parser, Peek, Result as ParserResult, T, ToNumberValue,
 	};
-	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan, Visitable};
+	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan};
 	pub(crate) use csskit_proc_macro::syntax;
 }

--- a/crates/css_ast/src/types/none_or.rs
+++ b/crates/css_ast/src/types/none_or.rs
@@ -1,10 +1,11 @@
 use super::prelude::*;
 use css_parse::token_macros::Ident;
 
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub enum NoneOr<T> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::None)]
 	None(Ident),
 	Some(T),

--- a/crates/css_ast/src/types/opacity_value.rs
+++ b/crates/css_ast/src/types/opacity_value.rs
@@ -1,9 +1,9 @@
 use super::prelude::*;
 use crate::Percentage;
 
-#[derive(IntoCursor, Peek, Parse, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Peek, Parse, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum OpacityValue {
 	Number(#[in_range(0.0..=1.0)] T![Number]),
 	Percent(#[in_range(0.0..=100.0)] Percentage),

--- a/crates/css_ast/src/types/outline_style.rs
+++ b/crates/css_ast/src/types/outline_style.rs
@@ -9,9 +9,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <line-style> = none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum OutlineLineStyle {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/types/overflow_position.rs
+++ b/crates/css_ast/src/types/overflow_position.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <overflow-position> = unsafe | safe
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum OverflowPosition {
 	#[atom(CssAtomSet::Unsafe)]
 	Unsafe(T![Ident]),

--- a/crates/css_ast/src/types/paint_box.rs
+++ b/crates/css_ast/src/types/paint_box.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <paint-box> = <visual-box> | fill-box | stroke-box
 /// ```
-#[derive(Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum PaintBox {
 	#[atom(CssAtomSet::ContentBox)]
 	ContentBox(T![Ident]),

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -14,9 +14,9 @@ use css_parse::Token;
 //   [ [ left | right ] <length-percentage> ] &&
 //   [ [ top | bottom ] <length-percentage> ]
 // ]
-#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum Position {
 	SingleValue(PositionSingleValue),
 	TwoValue(PositionHorizontal, PositionVertical),
@@ -168,9 +168,9 @@ pub enum PositionVertical {
 	LengthPercentage(LengthPercentage),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum PositionHorizontalKeyword {
 	#[atom(CssAtomSet::Left)]
 	Left(T![Ident]),
@@ -178,9 +178,9 @@ pub enum PositionHorizontalKeyword {
 	Right(T![Ident]),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum PositionVerticalKeyword {
 	#[atom(CssAtomSet::Top)]
 	Top(T![Ident]),

--- a/crates/css_ast/src/types/position_area.rs
+++ b/crates/css_ast/src/types/position_area.rs
@@ -27,9 +27,9 @@ use super::prelude::*;
 // |
 //   [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}
 // ]
-#[derive(ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum PositionArea {
 	Physical(Option<PositionAreaPhsyicalHorizontal>, Option<PositionAreaPhsyicalVertical>),
 	Logical(Option<PositionAreaBlock>, Option<PositionAreaInline>),

--- a/crates/css_ast/src/types/quote.rs
+++ b/crates/css_ast/src/types/quote.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <quote> = open-quote | close-quote | no-open-quote | no-close-quote
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum Quote {
 	#[atom(CssAtomSet::OpenQuote)]
 	OpenQuote(T![Ident]),

--- a/crates/css_ast/src/types/ratio.rs
+++ b/crates/css_ast/src/types/ratio.rs
@@ -2,9 +2,9 @@ use super::prelude::*;
 use crate::units::CSSInt;
 
 // https://drafts.csswg.org/css-values-4/#ratios
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Ratio {
 	pub numerator: CSSInt,
 	pub slash: Option<T![/]>,

--- a/crates/css_ast/src/types/relative_size.rs
+++ b/crates/css_ast/src/types/relative_size.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <relative-size> = larger | smaller
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum RelativeSize {
 	#[atom(CssAtomSet::Larger)]
 	Larger(T![Ident]),

--- a/crates/css_ast/src/types/repeat_style.rs
+++ b/crates/css_ast/src/types/repeat_style.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <repeat-style> = repeat-x | repeat-y | <repetition>{1,2}
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum RepeatStyle {
 	#[atom(CssAtomSet::RepeatX)]
 	RepeatX(T![Ident]),
@@ -21,9 +21,9 @@ pub enum RepeatStyle {
 /// ```text,ignore
 /// <repetition> = repeat | space | round | no-repeat
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum Repetition {
 	#[atom(CssAtomSet::Repeat)]
 	Repeat(T![Ident]),

--- a/crates/css_ast/src/types/self_position.rs
+++ b/crates/css_ast/src/types/self_position.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <self-position> = center | start | end | self-start | self-end | flex-start | flex-end
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SelfPosition {
 	#[atom(CssAtomSet::Center)]
 	Center(T![Ident]),

--- a/crates/css_ast/src/types/shadow.rs
+++ b/crates/css_ast/src/types/shadow.rs
@@ -3,15 +3,15 @@ use crate::{Color, Length};
 
 // https://drafts.csswg.org/css-backgrounds-3/#typedef-shadow
 // <shadow> = <color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?
-#[derive(ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct Shadow {
 	pub color: Option<Color>,
 	pub offset: (Length, Length),
 	pub blur_radius: Option<Length>,
 	pub spread_radius: Option<Length>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub inset: Option<T![Ident]>,
 }
 
@@ -53,7 +53,6 @@ impl<'a> Parse<'a> for Shadow {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use crate::assert_visits;
 	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
@@ -98,7 +97,9 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
+		use crate::assert_visits;
 		assert_visits!("10px 20px", Shadow, Length, Length);
 		assert_visits!("red 10px 20px", Shadow, Color, Length, Length);
 		assert_visits!("10px 20px 5px", Shadow, Length, Length, Length);

--- a/crates/css_ast/src/types/single_animation_composition.rs
+++ b/crates/css_ast/src/types/single_animation_composition.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-composition> = replace | add | accumulate
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SingleAnimationComposition {
 	#[atom(CssAtomSet::Replace)]
 	Replace(T![Ident]),

--- a/crates/css_ast/src/types/single_animation_direction.rs
+++ b/crates/css_ast/src/types/single_animation_direction.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-direction> = normal | reverse | alternate | alternate-reverse
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SingleAnimationDirection {
 	#[atom(CssAtomSet::Normal)]
 	Normal(T![Ident]),

--- a/crates/css_ast/src/types/single_animation_fill_mode.rs
+++ b/crates/css_ast/src/types/single_animation_fill_mode.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-fill-mode> = none | forwards | backwards | both
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SingleAnimationFillMode {
 	#[atom(CssAtomSet::None)]
 	None(T![Ident]),

--- a/crates/css_ast/src/types/single_animation_iteration_count.rs
+++ b/crates/css_ast/src/types/single_animation_iteration_count.rs
@@ -2,9 +2,9 @@ use super::prelude::*;
 
 // https://drafts.csswg.org/css-animations/#typedef-single-animation-iteration-count
 // <single-animation-iteration-count> = infinite | <number [0,∞]>
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SingleAnimationIterationCount {
 	#[atom(CssAtomSet::Infinite)]
 	Infinite(T![Ident]),

--- a/crates/css_ast/src/types/single_animation_play_state.rs
+++ b/crates/css_ast/src/types/single_animation_play_state.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-play-state> = running | paused
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SingleAnimationPlayState {
 	#[atom(CssAtomSet::Running)]
 	Running(T![Ident]),

--- a/crates/css_ast/src/types/single_animation_timeline.rs
+++ b/crates/css_ast/src/types/single_animation_timeline.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-timeline> = auto | none | <dashed-ident> | <scroll()> | <view()>
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SingleAnimationTimeline {
 	#[atom(CssAtomSet::Auto)]
 	Auto(T![Ident]),

--- a/crates/css_ast/src/types/single_animation_trigger_behavior.rs
+++ b/crates/css_ast/src/types/single_animation_trigger_behavior.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-trigger-behavior> = once | repeat | alternate | state
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SingleAnimationTriggerBehavior {
 	#[atom(CssAtomSet::Once)]
 	Once(T![Ident]),

--- a/crates/css_ast/src/types/single_animation_trigger_type.rs
+++ b/crates/css_ast/src/types/single_animation_trigger_type.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-trigger-type> = once | repeat | alternate | state
 /// ```
-#[derive(Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum SingleAnimationTriggerType {
 	#[atom(CssAtomSet::Once)]
 	Once(T![Ident]),

--- a/crates/css_ast/src/types/single_transition.rs
+++ b/crates/css_ast/src/types/single_transition.rs
@@ -4,16 +4,16 @@ use css_parse::parse_optionals;
 
 // https://drafts.csswg.org/css-transitions-2/#single-transition
 // <single-transition> = [ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>
-#[derive(ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct SingleTransition<'a> {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub property: Option<NoneOr<SingleTransitionProperty>>,
 	pub duration: Option<Time>,
 	pub easing: Option<EasingFunction<'a>>,
 	pub delay: Option<Time>,
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub behavior: Option<TransitionBehaviorValue>,
 }
 
@@ -34,7 +34,6 @@ impl<'a> Parse<'a> for SingleTransition<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use crate::assert_visits;
 	use css_parse::{assert_parse, assert_parse_error};
 
 	type NoneOrSingleTransitionProperty = NoneOr<SingleTransitionProperty>;
@@ -85,7 +84,9 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
+		use crate::assert_visits;
 		assert_visits!("1s", SingleTransition, Time);
 		assert_visits!("ease-in", SingleTransition, EasingFunction);
 		assert_visits!("1s 2s", SingleTransition, Time, Time);

--- a/crates/css_ast/src/types/single_transition_property.rs
+++ b/crates/css_ast/src/types/single_transition_property.rs
@@ -2,9 +2,9 @@ use super::prelude::*;
 
 // https://drafts.csswg.org/css-transitions-1/#single-transition-property
 // <single-transition-property> = all | <custom-ident>
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum SingleTransitionProperty {
 	#[atom(CssAtomSet::All)]
 	All(T![Ident]),

--- a/crates/css_ast/src/types/spacing_trim.rs
+++ b/crates/css_ast/src/types/spacing_trim.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <spacing-trim> = space-all | normal | space-first | trim-start | trim-both | trim-all
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum SpacingTrim {
 	#[atom(CssAtomSet::SpaceAll)]
 	SpaceAll(T![Ident]),

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -4,16 +4,15 @@ use crate::TransformFunction;
 
 // https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
 // <transform-list> = <transform-function>+
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub struct TransformList<'a>(pub Vec<'a, TransformFunction>);
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use crate::assert_visits;
 	use css_parse::{assert_parse, assert_parse_error};
 
 	#[test]
@@ -52,7 +51,9 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "visitable")]
 	fn test_visits() {
+		use crate::assert_visits;
 		assert_visits!("scale(2)", TransformList, TransformFunction, ScaleFunction);
 		assert_visits!(
 			"rotate(45deg) scale(2)",

--- a/crates/css_ast/src/types/transition_behavior_value.rs
+++ b/crates/css_ast/src/types/transition_behavior_value.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <transition-behavior-value> = normal | allow-discrete
 /// ```
-#[derive(Parse, Peek, ToCursors, ToSpan, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum TransitionBehaviorValue {
 	#[atom(CssAtomSet::Normal)]
 	Normal(T![Ident]),

--- a/crates/css_ast/src/types/try_size.rs
+++ b/crates/css_ast/src/types/try_size.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <try-size> = most-width | most-height | most-block-size | most-inline-size
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum TrySize {
 	#[atom(CssAtomSet::MostWidth)]
 	MostWidth(T![Ident]),

--- a/crates/css_ast/src/types/visual_box.rs
+++ b/crates/css_ast/src/types/visual_box.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <visual-box> = content-box | padding-box | border-box
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum VisualBox {
 	#[atom(CssAtomSet::ContentBox)]
 	ContentBox(T![Ident]),

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -1,10 +1,10 @@
 use super::prelude::*;
 
 // https://drafts.csswg.org/css-values/#angles
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.types.angle"))]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum Angle {
 	#[atom(CssAtomSet::Grad)]
 	Grad(T![Dimension]),
@@ -48,21 +48,21 @@ impl Angle {
 	}
 }
 
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub enum AngleOrZero {
 	Angle(Angle),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	Zero(#[in_range(0.0..=0.0)] T![Number]),
 }
 
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub enum AngleOrNumber {
 	Angle(Angle),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	Number(T![Number]),
 }
 

--- a/crates/css_ast/src/units/decibel.rs
+++ b/crates/css_ast/src/units/decibel.rs
@@ -1,8 +1,8 @@
 use super::prelude::*;
 
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Decibel(#[atom(CssAtomSet::Db)] T![Dimension]);
 
 impl From<Decibel> for f32 {

--- a/crates/css_ast/src/units/flex.rs
+++ b/crates/css_ast/src/units/flex.rs
@@ -1,9 +1,9 @@
 use super::prelude::*;
 
 // https://www.w3.org/TR/css-grid-2/#typedef-flex
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Flex(#[atom(CssAtomSet::Fr)] T![Dimension]);
 
 impl ToNumberValue for Flex {

--- a/crates/css_ast/src/units/int.rs
+++ b/crates/css_ast/src/units/int.rs
@@ -1,8 +1,8 @@
 use super::prelude::*;
 
-#[derive(IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub struct CSSInt(T![Number]);
 
 impl CSSInt {

--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -66,9 +66,9 @@ macro_rules! apply_lengths {
 
 macro_rules! define_length {
 	( $($name: ident),+ $(,)* ) => {
-		#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-		#[visit(self)]
+		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 		pub enum Length {
 			Zero(#[in_range(0.0..0.0)] T![Number]),
 			$(
@@ -129,9 +129,9 @@ impl ToNumberValue for Length {
 	}
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum LengthPercentage {
 	Zero(#[in_range(0.0..0.0)] T![Number]),
 	Length(Length),
@@ -154,19 +154,19 @@ impl ToNumberValue for LengthPercentage {
 	}
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub enum LengthPercentageOrFlex {
 	Flex(Flex),
 	LengthPercentage(LengthPercentage),
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum NumberLength {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	Number(T![Number]),
 	Length(Length),
 }

--- a/crates/css_ast/src/units/line_width.rs
+++ b/crates/css_ast/src/units/line_width.rs
@@ -2,17 +2,17 @@ use super::prelude::*;
 
 use super::Length;
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum LineWidth {
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Thin)]
 	Thin(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Medium)]
 	Medium(T![Ident]),
-	#[visit(skip)]
+	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Thick)]
 	Thick(T![Ident]),
 	Length(Length),

--- a/crates/css_ast/src/units/mod.rs
+++ b/crates/css_ast/src/units/mod.rs
@@ -29,7 +29,7 @@ pub use time::*;
 mod prelude {
 	pub(crate) use crate::{CssAtomSet, CssDiagnostic};
 	pub(crate) use css_parse::{Cursor, Diagnostic, Parse, Parser, Peek, Result as ParserResult, T, ToNumberValue};
-	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, Visitable};
+	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, ToCursors};
 }
 
 pub trait AbsoluteUnit {

--- a/crates/css_ast/src/units/percentage.rs
+++ b/crates/css_ast/src/units/percentage.rs
@@ -1,8 +1,8 @@
 use super::prelude::*;
 
-#[derive(Peek, Parse, IntoCursor, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub struct Percentage(#[atom(CssAtomSet::Percentage)] T![Dimension]);
 
 impl Percentage {
@@ -29,9 +29,9 @@ impl ToNumberValue for Percentage {
 	}
 }
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum NumberPercentage {
 	Number(T![Number]),
 	Percentage(Percentage),

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -1,9 +1,9 @@
 use super::prelude::*;
 
 // https://drafts.csswg.org/css-values/#resolution
-#[derive(IntoCursor, Parse, Peek, ToCursors, Visitable, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(self)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 pub enum Time {
 	Zero(#[in_range(0.0..0.0)] T![Number]),
 	#[atom(CssAtomSet::Ms)]

--- a/crates/css_ast/src/values/align/mod.rs
+++ b/crates/css_ast/src/values/align/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-align-3/#align-content
 #[syntax(" normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "block containers, multicol containers, flex containers, and grid containers",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.align-content"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum AlignContentStyleValue {}
 
 // /// Represents the style value for `justify-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-content).
@@ -45,7 +45,7 @@ pub enum AlignContentStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-align-3/#justify-content
 // #[syntax(" normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "multicol containers, flex containers, and grid containers",
@@ -56,7 +56,7 @@ pub enum AlignContentStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.justify-content"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum JustifyContentStyleValue {}
 
 // /// Represents the style value for `place-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-content).
@@ -71,7 +71,7 @@ pub enum AlignContentStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-align-3/#place-content
 // #[syntax(" <'align-content'> <'justify-content'>? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "see individual properties",
@@ -82,7 +82,7 @@ pub enum AlignContentStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.place-content"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct PlaceContentStyleValue;
 
 // /// Represents the style value for `justify-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-self).
@@ -97,7 +97,7 @@ pub enum AlignContentStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-align-3/#justify-self
 // #[syntax(" auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "block-level boxes, absolutely-positioned boxes, and grid items",
@@ -108,7 +108,7 @@ pub enum AlignContentStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.justify-self"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum JustifySelfStyleValue {}
 
 /// Represents the style value for `align-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#align-self).
@@ -123,7 +123,7 @@ pub enum AlignContentStyleValue {}
 ///
 // https://drafts.csswg.org/css-align-3/#align-self
 #[syntax(" auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "flex items, grid items, and absolutely-positioned boxes",
@@ -134,7 +134,7 @@ pub enum AlignContentStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.align-self"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum AlignSelfStyleValue {}
 
 // /// Represents the style value for `place-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-self).
@@ -149,7 +149,7 @@ pub enum AlignSelfStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-align-3/#place-self
 // #[syntax(" <'align-self'> <'justify-self'>? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "see individual properties",
@@ -160,7 +160,7 @@ pub enum AlignSelfStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.place-self"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct PlaceSelfStyleValue;
 
 // /// Represents the style value for `justify-items` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-items).
@@ -177,7 +177,7 @@ pub enum AlignSelfStyleValue {}
 // #[syntax(
 // 	" normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "legacy",
 //   applies_to = "all elements",
@@ -188,7 +188,7 @@ pub enum AlignSelfStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.justify-items"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum JustifyItemsStyleValue {}
 
 // /// Represents the style value for `align-items` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#align-items).
@@ -203,7 +203,7 @@ pub enum AlignSelfStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-align-3/#align-items
 // #[syntax(" normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements",
@@ -214,7 +214,7 @@ pub enum AlignSelfStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.align-items"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum AlignItemsStyleValue {}
 
 // /// Represents the style value for `place-items` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-items).
@@ -229,7 +229,7 @@ pub enum AlignSelfStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-align-3/#place-items
 // #[syntax(" <'align-items'> <'justify-items'>? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "all elements",
@@ -240,7 +240,7 @@ pub enum AlignSelfStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.place-items"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct PlaceItemsStyleValue;
 
 /// Represents the style value for `row-gap` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#row-gap).
@@ -255,7 +255,7 @@ pub enum AlignSelfStyleValue {}
 ///
 // https://drafts.csswg.org/css-align-3/#row-gap
 #[syntax(" normal | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "multi-column containers, flex containers, grid containers",
@@ -266,7 +266,7 @@ pub enum AlignSelfStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-gap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RowGapStyleValue {}
 
 /// Represents the style value for `column-gap` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#column-gap).
@@ -281,7 +281,7 @@ pub enum RowGapStyleValue {}
 ///
 // https://drafts.csswg.org/css-align-3/#column-gap
 #[syntax(" normal | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "multi-column containers, flex containers, grid containers",
@@ -292,7 +292,7 @@ pub enum RowGapStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-gap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnGapStyleValue {}
 
 /// Represents the style value for `gap` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#gap).
@@ -307,7 +307,7 @@ pub enum ColumnGapStyleValue {}
 ///
 // https://drafts.csswg.org/css-align-3/#gap
 #[syntax(" <'row-gap'> <'column-gap'>? ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "multi-column containers, flex containers, grid containers",
@@ -318,5 +318,5 @@ pub enum ColumnGapStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.gap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct GapStyleValue;

--- a/crates/css_ast/src/values/anchor_position/mod.rs
+++ b/crates/css_ast/src/values/anchor_position/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-anchor-position-2/#anchor-name
 #[syntax(" none | <dashed-ident># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements that generate a principal box",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.anchor-name"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnchorNameStyleValue<'a>;
 
 /// Represents the style value for `anchor-scope` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#anchor-scope).
@@ -45,7 +45,7 @@ pub struct AnchorNameStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-anchor-position-2/#anchor-scope
 #[syntax(" none | all | <dashed-ident># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -56,7 +56,7 @@ pub struct AnchorNameStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.anchor-scope"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum AnchorScopeStyleValue<'a> {}
 
 /// Represents the style value for `position-anchor` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-anchor).
@@ -71,7 +71,7 @@ pub enum AnchorScopeStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-anchor-position-2/#position-anchor
 #[syntax(" auto | <anchor-name> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "absolutely positioned boxes",
@@ -82,7 +82,7 @@ pub enum AnchorScopeStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position-anchor"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PositionAnchorStyleValue;
 
 /// Represents the style value for `position-area` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-area).
@@ -97,7 +97,7 @@ pub struct PositionAnchorStyleValue;
 ///
 // https://drafts.csswg.org/css-anchor-position-2/#position-area
 #[syntax(" none | <position-area> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "positioned boxes with a default anchor box",
@@ -108,7 +108,7 @@ pub struct PositionAnchorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position-area"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PositionAreaStyleValue;
 
 // /// Represents the style value for `position-try-fallbacks` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-try-fallbacks).
@@ -123,7 +123,7 @@ pub struct PositionAreaStyleValue;
 // ///
 // // https://drafts.csswg.org/css-anchor-position-2/#position-try-fallbacks
 // #[syntax(" none | [ [<dashed-ident> || <try-tactic>] | <position-area> ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "absolutely positioned boxes",
@@ -134,7 +134,7 @@ pub struct PositionAreaStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position-try-fallbacks"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum PositionTryFallbacksStyleValue<'a> {}
 
 /// Represents the style value for `position-try-order` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-try-order).
@@ -149,7 +149,7 @@ pub struct PositionAreaStyleValue;
 ///
 // https://drafts.csswg.org/css-anchor-position-2/#position-try-order
 #[syntax(" normal | <try-size> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "absolutely positioned boxes",
@@ -160,7 +160,7 @@ pub struct PositionAreaStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position-try-order"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum PositionTryOrderStyleValue {}
 
 // /// Represents the style value for `position-try` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-try).
@@ -175,7 +175,7 @@ pub enum PositionTryOrderStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-anchor-position-2/#position-try
 // #[syntax(" <'position-try-order'>? <'position-try-fallbacks'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -186,7 +186,7 @@ pub enum PositionTryOrderStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position-try"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct PositionTryStyleValue;
 
 // /// Represents the style value for `position-visibility` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-visibility).
@@ -201,7 +201,7 @@ pub enum PositionTryOrderStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-anchor-position-2/#position-visibility
 // #[syntax(" always | [ anchors-valid || anchors-visible || no-overflow ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "anchors-visible",
 //   applies_to = "absolutely positioned boxes",
@@ -212,5 +212,5 @@ pub enum PositionTryOrderStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position-visibility"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum PositionVisibilityStyleValue {}

--- a/crates/css_ast/src/values/animations/mod.rs
+++ b/crates/css_ast/src/values/animations/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-name
 #[syntax(" [ none | <keyframes-name> ]# ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-name"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationNameStyleValue<'a>;
 
 /// Represents the style value for `animation-duration` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-duration).
@@ -45,7 +45,7 @@ pub struct AnimationNameStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-duration
 #[syntax(" [ auto | <time [0s,∞]> ]# ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -56,7 +56,7 @@ pub struct AnimationNameStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-duration"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationDurationStyleValue<'a>;
 
 /// Represents the style value for `animation-timing-function` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-timing-function).
@@ -71,7 +71,7 @@ pub struct AnimationDurationStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-timing-function
 #[syntax(" <easing-function># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "ease",
 	applies_to = "all elements",
@@ -82,7 +82,7 @@ pub struct AnimationDurationStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-timing-function"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationTimingFunctionStyleValue<'a>;
 
 /// Represents the style value for `animation-iteration-count` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-iteration-count).
@@ -97,7 +97,7 @@ pub struct AnimationTimingFunctionStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-iteration-count
 #[syntax(" <single-animation-iteration-count># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "1",
 	applies_to = "all elements",
@@ -108,7 +108,7 @@ pub struct AnimationTimingFunctionStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-iteration-count"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationIterationCountStyleValue<'a>;
 
 /// Represents the style value for `animation-direction` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-direction).
@@ -123,7 +123,7 @@ pub struct AnimationIterationCountStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-direction
 #[syntax(" <single-animation-direction># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -134,7 +134,7 @@ pub struct AnimationIterationCountStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-direction"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationDirectionStyleValue<'a>;
 
 /// Represents the style value for `animation-play-state` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-play-state).
@@ -149,7 +149,7 @@ pub struct AnimationDirectionStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-play-state
 #[syntax(" <single-animation-play-state># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "running",
 	applies_to = "all elements",
@@ -160,7 +160,7 @@ pub struct AnimationDirectionStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-play-state"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationPlayStateStyleValue<'a>;
 
 /// Represents the style value for `animation-delay` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-delay).
@@ -175,7 +175,7 @@ pub struct AnimationPlayStateStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-delay
 #[syntax(" <time># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0s",
 	applies_to = "all elements",
@@ -186,7 +186,7 @@ pub struct AnimationPlayStateStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-delay"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationDelayStyleValue<'a>;
 
 /// Represents the style value for `animation-fill-mode` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-fill-mode).
@@ -201,7 +201,7 @@ pub struct AnimationDelayStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-fill-mode
 #[syntax(" <single-animation-fill-mode># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -212,7 +212,7 @@ pub struct AnimationDelayStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-fill-mode"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationFillModeStyleValue<'a>;
 
 // /// Represents the style value for `animation` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation).
@@ -227,7 +227,7 @@ pub struct AnimationFillModeStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-animations-2/#animation
 // #[syntax(" <single-animation># ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "all elements",
@@ -238,7 +238,7 @@ pub struct AnimationFillModeStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct AnimationStyleValue<'a>;
 
 /// Represents the style value for `animation-composition` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-composition).
@@ -253,7 +253,7 @@ pub struct AnimationFillModeStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-composition
 #[syntax(" <single-animation-composition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "replace",
 	applies_to = "all elements",
@@ -264,7 +264,7 @@ pub struct AnimationFillModeStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-composition"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationCompositionStyleValue<'a>;
 
 /// Represents the style value for `animation-timeline` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-timeline).
@@ -279,7 +279,7 @@ pub struct AnimationCompositionStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-timeline
 #[syntax(" <single-animation-timeline># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -290,7 +290,7 @@ pub struct AnimationCompositionStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-timeline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationTimelineStyleValue<'a>;
 
 /// Represents the style value for `animation-trigger-behavior` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-behavior).
@@ -303,7 +303,7 @@ pub struct AnimationTimelineStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-trigger-behavior
 #[syntax(" <single-animation-trigger-behavior># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "once",
 	applies_to = "all elements",
@@ -318,7 +318,7 @@ pub struct AnimationTimelineStyleValue<'a>;
 	derive(ToCSSFeature),
 	css_feature("css.properties.animation-trigger-behavior")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationTriggerBehaviorStyleValue<'a>;
 
 /// Represents the style value for `animation-trigger-timeline` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-timeline).
@@ -331,7 +331,7 @@ pub struct AnimationTriggerBehaviorStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-trigger-timeline
 #[syntax(" <single-animation-timeline># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -346,7 +346,7 @@ pub struct AnimationTriggerBehaviorStyleValue<'a>;
 	derive(ToCSSFeature),
 	css_feature("css.properties.animation-trigger-timeline")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationTriggerTimelineStyleValue<'a>;
 
 // /// Represents the style value for `animation-trigger-range` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-range).
@@ -359,7 +359,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-animations-2/#animation-trigger-range
 // #[syntax(" [ <'animation-trigger-range-start'> <'animation-trigger-range-end'>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -370,7 +370,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-range"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct AnimationTriggerRangeStyleValue<'a>;
 
 // /// Represents the style value for `animation-trigger-range-start` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-range-start).
@@ -383,7 +383,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-animations-2/#animation-trigger-range-start
 // #[syntax(" [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements",
@@ -394,7 +394,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-range-start"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct AnimationTriggerRangeStartStyleValue<'a>;
 
 // /// Represents the style value for `animation-trigger-range-end` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-range-end).
@@ -407,7 +407,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-animations-2/#animation-trigger-range-end
 // #[syntax(" [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements",
@@ -418,7 +418,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-range-end"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct AnimationTriggerRangeEndStyleValue<'a>;
 
 // /// Represents the style value for `animation-trigger-exit-range` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range).
@@ -431,7 +431,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range
 // #[syntax(" [ <'animation-trigger-exit-range-start'> <'animation-trigger-exit-range-end'>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -442,7 +442,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-exit-range"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct AnimationTriggerExitRangeStyleValue<'a>;
 
 // /// Represents the style value for `animation-trigger-exit-range-start` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-start).
@@ -455,7 +455,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-start
 // #[syntax(" [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "all elements",
@@ -466,7 +466,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-exit-range-start"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct AnimationTriggerExitRangeStartStyleValue<'a>;
 
 // /// Represents the style value for `animation-trigger-exit-range-end` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-end).
@@ -479,7 +479,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-end
 // #[syntax(" [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "all elements",
@@ -490,7 +490,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-exit-range-end"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct AnimationTriggerExitRangeEndStyleValue<'a>;
 
 /// Represents the style value for `animation-trigger` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger).
@@ -503,7 +503,7 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-animations-2/#animation-trigger
 #[syntax(" <single-animation-trigger># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "all elements",
@@ -514,5 +514,5 @@ pub struct AnimationTriggerTimelineStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationTriggerStyleValue<'a>;

--- a/crates/css_ast/src/values/backgrounds/mod.rs
+++ b/crates/css_ast/src/values/backgrounds/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-color
 #[syntax(" <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "transparent",
 	applies_to = "all elements",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundColorStyleValue;
 
 /// Represents the style value for `background-image` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-image).
@@ -45,7 +45,7 @@ pub struct BackgroundColorStyleValue;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-image
 #[syntax(" <bg-image># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -56,7 +56,7 @@ pub struct BackgroundColorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-image"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundImageStyleValue<'a>;
 
 /// Represents the style value for `background-repeat` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat).
@@ -71,7 +71,7 @@ pub struct BackgroundImageStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-repeat
 #[syntax(" <repeat-style># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "repeat",
 	applies_to = "all elements",
@@ -82,7 +82,7 @@ pub struct BackgroundImageStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundRepeatStyleValue<'a>;
 
 /// Represents the style value for `background-attachment` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-attachment).
@@ -97,7 +97,7 @@ pub struct BackgroundRepeatStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-attachment
 #[syntax(" <attachment># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "scroll",
 	applies_to = "all elements",
@@ -108,7 +108,7 @@ pub struct BackgroundRepeatStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-attachment"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundAttachmentStyleValue<'a>;
 
 // /// Represents the style value for `background-position` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position).
@@ -123,7 +123,7 @@ pub struct BackgroundAttachmentStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-backgrounds-4/#background-position
 // #[syntax(" <bg-position># ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0% 0%",
 //   applies_to = "all elements",
@@ -134,7 +134,7 @@ pub struct BackgroundAttachmentStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-position"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BackgroundPositionStyleValue<'a>;
 
 /// Represents the style value for `background-clip` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-clip).
@@ -149,7 +149,7 @@ pub struct BackgroundAttachmentStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-clip
 #[syntax(" <bg-clip># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "border-box",
 	applies_to = "all elements",
@@ -160,7 +160,7 @@ pub struct BackgroundAttachmentStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-clip"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundClipStyleValue<'a>;
 
 /// Represents the style value for `background-origin` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-origin).
@@ -175,7 +175,7 @@ pub struct BackgroundClipStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-origin
 #[syntax(" <visual-box># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "padding-box",
 	applies_to = "all elements",
@@ -186,7 +186,7 @@ pub struct BackgroundClipStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-origin"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundOriginStyleValue<'a>;
 
 /// Represents the style value for `background-size` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-size).
@@ -201,7 +201,7 @@ pub struct BackgroundOriginStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-size
 #[syntax(" <bg-size># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -212,7 +212,7 @@ pub struct BackgroundOriginStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundSizeStyleValue<'a>;
 
 // /// Represents the style value for `background` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background).
@@ -227,7 +227,7 @@ pub struct BackgroundSizeStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-backgrounds-4/#background
 // #[syntax(" <bg-layer>#? , <final-bg-layer> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "all elements",
@@ -238,7 +238,7 @@ pub struct BackgroundSizeStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BackgroundStyleValue<'a>;
 
 /// Represents the style value for `background-repeat-x` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-x).
@@ -251,7 +251,7 @@ pub struct BackgroundSizeStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-repeat-x
 #[syntax(" <repetition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "repeat",
 	applies_to = "all elements",
@@ -262,7 +262,7 @@ pub struct BackgroundSizeStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-x"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundRepeatXStyleValue<'a>;
 
 /// Represents the style value for `background-repeat-y` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-y).
@@ -275,7 +275,7 @@ pub struct BackgroundRepeatXStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-repeat-y
 #[syntax(" <repetition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "repeat",
 	applies_to = "all elements",
@@ -286,7 +286,7 @@ pub struct BackgroundRepeatXStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-y"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundRepeatYStyleValue<'a>;
 
 /// Represents the style value for `background-repeat-block` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-block).
@@ -299,7 +299,7 @@ pub struct BackgroundRepeatYStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-repeat-block
 #[syntax(" <repetition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "repeat",
 	applies_to = "all elements",
@@ -310,7 +310,7 @@ pub struct BackgroundRepeatYStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-block"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundRepeatBlockStyleValue<'a>;
 
 /// Represents the style value for `background-repeat-inline` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-inline).
@@ -323,7 +323,7 @@ pub struct BackgroundRepeatBlockStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-backgrounds-4/#background-repeat-inline
 #[syntax(" <repetition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "repeat",
 	applies_to = "all elements",
@@ -334,7 +334,7 @@ pub struct BackgroundRepeatBlockStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-inline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundRepeatInlineStyleValue<'a>;
 
 // /// Represents the style value for `background-position-x` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position-x).
@@ -349,7 +349,7 @@ pub struct BackgroundRepeatInlineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-backgrounds-4/#background-position-x
 // #[syntax(" [ center | [ [ left | right | x-start | x-end ]? <length-percentage>? ]! ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0%",
 //   applies_to = "all elements",
@@ -360,7 +360,7 @@ pub struct BackgroundRepeatInlineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-position-x"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum BackgroundPositionXStyleValue<'a> {}
 
 // /// Represents the style value for `background-position-y` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position-y).
@@ -375,7 +375,7 @@ pub struct BackgroundRepeatInlineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-backgrounds-4/#background-position-y
 // #[syntax(" [ center | [ [ top | bottom | y-start | y-end ]? <length-percentage>? ]! ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0%",
 //   applies_to = "all elements",
@@ -386,7 +386,7 @@ pub struct BackgroundRepeatInlineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-position-y"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum BackgroundPositionYStyleValue<'a> {}
 
 // /// Represents the style value for `background-position-inline` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position-inline).
@@ -399,7 +399,7 @@ pub struct BackgroundRepeatInlineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-backgrounds-4/#background-position-inline
 // #[syntax(" [ center | [ [ start | end ]? <length-percentage>? ]! ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0%",
 //   applies_to = "all elements",
@@ -410,7 +410,7 @@ pub struct BackgroundRepeatInlineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-position-inline"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum BackgroundPositionInlineStyleValue<'a> {}
 
 // /// Represents the style value for `background-position-block` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position-block).
@@ -423,7 +423,7 @@ pub struct BackgroundRepeatInlineStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-backgrounds-4/#background-position-block
 // #[syntax(" [ center | [ [ start | end ]? <length-percentage>? ]! ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0%",
 //   applies_to = "all elements",
@@ -434,5 +434,5 @@ pub struct BackgroundRepeatInlineStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-position-block"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum BackgroundPositionBlockStyleValue<'a> {}

--- a/crates/css_ast/src/values/borders/mod.rs
+++ b/crates/css_ast/src/values/borders/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-top-color
 #[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderTopColorStyleValue<'a> {}
 
 /// Represents the style value for `border-right-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-color).
@@ -45,7 +45,7 @@ pub enum BorderTopColorStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-right-color
 #[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -56,7 +56,7 @@ pub enum BorderTopColorStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderRightColorStyleValue<'a> {}
 
 /// Represents the style value for `border-bottom-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-color).
@@ -71,7 +71,7 @@ pub enum BorderRightColorStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-bottom-color
 #[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -82,7 +82,7 @@ pub enum BorderRightColorStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderBottomColorStyleValue<'a> {}
 
 /// Represents the style value for `border-left-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-color).
@@ -97,7 +97,7 @@ pub enum BorderBottomColorStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-left-color
 #[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -108,7 +108,7 @@ pub enum BorderBottomColorStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderLeftColorStyleValue<'a> {}
 
 /// Represents the style value for `border-block-start-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-color).
@@ -123,7 +123,7 @@ pub enum BorderLeftColorStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-start-color
 #[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -134,7 +134,7 @@ pub enum BorderLeftColorStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderBlockStartColorStyleValue<'a> {}
 
 /// Represents the style value for `border-block-end-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-color).
@@ -149,7 +149,7 @@ pub enum BorderBlockStartColorStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-end-color
 #[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -160,7 +160,7 @@ pub enum BorderBlockStartColorStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderBlockEndColorStyleValue<'a> {}
 
 /// Represents the style value for `border-inline-start-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-color).
@@ -175,7 +175,7 @@ pub enum BorderBlockEndColorStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-start-color
 #[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -186,7 +186,7 @@ pub enum BorderBlockEndColorStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderInlineStartColorStyleValue<'a> {}
 
 /// Represents the style value for `border-inline-end-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-color).
@@ -201,7 +201,7 @@ pub enum BorderInlineStartColorStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-end-color
 #[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -212,7 +212,7 @@ pub enum BorderInlineStartColorStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderInlineEndColorStyleValue<'a> {}
 
 // /// Represents the style value for `border-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-color).
@@ -227,7 +227,7 @@ pub enum BorderInlineEndColorStyleValue<'a> {}
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-color
 // #[syntax(" [ <color> | <image-1D> ]{1,4} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -238,7 +238,7 @@ pub enum BorderInlineEndColorStyleValue<'a> {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-color"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderColorStyleValue<'a>;
 
 /// Represents the style value for `border-block-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-color).
@@ -253,7 +253,7 @@ pub enum BorderInlineEndColorStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-color
 #[syntax(" <'border-top-color'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -264,7 +264,7 @@ pub enum BorderInlineEndColorStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockColorStyleValue<'a>;
 
 /// Represents the style value for `border-inline-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-color).
@@ -279,7 +279,7 @@ pub struct BorderBlockColorStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-color
 #[syntax(" <'border-top-color'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -290,7 +290,7 @@ pub struct BorderBlockColorStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineColorStyleValue<'a>;
 
 /// Represents the style value for `border-top-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-style).
@@ -305,7 +305,7 @@ pub struct BorderInlineColorStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-top-style
 #[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -316,7 +316,7 @@ pub struct BorderInlineColorStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderTopStyleStyleValue;
 
 /// Represents the style value for `border-right-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-style).
@@ -331,7 +331,7 @@ pub struct BorderTopStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-right-style
 #[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -342,7 +342,7 @@ pub struct BorderTopStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderRightStyleStyleValue;
 
 /// Represents the style value for `border-bottom-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-style).
@@ -357,7 +357,7 @@ pub struct BorderRightStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-bottom-style
 #[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -368,7 +368,7 @@ pub struct BorderRightStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBottomStyleStyleValue;
 
 /// Represents the style value for `border-left-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-style).
@@ -383,7 +383,7 @@ pub struct BorderBottomStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-left-style
 #[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -394,7 +394,7 @@ pub struct BorderBottomStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderLeftStyleStyleValue;
 
 /// Represents the style value for `border-block-start-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-style).
@@ -409,7 +409,7 @@ pub struct BorderLeftStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-start-style
 #[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -420,7 +420,7 @@ pub struct BorderLeftStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockStartStyleStyleValue;
 
 /// Represents the style value for `border-block-end-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-style).
@@ -435,7 +435,7 @@ pub struct BorderBlockStartStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-end-style
 #[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -446,7 +446,7 @@ pub struct BorderBlockStartStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockEndStyleStyleValue;
 
 /// Represents the style value for `border-inline-start-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-style).
@@ -461,7 +461,7 @@ pub struct BorderBlockEndStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-start-style
 #[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -472,7 +472,7 @@ pub struct BorderBlockEndStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineStartStyleStyleValue;
 
 /// Represents the style value for `border-inline-end-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-style).
@@ -487,7 +487,7 @@ pub struct BorderInlineStartStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-end-style
 #[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -498,7 +498,7 @@ pub struct BorderInlineStartStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineEndStyleStyleValue;
 
 /// Represents the style value for `border-block-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-style).
@@ -513,7 +513,7 @@ pub struct BorderInlineEndStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-style
 #[syntax(" <'border-top-style'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -524,7 +524,7 @@ pub struct BorderInlineEndStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockStyleStyleValue;
 
 /// Represents the style value for `border-inline-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-style).
@@ -539,7 +539,7 @@ pub struct BorderBlockStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-style
 #[syntax(" <'border-top-style'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -550,7 +550,7 @@ pub struct BorderBlockStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineStyleStyleValue;
 
 /// Represents the style value for `border-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-style).
@@ -565,7 +565,7 @@ pub struct BorderInlineStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-style
 #[syntax(" <'border-top-style'>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -576,7 +576,7 @@ pub struct BorderInlineStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderStyleStyleValue;
 
 /// Represents the style value for `border-top-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-width).
@@ -591,7 +591,7 @@ pub struct BorderStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-top-width
 #[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -602,7 +602,7 @@ pub struct BorderStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderTopWidthStyleValue;
 
 /// Represents the style value for `border-right-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-width).
@@ -617,7 +617,7 @@ pub struct BorderTopWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-right-width
 #[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -628,7 +628,7 @@ pub struct BorderTopWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderRightWidthStyleValue;
 
 /// Represents the style value for `border-bottom-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-width).
@@ -643,7 +643,7 @@ pub struct BorderRightWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-bottom-width
 #[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -654,7 +654,7 @@ pub struct BorderRightWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBottomWidthStyleValue;
 
 /// Represents the style value for `border-left-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-width).
@@ -669,7 +669,7 @@ pub struct BorderBottomWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-left-width
 #[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -680,7 +680,7 @@ pub struct BorderBottomWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderLeftWidthStyleValue;
 
 /// Represents the style value for `border-block-start-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-width).
@@ -695,7 +695,7 @@ pub struct BorderLeftWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-start-width
 #[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -706,7 +706,7 @@ pub struct BorderLeftWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockStartWidthStyleValue;
 
 /// Represents the style value for `border-block-end-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-width).
@@ -721,7 +721,7 @@ pub struct BorderBlockStartWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-end-width
 #[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -732,7 +732,7 @@ pub struct BorderBlockStartWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockEndWidthStyleValue;
 
 /// Represents the style value for `border-inline-start-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-width).
@@ -747,7 +747,7 @@ pub struct BorderBlockEndWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-start-width
 #[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -758,7 +758,7 @@ pub struct BorderBlockEndWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineStartWidthStyleValue;
 
 /// Represents the style value for `border-inline-end-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-width).
@@ -773,7 +773,7 @@ pub struct BorderInlineStartWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-end-width
 #[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -784,7 +784,7 @@ pub struct BorderInlineStartWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineEndWidthStyleValue;
 
 /// Represents the style value for `border-block-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-width).
@@ -799,7 +799,7 @@ pub struct BorderInlineEndWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-width
 #[syntax(" <'border-top-width'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -810,7 +810,7 @@ pub struct BorderInlineEndWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockWidthStyleValue;
 
 /// Represents the style value for `border-inline-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-width).
@@ -825,7 +825,7 @@ pub struct BorderBlockWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-width
 #[syntax(" <'border-top-width'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -836,7 +836,7 @@ pub struct BorderBlockWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineWidthStyleValue;
 
 /// Represents the style value for `border-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-width).
@@ -851,7 +851,7 @@ pub struct BorderInlineWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-width
 #[syntax(" <'border-top-width'>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -862,7 +862,7 @@ pub struct BorderInlineWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderWidthStyleValue;
 
 /// Represents the style value for `border-top` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top).
@@ -877,7 +877,7 @@ pub struct BorderWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-top
 #[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "See individual properties",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -888,7 +888,7 @@ pub struct BorderWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderTopStyleValue;
 
 /// Represents the style value for `border-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right).
@@ -903,7 +903,7 @@ pub struct BorderTopStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-right
 #[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "See individual properties",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -914,7 +914,7 @@ pub struct BorderTopStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderRightStyleValue;
 
 /// Represents the style value for `border-bottom` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom).
@@ -929,7 +929,7 @@ pub struct BorderRightStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-bottom
 #[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "See individual properties",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -940,7 +940,7 @@ pub struct BorderRightStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBottomStyleValue;
 
 /// Represents the style value for `border-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left).
@@ -955,7 +955,7 @@ pub struct BorderBottomStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-left
 #[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "See individual properties",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -966,7 +966,7 @@ pub struct BorderBottomStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderLeftStyleValue;
 
 /// Represents the style value for `border-block-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start).
@@ -981,7 +981,7 @@ pub struct BorderLeftStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-start
 #[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "See individual properties",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -992,7 +992,7 @@ pub struct BorderLeftStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockStartStyleValue;
 
 /// Represents the style value for `border-block-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end).
@@ -1007,7 +1007,7 @@ pub struct BorderBlockStartStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block-end
 #[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "See individual properties",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -1018,7 +1018,7 @@ pub struct BorderBlockStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockEndStyleValue;
 
 /// Represents the style value for `border-inline-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start).
@@ -1033,7 +1033,7 @@ pub struct BorderBlockEndStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-start
 #[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "See individual properties",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -1044,7 +1044,7 @@ pub struct BorderBlockEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineStartStyleValue;
 
 /// Represents the style value for `border-inline-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end).
@@ -1059,7 +1059,7 @@ pub struct BorderInlineStartStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline-end
 #[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "See individual properties",
 	applies_to = "all elements except ruby base containers and ruby annotation containers",
@@ -1070,7 +1070,7 @@ pub struct BorderInlineStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineEndStyleValue;
 
 /// Represents the style value for `border-block` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block).
@@ -1085,7 +1085,7 @@ pub struct BorderInlineEndStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-block
 #[syntax(" <'border-block-start'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1096,7 +1096,7 @@ pub struct BorderInlineEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockStyleValue;
 
 /// Represents the style value for `border-inline` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline).
@@ -1111,7 +1111,7 @@ pub struct BorderBlockStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-inline
 #[syntax(" <'border-block-start'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1122,7 +1122,7 @@ pub struct BorderBlockStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderInlineStyleValue;
 
 /// Represents the style value for `border` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border).
@@ -1137,7 +1137,7 @@ pub struct BorderInlineStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border
 #[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1148,7 +1148,7 @@ pub struct BorderInlineStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderStyleValue;
 
 /// Represents the style value for `border-top-left-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-left-radius).
@@ -1163,7 +1163,7 @@ pub struct BorderStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-top-left-radius
 #[syntax(" <length-percentage [0,∞]>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements (but see prose)",
@@ -1174,7 +1174,7 @@ pub struct BorderStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-left-radius"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderTopLeftRadiusStyleValue;
 
 /// Represents the style value for `border-top-right-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-right-radius).
@@ -1189,7 +1189,7 @@ pub struct BorderTopLeftRadiusStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-top-right-radius
 #[syntax(" <length-percentage [0,∞]>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements (but see prose)",
@@ -1200,7 +1200,7 @@ pub struct BorderTopLeftRadiusStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-right-radius"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderTopRightRadiusStyleValue;
 
 /// Represents the style value for `border-bottom-right-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-right-radius).
@@ -1215,7 +1215,7 @@ pub struct BorderTopRightRadiusStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-bottom-right-radius
 #[syntax(" <length-percentage [0,∞]>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements (but see prose)",
@@ -1230,7 +1230,7 @@ pub struct BorderTopRightRadiusStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.border-bottom-right-radius")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBottomRightRadiusStyleValue;
 
 /// Represents the style value for `border-bottom-left-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-left-radius).
@@ -1245,7 +1245,7 @@ pub struct BorderBottomRightRadiusStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-bottom-left-radius
 #[syntax(" <length-percentage [0,∞]>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements (but see prose)",
@@ -1256,7 +1256,7 @@ pub struct BorderBottomRightRadiusStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-left-radius"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBottomLeftRadiusStyleValue;
 
 /// Represents the style value for `border-start-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-start-start-radius).
@@ -1271,7 +1271,7 @@ pub struct BorderBottomLeftRadiusStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-start-start-radius
 #[syntax(" <length-percentage [0,∞]>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements (but see prose)",
@@ -1282,7 +1282,7 @@ pub struct BorderBottomLeftRadiusStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-start-start-radius"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderStartStartRadiusStyleValue;
 
 /// Represents the style value for `border-start-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-start-end-radius).
@@ -1297,7 +1297,7 @@ pub struct BorderStartStartRadiusStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-start-end-radius
 #[syntax(" <length-percentage [0,∞]>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements (but see prose)",
@@ -1308,7 +1308,7 @@ pub struct BorderStartStartRadiusStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-start-end-radius"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderStartEndRadiusStyleValue;
 
 /// Represents the style value for `border-end-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-end-start-radius).
@@ -1323,7 +1323,7 @@ pub struct BorderStartEndRadiusStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-end-start-radius
 #[syntax(" <length-percentage [0,∞]>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements (but see prose)",
@@ -1334,7 +1334,7 @@ pub struct BorderStartEndRadiusStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-end-start-radius"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderEndStartRadiusStyleValue;
 
 /// Represents the style value for `border-end-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-end-end-radius).
@@ -1349,7 +1349,7 @@ pub struct BorderEndStartRadiusStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-end-end-radius
 #[syntax(" <length-percentage [0,∞]>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements (but see prose)",
@@ -1360,7 +1360,7 @@ pub struct BorderEndStartRadiusStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-end-end-radius"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderEndEndRadiusStyleValue;
 
 // /// Represents the style value for `border-top-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-radius).
@@ -1373,7 +1373,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-top-radius
 // #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -1384,7 +1384,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-radius"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderTopRadiusStyleValue;
 
 // /// Represents the style value for `border-right-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-radius).
@@ -1397,7 +1397,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-right-radius
 // #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -1408,7 +1408,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-radius"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderRightRadiusStyleValue;
 
 // /// Represents the style value for `border-bottom-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-radius).
@@ -1421,7 +1421,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-bottom-radius
 // #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -1432,7 +1432,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-radius"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderBottomRadiusStyleValue;
 
 // /// Represents the style value for `border-left-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-radius).
@@ -1445,7 +1445,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-left-radius
 // #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -1456,7 +1456,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-radius"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderLeftRadiusStyleValue;
 
 // /// Represents the style value for `border-block-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-radius).
@@ -1469,7 +1469,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-block-start-radius
 // #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -1480,7 +1480,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-radius"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderBlockStartRadiusStyleValue;
 
 // /// Represents the style value for `border-block-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-radius).
@@ -1493,7 +1493,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-block-end-radius
 // #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -1504,7 +1504,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-radius"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderBlockEndRadiusStyleValue;
 
 // /// Represents the style value for `border-inline-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-radius).
@@ -1517,7 +1517,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-inline-start-radius
 // #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -1528,7 +1528,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-radius"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderInlineStartRadiusStyleValue;
 
 // /// Represents the style value for `border-inline-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-radius).
@@ -1541,7 +1541,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-inline-end-radius
 // #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -1552,7 +1552,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-radius"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderInlineEndRadiusStyleValue;
 
 // /// Represents the style value for `border-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-radius).
@@ -1567,7 +1567,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-radius
 // #[syntax(" <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -1578,7 +1578,7 @@ pub struct BorderEndEndRadiusStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-radius"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderRadiusStyleValue;
 
 /// Represents the style value for `corner-top-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-left-shape).
@@ -1593,7 +1593,7 @@ pub struct BorderEndEndRadiusStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-top-left-shape
 #[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "round",
 	applies_to = "all elements where border-radius can apply",
@@ -1604,7 +1604,7 @@ pub struct BorderEndEndRadiusStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-left-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerTopLeftShapeStyleValue;
 
 /// Represents the style value for `corner-top-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-right-shape).
@@ -1619,7 +1619,7 @@ pub struct CornerTopLeftShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-top-right-shape
 #[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "round",
 	applies_to = "all elements where border-radius can apply",
@@ -1630,7 +1630,7 @@ pub struct CornerTopLeftShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-right-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerTopRightShapeStyleValue;
 
 /// Represents the style value for `corner-bottom-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-right-shape).
@@ -1645,7 +1645,7 @@ pub struct CornerTopRightShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-bottom-right-shape
 #[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "round",
 	applies_to = "all elements where border-radius can apply",
@@ -1656,7 +1656,7 @@ pub struct CornerTopRightShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-right-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerBottomRightShapeStyleValue;
 
 /// Represents the style value for `corner-bottom-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-left-shape).
@@ -1671,7 +1671,7 @@ pub struct CornerBottomRightShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-bottom-left-shape
 #[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "round",
 	applies_to = "all elements where border-radius can apply",
@@ -1682,7 +1682,7 @@ pub struct CornerBottomRightShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-left-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerBottomLeftShapeStyleValue;
 
 /// Represents the style value for `corner-start-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-start-shape).
@@ -1697,7 +1697,7 @@ pub struct CornerBottomLeftShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-start-start-shape
 #[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "round",
 	applies_to = "all elements where border-radius can apply",
@@ -1708,7 +1708,7 @@ pub struct CornerBottomLeftShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-start-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerStartStartShapeStyleValue;
 
 /// Represents the style value for `corner-start-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-end-shape).
@@ -1723,7 +1723,7 @@ pub struct CornerStartStartShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-start-end-shape
 #[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "round",
 	applies_to = "all elements where border-radius can apply",
@@ -1734,7 +1734,7 @@ pub struct CornerStartStartShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-end-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerStartEndShapeStyleValue;
 
 /// Represents the style value for `corner-end-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-start-shape).
@@ -1749,7 +1749,7 @@ pub struct CornerStartEndShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-end-start-shape
 #[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "round",
 	applies_to = "all elements where border-radius can apply",
@@ -1760,7 +1760,7 @@ pub struct CornerStartEndShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-start-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerEndStartShapeStyleValue;
 
 /// Represents the style value for `corner-end-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-end-shape).
@@ -1775,7 +1775,7 @@ pub struct CornerEndStartShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-end-end-shape
 #[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "round",
 	applies_to = "all elements where border-radius can apply",
@@ -1786,7 +1786,7 @@ pub struct CornerEndStartShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-end-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerEndEndShapeStyleValue;
 
 /// Represents the style value for `corner-top-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-shape).
@@ -1801,7 +1801,7 @@ pub struct CornerEndEndShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-top-shape
 #[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1812,7 +1812,7 @@ pub struct CornerEndEndShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerTopShapeStyleValue;
 
 /// Represents the style value for `corner-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-right-shape).
@@ -1827,7 +1827,7 @@ pub struct CornerTopShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-right-shape
 #[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1838,7 +1838,7 @@ pub struct CornerTopShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-right-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerRightShapeStyleValue;
 
 /// Represents the style value for `corner-bottom-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-shape).
@@ -1853,7 +1853,7 @@ pub struct CornerRightShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-bottom-shape
 #[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1864,7 +1864,7 @@ pub struct CornerRightShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerBottomShapeStyleValue;
 
 /// Represents the style value for `corner-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-left-shape).
@@ -1879,7 +1879,7 @@ pub struct CornerBottomShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-left-shape
 #[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1890,7 +1890,7 @@ pub struct CornerBottomShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-left-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerLeftShapeStyleValue;
 
 /// Represents the style value for `corner-block-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-start-shape).
@@ -1905,7 +1905,7 @@ pub struct CornerLeftShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-block-start-shape
 #[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1916,7 +1916,7 @@ pub struct CornerLeftShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-start-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerBlockStartShapeStyleValue;
 
 /// Represents the style value for `corner-block-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-end-shape).
@@ -1931,7 +1931,7 @@ pub struct CornerBlockStartShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-block-end-shape
 #[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1942,7 +1942,7 @@ pub struct CornerBlockStartShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-end-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerBlockEndShapeStyleValue;
 
 /// Represents the style value for `corner-inline-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-start-shape).
@@ -1957,7 +1957,7 @@ pub struct CornerBlockEndShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-inline-start-shape
 #[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1968,7 +1968,7 @@ pub struct CornerBlockEndShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-start-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerInlineStartShapeStyleValue;
 
 /// Represents the style value for `corner-inline-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-end-shape).
@@ -1983,7 +1983,7 @@ pub struct CornerInlineStartShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-inline-end-shape
 #[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -1994,7 +1994,7 @@ pub struct CornerInlineStartShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-end-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerInlineEndShapeStyleValue;
 
 /// Represents the style value for `corner-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-shape).
@@ -2009,7 +2009,7 @@ pub struct CornerInlineEndShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#corner-shape
 #[syntax(" <'corner-top-left-shape'>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "round",
 	applies_to = "all elements where border-radius can apply",
@@ -2020,7 +2020,7 @@ pub struct CornerInlineEndShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CornerShapeStyleValue;
 
 // /// Represents the style value for `corner-top-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-left).
@@ -2033,7 +2033,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-top-left
 // #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2044,7 +2044,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-left"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerTopLeftStyleValue;
 
 // /// Represents the style value for `corner-top-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-right).
@@ -2057,7 +2057,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-top-right
 // #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2068,7 +2068,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-right"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerTopRightStyleValue;
 
 // /// Represents the style value for `corner-bottom-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-left).
@@ -2081,7 +2081,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-bottom-left
 // #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2092,7 +2092,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-left"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerBottomLeftStyleValue;
 
 // /// Represents the style value for `corner-bottom-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-right).
@@ -2105,7 +2105,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-bottom-right
 // #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2116,7 +2116,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-right"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerBottomRightStyleValue;
 
 // /// Represents the style value for `corner-start-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-start).
@@ -2129,7 +2129,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-start-start
 // #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2140,7 +2140,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-start"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerStartStartStyleValue;
 
 // /// Represents the style value for `corner-start-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-end).
@@ -2153,7 +2153,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-start-end
 // #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2164,7 +2164,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-end"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerStartEndStyleValue;
 
 // /// Represents the style value for `corner-end-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-start).
@@ -2177,7 +2177,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-end-start
 // #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2188,7 +2188,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-start"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerEndStartStyleValue;
 
 // /// Represents the style value for `corner-end-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-end).
@@ -2201,7 +2201,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-end-end
 // #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2212,7 +2212,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-end"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerEndEndStyleValue;
 
 // /// Represents the style value for `corner-top` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top).
@@ -2225,7 +2225,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-top
 // #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2236,7 +2236,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerTopStyleValue;
 
 // /// Represents the style value for `corner-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-right).
@@ -2249,7 +2249,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-right
 // #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2260,7 +2260,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-right"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerRightStyleValue;
 
 // /// Represents the style value for `corner-bottom` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom).
@@ -2273,7 +2273,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-bottom
 // #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2284,7 +2284,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerBottomStyleValue;
 
 // /// Represents the style value for `corner-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-left).
@@ -2297,7 +2297,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-left
 // #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2308,7 +2308,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-left"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerLeftStyleValue;
 
 // /// Represents the style value for `corner-block-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-start).
@@ -2321,7 +2321,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-block-start
 // #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2332,7 +2332,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-start"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerBlockStartStyleValue;
 
 // /// Represents the style value for `corner-block-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-end).
@@ -2345,7 +2345,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-block-end
 // #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2356,7 +2356,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-end"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerBlockEndStyleValue;
 
 // /// Represents the style value for `corner-inline-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-start).
@@ -2369,7 +2369,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-inline-start
 // #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2380,7 +2380,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-start"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerInlineStartStyleValue;
 
 // /// Represents the style value for `corner-inline-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-end).
@@ -2393,7 +2393,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner-inline-end
 // #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2404,7 +2404,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-end"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerInlineEndStyleValue;
 
 // /// Represents the style value for `corner` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner).
@@ -2417,7 +2417,7 @@ pub struct CornerShapeStyleValue;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#corner
 // #[syntax(" <'border-radius'> || <'corner-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "all elements (but see prose)",
@@ -2428,7 +2428,7 @@ pub struct CornerShapeStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CornerStyleValue;
 
 /// Represents the style value for `border-image-source` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-source).
@@ -2443,7 +2443,7 @@ pub struct CornerShapeStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-image-source
 #[syntax(" none | <image> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "All elements, except internal table elements when border-collapse is collapse",
@@ -2454,7 +2454,7 @@ pub struct CornerShapeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-source"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderImageSourceStyleValue<'a>;
 
 // /// Represents the style value for `border-image-slice` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-slice).
@@ -2469,7 +2469,7 @@ pub struct BorderImageSourceStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-image-slice
 // #[syntax(" [<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "100%",
 //   applies_to = "All elements, except internal table elements when border-collapse is collapse",
@@ -2480,7 +2480,7 @@ pub struct BorderImageSourceStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-slice"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderImageSliceStyleValue;
 
 // /// Represents the style value for `border-image-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-width).
@@ -2495,7 +2495,7 @@ pub struct BorderImageSourceStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-image-width
 // #[syntax(" [ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "1",
 //   applies_to = "All elements, except internal table elements when border-collapse is collapse",
@@ -2506,7 +2506,7 @@ pub struct BorderImageSourceStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-width"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderImageWidthStyleValue;
 
 /// Represents the style value for `border-image-outset` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-outset).
@@ -2521,7 +2521,7 @@ pub struct BorderImageSourceStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-image-outset
 #[syntax(" [ <length [0,∞]> | <number [0,∞]> ]{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "All elements, except internal table elements when border-collapse is collapse",
@@ -2532,7 +2532,7 @@ pub struct BorderImageSourceStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-outset"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderImageOutsetStyleValue;
 
 /// Represents the style value for `border-image-repeat` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-repeat).
@@ -2547,7 +2547,7 @@ pub struct BorderImageOutsetStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-image-repeat
 #[syntax(" [ stretch | repeat | round | space ]{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "stretch",
 	applies_to = "All elements, except internal table elements when border-collapse is collapse",
@@ -2558,7 +2558,7 @@ pub struct BorderImageOutsetStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-repeat"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderImageRepeatStyleValue;
 
 // /// Represents the style value for `border-image` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image).
@@ -2575,7 +2575,7 @@ pub struct BorderImageRepeatStyleValue;
 // #[syntax(
 // 	" <'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'> "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "See individual properties",
 //   applies_to = "See individual properties",
@@ -2586,7 +2586,7 @@ pub struct BorderImageRepeatStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BorderImageStyleValue;
 
 // /// Represents the style value for `border-limit` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-limit).
@@ -2601,7 +2601,7 @@ pub struct BorderImageRepeatStyleValue;
 // #[syntax(
 // 	" all | [ sides | corners ] <length-percentage [0,∞]>? | [ top | right | bottom | left ] <length-percentage [0,∞]> "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "all",
 //   applies_to = "all elements, except table element when border-collapse is collapse",
@@ -2612,7 +2612,7 @@ pub struct BorderImageRepeatStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-limit"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum BorderLimitStyleValue {}
 
 /// Represents the style value for `border-clip` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip).
@@ -2625,7 +2625,7 @@ pub struct BorderImageRepeatStyleValue;
 ///
 // https://drafts.csswg.org/css-borders-4/#border-clip
 #[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -2636,7 +2636,7 @@ pub struct BorderImageRepeatStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderClipStyleValue<'a> {}
 
 /// Represents the style value for `border-clip-top` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-top).
@@ -2649,7 +2649,7 @@ pub enum BorderClipStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-clip-top
 #[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -2660,7 +2660,7 @@ pub enum BorderClipStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-top"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderClipTopStyleValue<'a> {}
 
 /// Represents the style value for `border-clip-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-right).
@@ -2673,7 +2673,7 @@ pub enum BorderClipTopStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-clip-right
 #[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -2684,7 +2684,7 @@ pub enum BorderClipTopStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-right"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderClipRightStyleValue<'a> {}
 
 /// Represents the style value for `border-clip-bottom` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-bottom).
@@ -2697,7 +2697,7 @@ pub enum BorderClipRightStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-clip-bottom
 #[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -2708,7 +2708,7 @@ pub enum BorderClipRightStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-bottom"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderClipBottomStyleValue<'a> {}
 
 /// Represents the style value for `border-clip-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-left).
@@ -2721,7 +2721,7 @@ pub enum BorderClipBottomStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#border-clip-left
 #[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -2732,7 +2732,7 @@ pub enum BorderClipBottomStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-left"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderClipLeftStyleValue<'a> {}
 
 /// Represents the style value for `box-shadow-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-color).
@@ -2745,7 +2745,7 @@ pub enum BorderClipLeftStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-borders-4/#box-shadow-color
 #[syntax(" <color># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements",
@@ -2756,7 +2756,7 @@ pub enum BorderClipLeftStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BoxShadowColorStyleValue<'a>;
 
 // /// Represents the style value for `box-shadow-offset` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-offset).
@@ -2769,7 +2769,7 @@ pub struct BoxShadowColorStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#box-shadow-offset
 // #[syntax(" [ none | <length>{2} ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements",
@@ -2780,7 +2780,7 @@ pub struct BoxShadowColorStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow-offset"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BoxShadowOffsetStyleValue<'a>;
 
 /// Represents the style value for `box-shadow-blur` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-blur).
@@ -2793,7 +2793,7 @@ pub struct BoxShadowColorStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-borders-4/#box-shadow-blur
 #[syntax(" <length [0,∞]># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -2804,7 +2804,7 @@ pub struct BoxShadowColorStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow-blur"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BoxShadowBlurStyleValue<'a>;
 
 /// Represents the style value for `box-shadow-spread` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-spread).
@@ -2817,7 +2817,7 @@ pub struct BoxShadowBlurStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-borders-4/#box-shadow-spread
 #[syntax(" <length># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -2828,7 +2828,7 @@ pub struct BoxShadowBlurStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow-spread"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BoxShadowSpreadStyleValue<'a>;
 
 /// Represents the style value for `box-shadow-position` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-position).
@@ -2841,7 +2841,7 @@ pub struct BoxShadowSpreadStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-borders-4/#box-shadow-position
 #[syntax(" [ outset | inset ]# ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "outset",
 	applies_to = "all elements",
@@ -2852,7 +2852,7 @@ pub struct BoxShadowSpreadStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow-position"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BoxShadowPositionStyleValue<'a>;
 
 /// Represents the style value for `box-shadow` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow).
@@ -2867,7 +2867,7 @@ pub struct BoxShadowPositionStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-borders-4/#box-shadow
 #[syntax(" <spread-shadow># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -2878,7 +2878,7 @@ pub struct BoxShadowPositionStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BoxShadowStyleValue<'a>;
 
 // /// Represents the style value for `border-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-shape).
@@ -2891,16 +2891,16 @@ pub struct BoxShadowStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-borders-4/#border-shape
 // #[syntax(" none | [ <basic-shape> <geometry-box>?]{1,2} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements",
 // 	inherited = "no",
-// 	percentages = "relative to the given <geometry-box>, or to border box if not given.",
+// 	percentages = "see prose",
 // 	canonical_order = "per grammar",
 // 	animation_type = "by computed value",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-shape"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum BorderShapeStyleValue {}

--- a/crates/css_ast/src/values/box/mod.rs
+++ b/crates/css_ast/src/values/box/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-box-4/#margin-top
 #[syntax(" <length-percentage> | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except internal table elements, ruby base containers, and ruby annotation containers",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-top"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginTopStyleValue;
 
 /// Represents the style value for `margin-right` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-right).
@@ -45,7 +45,7 @@ pub struct MarginTopStyleValue;
 ///
 // https://drafts.csswg.org/css-box-4/#margin-right
 #[syntax(" <length-percentage> | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except internal table elements, ruby base containers, and ruby annotation containers",
@@ -56,7 +56,7 @@ pub struct MarginTopStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-right"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginRightStyleValue;
 
 /// Represents the style value for `margin-bottom` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-bottom).
@@ -71,7 +71,7 @@ pub struct MarginRightStyleValue;
 ///
 // https://drafts.csswg.org/css-box-4/#margin-bottom
 #[syntax(" <length-percentage> | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except internal table elements, ruby base containers, and ruby annotation containers",
@@ -82,7 +82,7 @@ pub struct MarginRightStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-bottom"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginBottomStyleValue;
 
 /// Represents the style value for `margin-left` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-left).
@@ -97,7 +97,7 @@ pub struct MarginBottomStyleValue;
 ///
 // https://drafts.csswg.org/css-box-4/#margin-left
 #[syntax(" <length-percentage> | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except internal table elements, ruby base containers, and ruby annotation containers",
@@ -108,7 +108,7 @@ pub struct MarginBottomStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-left"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginLeftStyleValue;
 
 /// Represents the style value for `margin` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin).
@@ -123,7 +123,7 @@ pub struct MarginLeftStyleValue;
 ///
 // https://drafts.csswg.org/css-box-4/#margin
 #[syntax(" <'margin-top'>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except internal table elements, ruby base containers, and ruby annotation containers",
@@ -134,7 +134,7 @@ pub struct MarginLeftStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginStyleValue;
 
 /// Represents the style value for `padding-top` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding-top).
@@ -149,7 +149,7 @@ pub struct MarginStyleValue;
 ///
 // https://drafts.csswg.org/css-box-4/#padding-top
 #[syntax(" <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except: internal table elements other than table cells, ruby base containers, and ruby annotation containers",
@@ -160,7 +160,7 @@ pub struct MarginStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-top"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingTopStyleValue;
 
 /// Represents the style value for `padding-right` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding-right).
@@ -175,7 +175,7 @@ pub struct PaddingTopStyleValue;
 ///
 // https://drafts.csswg.org/css-box-4/#padding-right
 #[syntax(" <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except: internal table elements other than table cells, ruby base containers, and ruby annotation containers",
@@ -186,7 +186,7 @@ pub struct PaddingTopStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-right"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingRightStyleValue;
 
 /// Represents the style value for `padding-bottom` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding-bottom).
@@ -201,7 +201,7 @@ pub struct PaddingRightStyleValue;
 ///
 // https://drafts.csswg.org/css-box-4/#padding-bottom
 #[syntax(" <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except: internal table elements other than table cells, ruby base containers, and ruby annotation containers",
@@ -212,7 +212,7 @@ pub struct PaddingRightStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-bottom"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingBottomStyleValue;
 
 /// Represents the style value for `padding-left` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding-left).
@@ -227,7 +227,7 @@ pub struct PaddingBottomStyleValue;
 ///
 // https://drafts.csswg.org/css-box-4/#padding-left
 #[syntax(" <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except: internal table elements other than table cells, ruby base containers, and ruby annotation containers",
@@ -238,7 +238,7 @@ pub struct PaddingBottomStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-left"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingLeftStyleValue;
 
 /// Represents the style value for `padding` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding).
@@ -253,7 +253,7 @@ pub struct PaddingLeftStyleValue;
 ///
 // https://drafts.csswg.org/css-box-4/#padding
 #[syntax(" <'padding-top'>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements except: internal table elements other than table cells, ruby base containers, and ruby annotation containers",
@@ -264,7 +264,7 @@ pub struct PaddingLeftStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingStyleValue;
 
 // /// Represents the style value for `margin-trim` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-trim).
@@ -279,7 +279,7 @@ pub struct PaddingStyleValue;
 // ///
 // // https://drafts.csswg.org/css-box-4/#margin-trim
 // #[syntax(" none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "block containers, multi-column containers, flex containers, grid containers",
@@ -290,5 +290,5 @@ pub struct PaddingStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-trim"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum MarginTrimStyleValue {}

--- a/crates/css_ast/src/values/break/mod.rs
+++ b/crates/css_ast/src/values/break/mod.rs
@@ -21,7 +21,7 @@ use impls::*;
 #[syntax(
 	" auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block-level boxes, grid items, flex items, table row groups, table rows (but see prose)",
@@ -32,7 +32,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.break-before"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BreakBeforeStyleValue {}
 
 /// Represents the style value for `break-after` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#break-after).
@@ -49,7 +49,7 @@ pub enum BreakBeforeStyleValue {}
 #[syntax(
 	" auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block-level boxes, grid items, flex items, table row groups, table rows (but see prose)",
@@ -60,7 +60,7 @@ pub enum BreakBeforeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.break-after"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BreakAfterStyleValue {}
 
 /// Represents the style value for `break-inside` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#break-inside).
@@ -75,7 +75,7 @@ pub enum BreakAfterStyleValue {}
 ///
 // https://drafts.csswg.org/css-break-4/#break-inside
 #[syntax(" auto | avoid | avoid-page | avoid-column | avoid-region ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements except inline-level boxes, internal ruby boxes, table column boxes, table column group boxes, absolutely-positioned boxes",
@@ -86,7 +86,7 @@ pub enum BreakAfterStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.break-inside"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BreakInsideStyleValue {}
 
 /// Represents the style value for `orphans` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#orphans).
@@ -101,7 +101,7 @@ pub enum BreakInsideStyleValue {}
 ///
 // https://drafts.csswg.org/css-break-4/#orphans
 #[syntax(" <integer [1,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "2",
 	applies_to = "block containers that establish an inline formatting context",
@@ -112,7 +112,7 @@ pub enum BreakInsideStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.orphans"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OrphansStyleValue;
 
 /// Represents the style value for `widows` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#widows).
@@ -127,7 +127,7 @@ pub struct OrphansStyleValue;
 ///
 // https://drafts.csswg.org/css-break-4/#widows
 #[syntax(" <integer [1,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "2",
 	applies_to = "block containers that establish an inline formatting context",
@@ -138,7 +138,7 @@ pub struct OrphansStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.widows"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct WidowsStyleValue;
 
 /// Represents the style value for `box-decoration-break` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#box-decoration-break).
@@ -153,7 +153,7 @@ pub struct WidowsStyleValue;
 ///
 // https://drafts.csswg.org/css-break-4/#box-decoration-break
 #[syntax(" slice | clone ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "slice",
 	applies_to = "all elements",
@@ -164,7 +164,7 @@ pub struct WidowsStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-decoration-break"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BoxDecorationBreakStyleValue {}
 
 /// Represents the style value for `margin-break` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#margin-break).
@@ -177,7 +177,7 @@ pub enum BoxDecorationBreakStyleValue {}
 ///
 // https://drafts.csswg.org/css-break-4/#margin-break
 #[syntax(" auto | keep | discard ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -188,5 +188,5 @@ pub enum BoxDecorationBreakStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-break"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum MarginBreakStyleValue {}

--- a/crates/css_ast/src/values/cascade/mod.rs
+++ b/crates/css_ast/src/values/cascade/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-cascade-6/#all
 #[syntax(" initial | inherit | unset | revert | revert-layer ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -30,5 +30,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.all"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum AllStyleValue {}

--- a/crates/css_ast/src/values/color/impls.rs
+++ b/crates/css_ast/src/values/color/impls.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
 	use super::super::*;
+	use crate::Color;
 	use crate::CssAtomSet;
-	use crate::{Color, assert_visits};
 	use css_parse::assert_parse;
 
 	#[test]

--- a/crates/css_ast/src/values/color/mod.rs
+++ b/crates/css_ast/src/values/color/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-color-6/#color
 #[syntax(" <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "CanvasText",
 	applies_to = "all elements and text",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ColorStyleValue;
 
 /// Represents the style value for `opacity` as defined in [css-color-6](https://drafts.csswg.org/css-color-6/#opacity).
@@ -45,7 +45,7 @@ pub struct ColorStyleValue;
 ///
 // https://drafts.csswg.org/css-color-6/#opacity
 #[syntax(" <opacity-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "1",
 	applies_to = "all elements",
@@ -56,5 +56,5 @@ pub struct ColorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.opacity"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OpacityStyleValue;

--- a/crates/css_ast/src/values/color_adjust/mod.rs
+++ b/crates/css_ast/src/values/color_adjust/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-color-adjust-1/#color-scheme
 // #[syntax(" normal | [ light | dark | <custom-ident> ]+ && only? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements and text",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.color-scheme"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ColorSchemeStyleValue<'a> {}
 
 /// Represents the style value for `forced-color-adjust` as defined in [css-color-adjust-1](https://drafts.csswg.org/css-color-adjust-1/#forced-color-adjust).
@@ -45,7 +45,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-color-adjust-1/#forced-color-adjust
 #[syntax(" auto | none | preserve-parent-color ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements and text",
@@ -56,7 +56,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.forced-color-adjust"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ForcedColorAdjustStyleValue {}
 
 /// Represents the style value for `print-color-adjust` as defined in [css-color-adjust-1](https://drafts.csswg.org/css-color-adjust-1/#print-color-adjust).
@@ -71,7 +71,7 @@ pub enum ForcedColorAdjustStyleValue {}
 ///
 // https://drafts.csswg.org/css-color-adjust-1/#print-color-adjust
 #[syntax(" economy | exact ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "economy",
 	applies_to = "all elements",
@@ -82,7 +82,7 @@ pub enum ForcedColorAdjustStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.print-color-adjust"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum PrintColorAdjustStyleValue {}
 
 /// Represents the style value for `color-adjust` as defined in [css-color-adjust-1](https://drafts.csswg.org/css-color-adjust-1/#color-adjust).
@@ -97,7 +97,7 @@ pub enum PrintColorAdjustStyleValue {}
 ///
 // https://drafts.csswg.org/css-color-adjust-1/#color-adjust
 #[syntax(" <'print-color-adjust'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -108,5 +108,5 @@ pub enum PrintColorAdjustStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.color-adjust"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ColorAdjustStyleValue;

--- a/crates/css_ast/src/values/color_hdr/mod.rs
+++ b/crates/css_ast/src/values/color_hdr/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-color-hdr-1/#dynamic-range-limit
 #[syntax(" standard | no-limit | constrained | <dynamic-range-limit-mix()> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "no-limit",
 	applies_to = "all elements",
@@ -28,5 +28,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.dynamic-range-limit"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum DynamicRangeLimitStyleValue<'a> {}

--- a/crates/css_ast/src/values/conditional/mod.rs
+++ b/crates/css_ast/src/values/conditional/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-conditional-5/#container-type
 // #[syntax(" normal | [ [ size | inline-size ] || scroll-state ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.container-type"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ContainerTypeStyleValue {}
 
 /// Represents the style value for `container-name` as defined in [css-conditional-5](https://drafts.csswg.org/css-conditional-5/#container-name).
@@ -45,7 +45,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-conditional-5/#container-name
 #[syntax(" none | <custom-ident>+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -56,7 +56,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.container-name"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ContainerNameStyleValue<'a>;
 
 // /// Represents the style value for `container` as defined in [css-conditional-5](https://drafts.csswg.org/css-conditional-5/#container).
@@ -71,7 +71,7 @@ pub struct ContainerNameStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-conditional-5/#container
 // #[syntax(" <'container-name'> [ / <'container-type'> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -82,5 +82,5 @@ pub struct ContainerNameStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.container"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ContainerStyleValue;

--- a/crates/css_ast/src/values/contain/mod.rs
+++ b/crates/css_ast/src/values/contain/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-contain-4/#contain
 // #[syntax(" none | strict | content | [ [size | inline-size] || layout || style || paint ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "See below",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ContainStyleValue {}
 
 /// Represents the style value for `content-visibility` as defined in [css-contain-4](https://drafts.csswg.org/css-contain-4/#content-visibility).
@@ -45,7 +45,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-contain-4/#content-visibility
 #[syntax(" visible | auto | hidden ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "visible",
 	applies_to = "elements for which size containment can apply",
@@ -56,5 +56,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.content-visibility"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ContentVisibilityStyleValue {}

--- a/crates/css_ast/src/values/content/mod.rs
+++ b/crates/css_ast/src/values/content/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-content-3/#content
 // #[syntax(" normal | none | [ <content-replacement> | <content-list> ] [/ [ <string> | <counter> | <attr()> ]+ ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements, tree-abiding pseudo-elements, and page margin boxes",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.content"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ContentStyleValue<'a> {}
 
 // /// Represents the style value for `quotes` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#quotes).
@@ -45,7 +45,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-content-3/#quotes
 // #[syntax(" auto | none | match-parent | [ <string> <string> ]+ ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "all elements",
@@ -56,7 +56,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.quotes"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum QuotesStyleValue<'a> {}
 
 /// Represents the style value for `bookmark-level` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-level).
@@ -69,7 +69,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-content-3/#bookmark-level
 #[syntax(" none | <integer [1,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -80,7 +80,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bookmark-level"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BookmarkLevelStyleValue;
 
 /// Represents the style value for `bookmark-label` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-label).
@@ -93,7 +93,7 @@ pub struct BookmarkLevelStyleValue;
 ///
 // https://drafts.csswg.org/css-content-3/#bookmark-label
 #[syntax(" <content-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "content(text)",
 	applies_to = "all elements",
@@ -104,7 +104,7 @@ pub struct BookmarkLevelStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bookmark-label"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BookmarkLabelStyleValue<'a>;
 
 /// Represents the style value for `bookmark-state` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-state).
@@ -117,7 +117,7 @@ pub struct BookmarkLabelStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-content-3/#bookmark-state
 #[syntax(" open | closed ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "open",
 	applies_to = "block-level elements",
@@ -128,5 +128,5 @@ pub struct BookmarkLabelStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bookmark-state"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BookmarkStateStyleValue {}

--- a/crates/css_ast/src/values/display/mod.rs
+++ b/crates/css_ast/src/values/display/mod.rs
@@ -21,7 +21,7 @@ use impls::*;
 // #[syntax(
 // 	" [ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "inline",
 //   applies_to = "all elements",
@@ -32,7 +32,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.display"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum DisplayStyleValue {}
 
 /// Represents the style value for `order` as defined in [css-display-4](https://drafts.csswg.org/css-display-4/#order).
@@ -47,7 +47,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-display-4/#order
 #[syntax(" <integer> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "flex items and grid items",
@@ -58,7 +58,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.order"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OrderStyleValue;
 
 /// Represents the style value for `visibility` as defined in [css-display-4](https://drafts.csswg.org/css-display-4/#visibility).
@@ -73,7 +73,7 @@ pub struct OrderStyleValue;
 ///
 // https://drafts.csswg.org/css-display-4/#visibility
 #[syntax(" visible | hidden | force-hidden | collapse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "visible",
 	applies_to = "all elements",
@@ -84,7 +84,7 @@ pub struct OrderStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.visibility"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum VisibilityStyleValue {}
 
 /// Represents the style value for `reading-flow` as defined in [css-display-4](https://drafts.csswg.org/css-display-4/#reading-flow).
@@ -99,7 +99,7 @@ pub enum VisibilityStyleValue {}
 ///
 // https://drafts.csswg.org/css-display-4/#reading-flow
 #[syntax(" normal | source-order | flex-visual | flex-flow | grid-rows | grid-columns | grid-order ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "block, flex and grid containers",
@@ -110,7 +110,7 @@ pub enum VisibilityStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.reading-flow"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ReadingFlowStyleValue {}
 
 /// Represents the style value for `reading-order` as defined in [css-display-4](https://drafts.csswg.org/css-display-4/#reading-order).
@@ -125,7 +125,7 @@ pub enum ReadingFlowStyleValue {}
 ///
 // https://drafts.csswg.org/css-display-4/#reading-order
 #[syntax(" <integer> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "Direct block-level, grid item, or flex item children of a reading flow container.",
@@ -136,5 +136,5 @@ pub enum ReadingFlowStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.reading-order"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ReadingOrderStyleValue;

--- a/crates/css_ast/src/values/exclusions/mod.rs
+++ b/crates/css_ast/src/values/exclusions/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-exclusions-1/#wrap-flow
 #[syntax(" auto | both | start | end | minimum | maximum | clear ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block-level elements.",
@@ -28,7 +28,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-flow"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WrapFlowStyleValue {}
 
 /// Represents the style value for `wrap-through` as defined in [css-exclusions-1](https://drafts.csswg.org/css-exclusions-1/#wrap-through).
@@ -41,7 +41,7 @@ pub enum WrapFlowStyleValue {}
 ///
 // https://drafts.csswg.org/css-exclusions-1/#wrap-through
 #[syntax(" wrap | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "wrap",
 	applies_to = "block-level elements",
@@ -52,5 +52,5 @@ pub enum WrapFlowStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-through"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WrapThroughStyleValue {}

--- a/crates/css_ast/src/values/flexbox/mod.rs
+++ b/crates/css_ast/src/values/flexbox/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-flexbox-1/#flex-direction
 #[syntax(" row | row-reverse | column | column-reverse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "row",
 	applies_to = "flex containers",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-direction"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FlexDirectionStyleValue {}
 
 /// Represents the style value for `flex-wrap` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-wrap).
@@ -45,7 +45,7 @@ pub enum FlexDirectionStyleValue {}
 ///
 // https://drafts.csswg.org/css-flexbox-1/#flex-wrap
 #[syntax(" nowrap | wrap | wrap-reverse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "nowrap",
 	applies_to = "flex containers",
@@ -56,7 +56,7 @@ pub enum FlexDirectionStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-wrap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FlexWrapStyleValue {}
 
 /// Represents the style value for `flex-flow` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-flow).
@@ -71,7 +71,7 @@ pub enum FlexWrapStyleValue {}
 ///
 // https://drafts.csswg.org/css-flexbox-1/#flex-flow
 #[syntax(" <'flex-direction'> || <'flex-wrap'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -82,7 +82,7 @@ pub enum FlexWrapStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-flow"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FlexFlowStyleValue;
 
 // /// Represents the style value for `flex` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex).
@@ -97,7 +97,7 @@ pub struct FlexFlowStyleValue;
 // ///
 // // https://drafts.csswg.org/css-flexbox-1/#flex
 // #[syntax(" none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0 1 auto",
 //   applies_to = "flex items",
@@ -108,7 +108,7 @@ pub struct FlexFlowStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FlexStyleValue {}
 
 /// Represents the style value for `flex-grow` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-grow).
@@ -123,7 +123,7 @@ pub struct FlexFlowStyleValue;
 ///
 // https://drafts.csswg.org/css-flexbox-1/#flex-grow
 #[syntax(" <number [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "flex items",
@@ -134,7 +134,7 @@ pub struct FlexFlowStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-grow"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FlexGrowStyleValue;
 
 /// Represents the style value for `flex-shrink` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-shrink).
@@ -149,7 +149,7 @@ pub struct FlexGrowStyleValue;
 ///
 // https://drafts.csswg.org/css-flexbox-1/#flex-shrink
 #[syntax(" <number [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "1",
 	applies_to = "flex items",
@@ -160,7 +160,7 @@ pub struct FlexGrowStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-shrink"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FlexShrinkStyleValue;
 
 /// Represents the style value for `flex-basis` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-basis).
@@ -175,7 +175,7 @@ pub struct FlexShrinkStyleValue;
 ///
 // https://drafts.csswg.org/css-flexbox-1/#flex-basis
 #[syntax(" content | <'width'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "flex items",
@@ -186,5 +186,5 @@ pub struct FlexShrinkStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-basis"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FlexBasisStyleValue {}

--- a/crates/css_ast/src/values/fonts/mod.rs
+++ b/crates/css_ast/src/values/fonts/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-family
 #[syntax(" [ <family-name> | <generic-family> ]# ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "depends on user agent",
 	applies_to = "all elements and text",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-family"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FontFamilyStyleValue<'a>;
 
 /// Represents the style value for `font-weight` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-weight).
@@ -45,7 +45,7 @@ pub struct FontFamilyStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-weight
 #[syntax(" <font-weight-absolute> | bolder | lighter ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements and text",
@@ -56,7 +56,7 @@ pub struct FontFamilyStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-weight"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontWeightStyleValue {}
 
 /// Represents the style value for `font-width` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-width).
@@ -73,7 +73,7 @@ pub enum FontWeightStyleValue {}
 #[syntax(
 	" normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements and text",
@@ -84,7 +84,7 @@ pub enum FontWeightStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontWidthStyleValue {}
 
 /// Represents the style value for `font-style` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-style).
@@ -99,7 +99,7 @@ pub enum FontWidthStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-style
 #[syntax(" normal | italic | left | right | oblique <angle [-90deg,90deg]>? ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements and text",
@@ -110,7 +110,7 @@ pub enum FontWidthStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontStyleStyleValue {}
 
 /// Represents the style value for `font-size` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-size).
@@ -125,7 +125,7 @@ pub enum FontStyleStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-size
 #[syntax(" <absolute-size> | <relative-size> | <length-percentage [0,∞]> | math ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements and text",
@@ -136,7 +136,7 @@ pub enum FontStyleStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontSizeStyleValue {}
 
 // /// Represents the style value for `font-size-adjust` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-size-adjust).
@@ -151,7 +151,7 @@ pub enum FontSizeStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-fonts-5/#font-size-adjust
 // #[syntax(" none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number [0,∞]> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements and text",
@@ -162,7 +162,7 @@ pub enum FontSizeStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-size-adjust"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontSizeAdjustStyleValue {}
 
 // /// Represents the style value for `font` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font).
@@ -179,7 +179,7 @@ pub enum FontSizeStyleValue {}
 // #[syntax(
 // 	" [ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name> "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "all elements and text",
@@ -190,7 +190,7 @@ pub enum FontSizeStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontStyleValue<'a> {}
 
 /// Represents the style value for `font-synthesis-weight` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-weight).
@@ -205,7 +205,7 @@ pub enum FontSizeStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-synthesis-weight
 #[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements and text",
@@ -216,7 +216,7 @@ pub enum FontSizeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-weight"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontSynthesisWeightStyleValue {}
 
 /// Represents the style value for `font-synthesis-style` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-style).
@@ -231,7 +231,7 @@ pub enum FontSynthesisWeightStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-synthesis-style
 #[syntax(" auto | none | oblique-only ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements and text",
@@ -242,7 +242,7 @@ pub enum FontSynthesisWeightStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontSynthesisStyleStyleValue {}
 
 /// Represents the style value for `font-synthesis-small-caps` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-small-caps).
@@ -257,7 +257,7 @@ pub enum FontSynthesisStyleStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-synthesis-small-caps
 #[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements and text",
@@ -268,7 +268,7 @@ pub enum FontSynthesisStyleStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-small-caps"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontSynthesisSmallCapsStyleValue {}
 
 /// Represents the style value for `font-synthesis-position` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-position).
@@ -283,7 +283,7 @@ pub enum FontSynthesisSmallCapsStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-synthesis-position
 #[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements and text",
@@ -294,7 +294,7 @@ pub enum FontSynthesisSmallCapsStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-position"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontSynthesisPositionStyleValue {}
 
 // /// Represents the style value for `font-synthesis` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis).
@@ -309,7 +309,7 @@ pub enum FontSynthesisPositionStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-fonts-5/#font-synthesis
 // #[syntax(" none | [ weight || style || small-caps || position] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "weight style small-caps position",
 //   applies_to = "all elements and text",
@@ -320,7 +320,7 @@ pub enum FontSynthesisPositionStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontSynthesisStyleValue {}
 
 /// Represents the style value for `font-kerning` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-kerning).
@@ -335,7 +335,7 @@ pub enum FontSynthesisPositionStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-kerning
 #[syntax(" auto | normal | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements and text",
@@ -346,7 +346,7 @@ pub enum FontSynthesisPositionStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-kerning"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontKerningStyleValue {}
 
 // /// Represents the style value for `font-variant-ligatures` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-ligatures).
@@ -363,7 +363,7 @@ pub enum FontKerningStyleValue {}
 // #[syntax(
 // 	" normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements and text",
@@ -374,7 +374,7 @@ pub enum FontKerningStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-ligatures"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontVariantLigaturesStyleValue {}
 
 /// Represents the style value for `font-variant-position` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-position).
@@ -389,7 +389,7 @@ pub enum FontKerningStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-variant-position
 #[syntax(" normal | sub | super ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements and text",
@@ -400,7 +400,7 @@ pub enum FontKerningStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-position"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontVariantPositionStyleValue {}
 
 /// Represents the style value for `font-variant-caps` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-caps).
@@ -415,7 +415,7 @@ pub enum FontVariantPositionStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-variant-caps
 #[syntax(" normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements and text",
@@ -426,7 +426,7 @@ pub enum FontVariantPositionStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-caps"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontVariantCapsStyleValue {}
 
 // /// Represents the style value for `font-variant-numeric` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-numeric).
@@ -443,7 +443,7 @@ pub enum FontVariantCapsStyleValue {}
 // #[syntax(
 // 	" normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements and text",
@@ -454,7 +454,7 @@ pub enum FontVariantCapsStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-numeric"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontVariantNumericStyleValue {}
 
 // /// Represents the style value for `font-variant-alternates` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-alternates).
@@ -471,7 +471,7 @@ pub enum FontVariantCapsStyleValue {}
 // #[syntax(
 // 	" normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements and text",
@@ -482,7 +482,7 @@ pub enum FontVariantCapsStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-alternates"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontVariantAlternatesStyleValue<'a> {}
 
 // /// Represents the style value for `font-variant-east-asian` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-east-asian).
@@ -497,7 +497,7 @@ pub enum FontVariantCapsStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-fonts-5/#font-variant-east-asian
 // #[syntax(" normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements and text",
@@ -508,7 +508,7 @@ pub enum FontVariantCapsStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-east-asian"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontVariantEastAsianStyleValue {}
 
 // /// Represents the style value for `font-variant` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant).
@@ -525,7 +525,7 @@ pub enum FontVariantCapsStyleValue {}
 // #[syntax(
 // 	" normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ] "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements and text",
@@ -536,7 +536,7 @@ pub enum FontVariantCapsStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontVariantStyleValue<'a> {}
 
 // /// Represents the style value for `font-feature-settings` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-feature-settings).
@@ -551,7 +551,7 @@ pub enum FontVariantCapsStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-fonts-5/#font-feature-settings
 // #[syntax(" normal | <feature-tag-value># ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements and text",
@@ -562,7 +562,7 @@ pub enum FontVariantCapsStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-feature-settings"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontFeatureSettingsStyleValue<'a> {}
 
 /// Represents the style value for `font-language-override` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-language-override).
@@ -577,7 +577,7 @@ pub enum FontVariantCapsStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-language-override
 #[syntax(" normal | <string> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements and text",
@@ -588,7 +588,7 @@ pub enum FontVariantCapsStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-language-override"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontLanguageOverrideStyleValue {}
 
 /// Represents the style value for `font-optical-sizing` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-optical-sizing).
@@ -603,7 +603,7 @@ pub enum FontLanguageOverrideStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-optical-sizing
 #[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements and text",
@@ -614,7 +614,7 @@ pub enum FontLanguageOverrideStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-optical-sizing"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontOpticalSizingStyleValue {}
 
 // /// Represents the style value for `font-variation-settings` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variation-settings).
@@ -629,7 +629,7 @@ pub enum FontOpticalSizingStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-fonts-5/#font-variation-settings
 // #[syntax(" normal | [ <opentype-tag> <number> ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements and text",
@@ -640,7 +640,7 @@ pub enum FontOpticalSizingStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variation-settings"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontVariationSettingsStyleValue<'a> {}
 
 // /// Represents the style value for `font-palette` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-palette).
@@ -655,7 +655,7 @@ pub enum FontOpticalSizingStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-fonts-5/#font-palette
 // #[syntax(" normal | light | dark | <palette-identifier> | <palette-mix()> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements and text",
@@ -666,7 +666,7 @@ pub enum FontOpticalSizingStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-palette"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FontPaletteStyleValue {}
 
 /// Represents the style value for `font-variant-emoji` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-emoji).
@@ -681,7 +681,7 @@ pub enum FontOpticalSizingStyleValue {}
 ///
 // https://drafts.csswg.org/css-fonts-5/#font-variant-emoji
 #[syntax(" normal | text | emoji | unicode ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements and text",
@@ -692,5 +692,5 @@ pub enum FontOpticalSizingStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-emoji"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontVariantEmojiStyleValue {}

--- a/crates/css_ast/src/values/forms/mod.rs
+++ b/crates/css_ast/src/values/forms/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-forms-1/#field-sizing
 #[syntax(" fixed | content ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "fixed",
 	applies_to = "elements with default preferred size",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.field-sizing"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FieldSizingStyleValue {}
 
 /// Represents the style value for `slider-orientation` as defined in [css-forms-1](https://drafts.csswg.org/css-forms-1/#slider-orientation).
@@ -43,7 +43,7 @@ pub enum FieldSizingStyleValue {}
 ///
 // https://drafts.csswg.org/css-forms-1/#slider-orientation
 #[syntax(" auto | left-to-right | right-to-left | top-to-bottom | bottom-to-top ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -54,7 +54,7 @@ pub enum FieldSizingStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.slider-orientation"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum SliderOrientationStyleValue {}
 
 /// Represents the style value for `input-security` as defined in [css-forms-1](https://drafts.csswg.org/css-forms-1/#input-security).
@@ -67,7 +67,7 @@ pub enum SliderOrientationStyleValue {}
 ///
 // https://drafts.csswg.org/css-forms-1/#input-security
 #[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "sensitive text inputs",
@@ -78,5 +78,5 @@ pub enum SliderOrientationStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.input-security"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum InputSecurityStyleValue {}

--- a/crates/css_ast/src/values/gaps/mod.rs
+++ b/crates/css_ast/src/values/gaps/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-gaps-1/#column-rule-break
 #[syntax(" none | spanning-item | intersection ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "spanning-item",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -28,7 +28,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-break"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnRuleBreakStyleValue {}
 
 /// Represents the style value for `row-rule-break` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-break).
@@ -41,7 +41,7 @@ pub enum ColumnRuleBreakStyleValue {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#row-rule-break
 #[syntax(" none | spanning-item | intersection ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "spanning-item",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -52,7 +52,7 @@ pub enum ColumnRuleBreakStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-break"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RowRuleBreakStyleValue {}
 
 /// Represents the style value for `rule-break` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-break).
@@ -65,7 +65,7 @@ pub enum RowRuleBreakStyleValue {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#rule-break
 #[syntax(" <'column-rule-break'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "Same as column-rule-break and row-rule-break",
@@ -76,7 +76,7 @@ pub enum RowRuleBreakStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-break"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RuleBreakStyleValue;
 
 /// Represents the style value for `column-rule-outset` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-outset).
@@ -89,7 +89,7 @@ pub struct RuleBreakStyleValue;
 ///
 // https://drafts.csswg.org/css-gaps-1/#column-rule-outset
 #[syntax(" <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "50%",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -100,7 +100,7 @@ pub struct RuleBreakStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-outset"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ColumnRuleOutsetStyleValue;
 
 /// Represents the style value for `row-rule-outset` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-outset).
@@ -113,7 +113,7 @@ pub struct ColumnRuleOutsetStyleValue;
 ///
 // https://drafts.csswg.org/css-gaps-1/#row-rule-outset
 #[syntax(" <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "50%",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -124,7 +124,7 @@ pub struct ColumnRuleOutsetStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-outset"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RowRuleOutsetStyleValue;
 
 /// Represents the style value for `rule-outset` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-outset).
@@ -137,7 +137,7 @@ pub struct RowRuleOutsetStyleValue;
 ///
 // https://drafts.csswg.org/css-gaps-1/#rule-outset
 #[syntax(" <'column-rule-outset'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "Same as column-rule-outset and row-rule-outset",
@@ -148,7 +148,7 @@ pub struct RowRuleOutsetStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-outset"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RuleOutsetStyleValue;
 
 /// Represents the style value for `rule-overlap` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-overlap).
@@ -161,7 +161,7 @@ pub struct RuleOutsetStyleValue;
 ///
 // https://drafts.csswg.org/css-gaps-1/#rule-overlap
 #[syntax(" row-over-column | column-over-row ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "row-over-column",
 	applies_to = "grid containers, flex containers, and masonry containers",
@@ -172,7 +172,7 @@ pub struct RuleOutsetStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-overlap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RuleOverlapStyleValue {}
 
 /// Represents the style value for `column-rule-color` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-color).
@@ -187,7 +187,7 @@ pub enum RuleOverlapStyleValue {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#column-rule-color
 #[syntax(" <line-color-list> | <auto-line-color-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -198,7 +198,7 @@ pub enum RuleOverlapStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnRuleColorStyleValue {}
 
 /// Represents the style value for `row-rule-color` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-color).
@@ -211,7 +211,7 @@ pub enum ColumnRuleColorStyleValue {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#row-rule-color
 #[syntax(" <line-color-list> | <auto-line-color-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -222,7 +222,7 @@ pub enum ColumnRuleColorStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RowRuleColorStyleValue {}
 
 /// Represents the style value for `column-rule-style` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-style).
@@ -237,7 +237,7 @@ pub enum RowRuleColorStyleValue {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#column-rule-style
 #[syntax(" <line-style-list> | <auto-line-style-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -248,7 +248,7 @@ pub enum RowRuleColorStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnRuleStyleStyleValue {}
 
 /// Represents the style value for `row-rule-style` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-style).
@@ -261,7 +261,7 @@ pub enum ColumnRuleStyleStyleValue {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#row-rule-style
 #[syntax(" <line-style-list> | <auto-line-style-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -272,7 +272,7 @@ pub enum ColumnRuleStyleStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RowRuleStyleStyleValue {}
 
 /// Represents the style value for `column-rule-width` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-width).
@@ -287,7 +287,7 @@ pub enum RowRuleStyleStyleValue {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#column-rule-width
 #[syntax(" <line-width-list> | <auto-line-width-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -298,7 +298,7 @@ pub enum RowRuleStyleStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnRuleWidthStyleValue<'a> {}
 
 /// Represents the style value for `row-rule-width` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-width).
@@ -311,7 +311,7 @@ pub enum ColumnRuleWidthStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#row-rule-width
 #[syntax(" <line-width-list> | <auto-line-width-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
@@ -322,7 +322,7 @@ pub enum ColumnRuleWidthStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RowRuleWidthStyleValue<'a> {}
 
 /// Represents the style value for `column-rule` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule).
@@ -337,7 +337,7 @@ pub enum RowRuleWidthStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#column-rule
 #[syntax(" <gap-rule-list> | <gap-auto-rule-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -348,7 +348,7 @@ pub enum RowRuleWidthStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnRuleStyleValue {}
 
 /// Represents the style value for `row-rule` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule).
@@ -361,7 +361,7 @@ pub enum ColumnRuleStyleValue {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#row-rule
 #[syntax(" <gap-rule-list> | <gap-auto-rule-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -372,7 +372,7 @@ pub enum ColumnRuleStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RowRuleStyleValue {}
 
 /// Represents the style value for `rule-color` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-color).
@@ -385,7 +385,7 @@ pub enum RowRuleStyleValue {}
 ///
 // https://drafts.csswg.org/css-gaps-1/#rule-color
 #[syntax(" <'column-rule-color'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "Same as column-rule-color and row-rule-color",
@@ -396,7 +396,7 @@ pub enum RowRuleStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RuleColorStyleValue;
 
 /// Represents the style value for `rule-style` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-style).
@@ -409,7 +409,7 @@ pub struct RuleColorStyleValue;
 ///
 // https://drafts.csswg.org/css-gaps-1/#rule-style
 #[syntax(" <'column-rule-style'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "Same as column-rule-style and row-rule-style",
@@ -420,7 +420,7 @@ pub struct RuleColorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RuleStyleStyleValue;
 
 /// Represents the style value for `rule-width` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-width).
@@ -433,7 +433,7 @@ pub struct RuleStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-gaps-1/#rule-width
 #[syntax(" <'column-rule-width'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "Same as column-rule-width and row-rule-width",
@@ -444,7 +444,7 @@ pub struct RuleStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RuleWidthStyleValue<'a>;
 
 /// Represents the style value for `rule` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule).
@@ -457,7 +457,7 @@ pub struct RuleWidthStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-gaps-1/#rule
 #[syntax(" <'column-rule'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "Same as column-rule and row-rule",
@@ -468,5 +468,5 @@ pub struct RuleWidthStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RuleStyleValue;

--- a/crates/css_ast/src/values/gcpm/mod.rs
+++ b/crates/css_ast/src/values/gcpm/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-gcpm-4/#string-set
 // #[syntax(" [ <custom-ident> <content-list> ]# | none ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements, but not pseudo-elements",
@@ -28,7 +28,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.string-set"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum StringSetStyleValue<'a> {}
 
 /// Represents the style value for `running` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#running).
@@ -41,7 +41,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-gcpm-4/#running
 #[syntax(" <custom-ident> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "elements",
@@ -52,7 +52,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.running"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RunningStyleValue;
 
 /// Represents the style value for `footnote-display` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#footnote-display).
@@ -65,7 +65,7 @@ pub struct RunningStyleValue;
 ///
 // https://drafts.csswg.org/css-gcpm-4/#footnote-display
 #[syntax(" block | inline | compact ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "block",
 	applies_to = "elements",
@@ -76,7 +76,7 @@ pub struct RunningStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.footnote-display"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FootnoteDisplayStyleValue {}
 
 /// Represents the style value for `footnote-policy` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#footnote-policy).
@@ -89,7 +89,7 @@ pub enum FootnoteDisplayStyleValue {}
 ///
 // https://drafts.csswg.org/css-gcpm-4/#footnote-policy
 #[syntax(" auto | line | block ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "elements",
@@ -100,7 +100,7 @@ pub enum FootnoteDisplayStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.footnote-policy"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FootnotePolicyStyleValue {}
 
 // /// Represents the style value for `copy-into` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#copy-into).
@@ -113,7 +113,7 @@ pub enum FootnotePolicyStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-gcpm-4/#copy-into
 // #[syntax(" none |  [ [ <custom-ident>  <content-level>] [,  <custom-ident>  <content-level>]*  ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements and pseudo-elements, but not ::first-line or ::first-letter.",
@@ -124,5 +124,5 @@ pub enum FootnotePolicyStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.copy-into"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum CopyIntoStyleValue {}

--- a/crates/css_ast/src/values/grid/mod.rs
+++ b/crates/css_ast/src/values/grid/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-grid-3/#grid-template-columns
 // #[syntax(" none | <track-list> | <auto-track-list> | subgrid <line-name-list>? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "grid containers",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-template-columns"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum GridTemplateColumnsStyleValue {}
 
 // /// Represents the style value for `grid-template-rows` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-template-rows).
@@ -45,7 +45,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-grid-3/#grid-template-rows
 // #[syntax(" none | <track-list> | <auto-track-list> | subgrid <line-name-list>? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "grid containers",
@@ -56,7 +56,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-template-rows"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum GridTemplateRowsStyleValue {}
 
 /// Represents the style value for `grid-template-areas` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-template-areas).
@@ -71,7 +71,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-grid-3/#grid-template-areas
 #[syntax(" none | <string>+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "grid containers",
@@ -82,7 +82,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-template-areas"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct GridTemplateAreasStyleValue<'a>;
 
 // /// Represents the style value for `grid-template` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-template).
@@ -99,7 +99,7 @@ pub struct GridTemplateAreasStyleValue<'a>;
 // #[syntax(
 // 	" none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]? "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "grid containers",
@@ -110,7 +110,7 @@ pub struct GridTemplateAreasStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-template"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum GridTemplateStyleValue<'a> {}
 
 /// Represents the style value for `grid-auto-columns` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-auto-columns).
@@ -125,7 +125,7 @@ pub struct GridTemplateAreasStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-grid-3/#grid-auto-columns
 #[syntax(" <track-size>+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "grid containers",
@@ -136,7 +136,7 @@ pub struct GridTemplateAreasStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-auto-columns"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct GridAutoColumnsStyleValue<'a>;
 
 /// Represents the style value for `grid-auto-rows` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-auto-rows).
@@ -151,7 +151,7 @@ pub struct GridAutoColumnsStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-grid-3/#grid-auto-rows
 #[syntax(" <track-size>+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "grid containers",
@@ -162,7 +162,7 @@ pub struct GridAutoColumnsStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-auto-rows"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct GridAutoRowsStyleValue<'a>;
 
 // /// Represents the style value for `grid-auto-flow` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-auto-flow).
@@ -177,7 +177,7 @@ pub struct GridAutoRowsStyleValue<'a>;
 // ///
 // // https://drafts.csswg.org/css-grid-3/#grid-auto-flow
 // #[syntax(" [ row | column ] || dense ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "row",
 //   applies_to = "grid containers",
@@ -188,7 +188,7 @@ pub struct GridAutoRowsStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-auto-flow"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct GridAutoFlowStyleValue;
 
 // /// Represents the style value for `grid` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid).
@@ -205,7 +205,7 @@ pub struct GridAutoRowsStyleValue<'a>;
 // #[syntax(
 // 	" <'grid-template'> | <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? | [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'> "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "grid containers",
@@ -216,7 +216,7 @@ pub struct GridAutoRowsStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum GridStyleValue {}
 
 /// Represents the style value for `grid-row-start` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-row-start).
@@ -231,7 +231,7 @@ pub struct GridAutoRowsStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-grid-3/#grid-row-start
 #[syntax(" <grid-line> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
@@ -242,7 +242,7 @@ pub struct GridAutoRowsStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-row-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct GridRowStartStyleValue;
 
 /// Represents the style value for `grid-column-start` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-column-start).
@@ -257,7 +257,7 @@ pub struct GridRowStartStyleValue;
 ///
 // https://drafts.csswg.org/css-grid-3/#grid-column-start
 #[syntax(" <grid-line> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
@@ -268,7 +268,7 @@ pub struct GridRowStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-column-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct GridColumnStartStyleValue;
 
 /// Represents the style value for `grid-row-end` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-row-end).
@@ -283,7 +283,7 @@ pub struct GridColumnStartStyleValue;
 ///
 // https://drafts.csswg.org/css-grid-3/#grid-row-end
 #[syntax(" <grid-line> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
@@ -294,7 +294,7 @@ pub struct GridColumnStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-row-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct GridRowEndStyleValue;
 
 /// Represents the style value for `grid-column-end` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-column-end).
@@ -309,7 +309,7 @@ pub struct GridRowEndStyleValue;
 ///
 // https://drafts.csswg.org/css-grid-3/#grid-column-end
 #[syntax(" <grid-line> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
@@ -320,7 +320,7 @@ pub struct GridRowEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-column-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct GridColumnEndStyleValue;
 
 // /// Represents the style value for `grid-row` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-row).
@@ -335,7 +335,7 @@ pub struct GridColumnEndStyleValue;
 // ///
 // // https://drafts.csswg.org/css-grid-3/#grid-row
 // #[syntax(" <grid-line> [ / <grid-line> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
@@ -346,7 +346,7 @@ pub struct GridColumnEndStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-row"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct GridRowStyleValue;
 
 // /// Represents the style value for `grid-column` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-column).
@@ -361,7 +361,7 @@ pub struct GridColumnEndStyleValue;
 // ///
 // // https://drafts.csswg.org/css-grid-3/#grid-column
 // #[syntax(" <grid-line> [ / <grid-line> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
@@ -372,7 +372,7 @@ pub struct GridColumnEndStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-column"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct GridColumnStyleValue;
 
 // /// Represents the style value for `grid-area` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-area).
@@ -387,7 +387,7 @@ pub struct GridColumnEndStyleValue;
 // ///
 // // https://drafts.csswg.org/css-grid-3/#grid-area
 // #[syntax(" <grid-line> [ / <grid-line> ]{0,3} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
@@ -398,7 +398,7 @@ pub struct GridColumnEndStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-area"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct GridAreaStyleValue;
 
 /// Represents the style value for `item-tolerance` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-tolerance).
@@ -411,7 +411,7 @@ pub struct GridColumnEndStyleValue;
 ///
 // https://drafts.csswg.org/css-grid-3/#item-tolerance
 #[syntax(" normal | <length-percentage> | infinite ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "masonry containers",
@@ -422,7 +422,7 @@ pub struct GridColumnEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-tolerance"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ItemToleranceStyleValue {}
 
 /// Represents the style value for `item-direction` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-direction).
@@ -435,7 +435,7 @@ pub enum ItemToleranceStyleValue {}
 ///
 // https://drafts.csswg.org/css-grid-3/#item-direction
 #[syntax(" auto | row | column | row-reverse | column-reverse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "flex containers, grid containers, masonry containers",
@@ -446,7 +446,7 @@ pub enum ItemToleranceStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-direction"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ItemDirectionStyleValue {}
 
 /// Represents the style value for `item-track` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-track).
@@ -459,7 +459,7 @@ pub enum ItemDirectionStyleValue {}
 ///
 // https://drafts.csswg.org/css-grid-3/#item-track
 #[syntax(" auto | row | column | row-reverse | column-reverse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "flex containers, grid containers, masonry containers",
@@ -470,7 +470,7 @@ pub enum ItemDirectionStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-track"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ItemTrackStyleValue {}
 
 // /// Represents the style value for `item-wrap` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-wrap).
@@ -483,7 +483,7 @@ pub enum ItemTrackStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-grid-3/#item-wrap
 // #[syntax(" [ auto | nowrap | wrap ] || [ normal | reverse ] | wrap-reverse ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "flex containers, grid containers, masonry containers",
@@ -494,7 +494,7 @@ pub enum ItemTrackStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-wrap"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ItemWrapStyleValue {}
 
 // /// Represents the style value for `item-cross` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-cross).
@@ -507,7 +507,7 @@ pub enum ItemTrackStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-grid-3/#item-cross
 // #[syntax(" [ auto | nowrap | wrap ] || [ normal | reverse ] | wrap-reverse ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "flex containers, grid containers, masonry containers",
@@ -518,7 +518,7 @@ pub enum ItemTrackStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-cross"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ItemCrossStyleValue {}
 
 // /// Represents the style value for `item-pack` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-pack).
@@ -531,7 +531,7 @@ pub enum ItemTrackStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-grid-3/#item-pack
 // #[syntax(" normal | dense || balance ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "flex containers, grid containers, masonry containers",
@@ -542,7 +542,7 @@ pub enum ItemTrackStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-pack"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ItemPackStyleValue {}
 
 // /// Represents the style value for `item-flow` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-flow).
@@ -555,7 +555,7 @@ pub enum ItemTrackStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-grid-3/#item-flow
 // #[syntax(" <'item-direction'> || <'item-wrap'> || <'item-pack'> || <'item-tolerance'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -566,5 +566,5 @@ pub enum ItemTrackStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-flow"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ItemFlowStyleValue;

--- a/crates/css_ast/src/values/images/mod.rs
+++ b/crates/css_ast/src/values/images/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-images-5/#object-fit
 // #[syntax(" fill | none | [contain | cover] || scale-down ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "fill",
 //   applies_to = "replaced elements",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.object-fit"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ObjectFitStyleValue {}
 
 /// Represents the style value for `object-position` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#object-position).
@@ -45,7 +45,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-images-5/#object-position
 #[syntax(" <position> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "50% 50%",
 	applies_to = "replaced elements",
@@ -56,7 +56,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.object-position"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ObjectPositionStyleValue;
 
 // /// Represents the style value for `image-orientation` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#image-orientation).
@@ -71,7 +71,7 @@ pub struct ObjectPositionStyleValue;
 // ///
 // // https://drafts.csswg.org/css-images-5/#image-orientation
 // #[syntax(" from-image | none | [ <angle> || flip ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "from-image",
 //   applies_to = "all elements",
@@ -82,7 +82,7 @@ pub struct ObjectPositionStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.image-orientation"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ImageOrientationStyleValue {}
 
 /// Represents the style value for `image-rendering` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#image-rendering).
@@ -97,7 +97,7 @@ pub struct ObjectPositionStyleValue;
 ///
 // https://drafts.csswg.org/css-images-5/#image-rendering
 #[syntax(" auto | smooth | high-quality | pixelated | crisp-edges ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -108,7 +108,7 @@ pub struct ObjectPositionStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.image-rendering"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ImageRenderingStyleValue {}
 
 // /// Represents the style value for `image-resolution` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#image-resolution).
@@ -121,7 +121,7 @@ pub enum ImageRenderingStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-images-5/#image-resolution
 // #[syntax(" [ from-image || <resolution> ] && snap? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "1dppx",
 //   applies_to = "all elements",
@@ -132,7 +132,7 @@ pub enum ImageRenderingStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.image-resolution"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ImageResolutionStyleValue;
 
 /// Represents the style value for `object-view-box` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#object-view-box).
@@ -147,7 +147,7 @@ pub enum ImageRenderingStyleValue {}
 ///
 // https://drafts.csswg.org/css-images-5/#object-view-box
 #[syntax(" none | <basic-shape-rect> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "replaced elements",
@@ -158,5 +158,5 @@ pub enum ImageRenderingStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.object-view-box"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ObjectViewBoxStyleValue;

--- a/crates/css_ast/src/values/inline/mod.rs
+++ b/crates/css_ast/src/values/inline/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-inline-3/#dominant-baseline
 #[syntax(" auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block containers, inline boxes, table rows, grid containers, flex containers, and SVG text content elements",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.dominant-baseline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum DominantBaselineStyleValue {}
 
 // /// Represents the style value for `vertical-align` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#vertical-align).
@@ -45,7 +45,7 @@ pub enum DominantBaselineStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-inline-3/#vertical-align
 // #[syntax(" [ first | last] || <'alignment-baseline'> || <'baseline-shift'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "baseline",
 //   applies_to = "see individual properties",
@@ -56,7 +56,7 @@ pub enum DominantBaselineStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.vertical-align"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct VerticalAlignStyleValue;
 
 /// Represents the style value for `baseline-source` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#baseline-source).
@@ -71,7 +71,7 @@ pub enum DominantBaselineStyleValue {}
 ///
 // https://drafts.csswg.org/css-inline-3/#baseline-source
 #[syntax(" auto | first | last ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "inline-level boxes",
@@ -82,7 +82,7 @@ pub enum DominantBaselineStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.baseline-source"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BaselineSourceStyleValue {}
 
 /// Represents the style value for `alignment-baseline` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#alignment-baseline).
@@ -97,7 +97,7 @@ pub enum BaselineSourceStyleValue {}
 ///
 // https://drafts.csswg.org/css-inline-3/#alignment-baseline
 #[syntax(" baseline | text-bottom | alphabetic | ideographic | middle | central | mathematical | text-top ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "baseline",
 	applies_to = "inline-level boxes, flex items, grid items, table cells, and SVG text content elements",
@@ -108,7 +108,7 @@ pub enum BaselineSourceStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.alignment-baseline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum AlignmentBaselineStyleValue {}
 
 /// Represents the style value for `baseline-shift` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#baseline-shift).
@@ -123,7 +123,7 @@ pub enum AlignmentBaselineStyleValue {}
 ///
 // https://drafts.csswg.org/css-inline-3/#baseline-shift
 #[syntax(" <length-percentage> | sub | super | top | center | bottom ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "inline-level boxes and SVG text content elements",
@@ -134,7 +134,7 @@ pub enum AlignmentBaselineStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.baseline-shift"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BaselineShiftStyleValue {}
 
 /// Represents the style value for `line-height` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#line-height).
@@ -149,7 +149,7 @@ pub enum BaselineShiftStyleValue {}
 ///
 // https://drafts.csswg.org/css-inline-3/#line-height
 #[syntax(" normal | <number [0,∞]> | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "non-replaced inline boxes and SVG text content elements",
@@ -160,7 +160,7 @@ pub enum BaselineShiftStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-height"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum LineHeightStyleValue {}
 
 /// Represents the style value for `line-fit-edge` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#line-fit-edge).
@@ -173,7 +173,7 @@ pub enum LineHeightStyleValue {}
 ///
 // https://drafts.csswg.org/css-inline-3/#line-fit-edge
 #[syntax(" leading | <text-edge> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "leading",
 	applies_to = "inline boxes",
@@ -184,7 +184,7 @@ pub enum LineHeightStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-fit-edge"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum LineFitEdgeStyleValue {}
 
 // /// Represents the style value for `text-box` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#text-box).
@@ -199,7 +199,7 @@ pub enum LineFitEdgeStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-inline-3/#text-box
 // #[syntax(" normal | <'text-box-trim'> || <'text-box-edge'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "block containers, multi-column containers, and inline boxes",
@@ -210,7 +210,7 @@ pub enum LineFitEdgeStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-box"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum TextBoxStyleValue {}
 
 /// Represents the style value for `text-box-trim` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#text-box-trim).
@@ -225,7 +225,7 @@ pub enum LineFitEdgeStyleValue {}
 ///
 // https://drafts.csswg.org/css-inline-3/#text-box-trim
 #[syntax(" none | trim-start | trim-end | trim-both ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "block containers, multi-column containers, and inline boxes",
@@ -236,7 +236,7 @@ pub enum LineFitEdgeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-box-trim"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextBoxTrimStyleValue {}
 
 /// Represents the style value for `text-box-edge` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#text-box-edge).
@@ -251,7 +251,7 @@ pub enum TextBoxTrimStyleValue {}
 ///
 // https://drafts.csswg.org/css-inline-3/#text-box-edge
 #[syntax(" auto | <text-edge> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block containers and inline boxes",
@@ -262,7 +262,7 @@ pub enum TextBoxTrimStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-box-edge"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextBoxEdgeStyleValue;
 
 /// Represents the style value for `inline-sizing` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#inline-sizing).
@@ -275,7 +275,7 @@ pub struct TextBoxEdgeStyleValue;
 ///
 // https://drafts.csswg.org/css-inline-3/#inline-sizing
 #[syntax(" normal | stretch ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "inline boxes, but not ruby container boxes nor internal ruby boxes",
@@ -286,7 +286,7 @@ pub struct TextBoxEdgeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inline-sizing"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum InlineSizingStyleValue {}
 
 // /// Represents the style value for `initial-letter` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#initial-letter).
@@ -301,7 +301,7 @@ pub enum InlineSizingStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-inline-3/#initial-letter
 // #[syntax(" normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "certain inline-level boxes and ::first-letter and inside ::marker boxes (see prose)",
@@ -312,7 +312,7 @@ pub enum InlineSizingStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.initial-letter"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum InitialLetterStyleValue {}
 
 // /// Represents the style value for `initial-letter-align` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#initial-letter-align).
@@ -325,7 +325,7 @@ pub enum InlineSizingStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-inline-3/#initial-letter-align
 // #[syntax(" [ border-box? [ alphabetic | ideographic | hanging | leading ]? ]! ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "alphabetic",
 //   applies_to = "certain inline-level boxes and ::first-letter and inside ::marker boxes (see prose)",
@@ -336,7 +336,7 @@ pub enum InlineSizingStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.initial-letter-align"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct InitialLetterAlignStyleValue;
 
 /// Represents the style value for `initial-letter-wrap` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#initial-letter-wrap).
@@ -349,7 +349,7 @@ pub enum InlineSizingStyleValue {}
 ///
 // https://drafts.csswg.org/css-inline-3/#initial-letter-wrap
 #[syntax(" none | first | all | grid | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "certain inline-level boxes and ::first-letter and inside ::marker boxes (see prose)",
@@ -360,5 +360,5 @@ pub enum InlineSizingStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.initial-letter-wrap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum InitialLetterWrapStyleValue {}

--- a/crates/css_ast/src/values/line_grid/mod.rs
+++ b/crates/css_ast/src/values/line_grid/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-line-grid-1/#line-grid
 #[syntax(" match-parent | create ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "match-parent",
 	applies_to = "block, flex and grid containers",
@@ -28,7 +28,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-grid"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum LineGridStyleValue {}
 
 /// Represents the style value for `line-snap` as defined in [css-line-grid-1](https://drafts.csswg.org/css-line-grid-1/#line-snap).
@@ -41,7 +41,7 @@ pub enum LineGridStyleValue {}
 ///
 // https://drafts.csswg.org/css-line-grid-1/#line-snap
 #[syntax(" none | baseline | contain ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "block container elements",
@@ -52,7 +52,7 @@ pub enum LineGridStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-snap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum LineSnapStyleValue {}
 
 /// Represents the style value for `box-snap` as defined in [css-line-grid-1](https://drafts.csswg.org/css-line-grid-1/#box-snap).
@@ -65,7 +65,7 @@ pub enum LineSnapStyleValue {}
 ///
 // https://drafts.csswg.org/css-line-grid-1/#box-snap
 #[syntax(" none | block-start | block-end | center | baseline | last-baseline ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "block-level boxes and internal table elements except table cells",
@@ -76,5 +76,5 @@ pub enum LineSnapStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-snap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BoxSnapStyleValue {}

--- a/crates/css_ast/src/values/link_params/mod.rs
+++ b/crates/css_ast/src/values/link_params/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-link-params-1/#link-parameters
 #[syntax(" none | <param()># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements and pseudo-elements",
@@ -28,5 +28,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.link-parameters"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct LinkParametersStyleValue<'a>;

--- a/crates/css_ast/src/values/lists/mod.rs
+++ b/crates/css_ast/src/values/lists/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-lists-3/#list-style-image
 #[syntax(" <image> | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "list items",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style-image"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ListStyleImageStyleValue<'a>;
 
 /// Represents the style value for `list-style-type` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style-type).
@@ -45,7 +45,7 @@ pub struct ListStyleImageStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-lists-3/#list-style-type
 #[syntax(" <counter-style> | <string> | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "disc",
 	applies_to = "list items",
@@ -56,7 +56,7 @@ pub struct ListStyleImageStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style-type"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ListStyleTypeStyleValue<'a> {}
 
 /// Represents the style value for `list-style-position` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style-position).
@@ -71,7 +71,7 @@ pub enum ListStyleTypeStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-lists-3/#list-style-position
 #[syntax(" inside | outside ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "outside",
 	applies_to = "list items",
@@ -82,7 +82,7 @@ pub enum ListStyleTypeStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style-position"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ListStylePositionStyleValue {}
 
 // /// Represents the style value for `list-style` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style).
@@ -97,7 +97,7 @@ pub enum ListStylePositionStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-lists-3/#list-style
 // #[syntax(" <'list-style-position'> || <'list-style-image'> || <'list-style-type'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "list items",
@@ -108,7 +108,7 @@ pub enum ListStylePositionStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ListStyleStyleValue;
 
 /// Represents the style value for `marker-side` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#marker-side).
@@ -121,7 +121,7 @@ pub enum ListStylePositionStyleValue {}
 ///
 // https://drafts.csswg.org/css-lists-3/#marker-side
 #[syntax(" match-self | match-parent ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "match-self",
 	applies_to = "list items",
@@ -132,7 +132,7 @@ pub enum ListStylePositionStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.marker-side"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum MarkerSideStyleValue {}
 
 // /// Represents the style value for `counter-reset` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#counter-reset).
@@ -147,7 +147,7 @@ pub enum MarkerSideStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-lists-3/#counter-reset
 // #[syntax(" [ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+ | none ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements",
@@ -158,7 +158,7 @@ pub enum MarkerSideStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.counter-reset"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum CounterResetStyleValue<'a> {}
 
 // /// Represents the style value for `counter-increment` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#counter-increment).
@@ -173,7 +173,7 @@ pub enum MarkerSideStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-lists-3/#counter-increment
 // #[syntax(" [ <counter-name> <integer>? ]+ | none ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements",
@@ -184,7 +184,7 @@ pub enum MarkerSideStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.counter-increment"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum CounterIncrementStyleValue<'a> {}
 
 // /// Represents the style value for `counter-set` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#counter-set).
@@ -199,7 +199,7 @@ pub enum MarkerSideStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-lists-3/#counter-set
 // #[syntax(" [ <counter-name> <integer>? ]+ | none ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements",
@@ -210,5 +210,5 @@ pub enum MarkerSideStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.counter-set"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum CounterSetStyleValue<'a> {}

--- a/crates/css_ast/src/values/logical/mod.rs
+++ b/crates/css_ast/src/values/logical/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-logical-1/#block-size
 #[syntax(" <'width'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "Same as height and width",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BlockSizeStyleValue;
 
 /// Represents the style value for `inline-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#inline-size).
@@ -45,7 +45,7 @@ pub struct BlockSizeStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#inline-size
 #[syntax(" <'width'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "Same as height and width",
@@ -56,7 +56,7 @@ pub struct BlockSizeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inline-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InlineSizeStyleValue;
 
 /// Represents the style value for `min-block-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#min-block-size).
@@ -71,7 +71,7 @@ pub struct InlineSizeStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#min-block-size
 #[syntax(" <'min-width'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "same as height and width",
@@ -82,7 +82,7 @@ pub struct InlineSizeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-block-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MinBlockSizeStyleValue;
 
 /// Represents the style value for `min-inline-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#min-inline-size).
@@ -97,7 +97,7 @@ pub struct MinBlockSizeStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#min-inline-size
 #[syntax(" <'min-width'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "same as height and width",
@@ -108,7 +108,7 @@ pub struct MinBlockSizeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-inline-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MinInlineSizeStyleValue;
 
 /// Represents the style value for `max-block-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#max-block-size).
@@ -123,7 +123,7 @@ pub struct MinInlineSizeStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#max-block-size
 #[syntax(" <'max-width'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "same as height and width",
@@ -134,7 +134,7 @@ pub struct MinInlineSizeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-block-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MaxBlockSizeStyleValue;
 
 /// Represents the style value for `max-inline-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#max-inline-size).
@@ -149,7 +149,7 @@ pub struct MaxBlockSizeStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#max-inline-size
 #[syntax(" <'max-width'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "same as height and width",
@@ -160,7 +160,7 @@ pub struct MaxBlockSizeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-inline-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MaxInlineSizeStyleValue;
 
 /// Represents the style value for `margin-block-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block-start).
@@ -175,7 +175,7 @@ pub struct MaxInlineSizeStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#margin-block-start
 #[syntax(" <'margin-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "Same as margin-top",
@@ -186,7 +186,7 @@ pub struct MaxInlineSizeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-block-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginBlockStartStyleValue;
 
 /// Represents the style value for `margin-block-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block-end).
@@ -201,7 +201,7 @@ pub struct MarginBlockStartStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#margin-block-end
 #[syntax(" <'margin-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "Same as margin-top",
@@ -212,7 +212,7 @@ pub struct MarginBlockStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-block-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginBlockEndStyleValue;
 
 /// Represents the style value for `margin-inline-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-inline-start).
@@ -227,7 +227,7 @@ pub struct MarginBlockEndStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#margin-inline-start
 #[syntax(" <'margin-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "Same as margin-top",
@@ -238,7 +238,7 @@ pub struct MarginBlockEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-inline-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginInlineStartStyleValue;
 
 /// Represents the style value for `margin-inline-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-inline-end).
@@ -253,7 +253,7 @@ pub struct MarginInlineStartStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#margin-inline-end
 #[syntax(" <'margin-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "Same as margin-top",
@@ -264,7 +264,7 @@ pub struct MarginInlineStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-inline-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginInlineEndStyleValue;
 
 /// Represents the style value for `margin-block` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block).
@@ -279,7 +279,7 @@ pub struct MarginInlineEndStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#margin-block
 #[syntax(" <'margin-top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -290,7 +290,7 @@ pub struct MarginInlineEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-block"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginBlockStyleValue;
 
 /// Represents the style value for `margin-inline` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-inline).
@@ -305,7 +305,7 @@ pub struct MarginBlockStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#margin-inline
 #[syntax(" <'margin-top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -316,7 +316,7 @@ pub struct MarginBlockStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-inline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginInlineStyleValue;
 
 /// Represents the style value for `padding-block-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-block-start).
@@ -331,7 +331,7 @@ pub struct MarginInlineStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#padding-block-start
 #[syntax(" <'padding-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "Same as padding-top",
@@ -342,7 +342,7 @@ pub struct MarginInlineStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-block-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingBlockStartStyleValue;
 
 /// Represents the style value for `padding-block-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-block-end).
@@ -357,7 +357,7 @@ pub struct PaddingBlockStartStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#padding-block-end
 #[syntax(" <'padding-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "Same as padding-top",
@@ -368,7 +368,7 @@ pub struct PaddingBlockStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-block-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingBlockEndStyleValue;
 
 /// Represents the style value for `padding-inline-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-inline-start).
@@ -383,7 +383,7 @@ pub struct PaddingBlockEndStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#padding-inline-start
 #[syntax(" <'padding-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "Same as padding-top",
@@ -394,7 +394,7 @@ pub struct PaddingBlockEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-inline-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingInlineStartStyleValue;
 
 /// Represents the style value for `padding-inline-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-inline-end).
@@ -409,7 +409,7 @@ pub struct PaddingInlineStartStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#padding-inline-end
 #[syntax(" <'padding-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "Same as padding-top",
@@ -420,7 +420,7 @@ pub struct PaddingInlineStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-inline-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingInlineEndStyleValue;
 
 /// Represents the style value for `padding-block` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-block).
@@ -435,7 +435,7 @@ pub struct PaddingInlineEndStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#padding-block
 #[syntax(" <'padding-top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -446,7 +446,7 @@ pub struct PaddingInlineEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-block"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingBlockStyleValue;
 
 /// Represents the style value for `padding-inline` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-inline).
@@ -461,7 +461,7 @@ pub struct PaddingBlockStyleValue;
 ///
 // https://drafts.csswg.org/css-logical-1/#padding-inline
 #[syntax(" <'padding-top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -472,5 +472,5 @@ pub struct PaddingBlockStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-inline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingInlineStyleValue;

--- a/crates/css_ast/src/values/multicol/mod.rs
+++ b/crates/css_ast/src/values/multicol/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-multicol-2/#column-width
 #[syntax(" auto | <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block containers except table wrapper boxes",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ColumnWidthStyleValue;
 
 /// Represents the style value for `column-count` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-count).
@@ -45,7 +45,7 @@ pub struct ColumnWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-multicol-2/#column-count
 #[syntax(" auto | <integer [1,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block containers except table wrapper boxes",
@@ -56,7 +56,7 @@ pub struct ColumnWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-count"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ColumnCountStyleValue;
 
 // /// Represents the style value for `columns` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#columns).
@@ -71,7 +71,7 @@ pub struct ColumnCountStyleValue;
 // ///
 // // https://drafts.csswg.org/css-multicol-2/#columns
 // #[syntax(" [ <'column-width'> || <'column-count'> ] [ / <'column-height'> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -82,7 +82,7 @@ pub struct ColumnCountStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.columns"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ColumnsStyleValue;
 
 /// Represents the style value for `column-span` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-span).
@@ -97,7 +97,7 @@ pub struct ColumnCountStyleValue;
 ///
 // https://drafts.csswg.org/css-multicol-2/#column-span
 #[syntax(" none | <integer [1,∞]> | all | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "in-flow block-level elements",
@@ -108,7 +108,7 @@ pub struct ColumnCountStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-span"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnSpanStyleValue {}
 
 /// Represents the style value for `column-fill` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-fill).
@@ -123,7 +123,7 @@ pub enum ColumnSpanStyleValue {}
 ///
 // https://drafts.csswg.org/css-multicol-2/#column-fill
 #[syntax(" auto | balance | balance-all ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "balance",
 	applies_to = "multicol containers",
@@ -134,7 +134,7 @@ pub enum ColumnSpanStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-fill"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnFillStyleValue {}
 
 /// Represents the style value for `column-height` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-height).
@@ -147,7 +147,7 @@ pub enum ColumnFillStyleValue {}
 ///
 // https://drafts.csswg.org/css-multicol-2/#column-height
 #[syntax(" auto | <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block containers except table wrapper boxes",
@@ -158,7 +158,7 @@ pub enum ColumnFillStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-height"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ColumnHeightStyleValue;
 
 /// Represents the style value for `column-wrap` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-wrap).
@@ -171,7 +171,7 @@ pub struct ColumnHeightStyleValue;
 ///
 // https://drafts.csswg.org/css-multicol-2/#column-wrap
 #[syntax(" auto | nowrap | wrap ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "multicol containers",
@@ -182,5 +182,5 @@ pub struct ColumnHeightStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-wrap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnWrapStyleValue {}

--- a/crates/css_ast/src/values/nav/mod.rs
+++ b/crates/css_ast/src/values/nav/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-nav-1/#spatial-navigation-contain
 #[syntax(" auto | contain ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -32,7 +32,7 @@ use impls::*;
 	derive(ToCSSFeature),
 	css_feature("css.properties.spatial-navigation-contain")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum SpatialNavigationContainStyleValue {}
 
 /// Represents the style value for `spatial-navigation-action` as defined in [css-nav-1](https://drafts.csswg.org/css-nav-1/#spatial-navigation-action).
@@ -45,7 +45,7 @@ pub enum SpatialNavigationContainStyleValue {}
 ///
 // https://drafts.csswg.org/css-nav-1/#spatial-navigation-action
 #[syntax(" auto | focus | scroll ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -56,7 +56,7 @@ pub enum SpatialNavigationContainStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.spatial-navigation-action"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum SpatialNavigationActionStyleValue {}
 
 /// Represents the style value for `spatial-navigation-function` as defined in [css-nav-1](https://drafts.csswg.org/css-nav-1/#spatial-navigation-function).
@@ -69,7 +69,7 @@ pub enum SpatialNavigationActionStyleValue {}
 ///
 // https://drafts.csswg.org/css-nav-1/#spatial-navigation-function
 #[syntax(" normal | grid ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "spatial navigation containers",
@@ -84,5 +84,5 @@ pub enum SpatialNavigationActionStyleValue {}
 	derive(ToCSSFeature),
 	css_feature("css.properties.spatial-navigation-function")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum SpatialNavigationFunctionStyleValue {}

--- a/crates/css_ast/src/values/overflow/mod.rs
+++ b/crates/css_ast/src/values/overflow/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-x
 #[syntax(" visible | hidden | clip | scroll | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "visible",
 	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], grid containers [CSS3-GRID-LAYOUT]",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-x"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverflowXStyleValue {}
 
 /// Represents the style value for `overflow-y` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-y).
@@ -45,7 +45,7 @@ pub enum OverflowXStyleValue {}
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-y
 #[syntax(" visible | hidden | clip | scroll | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "visible",
 	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], grid containers [CSS3-GRID-LAYOUT]",
@@ -56,7 +56,7 @@ pub enum OverflowXStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-y"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverflowYStyleValue {}
 
 /// Represents the style value for `overflow-block` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-block).
@@ -71,7 +71,7 @@ pub enum OverflowYStyleValue {}
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-block
 #[syntax(" visible | hidden | clip | scroll | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "visible",
 	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], grid containers [CSS3-GRID-LAYOUT]",
@@ -82,7 +82,7 @@ pub enum OverflowYStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-block"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverflowBlockStyleValue {}
 
 /// Represents the style value for `overflow-inline` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-inline).
@@ -97,7 +97,7 @@ pub enum OverflowBlockStyleValue {}
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-inline
 #[syntax(" visible | hidden | clip | scroll | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "visible",
 	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], grid containers [CSS3-GRID-LAYOUT]",
@@ -108,7 +108,7 @@ pub enum OverflowBlockStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-inline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverflowInlineStyleValue {}
 
 /// Represents the style value for `overflow` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow).
@@ -123,7 +123,7 @@ pub enum OverflowInlineStyleValue {}
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow
 #[syntax(" <'overflow-block'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "visible",
 	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], and grid containers [CSS3-GRID-LAYOUT]",
@@ -134,7 +134,7 @@ pub enum OverflowInlineStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowStyleValue;
 
 /// Represents the style value for `overflow-clip-margin` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin).
@@ -149,7 +149,7 @@ pub struct OverflowStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -160,7 +160,7 @@ pub struct OverflowStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-clip-margin"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginStyleValue;
 
 /// Represents the style value for `scroll-behavior` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scroll-behavior).
@@ -175,7 +175,7 @@ pub struct OverflowClipMarginStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#scroll-behavior
 #[syntax(" auto | smooth ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -186,7 +186,7 @@ pub struct OverflowClipMarginStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-behavior"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ScrollBehaviorStyleValue {}
 
 // /// Represents the style value for `scrollbar-gutter` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scrollbar-gutter).
@@ -201,7 +201,7 @@ pub enum ScrollBehaviorStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-overflow-5/#scrollbar-gutter
 // #[syntax(" auto | stable && both-edges? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "scroll containers",
@@ -212,7 +212,7 @@ pub enum ScrollBehaviorStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scrollbar-gutter"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ScrollbarGutterStyleValue {}
 
 // /// Represents the style value for `text-overflow` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#text-overflow).
@@ -227,7 +227,7 @@ pub enum ScrollBehaviorStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-overflow-5/#text-overflow
 // #[syntax(" [ clip | ellipsis | <string> | fade | <fade()> ]{1,2} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "clip",
 //   applies_to = "block containers",
@@ -238,7 +238,7 @@ pub enum ScrollBehaviorStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-overflow"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TextOverflowStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-top` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-top).
@@ -251,7 +251,7 @@ pub enum ScrollBehaviorStyleValue {}
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-top
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -262,7 +262,7 @@ pub enum ScrollBehaviorStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-clip-margin-top"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginTopStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-right` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-right).
@@ -275,7 +275,7 @@ pub struct OverflowClipMarginTopStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-right
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -290,7 +290,7 @@ pub struct OverflowClipMarginTopStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.overflow-clip-margin-right")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginRightStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-bottom` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-bottom).
@@ -303,7 +303,7 @@ pub struct OverflowClipMarginRightStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-bottom
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -318,7 +318,7 @@ pub struct OverflowClipMarginRightStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.overflow-clip-margin-bottom")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginBottomStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-left` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-left).
@@ -331,7 +331,7 @@ pub struct OverflowClipMarginBottomStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-left
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -342,7 +342,7 @@ pub struct OverflowClipMarginBottomStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-clip-margin-left"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginLeftStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-block-start` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-start).
@@ -355,7 +355,7 @@ pub struct OverflowClipMarginLeftStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-start
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -370,7 +370,7 @@ pub struct OverflowClipMarginLeftStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.overflow-clip-margin-block-start")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginBlockStartStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-inline-start` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-start).
@@ -383,7 +383,7 @@ pub struct OverflowClipMarginBlockStartStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-start
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -398,7 +398,7 @@ pub struct OverflowClipMarginBlockStartStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.overflow-clip-margin-inline-start")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginInlineStartStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-block-end` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-end).
@@ -411,7 +411,7 @@ pub struct OverflowClipMarginInlineStartStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-end
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -426,7 +426,7 @@ pub struct OverflowClipMarginInlineStartStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.overflow-clip-margin-block-end")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginBlockEndStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-inline-end` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-end).
@@ -439,7 +439,7 @@ pub struct OverflowClipMarginBlockEndStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-end
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -454,7 +454,7 @@ pub struct OverflowClipMarginBlockEndStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.overflow-clip-margin-inline-end")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginInlineEndStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-inline` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline).
@@ -467,7 +467,7 @@ pub struct OverflowClipMarginInlineEndStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -482,7 +482,7 @@ pub struct OverflowClipMarginInlineEndStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.overflow-clip-margin-inline")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginInlineStyleValue;
 
 /// Represents the style value for `overflow-clip-margin-block` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block).
@@ -495,7 +495,7 @@ pub struct OverflowClipMarginInlineStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block
 #[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px",
 	applies_to = "boxes to which overflow applies",
@@ -510,7 +510,7 @@ pub struct OverflowClipMarginInlineStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.overflow-clip-margin-block")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverflowClipMarginBlockStyleValue;
 
 /// Represents the style value for `block-ellipsis` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#block-ellipsis).
@@ -523,7 +523,7 @@ pub struct OverflowClipMarginBlockStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#block-ellipsis
 #[syntax(" no-ellipsis | auto | <string> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "no-ellipsis",
 	applies_to = "block containers",
@@ -534,7 +534,7 @@ pub struct OverflowClipMarginBlockStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-ellipsis"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BlockEllipsisStyleValue {}
 
 // /// Represents the style value for `line-clamp` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#line-clamp).
@@ -549,7 +549,7 @@ pub enum BlockEllipsisStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-overflow-5/#line-clamp
 // #[syntax(" none | [<integer [1,∞]> || <'block-ellipsis'>] -webkit-legacy? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "see individual properties",
@@ -560,7 +560,7 @@ pub enum BlockEllipsisStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-clamp"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum LineClampStyleValue {}
 
 /// Represents the style value for `-webkit-line-clamp` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#-webkit-line-clamp).
@@ -573,7 +573,7 @@ pub enum BlockEllipsisStyleValue {}
 ///
 // https://drafts.csswg.org/css-overflow-5/#-webkit-line-clamp
 #[syntax(" none | <integer [1,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "see individual properties",
@@ -584,7 +584,7 @@ pub enum BlockEllipsisStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.-webkit-line-clamp"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct WebkitLineClampStyleValue;
 
 /// Represents the style value for `max-lines` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#max-lines).
@@ -597,7 +597,7 @@ pub struct WebkitLineClampStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#max-lines
 #[syntax(" none | <integer [1,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "block containers which are also either line-clamp containers or fragmentation containers that capture region breaks",
@@ -608,7 +608,7 @@ pub struct WebkitLineClampStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-lines"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MaxLinesStyleValue;
 
 /// Represents the style value for `continue` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#continue).
@@ -621,7 +621,7 @@ pub struct MaxLinesStyleValue;
 ///
 // https://drafts.csswg.org/css-overflow-5/#continue
 #[syntax(" auto | discard | collapse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block containers and multicol containers",
@@ -632,7 +632,7 @@ pub struct MaxLinesStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.continue"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ContinueStyleValue {}
 
 /// Represents the style value for `scroll-target-group` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scroll-target-group).
@@ -645,7 +645,7 @@ pub enum ContinueStyleValue {}
 ///
 // https://drafts.csswg.org/css-overflow-5/#scroll-target-group
 #[syntax(" none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -656,7 +656,7 @@ pub enum ContinueStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-target-group"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ScrollTargetGroupStyleValue {}
 
 /// Represents the style value for `scroll-marker-group` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scroll-marker-group).
@@ -671,7 +671,7 @@ pub enum ScrollTargetGroupStyleValue {}
 ///
 // https://drafts.csswg.org/css-overflow-5/#scroll-marker-group
 #[syntax(" none | before | after ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "scroll containers",
@@ -682,5 +682,5 @@ pub enum ScrollTargetGroupStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-marker-group"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ScrollMarkerGroupStyleValue {}

--- a/crates/css_ast/src/values/overscroll/mod.rs
+++ b/crates/css_ast/src/values/overscroll/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior
 #[syntax(" [ contain | none | auto ]{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto auto",
 	applies_to = "scroll container elements",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overscroll-behavior"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverscrollBehaviorStyleValue;
 
 /// Represents the style value for `overscroll-behavior-x` as defined in [css-overscroll-1](https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-x).
@@ -45,7 +45,7 @@ pub struct OverscrollBehaviorStyleValue;
 ///
 // https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-x
 #[syntax(" contain | none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll container elements",
@@ -56,7 +56,7 @@ pub struct OverscrollBehaviorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overscroll-behavior-x"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverscrollBehaviorXStyleValue {}
 
 /// Represents the style value for `overscroll-behavior-y` as defined in [css-overscroll-1](https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-y).
@@ -71,7 +71,7 @@ pub enum OverscrollBehaviorXStyleValue {}
 ///
 // https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-y
 #[syntax(" contain | none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll container elements",
@@ -82,7 +82,7 @@ pub enum OverscrollBehaviorXStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overscroll-behavior-y"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverscrollBehaviorYStyleValue {}
 
 /// Represents the style value for `overscroll-behavior-inline` as defined in [css-overscroll-1](https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-inline).
@@ -97,7 +97,7 @@ pub enum OverscrollBehaviorYStyleValue {}
 ///
 // https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-inline
 #[syntax(" contain | none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll container elements",
@@ -112,7 +112,7 @@ pub enum OverscrollBehaviorYStyleValue {}
 	derive(ToCSSFeature),
 	css_feature("css.properties.overscroll-behavior-inline")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverscrollBehaviorInlineStyleValue {}
 
 /// Represents the style value for `overscroll-behavior-block` as defined in [css-overscroll-1](https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-block).
@@ -127,7 +127,7 @@ pub enum OverscrollBehaviorInlineStyleValue {}
 ///
 // https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-block
 #[syntax(" contain | none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll container elements",
@@ -138,5 +138,5 @@ pub enum OverscrollBehaviorInlineStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overscroll-behavior-block"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverscrollBehaviorBlockStyleValue {}

--- a/crates/css_ast/src/values/page/mod.rs
+++ b/crates/css_ast/src/values/page/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-page-4/#page
 #[syntax(" auto | <custom-ident> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "boxes that create class A break points",
@@ -30,5 +30,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.page"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PageStyleValue;

--- a/crates/css_ast/src/values/page_floats/mod.rs
+++ b/crates/css_ast/src/values/page_floats/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-page-floats-3/#float-reference
 #[syntax(" inline | column | region | page ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "inline",
 	applies_to = "all elements.",
@@ -28,7 +28,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.float-reference"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FloatReferenceStyleValue {}
 
 /// Represents the style value for `float` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#float).
@@ -45,7 +45,7 @@ pub enum FloatReferenceStyleValue {}
 #[syntax(
 	" block-start | block-end | inline-start | inline-end | snap-block | <snap-block()> | snap-inline | <snap-inline()> | left | right | top | bottom | none "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements.",
@@ -56,7 +56,7 @@ pub enum FloatReferenceStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.float"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FloatStyleValue {}
 
 /// Represents the style value for `clear` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#clear).
@@ -73,7 +73,7 @@ pub enum FloatStyleValue {}
 #[syntax(
 	" inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "block-level elements, floats, regions, pages",
@@ -84,7 +84,7 @@ pub enum FloatStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.clear"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ClearStyleValue {}
 
 /// Represents the style value for `float-defer` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#float-defer).
@@ -97,7 +97,7 @@ pub enum ClearStyleValue {}
 ///
 // https://drafts.csswg.org/css-page-floats-3/#float-defer
 #[syntax(" <integer> | last | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "floats",
@@ -108,7 +108,7 @@ pub enum ClearStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.float-defer"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FloatDeferStyleValue {}
 
 /// Represents the style value for `float-offset` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#float-offset).
@@ -121,7 +121,7 @@ pub enum FloatDeferStyleValue {}
 ///
 // https://drafts.csswg.org/css-page-floats-3/#float-offset
 #[syntax(" <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "floats",
@@ -132,5 +132,5 @@ pub enum FloatDeferStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.float-offset"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FloatOffsetStyleValue;

--- a/crates/css_ast/src/values/position/mod.rs
+++ b/crates/css_ast/src/values/position/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-position-4/#position
 #[syntax(" static | relative | absolute | sticky | fixed ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "static",
 	applies_to = "all elements except table-column-group and table-column",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum PositionStyleValue {}
 
 /// Represents the style value for `top` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#top).
@@ -45,7 +45,7 @@ pub enum PositionStyleValue {}
 ///
 // https://drafts.csswg.org/css-position-4/#top
 #[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -56,7 +56,7 @@ pub enum PositionStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.top"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TopStyleValue;
 
 /// Represents the style value for `right` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#right).
@@ -71,7 +71,7 @@ pub struct TopStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#right
 #[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -82,7 +82,7 @@ pub struct TopStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.right"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RightStyleValue;
 
 /// Represents the style value for `bottom` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#bottom).
@@ -97,7 +97,7 @@ pub struct RightStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#bottom
 #[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -108,7 +108,7 @@ pub struct RightStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bottom"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BottomStyleValue;
 
 /// Represents the style value for `left` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#left).
@@ -123,7 +123,7 @@ pub struct BottomStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#left
 #[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -134,7 +134,7 @@ pub struct BottomStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.left"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct LeftStyleValue;
 
 /// Represents the style value for `inset-block-start` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block-start).
@@ -149,7 +149,7 @@ pub struct LeftStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#inset-block-start
 #[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -160,7 +160,7 @@ pub struct LeftStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-block-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InsetBlockStartStyleValue;
 
 /// Represents the style value for `inset-inline-start` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline-start).
@@ -175,7 +175,7 @@ pub struct InsetBlockStartStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#inset-inline-start
 #[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -186,7 +186,7 @@ pub struct InsetBlockStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-inline-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InsetInlineStartStyleValue;
 
 /// Represents the style value for `inset-block-end` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block-end).
@@ -201,7 +201,7 @@ pub struct InsetInlineStartStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#inset-block-end
 #[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -212,7 +212,7 @@ pub struct InsetInlineStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-block-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InsetBlockEndStyleValue;
 
 /// Represents the style value for `inset-inline-end` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline-end).
@@ -227,7 +227,7 @@ pub struct InsetBlockEndStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#inset-inline-end
 #[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -238,7 +238,7 @@ pub struct InsetBlockEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-inline-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InsetInlineEndStyleValue;
 
 /// Represents the style value for `inset-block` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block).
@@ -253,7 +253,7 @@ pub struct InsetInlineEndStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#inset-block
 #[syntax(" <'top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -264,7 +264,7 @@ pub struct InsetInlineEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-block"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InsetBlockStyleValue;
 
 /// Represents the style value for `inset-inline` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline).
@@ -279,7 +279,7 @@ pub struct InsetBlockStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#inset-inline
 #[syntax(" <'top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -290,7 +290,7 @@ pub struct InsetBlockStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-inline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InsetInlineStyleValue;
 
 /// Represents the style value for `inset` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset).
@@ -305,7 +305,7 @@ pub struct InsetInlineStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#inset
 #[syntax(" <'top'>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "positioned elements",
@@ -316,7 +316,7 @@ pub struct InsetInlineStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InsetStyleValue;
 
 /// Represents the style value for `overlay` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#overlay).
@@ -331,7 +331,7 @@ pub struct InsetStyleValue;
 ///
 // https://drafts.csswg.org/css-position-4/#overlay
 #[syntax(" none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -342,5 +342,5 @@ pub struct InsetStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overlay"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverlayStyleValue {}

--- a/crates/css_ast/src/values/regions/mod.rs
+++ b/crates/css_ast/src/values/regions/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-regions-1/#flow-into
 // #[syntax(" none | <custom-ident> [element | content]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "All elements, but not pseudo-elements such as ::first-line, ::first-letter, ::before or ::after.",
@@ -28,7 +28,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flow-into"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum FlowIntoStyleValue {}
 
 /// Represents the style value for `flow-from` as defined in [css-regions-1](https://drafts.csswg.org/css-regions-1/#flow-from).
@@ -41,7 +41,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-regions-1/#flow-from
 #[syntax(" <custom-ident> | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "Non-replaced block containers.  This might be expanded in future versions of the specification to allow other types of containers to receive flow content.",
@@ -52,7 +52,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flow-from"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FlowFromStyleValue;
 
 /// Represents the style value for `region-fragment` as defined in [css-regions-1](https://drafts.csswg.org/css-regions-1/#region-fragment).
@@ -65,7 +65,7 @@ pub struct FlowFromStyleValue;
 ///
 // https://drafts.csswg.org/css-regions-1/#region-fragment
 #[syntax(" auto | break ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "CSS Regions",
@@ -76,5 +76,5 @@ pub struct FlowFromStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.region-fragment"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RegionFragmentStyleValue {}

--- a/crates/css_ast/src/values/rhythm/mod.rs
+++ b/crates/css_ast/src/values/rhythm/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-rhythm-1/#block-step-size
 #[syntax(" none | <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "block-level boxes",
@@ -28,7 +28,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BlockStepSizeStyleValue;
 
 /// Represents the style value for `block-step-insert` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step-insert).
@@ -41,7 +41,7 @@ pub struct BlockStepSizeStyleValue;
 ///
 // https://drafts.csswg.org/css-rhythm-1/#block-step-insert
 #[syntax(" margin-box | padding-box | content-box ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "margin-box",
 	applies_to = "block-level boxes",
@@ -52,7 +52,7 @@ pub struct BlockStepSizeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step-insert"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BlockStepInsertStyleValue {}
 
 /// Represents the style value for `block-step-align` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step-align).
@@ -65,7 +65,7 @@ pub enum BlockStepInsertStyleValue {}
 ///
 // https://drafts.csswg.org/css-rhythm-1/#block-step-align
 #[syntax(" auto | center | start | end ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block-level boxes",
@@ -76,7 +76,7 @@ pub enum BlockStepInsertStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step-align"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BlockStepAlignStyleValue {}
 
 /// Represents the style value for `block-step-round` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step-round).
@@ -89,7 +89,7 @@ pub enum BlockStepAlignStyleValue {}
 ///
 // https://drafts.csswg.org/css-rhythm-1/#block-step-round
 #[syntax(" up | down | nearest ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "up",
 	applies_to = "block-level boxes",
@@ -100,7 +100,7 @@ pub enum BlockStepAlignStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step-round"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BlockStepRoundStyleValue {}
 
 /// Represents the style value for `block-step` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step).
@@ -113,7 +113,7 @@ pub enum BlockStepRoundStyleValue {}
 ///
 // https://drafts.csswg.org/css-rhythm-1/#block-step
 #[syntax(" <'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "block-level boxes",
@@ -124,7 +124,7 @@ pub enum BlockStepRoundStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BlockStepStyleValue;
 
 /// Represents the style value for `line-height-step` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#line-height-step).
@@ -137,7 +137,7 @@ pub struct BlockStepStyleValue;
 ///
 // https://drafts.csswg.org/css-rhythm-1/#line-height-step
 #[syntax(" <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "block containers",
@@ -148,5 +148,5 @@ pub struct BlockStepStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-height-step"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct LineHeightStepStyleValue;

--- a/crates/css_ast/src/values/round_display/mod.rs
+++ b/crates/css_ast/src/values/round_display/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-round-display-1/#border-boundary
 #[syntax(" none | parent | display ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -28,5 +28,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-boundary"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderBoundaryStyleValue {}

--- a/crates/css_ast/src/values/ruby/mod.rs
+++ b/crates/css_ast/src/values/ruby/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-ruby-1/#ruby-position
 // #[syntax(" [ alternate || [ over | under ] ] | inter-character ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "alternate",
 //   applies_to = "ruby annotation containers",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.ruby-position"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum RubyPositionStyleValue {}
 
 /// Represents the style value for `ruby-merge` as defined in [css-ruby-1](https://drafts.csswg.org/css-ruby-1/#ruby-merge).
@@ -43,7 +43,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-ruby-1/#ruby-merge
 #[syntax(" separate | merge | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "separate",
 	applies_to = "interlinear ruby annotation containers",
@@ -54,7 +54,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.ruby-merge"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RubyMergeStyleValue {}
 
 /// Represents the style value for `ruby-align` as defined in [css-ruby-1](https://drafts.csswg.org/css-ruby-1/#ruby-align).
@@ -69,7 +69,7 @@ pub enum RubyMergeStyleValue {}
 ///
 // https://drafts.csswg.org/css-ruby-1/#ruby-align
 #[syntax(" start | center | space-between | space-around ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "space-around",
 	applies_to = "ruby bases, ruby annotations, ruby base containers, ruby annotation containers",
@@ -80,7 +80,7 @@ pub enum RubyMergeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.ruby-align"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RubyAlignStyleValue {}
 
 /// Represents the style value for `ruby-overhang` as defined in [css-ruby-1](https://drafts.csswg.org/css-ruby-1/#ruby-overhang).
@@ -95,7 +95,7 @@ pub enum RubyAlignStyleValue {}
 ///
 // https://drafts.csswg.org/css-ruby-1/#ruby-overhang
 #[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "ruby annotation containers",
@@ -106,5 +106,5 @@ pub enum RubyAlignStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.ruby-overhang"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RubyOverhangStyleValue {}

--- a/crates/css_ast/src/values/scroll_anchoring/mod.rs
+++ b/crates/css_ast/src/values/scroll_anchoring/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-scroll-anchoring-1/#overflow-anchor
 #[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -30,5 +30,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-anchor"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverflowAnchorStyleValue {}

--- a/crates/css_ast/src/values/scroll_snap/mod.rs
+++ b/crates/css_ast/src/values/scroll_snap/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-type
 // #[syntax(" none | [ x | y | block | inline | both ] [ mandatory | proximity ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-snap-type"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ScrollSnapTypeStyleValue {}
 
 /// Represents the style value for `scroll-padding` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding).
@@ -45,7 +45,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding
 #[syntax(" [ auto | <length-percentage [0,∞]> ]{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -56,7 +56,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingStyleValue;
 
 /// Represents the style value for `scroll-margin` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin).
@@ -71,7 +71,7 @@ pub struct ScrollPaddingStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin
 #[syntax(" <length>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -82,7 +82,7 @@ pub struct ScrollPaddingStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginStyleValue;
 
 /// Represents the style value for `scroll-snap-align` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-align).
@@ -97,7 +97,7 @@ pub struct ScrollMarginStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-align
 #[syntax(" [ none | start | end | center ]{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -108,7 +108,7 @@ pub struct ScrollMarginStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-snap-align"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollSnapAlignStyleValue;
 
 /// Represents the style value for `scroll-snap-stop` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-stop).
@@ -123,7 +123,7 @@ pub struct ScrollSnapAlignStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-stop
 #[syntax(" normal | always ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -134,7 +134,7 @@ pub struct ScrollSnapAlignStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-snap-stop"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ScrollSnapStopStyleValue {}
 
 /// Represents the style value for `scroll-padding-top` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-top).
@@ -149,7 +149,7 @@ pub enum ScrollSnapStopStyleValue {}
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-top
 #[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -160,7 +160,7 @@ pub enum ScrollSnapStopStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-top"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingTopStyleValue;
 
 /// Represents the style value for `scroll-padding-right` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-right).
@@ -175,7 +175,7 @@ pub struct ScrollPaddingTopStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-right
 #[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -186,7 +186,7 @@ pub struct ScrollPaddingTopStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-right"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingRightStyleValue;
 
 /// Represents the style value for `scroll-padding-bottom` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-bottom).
@@ -201,7 +201,7 @@ pub struct ScrollPaddingRightStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-bottom
 #[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -212,7 +212,7 @@ pub struct ScrollPaddingRightStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-bottom"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingBottomStyleValue;
 
 /// Represents the style value for `scroll-padding-left` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-left).
@@ -227,7 +227,7 @@ pub struct ScrollPaddingBottomStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-left
 #[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -238,7 +238,7 @@ pub struct ScrollPaddingBottomStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-left"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingLeftStyleValue;
 
 /// Represents the style value for `scroll-padding-inline-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-start).
@@ -253,7 +253,7 @@ pub struct ScrollPaddingLeftStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-start
 #[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -268,7 +268,7 @@ pub struct ScrollPaddingLeftStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.scroll-padding-inline-start")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingInlineStartStyleValue;
 
 /// Represents the style value for `scroll-padding-block-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-start).
@@ -283,7 +283,7 @@ pub struct ScrollPaddingInlineStartStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-start
 #[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -298,7 +298,7 @@ pub struct ScrollPaddingInlineStartStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.scroll-padding-block-start")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingBlockStartStyleValue;
 
 /// Represents the style value for `scroll-padding-inline-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-end).
@@ -313,7 +313,7 @@ pub struct ScrollPaddingBlockStartStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-end
 #[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -324,7 +324,7 @@ pub struct ScrollPaddingBlockStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-inline-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingInlineEndStyleValue;
 
 /// Represents the style value for `scroll-padding-block-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-end).
@@ -339,7 +339,7 @@ pub struct ScrollPaddingInlineEndStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-end
 #[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -350,7 +350,7 @@ pub struct ScrollPaddingInlineEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-block-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingBlockEndStyleValue;
 
 /// Represents the style value for `scroll-padding-block` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block).
@@ -365,7 +365,7 @@ pub struct ScrollPaddingBlockEndStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block
 #[syntax(" [ auto | <length-percentage [0,∞]> ]{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -376,7 +376,7 @@ pub struct ScrollPaddingBlockEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-block"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingBlockStyleValue;
 
 /// Represents the style value for `scroll-padding-inline` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline).
@@ -391,7 +391,7 @@ pub struct ScrollPaddingBlockStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline
 #[syntax(" [ auto | <length-percentage [0,∞]> ]{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -402,7 +402,7 @@ pub struct ScrollPaddingBlockStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-inline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingInlineStyleValue;
 
 /// Represents the style value for `scroll-margin-top` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-top).
@@ -417,7 +417,7 @@ pub struct ScrollPaddingInlineStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-top
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -428,7 +428,7 @@ pub struct ScrollPaddingInlineStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-top"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginTopStyleValue;
 
 /// Represents the style value for `scroll-margin-right` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-right).
@@ -443,7 +443,7 @@ pub struct ScrollMarginTopStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-right
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -454,7 +454,7 @@ pub struct ScrollMarginTopStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-right"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginRightStyleValue;
 
 /// Represents the style value for `scroll-margin-bottom` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-bottom).
@@ -469,7 +469,7 @@ pub struct ScrollMarginRightStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-bottom
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -480,7 +480,7 @@ pub struct ScrollMarginRightStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-bottom"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginBottomStyleValue;
 
 /// Represents the style value for `scroll-margin-left` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-left).
@@ -495,7 +495,7 @@ pub struct ScrollMarginBottomStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-left
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -506,7 +506,7 @@ pub struct ScrollMarginBottomStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-left"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginLeftStyleValue;
 
 /// Represents the style value for `scroll-margin-block-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-start).
@@ -521,7 +521,7 @@ pub struct ScrollMarginLeftStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-start
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -532,7 +532,7 @@ pub struct ScrollMarginLeftStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-block-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginBlockStartStyleValue;
 
 /// Represents the style value for `scroll-margin-inline-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-start).
@@ -547,7 +547,7 @@ pub struct ScrollMarginBlockStartStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-start
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -562,7 +562,7 @@ pub struct ScrollMarginBlockStartStyleValue;
 	derive(ToCSSFeature),
 	css_feature("css.properties.scroll-margin-inline-start")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginInlineStartStyleValue;
 
 /// Represents the style value for `scroll-margin-block-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-end).
@@ -577,7 +577,7 @@ pub struct ScrollMarginInlineStartStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-end
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -588,7 +588,7 @@ pub struct ScrollMarginInlineStartStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-block-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginBlockEndStyleValue;
 
 /// Represents the style value for `scroll-margin-inline-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-end).
@@ -603,7 +603,7 @@ pub struct ScrollMarginBlockEndStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-end
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -614,7 +614,7 @@ pub struct ScrollMarginBlockEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-inline-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginInlineEndStyleValue;
 
 /// Represents the style value for `scroll-margin-block` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block).
@@ -629,7 +629,7 @@ pub struct ScrollMarginInlineEndStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block
 #[syntax(" <length>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -640,7 +640,7 @@ pub struct ScrollMarginInlineEndStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-block"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginBlockStyleValue;
 
 /// Represents the style value for `scroll-margin-inline` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline).
@@ -655,7 +655,7 @@ pub struct ScrollMarginBlockStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline
 #[syntax(" <length>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -666,7 +666,7 @@ pub struct ScrollMarginBlockStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-inline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollMarginInlineStyleValue;
 
 /// Represents the style value for `scroll-initial-target` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-initial-target).
@@ -681,7 +681,7 @@ pub struct ScrollMarginInlineStyleValue;
 ///
 // https://drafts.csswg.org/css-scroll-snap-2/#scroll-initial-target
 #[syntax(" none | nearest ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -692,5 +692,5 @@ pub struct ScrollMarginInlineStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-initial-target"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ScrollInitialTargetStyleValue {}

--- a/crates/css_ast/src/values/scrollbars/mod.rs
+++ b/crates/css_ast/src/values/scrollbars/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-scrollbars-1/#scrollbar-color
 #[syntax(" auto | <color>{2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scrollbar-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollbarColorStyleValue;
 
 /// Represents the style value for `scrollbar-width` as defined in [css-scrollbars-1](https://drafts.csswg.org/css-scrollbars-1/#scrollbar-width).
@@ -45,7 +45,7 @@ pub struct ScrollbarColorStyleValue;
 ///
 // https://drafts.csswg.org/css-scrollbars-1/#scrollbar-width
 #[syntax(" auto | thin | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "scroll containers",
@@ -56,5 +56,5 @@ pub struct ScrollbarColorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scrollbar-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ScrollbarWidthStyleValue {}

--- a/crates/css_ast/src/values/shapes/mod.rs
+++ b/crates/css_ast/src/values/shapes/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-shapes-2/#shape-outside
 // #[syntax(" none | [ <basic-shape> || <shape-box> ] | <image> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "floats and initial letter boxes",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-outside"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ShapeOutsideStyleValue<'a> {}
 
 /// Represents the style value for `shape-image-threshold` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-image-threshold).
@@ -45,7 +45,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-shapes-2/#shape-image-threshold
 #[syntax(" <opacity-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "floats",
@@ -56,7 +56,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-image-threshold"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ShapeImageThresholdStyleValue;
 
 /// Represents the style value for `shape-margin` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-margin).
@@ -71,7 +71,7 @@ pub struct ShapeImageThresholdStyleValue;
 ///
 // https://drafts.csswg.org/css-shapes-2/#shape-margin
 #[syntax(" <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "floats and initial letter boxes",
@@ -82,7 +82,7 @@ pub struct ShapeImageThresholdStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-margin"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ShapeMarginStyleValue;
 
 // /// Represents the style value for `shape-inside` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-inside).
@@ -95,7 +95,7 @@ pub struct ShapeMarginStyleValue;
 // ///
 // // https://drafts.csswg.org/css-shapes-2/#shape-inside
 // #[syntax(" auto | outside-shape | [ <basic-shape> || shape-box ] | <image> | display ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "block-level elements",
@@ -106,7 +106,7 @@ pub struct ShapeMarginStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-inside"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ShapeInsideStyleValue<'a> {}
 
 /// Represents the style value for `shape-padding` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-padding).
@@ -119,7 +119,7 @@ pub struct ShapeMarginStyleValue;
 ///
 // https://drafts.csswg.org/css-shapes-2/#shape-padding
 #[syntax(" <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "block-level elements",
@@ -130,5 +130,5 @@ pub struct ShapeMarginStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-padding"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ShapePaddingStyleValue;

--- a/crates/css_ast/src/values/size_adjust/mod.rs
+++ b/crates/css_ast/src/values/size_adjust/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-size-adjust-1/#text-size-adjust
 #[syntax(" auto | none | <percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -30,5 +30,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-size-adjust"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextSizeAdjustStyleValue;

--- a/crates/css_ast/src/values/sizing/mod.rs
+++ b/crates/css_ast/src/values/sizing/mod.rs
@@ -21,7 +21,7 @@ use impls::*;
 #[syntax(
 	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements except non-replaced inlines",
@@ -32,7 +32,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WidthStyleValue {}
 
 /// Represents the style value for `height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#height).
@@ -49,7 +49,7 @@ pub enum WidthStyleValue {}
 #[syntax(
 	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements except non-replaced inlines",
@@ -60,7 +60,7 @@ pub enum WidthStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.height"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum HeightStyleValue {}
 
 /// Represents the style value for `min-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-width).
@@ -77,7 +77,7 @@ pub enum HeightStyleValue {}
 #[syntax(
 	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements that accept width or height",
@@ -88,7 +88,7 @@ pub enum HeightStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum MinWidthStyleValue {}
 
 /// Represents the style value for `min-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-height).
@@ -105,7 +105,7 @@ pub enum MinWidthStyleValue {}
 #[syntax(
 	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements that accept width or height",
@@ -116,7 +116,7 @@ pub enum MinWidthStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-height"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum MinHeightStyleValue {}
 
 /// Represents the style value for `max-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#max-width).
@@ -133,7 +133,7 @@ pub enum MinHeightStyleValue {}
 #[syntax(
 	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements that accept width or height",
@@ -144,7 +144,7 @@ pub enum MinHeightStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum MaxWidthStyleValue {}
 
 /// Represents the style value for `max-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#max-height).
@@ -161,7 +161,7 @@ pub enum MaxWidthStyleValue {}
 #[syntax(
 	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
 )]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements that accept width or height",
@@ -172,7 +172,7 @@ pub enum MaxWidthStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-height"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum MaxHeightStyleValue {}
 
 /// Represents the style value for `box-sizing` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#box-sizing).
@@ -187,7 +187,7 @@ pub enum MaxHeightStyleValue {}
 ///
 // https://drafts.csswg.org/css-sizing-4/#box-sizing
 #[syntax(" content-box | border-box ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "content-box",
 	applies_to = "all elements that accept width or height",
@@ -198,7 +198,7 @@ pub enum MaxHeightStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-sizing"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BoxSizingStyleValue {}
 
 /// Represents the style value for `aspect-ratio` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#aspect-ratio).
@@ -213,7 +213,7 @@ pub enum BoxSizingStyleValue {}
 ///
 // https://drafts.csswg.org/css-sizing-4/#aspect-ratio
 #[syntax(" auto || <ratio> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements except inline boxes and internal ruby or table boxes",
@@ -224,7 +224,7 @@ pub enum BoxSizingStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.aspect-ratio"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AspectRatioStyleValue;
 
 // /// Represents the style value for `contain-intrinsic-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-width).
@@ -239,7 +239,7 @@ pub struct AspectRatioStyleValue;
 // ///
 // // https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-width
 // #[syntax(" auto? [ none | <length [0,∞]> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "elements with size containment",
@@ -250,7 +250,7 @@ pub struct AspectRatioStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-width"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ContainIntrinsicWidthStyleValue;
 
 // /// Represents the style value for `contain-intrinsic-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-height).
@@ -265,7 +265,7 @@ pub struct AspectRatioStyleValue;
 // ///
 // // https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-height
 // #[syntax(" auto? [ none | <length [0,∞]> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "elements with size containment",
@@ -276,7 +276,7 @@ pub struct AspectRatioStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-height"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ContainIntrinsicHeightStyleValue;
 
 // /// Represents the style value for `contain-intrinsic-block-size` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-block-size).
@@ -291,7 +291,7 @@ pub struct AspectRatioStyleValue;
 // ///
 // // https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-block-size
 // #[syntax(" auto? [ none | <length [0,∞]> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "elements with size containment",
@@ -302,7 +302,7 @@ pub struct AspectRatioStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-block-size"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ContainIntrinsicBlockSizeStyleValue;
 
 // /// Represents the style value for `contain-intrinsic-inline-size` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-inline-size).
@@ -317,7 +317,7 @@ pub struct AspectRatioStyleValue;
 // ///
 // // https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-inline-size
 // #[syntax(" auto? [ none | <length [0,∞]> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "elements with size containment",
@@ -328,7 +328,7 @@ pub struct AspectRatioStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-inline-size"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ContainIntrinsicInlineSizeStyleValue;
 
 // /// Represents the style value for `contain-intrinsic-size` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-size).
@@ -343,7 +343,7 @@ pub struct AspectRatioStyleValue;
 // ///
 // // https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-size
 // #[syntax(" [ auto? [ none | <length> ] ]{1,2} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -354,7 +354,7 @@ pub struct AspectRatioStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-size"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ContainIntrinsicSizeStyleValue;
 
 // /// Represents the style value for `min-intrinsic-sizing` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-intrinsic-sizing).
@@ -367,7 +367,7 @@ pub struct AspectRatioStyleValue;
 // ///
 // // https://drafts.csswg.org/css-sizing-4/#min-intrinsic-sizing
 // #[syntax(" legacy | zero-if-scroll || zero-if-extrinsic ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "legacy",
 //   applies_to = "all elements except inline boxes",
@@ -378,5 +378,5 @@ pub struct AspectRatioStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-intrinsic-sizing"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum MinIntrinsicSizingStyleValue {}

--- a/crates/css_ast/src/values/speech/mod.rs
+++ b/crates/css_ast/src/values/speech/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-speech-1/#voice-volume
 // #[syntax(" silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "medium",
 //   applies_to = "all elements",
@@ -28,7 +28,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-volume"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum VoiceVolumeStyleValue {}
 
 /// Represents the style value for `voice-balance` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-balance).
@@ -41,7 +41,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-speech-1/#voice-balance
 #[syntax(" <number> | left | center | right | leftwards | rightwards ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "center",
 	applies_to = "all elements",
@@ -52,7 +52,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-balance"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum VoiceBalanceStyleValue {}
 
 /// Represents the style value for `speak` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#speak).
@@ -67,7 +67,7 @@ pub enum VoiceBalanceStyleValue {}
 ///
 // https://drafts.csswg.org/css-speech-1/#speak
 #[syntax(" auto | never | always ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -78,7 +78,7 @@ pub enum VoiceBalanceStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.speak"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum SpeakStyleValue {}
 
 // /// Represents the style value for `speak-as` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#speak-as).
@@ -93,7 +93,7 @@ pub enum SpeakStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-speech-1/#speak-as
 // #[syntax(" normal | spell-out || digits || [ literal-punctuation | no-punctuation ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements",
@@ -104,7 +104,7 @@ pub enum SpeakStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.speak-as"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum SpeakAsStyleValue {}
 
 /// Represents the style value for `pause-before` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#pause-before).
@@ -117,7 +117,7 @@ pub enum SpeakStyleValue {}
 ///
 // https://drafts.csswg.org/css-speech-1/#pause-before
 #[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -128,7 +128,7 @@ pub enum SpeakStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pause-before"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum PauseBeforeStyleValue {}
 
 /// Represents the style value for `pause-after` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#pause-after).
@@ -141,7 +141,7 @@ pub enum PauseBeforeStyleValue {}
 ///
 // https://drafts.csswg.org/css-speech-1/#pause-after
 #[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -152,7 +152,7 @@ pub enum PauseBeforeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pause-after"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum PauseAfterStyleValue {}
 
 /// Represents the style value for `pause` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#pause).
@@ -165,7 +165,7 @@ pub enum PauseAfterStyleValue {}
 ///
 // https://drafts.csswg.org/css-speech-1/#pause
 #[syntax(" <'pause-before'> <'pause-after'>? ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "all elements",
@@ -176,7 +176,7 @@ pub enum PauseAfterStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pause"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PauseStyleValue;
 
 /// Represents the style value for `rest-before` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#rest-before).
@@ -189,7 +189,7 @@ pub struct PauseStyleValue;
 ///
 // https://drafts.csswg.org/css-speech-1/#rest-before
 #[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -200,7 +200,7 @@ pub struct PauseStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rest-before"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RestBeforeStyleValue {}
 
 /// Represents the style value for `rest-after` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#rest-after).
@@ -213,7 +213,7 @@ pub enum RestBeforeStyleValue {}
 ///
 // https://drafts.csswg.org/css-speech-1/#rest-after
 #[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -224,7 +224,7 @@ pub enum RestBeforeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rest-after"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RestAfterStyleValue {}
 
 /// Represents the style value for `rest` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#rest).
@@ -237,7 +237,7 @@ pub enum RestAfterStyleValue {}
 ///
 // https://drafts.csswg.org/css-speech-1/#rest
 #[syntax(" <'rest-before'> <'rest-after'>? ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "all elements",
@@ -248,7 +248,7 @@ pub enum RestAfterStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rest"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RestStyleValue;
 
 /// Represents the style value for `cue-before` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#cue-before).
@@ -261,7 +261,7 @@ pub struct RestStyleValue;
 ///
 // https://drafts.csswg.org/css-speech-1/#cue-before
 #[syntax(" <uri> <decibel>? | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -272,7 +272,7 @@ pub struct RestStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cue-before"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CueBeforeStyleValue;
 
 /// Represents the style value for `cue-after` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#cue-after).
@@ -285,7 +285,7 @@ pub struct CueBeforeStyleValue;
 ///
 // https://drafts.csswg.org/css-speech-1/#cue-after
 #[syntax(" <uri> <decibel>? | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -296,7 +296,7 @@ pub struct CueBeforeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cue-after"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CueAfterStyleValue;
 
 /// Represents the style value for `cue` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#cue).
@@ -309,7 +309,7 @@ pub struct CueAfterStyleValue;
 ///
 // https://drafts.csswg.org/css-speech-1/#cue
 #[syntax(" <'cue-before'> <'cue-after'>? ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "all elements",
@@ -320,7 +320,7 @@ pub struct CueAfterStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cue"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CueStyleValue;
 
 // /// Represents the style value for `voice-family` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-family).
@@ -333,7 +333,7 @@ pub struct CueStyleValue;
 // ///
 // // https://drafts.csswg.org/css-speech-1/#voice-family
 // #[syntax(" [[<family-name> | <generic-voice>],]* [<family-name> | <generic-voice>] | preserve ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "implementation-dependent",
 //   applies_to = "all elements",
@@ -344,7 +344,7 @@ pub struct CueStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-family"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum VoiceFamilyStyleValue {}
 
 // /// Represents the style value for `voice-rate` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-rate).
@@ -357,7 +357,7 @@ pub struct CueStyleValue;
 // ///
 // // https://drafts.csswg.org/css-speech-1/#voice-rate
 // #[syntax(" [normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "all elements",
@@ -368,7 +368,7 @@ pub struct CueStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-rate"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct VoiceRateStyleValue;
 
 // /// Represents the style value for `voice-pitch` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-pitch).
@@ -383,7 +383,7 @@ pub struct CueStyleValue;
 // #[syntax(
 // 	" <frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]] "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "medium",
 //   applies_to = "all elements",
@@ -394,7 +394,7 @@ pub struct CueStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-pitch"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum VoicePitchStyleValue {}
 
 // /// Represents the style value for `voice-range` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-range).
@@ -409,7 +409,7 @@ pub struct CueStyleValue;
 // #[syntax(
 // 	" <frequency [0Hz,∞]> && absolute | [[x-low | low | medium | high | x-high] || [<frequency> | <semitones> | <percentage>]] "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "medium",
 //   applies_to = "all elements",
@@ -420,7 +420,7 @@ pub struct CueStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-range"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum VoiceRangeStyleValue {}
 
 /// Represents the style value for `voice-stress` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-stress).
@@ -433,7 +433,7 @@ pub struct CueStyleValue;
 ///
 // https://drafts.csswg.org/css-speech-1/#voice-stress
 #[syntax(" normal | strong | moderate | none | reduced ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -444,7 +444,7 @@ pub struct CueStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-stress"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum VoiceStressStyleValue {}
 
 /// Represents the style value for `voice-duration` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-duration).
@@ -457,7 +457,7 @@ pub enum VoiceStressStyleValue {}
 ///
 // https://drafts.csswg.org/css-speech-1/#voice-duration
 #[syntax(" auto | <time [0s,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -468,5 +468,5 @@ pub enum VoiceStressStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-duration"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct VoiceDurationStyleValue;

--- a/crates/css_ast/src/values/tables/mod.rs
+++ b/crates/css_ast/src/values/tables/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-tables-3/#table-layout
 #[syntax(" auto | fixed ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "table grid boxes",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.table-layout"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TableLayoutStyleValue {}
 
 /// Represents the style value for `border-collapse` as defined in [css-tables-3](https://drafts.csswg.org/css-tables-3/#border-collapse).
@@ -45,7 +45,7 @@ pub enum TableLayoutStyleValue {}
 ///
 // https://drafts.csswg.org/css-tables-3/#border-collapse
 #[syntax(" separate | collapse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "separate",
 	applies_to = "table grid boxes",
@@ -56,7 +56,7 @@ pub enum TableLayoutStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-collapse"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BorderCollapseStyleValue {}
 
 /// Represents the style value for `border-spacing` as defined in [css-tables-3](https://drafts.csswg.org/css-tables-3/#border-spacing).
@@ -71,7 +71,7 @@ pub enum BorderCollapseStyleValue {}
 ///
 // https://drafts.csswg.org/css-tables-3/#border-spacing
 #[syntax(" <length>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0px 0px",
 	applies_to = "table grid boxes when border-collapse is separate",
@@ -82,7 +82,7 @@ pub enum BorderCollapseStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-spacing"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderSpacingStyleValue;
 
 /// Represents the style value for `caption-side` as defined in [css-tables-3](https://drafts.csswg.org/css-tables-3/#caption-side).
@@ -97,7 +97,7 @@ pub struct BorderSpacingStyleValue;
 ///
 // https://drafts.csswg.org/css-tables-3/#caption-side
 #[syntax(" top | bottom ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "top",
 	applies_to = "table-caption boxes",
@@ -108,7 +108,7 @@ pub struct BorderSpacingStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caption-side"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum CaptionSideStyleValue {}
 
 /// Represents the style value for `empty-cells` as defined in [css-tables-3](https://drafts.csswg.org/css-tables-3/#empty-cells).
@@ -123,7 +123,7 @@ pub enum CaptionSideStyleValue {}
 ///
 // https://drafts.csswg.org/css-tables-3/#empty-cells
 #[syntax(" show | hide ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "show",
 	applies_to = "table-cell boxes",
@@ -134,5 +134,5 @@ pub enum CaptionSideStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.empty-cells"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum EmptyCellsStyleValue {}

--- a/crates/css_ast/src/values/text/mod.rs
+++ b/crates/css_ast/src/values/text/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-text-4/#text-transform
 // #[syntax(" none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "text",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-transform"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum TextTransformStyleValue {}
 
 // /// Represents the style value for `white-space` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#white-space).
@@ -47,7 +47,7 @@ use impls::*;
 // #[syntax(
 // 	" normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'> || <'white-space-trim'> "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "normal",
 //   applies_to = "text",
@@ -58,7 +58,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.white-space"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum WhiteSpaceStyleValue {}
 
 /// Represents the style value for `tab-size` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#tab-size).
@@ -73,7 +73,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-text-4/#tab-size
 #[syntax(" <number [0,∞]> | <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "8",
 	applies_to = "text",
@@ -84,7 +84,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.tab-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TabSizeStyleValue;
 
 /// Represents the style value for `word-break` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-break).
@@ -99,7 +99,7 @@ pub struct TabSizeStyleValue;
 ///
 // https://drafts.csswg.org/css-text-4/#word-break
 #[syntax(" normal | break-all | keep-all | manual | auto-phrase | break-word ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "text",
@@ -110,7 +110,7 @@ pub struct TabSizeStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-break"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WordBreakStyleValue {}
 
 /// Represents the style value for `line-break` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#line-break).
@@ -125,7 +125,7 @@ pub enum WordBreakStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#line-break
 #[syntax(" auto | loose | normal | strict | anywhere ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "text",
@@ -136,7 +136,7 @@ pub enum WordBreakStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-break"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum LineBreakStyleValue {}
 
 /// Represents the style value for `hyphens` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphens).
@@ -151,7 +151,7 @@ pub enum LineBreakStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#hyphens
 #[syntax(" none | manual | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "manual",
 	applies_to = "text",
@@ -162,7 +162,7 @@ pub enum LineBreakStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphens"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum HyphensStyleValue {}
 
 /// Represents the style value for `overflow-wrap` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#overflow-wrap).
@@ -177,7 +177,7 @@ pub enum HyphensStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#overflow-wrap
 #[syntax(" normal | break-word | anywhere ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "text",
@@ -188,7 +188,7 @@ pub enum HyphensStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-wrap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverflowWrapStyleValue {}
 
 /// Represents the style value for `word-wrap` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-wrap).
@@ -201,7 +201,7 @@ pub enum OverflowWrapStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#word-wrap
 #[syntax(" normal | break-word | anywhere ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "text",
@@ -212,7 +212,7 @@ pub enum OverflowWrapStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-wrap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WordWrapStyleValue {}
 
 /// Represents the style value for `text-align` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-align).
@@ -227,7 +227,7 @@ pub enum WordWrapStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#text-align
 #[syntax(" start | end | left | right | center | <string> | justify | match-parent | justify-all ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "start",
 	applies_to = "block containers",
@@ -238,7 +238,7 @@ pub enum WordWrapStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-align"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextAlignStyleValue {}
 
 /// Represents the style value for `text-align-all` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-align-all).
@@ -251,7 +251,7 @@ pub enum TextAlignStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#text-align-all
 #[syntax(" start | end | left | right | center | <string> | justify | match-parent ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "start",
 	applies_to = "block containers",
@@ -262,7 +262,7 @@ pub enum TextAlignStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-align-all"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextAlignAllStyleValue {}
 
 /// Represents the style value for `text-align-last` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-align-last).
@@ -277,7 +277,7 @@ pub enum TextAlignAllStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#text-align-last
 #[syntax(" auto | start | end | left | right | center | justify | match-parent ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block containers",
@@ -288,7 +288,7 @@ pub enum TextAlignAllStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-align-last"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextAlignLastStyleValue {}
 
 // /// Represents the style value for `text-justify` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-justify).
@@ -303,7 +303,7 @@ pub enum TextAlignLastStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-text-4/#text-justify
 // #[syntax(" [ auto | none | inter-word | inter-character | ruby ] || no-compress ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "text",
@@ -314,7 +314,7 @@ pub enum TextAlignLastStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-justify"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TextJustifyStyleValue;
 
 /// Represents the style value for `word-spacing` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-spacing).
@@ -329,7 +329,7 @@ pub enum TextAlignLastStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#word-spacing
 #[syntax(" normal | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "text",
@@ -340,7 +340,7 @@ pub enum TextAlignLastStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-spacing"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WordSpacingStyleValue {}
 
 /// Represents the style value for `letter-spacing` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#letter-spacing).
@@ -355,7 +355,7 @@ pub enum WordSpacingStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#letter-spacing
 #[syntax(" normal | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "inline boxes and text",
@@ -366,7 +366,7 @@ pub enum WordSpacingStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.letter-spacing"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum LetterSpacingStyleValue {}
 
 // /// Represents the style value for `text-indent` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-indent).
@@ -381,7 +381,7 @@ pub enum LetterSpacingStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-text-4/#text-indent
 // #[syntax(" [ <length-percentage> ] && hanging? && each-line? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "0",
 //   applies_to = "block containers",
@@ -392,7 +392,7 @@ pub enum LetterSpacingStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-indent"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TextIndentStyleValue;
 
 // /// Represents the style value for `hanging-punctuation` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hanging-punctuation).
@@ -407,7 +407,7 @@ pub enum LetterSpacingStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-text-4/#hanging-punctuation
 // #[syntax(" none | [ first || [ force-end | allow-end ] || last ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "text",
@@ -418,7 +418,7 @@ pub enum LetterSpacingStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hanging-punctuation"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum HangingPunctuationStyleValue {}
 
 // /// Represents the style value for `word-space-transform` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-space-transform).
@@ -431,7 +431,7 @@ pub enum LetterSpacingStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-text-4/#word-space-transform
 // #[syntax(" none | [ space | ideographic-space ] && auto-phrase? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "text",
@@ -442,7 +442,7 @@ pub enum LetterSpacingStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-space-transform"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum WordSpaceTransformStyleValue {}
 
 /// Represents the style value for `white-space-collapse` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#white-space-collapse).
@@ -457,7 +457,7 @@ pub enum LetterSpacingStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#white-space-collapse
 #[syntax(" collapse | discard | preserve | preserve-breaks | preserve-spaces | break-spaces ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "collapse",
 	applies_to = "text",
@@ -468,7 +468,7 @@ pub enum LetterSpacingStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.white-space-collapse"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WhiteSpaceCollapseStyleValue {}
 
 // /// Represents the style value for `white-space-trim` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#white-space-trim).
@@ -481,7 +481,7 @@ pub enum WhiteSpaceCollapseStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-text-4/#white-space-trim
 // #[syntax(" none | discard-before || discard-after || discard-inner ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "inline boxes and block containers",
@@ -492,7 +492,7 @@ pub enum WhiteSpaceCollapseStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.white-space-trim"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum WhiteSpaceTrimStyleValue {}
 
 /// Represents the style value for `text-wrap-mode` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-wrap-mode).
@@ -507,7 +507,7 @@ pub enum WhiteSpaceCollapseStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#text-wrap-mode
 #[syntax(" wrap | nowrap ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "wrap",
 	applies_to = "text",
@@ -518,7 +518,7 @@ pub enum WhiteSpaceCollapseStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-wrap-mode"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextWrapModeStyleValue {}
 
 /// Represents the style value for `wrap-inside` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#wrap-inside).
@@ -531,7 +531,7 @@ pub enum TextWrapModeStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#wrap-inside
 #[syntax(" auto | avoid ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "inline boxes",
@@ -542,7 +542,7 @@ pub enum TextWrapModeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-inside"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WrapInsideStyleValue {}
 
 /// Represents the style value for `wrap-before` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#wrap-before).
@@ -555,7 +555,7 @@ pub enum WrapInsideStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#wrap-before
 #[syntax(" auto | avoid | avoid-line | avoid-flex | line | flex ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "inline-level boxes and flex items",
@@ -566,7 +566,7 @@ pub enum WrapInsideStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-before"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WrapBeforeStyleValue {}
 
 /// Represents the style value for `wrap-after` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#wrap-after).
@@ -579,7 +579,7 @@ pub enum WrapBeforeStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#wrap-after
 #[syntax(" auto | avoid | avoid-line | avoid-flex | line | flex ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "inline-level boxes and flex items",
@@ -590,7 +590,7 @@ pub enum WrapBeforeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-after"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WrapAfterStyleValue {}
 
 /// Represents the style value for `text-wrap-style` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-wrap-style).
@@ -605,7 +605,7 @@ pub enum WrapAfterStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#text-wrap-style
 #[syntax(" auto | balance | stable | pretty | avoid-orphans ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "block containers hat establish an inline formatting context",
@@ -616,7 +616,7 @@ pub enum WrapAfterStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-wrap-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextWrapStyleStyleValue {}
 
 /// Represents the style value for `text-wrap` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-wrap).
@@ -631,7 +631,7 @@ pub enum TextWrapStyleStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#text-wrap
 #[syntax(" <'text-wrap-mode'> || <'text-wrap-style'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "wrap",
 	applies_to = "see individual properties",
@@ -642,7 +642,7 @@ pub enum TextWrapStyleStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-wrap"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextWrapStyleValue;
 
 /// Represents the style value for `hyphenate-character` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-character).
@@ -657,7 +657,7 @@ pub struct TextWrapStyleValue;
 ///
 // https://drafts.csswg.org/css-text-4/#hyphenate-character
 #[syntax(" auto | <string> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "text",
@@ -668,7 +668,7 @@ pub struct TextWrapStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-character"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct HyphenateCharacterStyleValue;
 
 /// Represents the style value for `hyphenate-limit-zone` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-zone).
@@ -681,7 +681,7 @@ pub struct HyphenateCharacterStyleValue;
 ///
 // https://drafts.csswg.org/css-text-4/#hyphenate-limit-zone
 #[syntax(" <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "block containers",
@@ -692,7 +692,7 @@ pub struct HyphenateCharacterStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-zone"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct HyphenateLimitZoneStyleValue;
 
 // /// Represents the style value for `hyphenate-limit-chars` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-chars).
@@ -707,7 +707,7 @@ pub struct HyphenateLimitZoneStyleValue;
 // ///
 // // https://drafts.csswg.org/css-text-4/#hyphenate-limit-chars
 // #[syntax(" [ auto | <integer> ]{1,3} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "text",
@@ -718,7 +718,7 @@ pub struct HyphenateLimitZoneStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-chars"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct HyphenateLimitCharsStyleValue;
 
 /// Represents the style value for `hyphenate-limit-lines` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-lines).
@@ -731,7 +731,7 @@ pub struct HyphenateLimitZoneStyleValue;
 ///
 // https://drafts.csswg.org/css-text-4/#hyphenate-limit-lines
 #[syntax(" no-limit | <integer> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "no-limit",
 	applies_to = "block containers",
@@ -742,7 +742,7 @@ pub struct HyphenateLimitZoneStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-lines"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum HyphenateLimitLinesStyleValue {}
 
 /// Represents the style value for `hyphenate-limit-last` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-last).
@@ -755,7 +755,7 @@ pub enum HyphenateLimitLinesStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#hyphenate-limit-last
 #[syntax(" none | always | column | page | spread ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "block containers",
@@ -766,7 +766,7 @@ pub enum HyphenateLimitLinesStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-last"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum HyphenateLimitLastStyleValue {}
 
 /// Represents the style value for `text-group-align` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-group-align).
@@ -779,7 +779,7 @@ pub enum HyphenateLimitLastStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#text-group-align
 #[syntax(" none | start | end | left | right | center ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "block containers",
@@ -790,7 +790,7 @@ pub enum HyphenateLimitLastStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-group-align"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextGroupAlignStyleValue {}
 
 /// Represents the style value for `line-padding` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#line-padding).
@@ -803,7 +803,7 @@ pub enum TextGroupAlignStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#line-padding
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "inline boxes",
@@ -814,7 +814,7 @@ pub enum TextGroupAlignStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-padding"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct LinePaddingStyleValue;
 
 /// Represents the style value for `text-autospace` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-autospace).
@@ -829,7 +829,7 @@ pub struct LinePaddingStyleValue;
 ///
 // https://drafts.csswg.org/css-text-4/#text-autospace
 #[syntax(" normal | <autospace> | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "text",
@@ -840,7 +840,7 @@ pub struct LinePaddingStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-autospace"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextAutospaceStyleValue {}
 
 /// Represents the style value for `text-spacing-trim` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-spacing-trim).
@@ -855,7 +855,7 @@ pub enum TextAutospaceStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-4/#text-spacing-trim
 #[syntax(" <spacing-trim> | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "text",
@@ -866,7 +866,7 @@ pub enum TextAutospaceStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-spacing-trim"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextSpacingTrimStyleValue;
 
 // /// Represents the style value for `text-spacing` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-spacing).
@@ -879,7 +879,7 @@ pub struct TextSpacingTrimStyleValue;
 // ///
 // // https://drafts.csswg.org/css-text-4/#text-spacing
 // #[syntax(" none | auto | <spacing-trim> || <autospace> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "text",
@@ -890,5 +890,5 @@ pub struct TextSpacingTrimStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-spacing"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum TextSpacingStyleValue {}

--- a/crates/css_ast/src/values/text_decor/mod.rs
+++ b/crates/css_ast/src/values/text_decor/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-text-decor-4/#text-decoration-line
 // #[syntax(" none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "all elements",
@@ -30,7 +30,7 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-line"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum TextDecorationLineStyleValue {}
 
 /// Represents the style value for `text-decoration-style` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-style).
@@ -45,7 +45,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-decoration-style
 #[syntax(" solid | double | dotted | dashed | wavy ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "solid",
 	applies_to = "all elements",
@@ -56,7 +56,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextDecorationStyleStyleValue {}
 
 /// Represents the style value for `text-decoration-color` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-color).
@@ -71,7 +71,7 @@ pub enum TextDecorationStyleStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-decoration-color
 #[syntax(" <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "all elements",
@@ -82,7 +82,7 @@ pub enum TextDecorationStyleStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextDecorationColorStyleValue;
 
 // /// Represents the style value for `text-decoration` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration).
@@ -99,7 +99,7 @@ pub struct TextDecorationColorStyleValue;
 // #[syntax(
 // 	" <'text-decoration-line'> || <'text-decoration-thickness'> || <'text-decoration-style'> || <'text-decoration-color'> "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -110,7 +110,7 @@ pub struct TextDecorationColorStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TextDecorationStyleValue;
 
 // /// Represents the style value for `text-underline-position` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-underline-position).
@@ -125,7 +125,7 @@ pub struct TextDecorationColorStyleValue;
 // ///
 // // https://drafts.csswg.org/css-text-decor-4/#text-underline-position
 // #[syntax(" auto | [ from-font | under ] || [ left | right ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "all elements",
@@ -136,7 +136,7 @@ pub struct TextDecorationColorStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-underline-position"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum TextUnderlinePositionStyleValue {}
 
 // /// Represents the style value for `text-emphasis-style` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-style).
@@ -151,7 +151,7 @@ pub struct TextDecorationColorStyleValue;
 // ///
 // // https://drafts.csswg.org/css-text-decor-4/#text-emphasis-style
 // #[syntax(" none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "text",
@@ -162,7 +162,7 @@ pub struct TextDecorationColorStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-style"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum TextEmphasisStyleStyleValue {}
 
 /// Represents the style value for `text-emphasis-color` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-color).
@@ -177,7 +177,7 @@ pub struct TextDecorationColorStyleValue;
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-emphasis-color
 #[syntax(" <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
 	applies_to = "text",
@@ -188,7 +188,7 @@ pub struct TextDecorationColorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextEmphasisColorStyleValue;
 
 // /// Represents the style value for `text-emphasis` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis).
@@ -203,7 +203,7 @@ pub struct TextEmphasisColorStyleValue;
 // ///
 // // https://drafts.csswg.org/css-text-decor-4/#text-emphasis
 // #[syntax(" <'text-emphasis-style'> || <'text-emphasis-color'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "see individual properties",
 //   applies_to = "see individual properties",
@@ -214,7 +214,7 @@ pub struct TextEmphasisColorStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TextEmphasisStyleValue;
 
 // /// Represents the style value for `text-emphasis-position` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-position).
@@ -229,7 +229,7 @@ pub struct TextEmphasisColorStyleValue;
 // ///
 // // https://drafts.csswg.org/css-text-decor-4/#text-emphasis-position
 // #[syntax(" [ over | under ] && [ right | left ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "over right",
 //   applies_to = "text",
@@ -240,7 +240,7 @@ pub struct TextEmphasisColorStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-position"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TextEmphasisPositionStyleValue;
 
 /// Represents the style value for `text-shadow` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-shadow).
@@ -255,7 +255,7 @@ pub struct TextEmphasisColorStyleValue;
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-shadow
 #[syntax(" none | <shadow># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "text",
@@ -266,7 +266,7 @@ pub struct TextEmphasisColorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-shadow"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextShadowStyleValue<'a>;
 
 /// Represents the style value for `text-decoration-thickness` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness).
@@ -281,7 +281,7 @@ pub struct TextShadowStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness
 #[syntax(" auto | from-font | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -292,7 +292,7 @@ pub struct TextShadowStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-thickness"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextDecorationThicknessStyleValue {}
 
 /// Represents the style value for `text-underline-offset` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-underline-offset).
@@ -307,7 +307,7 @@ pub enum TextDecorationThicknessStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-underline-offset
 #[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -318,7 +318,7 @@ pub enum TextDecorationThicknessStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-underline-offset"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextUnderlineOffsetStyleValue;
 
 /// Represents the style value for `text-decoration-trim` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-trim).
@@ -331,7 +331,7 @@ pub struct TextUnderlineOffsetStyleValue;
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-decoration-trim
 #[syntax(" <length>{1,2} | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -342,7 +342,7 @@ pub struct TextUnderlineOffsetStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-trim"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextDecorationTrimStyleValue;
 
 /// Represents the style value for `text-decoration-skip` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip).
@@ -357,7 +357,7 @@ pub struct TextDecorationTrimStyleValue;
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip
 #[syntax(" none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "See individual properties",
 	applies_to = "all elements",
@@ -368,7 +368,7 @@ pub struct TextDecorationTrimStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextDecorationSkipStyleValue {}
 
 // /// Represents the style value for `text-decoration-skip-self` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-self).
@@ -381,7 +381,7 @@ pub enum TextDecorationSkipStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-self
 // #[syntax(" auto | skip-all | [ skip-underline || skip-overline || skip-line-through ] | no-skip ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "all elements",
@@ -392,7 +392,7 @@ pub enum TextDecorationSkipStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip-self"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum TextDecorationSkipSelfStyleValue {}
 
 /// Represents the style value for `text-decoration-skip-box` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-box).
@@ -405,7 +405,7 @@ pub enum TextDecorationSkipStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-box
 #[syntax(" none | all ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -416,7 +416,7 @@ pub enum TextDecorationSkipStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip-box"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextDecorationSkipBoxStyleValue {}
 
 // /// Represents the style value for `text-decoration-skip-spaces` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-spaces).
@@ -429,7 +429,7 @@ pub enum TextDecorationSkipBoxStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-spaces
 // #[syntax(" none | all | [ start || end ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "start end",
 //   applies_to = "all elements",
@@ -440,7 +440,7 @@ pub enum TextDecorationSkipBoxStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip-spaces"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum TextDecorationSkipSpacesStyleValue {}
 
 /// Represents the style value for `text-decoration-skip-ink` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-ink).
@@ -455,7 +455,7 @@ pub enum TextDecorationSkipBoxStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-ink
 #[syntax(" auto | none | all ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -466,7 +466,7 @@ pub enum TextDecorationSkipBoxStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip-ink"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextDecorationSkipInkStyleValue {}
 
 /// Represents the style value for `text-emphasis-skip` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-skip).
@@ -479,7 +479,7 @@ pub enum TextDecorationSkipInkStyleValue {}
 ///
 // https://drafts.csswg.org/css-text-decor-4/#text-emphasis-skip
 #[syntax(" spaces || punctuation || symbols || narrow ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "spaces punctuation",
 	applies_to = "text",
@@ -490,5 +490,5 @@ pub enum TextDecorationSkipInkStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-skip"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextEmphasisSkipStyleValue;

--- a/crates/css_ast/src/values/transforms/mod.rs
+++ b/crates/css_ast/src/values/transforms/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-transforms-2/#transform
 #[syntax(" none | <transform-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "transformable elements",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TransformStyleValue<'a>;
 
 // /// Represents the style value for `transform-origin` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-origin).
@@ -47,7 +47,7 @@ pub struct TransformStyleValue<'a>;
 // #[syntax(
 // 	" [ left | center | right | top | bottom | <length-percentage> ] |   [ left | center | right | <length-percentage> ]  [ top | center | bottom | <length-percentage> ] <length>? |  [ [ center | left | right ] && [ center | top | bottom ] ] <length>? "
 // )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "50% 50%",
 //   applies_to = "transformable elements",
@@ -58,7 +58,7 @@ pub struct TransformStyleValue<'a>;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform-origin"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum TransformOriginStyleValue {}
 
 /// Represents the style value for `transform-box` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-box).
@@ -73,7 +73,7 @@ pub struct TransformStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-transforms-2/#transform-box
 #[syntax(" content-box | border-box | fill-box | stroke-box | view-box ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "view-box",
 	applies_to = "transformable elements",
@@ -84,7 +84,7 @@ pub struct TransformStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform-box"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TransformBoxStyleValue {}
 
 // /// Represents the style value for `translate` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#translate).
@@ -99,7 +99,7 @@ pub enum TransformBoxStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-transforms-2/#translate
 // #[syntax(" none | <length-percentage> [ <length-percentage> <length>? ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "transformable elements",
@@ -110,7 +110,7 @@ pub enum TransformBoxStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.translate"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TranslateStyleValue;
 
 // /// Represents the style value for `rotate` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#rotate).
@@ -125,7 +125,7 @@ pub enum TransformBoxStyleValue {}
 // ///
 // // https://drafts.csswg.org/css-transforms-2/#rotate
 // #[syntax(" none | <angle> | [ x | y | z | <number>{3} ] && <angle> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "transformable elements",
@@ -136,7 +136,7 @@ pub enum TransformBoxStyleValue {}
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rotate"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum RotateStyleValue {}
 
 /// Represents the style value for `scale` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#scale).
@@ -151,7 +151,7 @@ pub enum TransformBoxStyleValue {}
 ///
 // https://drafts.csswg.org/css-transforms-2/#scale
 #[syntax(" none | [ <number> | <percentage> ]{1,3} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "transformable elements",
@@ -162,7 +162,7 @@ pub enum TransformBoxStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scale"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScaleStyleValue;
 
 /// Represents the style value for `transform-style` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-style).
@@ -177,7 +177,7 @@ pub struct ScaleStyleValue;
 ///
 // https://drafts.csswg.org/css-transforms-2/#transform-style
 #[syntax(" flat | preserve-3d ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "flat",
 	applies_to = "transformable elements",
@@ -188,7 +188,7 @@ pub struct ScaleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TransformStyleStyleValue {}
 
 /// Represents the style value for `perspective` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#perspective).
@@ -203,7 +203,7 @@ pub enum TransformStyleStyleValue {}
 ///
 // https://drafts.csswg.org/css-transforms-2/#perspective
 #[syntax(" none | <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "transformable elements",
@@ -214,7 +214,7 @@ pub enum TransformStyleStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.perspective"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PerspectiveStyleValue;
 
 /// Represents the style value for `perspective-origin` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#perspective-origin).
@@ -229,7 +229,7 @@ pub struct PerspectiveStyleValue;
 ///
 // https://drafts.csswg.org/css-transforms-2/#perspective-origin
 #[syntax(" <position> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "50% 50%",
 	applies_to = "transformable elements",
@@ -240,7 +240,7 @@ pub struct PerspectiveStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.perspective-origin"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PerspectiveOriginStyleValue;
 
 /// Represents the style value for `backface-visibility` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#backface-visibility).
@@ -255,7 +255,7 @@ pub struct PerspectiveOriginStyleValue;
 ///
 // https://drafts.csswg.org/css-transforms-2/#backface-visibility
 #[syntax(" visible | hidden ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "visible",
 	applies_to = "transformable elements",
@@ -266,5 +266,5 @@ pub struct PerspectiveOriginStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.backface-visibility"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BackfaceVisibilityStyleValue {}

--- a/crates/css_ast/src/values/transitions/mod.rs
+++ b/crates/css_ast/src/values/transitions/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-transitions-2/#transition-property
 #[syntax(" none | <single-transition-property># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "all",
 	applies_to = "all elements",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-property"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TransitionPropertyStyleValue<'a>;
 
 /// Represents the style value for `transition-duration` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-duration).
@@ -45,7 +45,7 @@ pub struct TransitionPropertyStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-transitions-2/#transition-duration
 #[syntax(" <time [0s,∞]># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0s",
 	applies_to = "all elements",
@@ -56,7 +56,7 @@ pub struct TransitionPropertyStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-duration"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TransitionDurationStyleValue<'a>;
 
 /// Represents the style value for `transition-timing-function` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-timing-function).
@@ -71,7 +71,7 @@ pub struct TransitionDurationStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-transitions-2/#transition-timing-function
 #[syntax(" <easing-function># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "ease",
 	applies_to = "all elements",
@@ -86,7 +86,7 @@ pub struct TransitionDurationStyleValue<'a>;
 	derive(ToCSSFeature),
 	css_feature("css.properties.transition-timing-function")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TransitionTimingFunctionStyleValue<'a>;
 
 /// Represents the style value for `transition-delay` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-delay).
@@ -101,7 +101,7 @@ pub struct TransitionTimingFunctionStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-transitions-2/#transition-delay
 #[syntax(" <time># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0s",
 	applies_to = "all elements",
@@ -112,7 +112,7 @@ pub struct TransitionTimingFunctionStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-delay"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TransitionDelayStyleValue<'a>;
 
 /// Represents the style value for `transition` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition).
@@ -127,7 +127,7 @@ pub struct TransitionDelayStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-transitions-2/#transition
 #[syntax(" <single-transition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "all elements",
@@ -138,7 +138,7 @@ pub struct TransitionDelayStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TransitionStyleValue<'a>;
 
 /// Represents the style value for `transition-behavior` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-behavior).
@@ -153,7 +153,7 @@ pub struct TransitionStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-transitions-2/#transition-behavior
 #[syntax(" <transition-behavior-value># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -164,5 +164,5 @@ pub struct TransitionStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-behavior"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TransitionBehaviorStyleValue<'a>;

--- a/crates/css_ast/src/values/ui/mod.rs
+++ b/crates/css_ast/src/values/ui/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-ui-4/#outline
 #[syntax(" <'outline-width'> || <'outline-style'> || <'outline-color'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "all elements",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OutlineStyleValue<'a>;
 
 /// Represents the style value for `outline-width` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline-width).
@@ -45,7 +45,7 @@ pub struct OutlineStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-ui-4/#outline-width
 #[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "medium",
 	applies_to = "all elements",
@@ -56,7 +56,7 @@ pub struct OutlineStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline-width"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OutlineWidthStyleValue;
 
 /// Represents the style value for `outline-style` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline-style).
@@ -71,7 +71,7 @@ pub struct OutlineWidthStyleValue;
 ///
 // https://drafts.csswg.org/css-ui-4/#outline-style
 #[syntax(" auto | <outline-line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -82,7 +82,7 @@ pub struct OutlineWidthStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline-style"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OutlineStyleStyleValue;
 
 /// Represents the style value for `outline-color` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline-color).
@@ -97,7 +97,7 @@ pub struct OutlineStyleStyleValue;
 ///
 // https://drafts.csswg.org/css-ui-4/#outline-color
 #[syntax(" auto | <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -108,7 +108,7 @@ pub struct OutlineStyleStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OutlineColorStyleValue<'a> {}
 
 /// Represents the style value for `outline-offset` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline-offset).
@@ -123,7 +123,7 @@ pub enum OutlineColorStyleValue<'a> {}
 ///
 // https://drafts.csswg.org/css-ui-4/#outline-offset
 #[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
 	applies_to = "all elements",
@@ -134,7 +134,7 @@ pub enum OutlineColorStyleValue<'a> {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline-offset"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OutlineOffsetStyleValue;
 
 /// Represents the style value for `resize` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#resize).
@@ -149,7 +149,7 @@ pub struct OutlineOffsetStyleValue;
 ///
 // https://drafts.csswg.org/css-ui-4/#resize
 #[syntax(" none | both | horizontal | vertical | block | inline ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "elements that are scroll containers and optionally replaced elements such as images, videos, and iframes",
@@ -160,7 +160,7 @@ pub struct OutlineOffsetStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.resize"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ResizeStyleValue {}
 
 /// Represents the style value for `cursor` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#cursor).
@@ -175,7 +175,7 @@ pub enum ResizeStyleValue {}
 ///
 // https://drafts.csswg.org/css-ui-4/#cursor
 #[syntax(" <cursor-image>#? <cursor-predefined> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -186,7 +186,7 @@ pub enum ResizeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cursor"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CursorStyleValue<'a>;
 
 /// Represents the style value for `caret-color` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret-color).
@@ -201,7 +201,7 @@ pub struct CursorStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-ui-4/#caret-color
 #[syntax(" auto | <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "text or elements that accept text input",
@@ -212,7 +212,7 @@ pub struct CursorStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CaretColorStyleValue;
 
 /// Represents the style value for `caret-animation` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret-animation).
@@ -225,7 +225,7 @@ pub struct CaretColorStyleValue;
 ///
 // https://drafts.csswg.org/css-ui-4/#caret-animation
 #[syntax(" auto | manual ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "text or elements that accept text input",
@@ -236,10 +236,12 @@ pub struct CaretColorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret-animation"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum CaretAnimationStyleValue {}
 
 /// Represents the style value for `caret-shape` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret-shape).
+///
+/// The caret-shape CSS property controls the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.
 ///
 /// The grammar is defined as:
 ///
@@ -249,7 +251,7 @@ pub enum CaretAnimationStyleValue {}
 ///
 // https://drafts.csswg.org/css-ui-4/#caret-shape
 #[syntax(" auto | bar | block | underscore ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "text or elements that accept text input",
@@ -260,7 +262,7 @@ pub enum CaretAnimationStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret-shape"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum CaretShapeStyleValue {}
 
 /// Represents the style value for `caret` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret).
@@ -273,7 +275,7 @@ pub enum CaretShapeStyleValue {}
 ///
 // https://drafts.csswg.org/css-ui-4/#caret
 #[syntax(" <'caret-color'> || <'caret-animation'> || <'caret-shape'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "text or elements that accept text input",
@@ -284,7 +286,7 @@ pub enum CaretShapeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct CaretStyleValue;
 
 // /// Represents the style value for `nav-up` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-up).
@@ -297,7 +299,7 @@ pub struct CaretStyleValue;
 // ///
 // // https://drafts.csswg.org/css-ui-4/#nav-up
 // #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "all enabled elements",
@@ -308,7 +310,7 @@ pub struct CaretStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-up"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum NavUpStyleValue {}
 
 // /// Represents the style value for `nav-right` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-right).
@@ -321,7 +323,7 @@ pub struct CaretStyleValue;
 // ///
 // // https://drafts.csswg.org/css-ui-4/#nav-right
 // #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "all enabled elements",
@@ -332,7 +334,7 @@ pub struct CaretStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-right"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum NavRightStyleValue {}
 
 // /// Represents the style value for `nav-down` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-down).
@@ -345,7 +347,7 @@ pub struct CaretStyleValue;
 // ///
 // // https://drafts.csswg.org/css-ui-4/#nav-down
 // #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "all enabled elements",
@@ -356,7 +358,7 @@ pub struct CaretStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-down"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum NavDownStyleValue {}
 
 // /// Represents the style value for `nav-left` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-left).
@@ -369,7 +371,7 @@ pub struct CaretStyleValue;
 // ///
 // // https://drafts.csswg.org/css-ui-4/#nav-left
 // #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
 //   applies_to = "all enabled elements",
@@ -380,7 +382,7 @@ pub struct CaretStyleValue;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-left"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum NavLeftStyleValue {}
 
 /// Represents the style value for `user-select` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#user-select).
@@ -395,7 +397,7 @@ pub struct CaretStyleValue;
 ///
 // https://drafts.csswg.org/css-ui-4/#user-select
 #[syntax(" auto | text | none | contain | all ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements, and optionally to the ::before and ::after pseudo-elements",
@@ -406,7 +408,7 @@ pub struct CaretStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.user-select"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum UserSelectStyleValue {}
 
 /// Represents the style value for `pointer-events` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#pointer-events).
@@ -421,7 +423,7 @@ pub enum UserSelectStyleValue {}
 ///
 // https://drafts.csswg.org/css-ui-4/#pointer-events
 #[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -432,7 +434,7 @@ pub enum UserSelectStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pointer-events"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum PointerEventsStyleValue {}
 
 /// Represents the style value for `interactivity` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interactivity).
@@ -447,7 +449,7 @@ pub enum PointerEventsStyleValue {}
 ///
 // https://drafts.csswg.org/css-ui-4/#interactivity
 #[syntax(" auto | inert ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -458,7 +460,7 @@ pub enum PointerEventsStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interactivity"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum InteractivityStyleValue {}
 
 /// Represents the style value for `interest-delay-start` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interest-delay-start).
@@ -471,7 +473,7 @@ pub enum InteractivityStyleValue {}
 ///
 // https://drafts.csswg.org/css-ui-4/#interest-delay-start
 #[syntax(" normal | <time> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -482,7 +484,7 @@ pub enum InteractivityStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interest-delay-start"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum InterestDelayStartStyleValue {}
 
 /// Represents the style value for `interest-delay-end` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interest-delay-end).
@@ -495,7 +497,7 @@ pub enum InterestDelayStartStyleValue {}
 ///
 // https://drafts.csswg.org/css-ui-4/#interest-delay-end
 #[syntax(" normal | <time> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -506,7 +508,7 @@ pub enum InterestDelayStartStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interest-delay-end"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum InterestDelayEndStyleValue {}
 
 /// Represents the style value for `interest-delay` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interest-delay).
@@ -519,7 +521,7 @@ pub enum InterestDelayEndStyleValue {}
 ///
 // https://drafts.csswg.org/css-ui-4/#interest-delay
 #[syntax(" <'interest-delay-start'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
 	applies_to = "see individual properties",
@@ -530,7 +532,7 @@ pub enum InterestDelayEndStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interest-delay"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InterestDelayStyleValue;
 
 /// Represents the style value for `accent-color` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#accent-color).
@@ -545,7 +547,7 @@ pub struct InterestDelayStyleValue;
 ///
 // https://drafts.csswg.org/css-ui-4/#accent-color
 #[syntax(" auto | <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -556,7 +558,7 @@ pub struct InterestDelayStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.accent-color"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AccentColorStyleValue;
 
 /// Represents the style value for `appearance` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#appearance).
@@ -571,7 +573,7 @@ pub struct AccentColorStyleValue;
 ///
 // https://drafts.csswg.org/css-ui-4/#appearance
 #[syntax(" none | auto | base | base-select | <compat-auto> | <compat-special> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -582,5 +584,5 @@ pub struct AccentColorStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.appearance"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum AppearanceStyleValue {}

--- a/crates/css_ast/src/values/values/mod.rs
+++ b/crates/css_ast/src/values/values/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-values-5/#interpolate-size
 #[syntax(" numeric-only | allow-keywords ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "numeric-only",
 	applies_to = "all elements",
@@ -30,5 +30,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interpolate-size"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum InterpolateSizeStyleValue {}

--- a/crates/css_ast/src/values/variables/mod.rs
+++ b/crates/css_ast/src/values/variables/mod.rs
@@ -17,7 +17,7 @@ use impls::*;
 // ///
 // // https://drafts.csswg.org/css-variables-2/#defining-variables
 // #[syntax(" <declaration-value>? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "the guaranteed-invalid value",
 //   applies_to = "all elements and all pseudo-elements (including those with restricted property lists)",
@@ -28,5 +28,5 @@ use impls::*;
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.--*"))]
-// #[visit]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct CustomStyleValue;

--- a/crates/css_ast/src/values/view_transitions/mod.rs
+++ b/crates/css_ast/src/values/view_transitions/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-view-transitions-2/#view-transition-name
 #[syntax(" none | <custom-ident> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.view-transition-name"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ViewTransitionNameStyleValue;
 
 /// Represents the style value for `view-transition-class` as defined in [css-view-transitions-2](https://drafts.csswg.org/css-view-transitions-2/#view-transition-class).
@@ -45,7 +45,7 @@ pub struct ViewTransitionNameStyleValue;
 ///
 // https://drafts.csswg.org/css-view-transitions-2/#view-transition-class
 #[syntax(" none | <custom-ident>+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "all elements",
@@ -56,7 +56,7 @@ pub struct ViewTransitionNameStyleValue;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.view-transition-class"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ViewTransitionClassStyleValue<'a>;
 
 /// Represents the style value for `view-transition-group` as defined in [css-view-transitions-2](https://drafts.csswg.org/css-view-transitions-2/#view-transition-group).
@@ -69,7 +69,7 @@ pub struct ViewTransitionClassStyleValue<'a>;
 ///
 // https://drafts.csswg.org/css-view-transitions-2/#view-transition-group
 #[syntax(" normal | contain | nearest | <custom-ident> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements",
@@ -80,5 +80,5 @@ pub struct ViewTransitionClassStyleValue<'a>;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.view-transition-group"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ViewTransitionGroupStyleValue {}

--- a/crates/css_ast/src/values/viewport/mod.rs
+++ b/crates/css_ast/src/values/viewport/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-viewport-1/#zoom
 #[syntax(" <number [0,∞]> | <percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "1",
 	applies_to = "all <length> property values of all elements",
@@ -30,5 +30,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.zoom"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ZoomStyleValue;

--- a/crates/css_ast/src/values/will_change/mod.rs
+++ b/crates/css_ast/src/values/will_change/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-will-change-1/#will-change
 #[syntax(" auto | <animateable-feature># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "all elements",
@@ -30,5 +30,5 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.will-change"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct WillChangeStyleValue<'a>;

--- a/crates/css_ast/src/values/writing_modes/mod.rs
+++ b/crates/css_ast/src/values/writing_modes/mod.rs
@@ -19,7 +19,7 @@ use impls::*;
 ///
 // https://drafts.csswg.org/css-writing-modes-4/#direction
 #[syntax(" ltr | rtl ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "ltr",
 	applies_to = "all elements",
@@ -30,7 +30,7 @@ use impls::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.direction"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum DirectionStyleValue {}
 
 /// Represents the style value for `unicode-bidi` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#unicode-bidi).
@@ -45,7 +45,7 @@ pub enum DirectionStyleValue {}
 ///
 // https://drafts.csswg.org/css-writing-modes-4/#unicode-bidi
 #[syntax(" normal | embed | isolate | bidi-override | isolate-override | plaintext ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "all elements, but see prose",
@@ -56,7 +56,7 @@ pub enum DirectionStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.unicode-bidi"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum UnicodeBidiStyleValue {}
 
 /// Represents the style value for `writing-mode` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#writing-mode).
@@ -71,7 +71,7 @@ pub enum UnicodeBidiStyleValue {}
 ///
 // https://drafts.csswg.org/css-writing-modes-4/#writing-mode
 #[syntax(" horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "horizontal-tb",
 	applies_to = "All elements except table row groups, table column groups, table rows, table columns, ruby base containers, ruby annotation containers",
@@ -82,7 +82,7 @@ pub enum UnicodeBidiStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.writing-mode"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WritingModeStyleValue {}
 
 /// Represents the style value for `text-orientation` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#text-orientation).
@@ -97,7 +97,7 @@ pub enum WritingModeStyleValue {}
 ///
 // https://drafts.csswg.org/css-writing-modes-4/#text-orientation
 #[syntax(" mixed | upright | sideways ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "mixed",
 	applies_to = "all elements except table row groups, rows, column groups, and columns; and text",
@@ -108,7 +108,7 @@ pub enum WritingModeStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-orientation"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextOrientationStyleValue {}
 
 /// Represents the style value for `glyph-orientation-vertical` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#glyph-orientation-vertical).
@@ -123,7 +123,7 @@ pub enum TextOrientationStyleValue {}
 ///
 // https://drafts.csswg.org/css-writing-modes-4/#glyph-orientation-vertical
 #[syntax(" auto | 0deg | 90deg | 0 | 90 ")]
-#[derive(Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "n/a",
 	applies_to = "n/a",
@@ -138,7 +138,7 @@ pub enum TextOrientationStyleValue {}
 	derive(ToCSSFeature),
 	css_feature("css.properties.glyph-orientation-vertical")
 )]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum GlyphOrientationVerticalStyleValue {}
 
 /// Represents the style value for `text-combine-upright` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#text-combine-upright).
@@ -153,7 +153,7 @@ pub enum GlyphOrientationVerticalStyleValue {}
 ///
 // https://drafts.csswg.org/css-writing-modes-4/#text-combine-upright
 #[syntax(" none | all | [ digits <integer [2,4]>? ] ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
 	applies_to = "inline boxes and text",
@@ -164,5 +164,5 @@ pub enum GlyphOrientationVerticalStyleValue {}
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-combine-upright"))]
-#[visit]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextCombineUprightStyleValue {}

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -12,14 +12,14 @@ use crate::*;
 
 macro_rules! visit_mut_trait {
 	( $(
-		$name: ident$(<$life:lifetime>)?($obj: ty),
+		$name: ident$(<$($gen:tt),+>)?($obj: ty),
 	)+ ) => {
 		pub trait VisitMut: Sized {
 			fn visit_declaration<'a, T: DeclarationValue<'a>>(&mut self, _rule: &mut Declaration<'a, T>) {}
 			fn visit_bad_declaration<'a>(&mut self, _rule: &mut BadDeclaration<'a>) {}
 			fn visit_string(&mut self, _str: &mut token_macros::String) {}
 			$(
-				fn $name$(<$life>)?(&mut self, _rule: &mut $obj) {}
+				fn $name$(<$($gen),+>)?(&mut self, _rule: &mut $obj) {}
 			)+
 		}
 	}
@@ -28,14 +28,14 @@ apply_visit_methods!(visit_mut_trait);
 
 macro_rules! visit_trait {
 	( $(
-		$name: ident$(<$life:lifetime>)?($obj: ty),
+		$name: ident$(<$($gen:tt),+>)?($obj: ty),
 	)+ ) => {
 		pub trait Visit: Sized {
 			fn visit_declaration<'a, T: DeclarationValue<'a>>(&mut self, _rule: &Declaration<'a, T>) {}
 			fn visit_bad_declaration<'a>(&mut self, _rule: &BadDeclaration<'a>) {}
 			fn visit_string(&mut self, _str: &token_macros::String) {}
 			$(
-				fn $name$(<$life>)?(&mut self, _rule: &$obj) {}
+				fn $name$(<$($gen),+>)?(&mut self, _rule: &$obj) {}
 			)+
 		}
 	}

--- a/crates/css_feature_data/src/data.rs
+++ b/crates/css_feature_data/src/data.rs
@@ -1,5 +1,5 @@
 //! Auto-generated CSS features data
-//! Generated on: 2025-10-13T08:59:21.085Z
+//! Generated on: 2025-10-16T20:04:23.651Z
 
 use crate::*;
 use chrono::NaiveDate;
@@ -137,7 +137,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.8457,
+		popularity: 1.9862,
 	},
 	"css.properties.accent-color.auto" => CSSFeature {
 		id: "css.properties.accent-color.auto",
@@ -156,7 +156,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.8457,
+		popularity: 1.9862,
 	},
 	"css.selectors.active-view-transition" => CSSFeature {
 		id: "css.selectors.active-view-transition",
@@ -232,7 +232,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4458,
+		popularity: 0.5911,
 	},
 	"css.properties.alignment-baseline.alphabetic" => CSSFeature {
 		id: "css.properties.alignment-baseline.alphabetic",
@@ -251,7 +251,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4458,
+		popularity: 0.5911,
 	},
 	"css.properties.alignment-baseline.baseline" => CSSFeature {
 		id: "css.properties.alignment-baseline.baseline",
@@ -270,7 +270,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4458,
+		popularity: 0.5911,
 	},
 	"css.properties.alignment-baseline.central" => CSSFeature {
 		id: "css.properties.alignment-baseline.central",
@@ -289,7 +289,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4458,
+		popularity: 0.5911,
 	},
 	"css.properties.alignment-baseline.ideographic" => CSSFeature {
 		id: "css.properties.alignment-baseline.ideographic",
@@ -308,7 +308,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4458,
+		popularity: 0.5911,
 	},
 	"css.properties.alignment-baseline.mathematical" => CSSFeature {
 		id: "css.properties.alignment-baseline.mathematical",
@@ -327,7 +327,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4458,
+		popularity: 0.5911,
 	},
 	"css.properties.alignment-baseline.middle" => CSSFeature {
 		id: "css.properties.alignment-baseline.middle",
@@ -346,7 +346,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4458,
+		popularity: 0.5911,
 	},
 	"css.properties.alignment-baseline.text-after-edge" => CSSFeature {
 		id: "css.properties.alignment-baseline.text-after-edge",
@@ -365,7 +365,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4458,
+		popularity: 0.5911,
 	},
 	"css.properties.alignment-baseline.text-before-edge" => CSSFeature {
 		id: "css.properties.alignment-baseline.text-before-edge",
@@ -384,7 +384,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4458,
+		popularity: 0.5911,
 	},
 	"css.properties.all" => CSSFeature {
 		id: "css.properties.all",
@@ -403,7 +403,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-all"],
-		popularity: 11.5610,
+		popularity: 12.5599,
 	},
 	"css.properties.content.alt_text" => CSSFeature {
 		id: "css.properties.content.alt_text",
@@ -2892,7 +2892,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &[],
-		popularity: 0.2779,
+		popularity: 0.3733,
 	},
 	"css.at-rules.keyframes" => CSSFeature {
 		id: "css.at-rules.keyframes",
@@ -3424,7 +3424,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.auto" => CSSFeature {
 		id: "css.properties.appearance.auto",
@@ -3443,7 +3443,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.button" => CSSFeature {
 		id: "css.properties.appearance.button",
@@ -3462,7 +3462,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.checkbox" => CSSFeature {
 		id: "css.properties.appearance.checkbox",
@@ -3481,7 +3481,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.listbox" => CSSFeature {
 		id: "css.properties.appearance.listbox",
@@ -3500,7 +3500,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.menulist" => CSSFeature {
 		id: "css.properties.appearance.menulist",
@@ -3519,7 +3519,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.menulist-button" => CSSFeature {
 		id: "css.properties.appearance.menulist-button",
@@ -3538,7 +3538,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.meter" => CSSFeature {
 		id: "css.properties.appearance.meter",
@@ -3557,7 +3557,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.none" => CSSFeature {
 		id: "css.properties.appearance.none",
@@ -3576,7 +3576,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.progress-bar" => CSSFeature {
 		id: "css.properties.appearance.progress-bar",
@@ -3595,7 +3595,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.radio" => CSSFeature {
 		id: "css.properties.appearance.radio",
@@ -3614,7 +3614,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.searchfield" => CSSFeature {
 		id: "css.properties.appearance.searchfield",
@@ -3633,7 +3633,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.textarea" => CSSFeature {
 		id: "css.properties.appearance.textarea",
@@ -3652,7 +3652,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.appearance.textfield" => CSSFeature {
 		id: "css.properties.appearance.textfield",
@@ -3671,7 +3671,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.5090,
+		popularity: 45.9264,
 	},
 	"css.properties.aspect-ratio" => CSSFeature {
 		id: "css.properties.aspect-ratio",
@@ -3690,7 +3690,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,0),
 				},
 		caniuse: &[],
-		popularity: 32.7466,
+		popularity: 30.0296,
 	},
 	"css.properties.aspect-ratio.auto" => CSSFeature {
 		id: "css.properties.aspect-ratio.auto",
@@ -3709,7 +3709,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,0),
 				},
 		caniuse: &[],
-		popularity: 32.7466,
+		popularity: 30.0296,
 	},
 	"css.types.attr.fallback" => CSSFeature {
 		id: "css.types.attr.fallback",
@@ -4051,7 +4051,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,0),
 				},
 		caniuse: &["https://caniuse.com/css-backdrop-filter"],
-		popularity: 30.1843,
+		popularity: 28.1117,
 	},
 	"css.properties.background" => CSSFeature {
 		id: "css.properties.background",
@@ -4070,7 +4070,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/multibackgrounds"],
-		popularity: 87.3496,
+		popularity: 87.3020,
 	},
 	"css.properties.background.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background.multiple_backgrounds",
@@ -4089,7 +4089,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/multibackgrounds"],
-		popularity: 87.3496,
+		popularity: 87.3020,
 	},
 	"css.properties.background-attachment" => CSSFeature {
 		id: "css.properties.background-attachment",
@@ -4108,7 +4108,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.4387,
+		popularity: 8.4643,
 	},
 	"css.properties.background-attachment.fixed" => CSSFeature {
 		id: "css.properties.background-attachment.fixed",
@@ -4127,7 +4127,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.4387,
+		popularity: 8.4643,
 	},
 	"css.properties.background-attachment.local" => CSSFeature {
 		id: "css.properties.background-attachment.local",
@@ -4146,7 +4146,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.4387,
+		popularity: 8.4643,
 	},
 	"css.properties.background-attachment.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background-attachment.multiple_backgrounds",
@@ -4165,7 +4165,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.4387,
+		popularity: 8.4643,
 	},
 	"css.properties.background-attachment.scroll" => CSSFeature {
 		id: "css.properties.background-attachment.scroll",
@@ -4184,7 +4184,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.4387,
+		popularity: 8.4643,
 	},
 	"css.properties.background-blend-mode" => CSSFeature {
 		id: "css.properties.background-blend-mode",
@@ -4203,7 +4203,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-backgroundblendmode"],
-		popularity: 3.7422,
+		popularity: 4.0997,
 	},
 	"css.types.blend-mode" => CSSFeature {
 		id: "css.types.blend-mode",
@@ -4222,7 +4222,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-backgroundblendmode"],
-		popularity: 3.7422,
+		popularity: 4.0997,
 	},
 	"css.properties.background-clip" => CSSFeature {
 		id: "css.properties.background-clip",
@@ -4241,7 +4241,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.8067,
+		popularity: 43.3719,
 	},
 	"css.properties.background-clip.border-box" => CSSFeature {
 		id: "css.properties.background-clip.border-box",
@@ -4260,7 +4260,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.8067,
+		popularity: 43.3719,
 	},
 	"css.properties.background-clip.content-box" => CSSFeature {
 		id: "css.properties.background-clip.content-box",
@@ -4279,7 +4279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.8067,
+		popularity: 43.3719,
 	},
 	"css.properties.background-clip.padding-box" => CSSFeature {
 		id: "css.properties.background-clip.padding-box",
@@ -4298,7 +4298,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.8067,
+		popularity: 43.3719,
 	},
 	"css.properties.background.background-clip" => CSSFeature {
 		id: "css.properties.background.background-clip",
@@ -4317,7 +4317,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.8067,
+		popularity: 43.3719,
 	},
 	"css.properties.background-clip.border-area" => CSSFeature {
 		id: "css.properties.background-clip.border-area",
@@ -4374,7 +4374,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.6923,
+		popularity: 89.8858,
 	},
 	"css.properties.background-image" => CSSFeature {
 		id: "css.properties.background-image",
@@ -4393,7 +4393,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 77.9481,
+		popularity: 77.9347,
 	},
 	"css.properties.background-image.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background-image.multiple_backgrounds",
@@ -4412,7 +4412,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 77.9481,
+		popularity: 77.9347,
 	},
 	"css.properties.background-image.none" => CSSFeature {
 		id: "css.properties.background-image.none",
@@ -4431,7 +4431,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 77.9481,
+		popularity: 77.9347,
 	},
 	"css.properties.background-origin" => CSSFeature {
 		id: "css.properties.background-origin",
@@ -4450,7 +4450,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.6708,
+		popularity: 7.5018,
 	},
 	"css.properties.background-origin.border-box" => CSSFeature {
 		id: "css.properties.background-origin.border-box",
@@ -4469,7 +4469,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.6708,
+		popularity: 7.5018,
 	},
 	"css.properties.background-origin.content-box" => CSSFeature {
 		id: "css.properties.background-origin.content-box",
@@ -4488,7 +4488,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.6708,
+		popularity: 7.5018,
 	},
 	"css.properties.background-origin.padding-box" => CSSFeature {
 		id: "css.properties.background-origin.padding-box",
@@ -4507,7 +4507,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.6708,
+		popularity: 7.5018,
 	},
 	"css.properties.background.background-origin" => CSSFeature {
 		id: "css.properties.background.background-origin",
@@ -4526,7 +4526,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.6708,
+		popularity: 7.5018,
 	},
 	"css.properties.background-position" => CSSFeature {
 		id: "css.properties.background-position",
@@ -4545,7 +4545,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position-x" => CSSFeature {
 		id: "css.properties.background-position-x",
@@ -4564,7 +4564,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position-x.side-relative_values" => CSSFeature {
 		id: "css.properties.background-position-x.side-relative_values",
@@ -4583,7 +4583,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position-y" => CSSFeature {
 		id: "css.properties.background-position-y",
@@ -4602,7 +4602,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position-y.side-relative_values" => CSSFeature {
 		id: "css.properties.background-position-y.side-relative_values",
@@ -4621,7 +4621,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position.bottom" => CSSFeature {
 		id: "css.properties.background-position.bottom",
@@ -4640,7 +4640,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position.center" => CSSFeature {
 		id: "css.properties.background-position.center",
@@ -4659,7 +4659,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position.left" => CSSFeature {
 		id: "css.properties.background-position.left",
@@ -4678,7 +4678,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background-position.multiple_backgrounds",
@@ -4697,7 +4697,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position.right" => CSSFeature {
 		id: "css.properties.background-position.right",
@@ -4716,7 +4716,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position.side-relative_values" => CSSFeature {
 		id: "css.properties.background-position.side-relative_values",
@@ -4735,7 +4735,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-position.top" => CSSFeature {
 		id: "css.properties.background-position.top",
@@ -4754,7 +4754,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.6803,
+		popularity: 75.0860,
 	},
 	"css.properties.background-repeat" => CSSFeature {
 		id: "css.properties.background-repeat",
@@ -4773,7 +4773,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.9047,
+		popularity: 71.9669,
 	},
 	"css.properties.background-repeat.2-value" => CSSFeature {
 		id: "css.properties.background-repeat.2-value",
@@ -4792,7 +4792,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.9047,
+		popularity: 71.9669,
 	},
 	"css.properties.background-repeat.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background-repeat.multiple_backgrounds",
@@ -4811,7 +4811,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.9047,
+		popularity: 71.9669,
 	},
 	"css.properties.background-repeat.no-repeat" => CSSFeature {
 		id: "css.properties.background-repeat.no-repeat",
@@ -4830,7 +4830,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.9047,
+		popularity: 71.9669,
 	},
 	"css.properties.background-repeat.repeat" => CSSFeature {
 		id: "css.properties.background-repeat.repeat",
@@ -4849,7 +4849,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.9047,
+		popularity: 71.9669,
 	},
 	"css.properties.background-repeat.repeat-x" => CSSFeature {
 		id: "css.properties.background-repeat.repeat-x",
@@ -4868,7 +4868,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.9047,
+		popularity: 71.9669,
 	},
 	"css.properties.background-repeat.repeat-y" => CSSFeature {
 		id: "css.properties.background-repeat.repeat-y",
@@ -4887,7 +4887,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.9047,
+		popularity: 71.9669,
 	},
 	"css.properties.background-repeat.round" => CSSFeature {
 		id: "css.properties.background-repeat.round",
@@ -4906,7 +4906,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.9047,
+		popularity: 71.9669,
 	},
 	"css.properties.background-repeat.space" => CSSFeature {
 		id: "css.properties.background-repeat.space",
@@ -4925,7 +4925,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.9047,
+		popularity: 71.9669,
 	},
 	"css.properties.background-size" => CSSFeature {
 		id: "css.properties.background-size",
@@ -4944,7 +4944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.8332,
+		popularity: 72.2062,
 	},
 	"css.properties.background-size.auto" => CSSFeature {
 		id: "css.properties.background-size.auto",
@@ -4963,7 +4963,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.8332,
+		popularity: 72.2062,
 	},
 	"css.properties.background-size.contain" => CSSFeature {
 		id: "css.properties.background-size.contain",
@@ -4982,7 +4982,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.8332,
+		popularity: 72.2062,
 	},
 	"css.properties.background-size.cover" => CSSFeature {
 		id: "css.properties.background-size.cover",
@@ -5001,7 +5001,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.8332,
+		popularity: 72.2062,
 	},
 	"css.properties.background.background-size" => CSSFeature {
 		id: "css.properties.background.background-size",
@@ -5020,7 +5020,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.8332,
+		popularity: 72.2062,
 	},
 	"css.properties.baseline-shift" => CSSFeature {
 		id: "css.properties.baseline-shift",
@@ -5039,7 +5039,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.3906,
+		popularity: 0.4776,
 	},
 	"css.properties.baseline-shift.baseline" => CSSFeature {
 		id: "css.properties.baseline-shift.baseline",
@@ -5058,7 +5058,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.3906,
+		popularity: 0.4776,
 	},
 	"css.properties.baseline-shift.sub" => CSSFeature {
 		id: "css.properties.baseline-shift.sub",
@@ -5077,7 +5077,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.3906,
+		popularity: 0.4776,
 	},
 	"css.properties.baseline-shift.super" => CSSFeature {
 		id: "css.properties.baseline-shift.super",
@@ -5096,7 +5096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.3906,
+		popularity: 0.4776,
 	},
 	"css.properties.baseline-source" => CSSFeature {
 		id: "css.properties.baseline-source",
@@ -5115,7 +5115,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0259,
+		popularity: 0.0279,
 	},
 	"css.properties.baseline-source.auto" => CSSFeature {
 		id: "css.properties.baseline-source.auto",
@@ -5134,7 +5134,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0259,
+		popularity: 0.0279,
 	},
 	"css.properties.baseline-source.first" => CSSFeature {
 		id: "css.properties.baseline-source.first",
@@ -5153,7 +5153,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0259,
+		popularity: 0.0279,
 	},
 	"css.properties.baseline-source.last" => CSSFeature {
 		id: "css.properties.baseline-source.last",
@@ -5172,7 +5172,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0259,
+		popularity: 0.0279,
 	},
 	"css.selectors.after" => CSSFeature {
 		id: "css.selectors.after",
@@ -5267,7 +5267,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-outset" => CSSFeature {
 		id: "css.properties.border-image-outset",
@@ -5286,7 +5286,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-repeat" => CSSFeature {
 		id: "css.properties.border-image-repeat",
@@ -5305,7 +5305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-repeat.repeat" => CSSFeature {
 		id: "css.properties.border-image-repeat.repeat",
@@ -5324,7 +5324,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-repeat.round" => CSSFeature {
 		id: "css.properties.border-image-repeat.round",
@@ -5343,7 +5343,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-repeat.space" => CSSFeature {
 		id: "css.properties.border-image-repeat.space",
@@ -5362,7 +5362,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-repeat.stretch" => CSSFeature {
 		id: "css.properties.border-image-repeat.stretch",
@@ -5381,7 +5381,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-slice" => CSSFeature {
 		id: "css.properties.border-image-slice",
@@ -5400,7 +5400,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-source" => CSSFeature {
 		id: "css.properties.border-image-source",
@@ -5419,7 +5419,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-width" => CSSFeature {
 		id: "css.properties.border-image-width",
@@ -5438,7 +5438,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image-width.auto" => CSSFeature {
 		id: "css.properties.border-image-width.auto",
@@ -5457,7 +5457,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image.fill" => CSSFeature {
 		id: "css.properties.border-image.fill",
@@ -5476,7 +5476,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image.gradient" => CSSFeature {
 		id: "css.properties.border-image.gradient",
@@ -5495,7 +5495,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-image.optional_border_image_slice" => CSSFeature {
 		id: "css.properties.border-image.optional_border_image_slice",
@@ -5514,7 +5514,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.4052,
+		popularity: 5.3835,
 	},
 	"css.properties.border-bottom-left-radius" => CSSFeature {
 		id: "css.properties.border-bottom-left-radius",
@@ -5533,7 +5533,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-bottom-left-radius.elliptical_corners" => CSSFeature {
 		id: "css.properties.border-bottom-left-radius.elliptical_corners",
@@ -5552,7 +5552,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-bottom-left-radius.percentages" => CSSFeature {
 		id: "css.properties.border-bottom-left-radius.percentages",
@@ -5571,7 +5571,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-bottom-right-radius" => CSSFeature {
 		id: "css.properties.border-bottom-right-radius",
@@ -5590,7 +5590,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-bottom-right-radius.elliptical_corners" => CSSFeature {
 		id: "css.properties.border-bottom-right-radius.elliptical_corners",
@@ -5609,7 +5609,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-bottom-right-radius.percentages" => CSSFeature {
 		id: "css.properties.border-bottom-right-radius.percentages",
@@ -5628,7 +5628,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-radius" => CSSFeature {
 		id: "css.properties.border-radius",
@@ -5647,7 +5647,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-radius.4_values_for_4_corners" => CSSFeature {
 		id: "css.properties.border-radius.4_values_for_4_corners",
@@ -5666,7 +5666,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-radius.elliptical_borders" => CSSFeature {
 		id: "css.properties.border-radius.elliptical_borders",
@@ -5685,7 +5685,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-radius.percentages" => CSSFeature {
 		id: "css.properties.border-radius.percentages",
@@ -5704,7 +5704,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-top-left-radius" => CSSFeature {
 		id: "css.properties.border-top-left-radius",
@@ -5723,7 +5723,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-top-left-radius.elliptical_corners" => CSSFeature {
 		id: "css.properties.border-top-left-radius.elliptical_corners",
@@ -5742,7 +5742,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-top-left-radius.percentages" => CSSFeature {
 		id: "css.properties.border-top-left-radius.percentages",
@@ -5761,7 +5761,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-top-right-radius" => CSSFeature {
 		id: "css.properties.border-top-right-radius",
@@ -5780,7 +5780,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-top-right-radius.elliptical_corners" => CSSFeature {
 		id: "css.properties.border-top-right-radius.elliptical_corners",
@@ -5799,7 +5799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border-top-right-radius.percentages" => CSSFeature {
 		id: "css.properties.border-top-right-radius.percentages",
@@ -5818,7 +5818,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 86.3872,
+		popularity: 86.0072,
 	},
 	"css.properties.border" => CSSFeature {
 		id: "css.properties.border",
@@ -6426,7 +6426,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-boxdecorationbreak"],
-		popularity: 2.1070,
+		popularity: 2.5798,
 	},
 	"css.properties.box-decoration-break.clone" => CSSFeature {
 		id: "css.properties.box-decoration-break.clone",
@@ -6445,7 +6445,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-boxdecorationbreak"],
-		popularity: 2.1070,
+		popularity: 2.5798,
 	},
 	"css.properties.box-decoration-break.slice" => CSSFeature {
 		id: "css.properties.box-decoration-break.slice",
@@ -6464,7 +6464,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-boxdecorationbreak"],
-		popularity: 2.1070,
+		popularity: 2.5798,
 	},
 	"css.properties.box-shadow" => CSSFeature {
 		id: "css.properties.box-shadow",
@@ -6483,7 +6483,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &["https://caniuse.com/css-boxshadow"],
-		popularity: 81.7233,
+		popularity: 81.6361,
 	},
 	"css.properties.box-shadow.inset" => CSSFeature {
 		id: "css.properties.box-shadow.inset",
@@ -6502,7 +6502,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &["https://caniuse.com/css-boxshadow"],
-		popularity: 81.7233,
+		popularity: 81.6361,
 	},
 	"css.properties.box-shadow.multiple_shadows" => CSSFeature {
 		id: "css.properties.box-shadow.multiple_shadows",
@@ -6521,7 +6521,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &["https://caniuse.com/css-boxshadow"],
-		popularity: 81.7233,
+		popularity: 81.6361,
 	},
 	"css.properties.box-shadow.spread_radius" => CSSFeature {
 		id: "css.properties.box-shadow.spread_radius",
@@ -6540,7 +6540,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &["https://caniuse.com/css-boxshadow"],
-		popularity: 81.7233,
+		popularity: 81.6361,
 	},
 	"css.properties.box-sizing" => CSSFeature {
 		id: "css.properties.box-sizing",
@@ -6559,7 +6559,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(6,0),
 				},
 		caniuse: &["https://caniuse.com/css3-boxsizing"],
-		popularity: 85.6921,
+		popularity: 85.4881,
 	},
 	"css.properties.box-sizing.border-box" => CSSFeature {
 		id: "css.properties.box-sizing.border-box",
@@ -6578,7 +6578,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(6,0),
 				},
 		caniuse: &["https://caniuse.com/css3-boxsizing"],
-		popularity: 85.6921,
+		popularity: 85.4881,
 	},
 	"css.properties.box-sizing.content-box" => CSSFeature {
 		id: "css.properties.box-sizing.content-box",
@@ -6597,7 +6597,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(6,0),
 				},
 		caniuse: &["https://caniuse.com/css3-boxsizing"],
-		popularity: 85.6921,
+		popularity: 85.4881,
 	},
 	"css.types.calc" => CSSFeature {
 		id: "css.types.calc",
@@ -6825,7 +6825,102 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &["https://caniuse.com/css-caret-color"],
-		popularity: 13.1451,
+		popularity: 14.5799,
+	},
+	"css.properties.caret-shape" => CSSFeature {
+		id: "css.properties.caret-shape",
+		name: "caret-shape",
+		description: "The caret-shape CSS property controls the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
+		spec: "https://drafts.csswg.org/css-ui-4/#propdef-caret-shape",
+		groups: &[],
+		baseline_status: BaselineStatus::False,
+		browser_support: BrowserSupport {
+						chrome: BrowserVersion(0, 0),
+						chrome_android: BrowserVersion(0, 0),
+						edge: BrowserVersion(0, 0),
+						firefox: BrowserVersion(0, 0),
+						firefox_android: BrowserVersion(0, 0),
+						safari: BrowserVersion(0, 0),
+						safari_ios: BrowserVersion(0, 0),
+				},
+		caniuse: &[],
+		popularity: 0.0000,
+	},
+	"css.properties.caret-shape.auto" => CSSFeature {
+		id: "css.properties.caret-shape.auto",
+		name: "caret-shape",
+		description: "The caret-shape CSS property controls the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
+		spec: "https://drafts.csswg.org/css-ui-4/#propdef-caret-shape",
+		groups: &[],
+		baseline_status: BaselineStatus::False,
+		browser_support: BrowserSupport {
+						chrome: BrowserVersion(0, 0),
+						chrome_android: BrowserVersion(0, 0),
+						edge: BrowserVersion(0, 0),
+						firefox: BrowserVersion(0, 0),
+						firefox_android: BrowserVersion(0, 0),
+						safari: BrowserVersion(0, 0),
+						safari_ios: BrowserVersion(0, 0),
+				},
+		caniuse: &[],
+		popularity: 0.0000,
+	},
+	"css.properties.caret-shape.bar" => CSSFeature {
+		id: "css.properties.caret-shape.bar",
+		name: "caret-shape",
+		description: "The caret-shape CSS property controls the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
+		spec: "https://drafts.csswg.org/css-ui-4/#propdef-caret-shape",
+		groups: &[],
+		baseline_status: BaselineStatus::False,
+		browser_support: BrowserSupport {
+						chrome: BrowserVersion(0, 0),
+						chrome_android: BrowserVersion(0, 0),
+						edge: BrowserVersion(0, 0),
+						firefox: BrowserVersion(0, 0),
+						firefox_android: BrowserVersion(0, 0),
+						safari: BrowserVersion(0, 0),
+						safari_ios: BrowserVersion(0, 0),
+				},
+		caniuse: &[],
+		popularity: 0.0000,
+	},
+	"css.properties.caret-shape.block" => CSSFeature {
+		id: "css.properties.caret-shape.block",
+		name: "caret-shape",
+		description: "The caret-shape CSS property controls the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
+		spec: "https://drafts.csswg.org/css-ui-4/#propdef-caret-shape",
+		groups: &[],
+		baseline_status: BaselineStatus::False,
+		browser_support: BrowserSupport {
+						chrome: BrowserVersion(0, 0),
+						chrome_android: BrowserVersion(0, 0),
+						edge: BrowserVersion(0, 0),
+						firefox: BrowserVersion(0, 0),
+						firefox_android: BrowserVersion(0, 0),
+						safari: BrowserVersion(0, 0),
+						safari_ios: BrowserVersion(0, 0),
+				},
+		caniuse: &[],
+		popularity: 0.0000,
+	},
+	"css.properties.caret-shape.underscore" => CSSFeature {
+		id: "css.properties.caret-shape.underscore",
+		name: "caret-shape",
+		description: "The caret-shape CSS property controls the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
+		spec: "https://drafts.csswg.org/css-ui-4/#propdef-caret-shape",
+		groups: &[],
+		baseline_status: BaselineStatus::False,
+		browser_support: BrowserSupport {
+						chrome: BrowserVersion(0, 0),
+						chrome_android: BrowserVersion(0, 0),
+						edge: BrowserVersion(0, 0),
+						firefox: BrowserVersion(0, 0),
+						firefox_android: BrowserVersion(0, 0),
+						safari: BrowserVersion(0, 0),
+						safari_ios: BrowserVersion(0, 0),
+				},
+		caniuse: &[],
+		popularity: 0.0000,
 	},
 	"css.at-rules.import.layer" => CSSFeature {
 		id: "css.at-rules.import.layer",
@@ -6977,7 +7072,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 50.0112,
+		popularity: 51.6700,
 	},
 	"css.properties.clip.auto" => CSSFeature {
 		id: "css.properties.clip.auto",
@@ -6996,7 +7091,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 50.0112,
+		popularity: 51.6700,
 	},
 	"css.types.shape" => CSSFeature {
 		id: "css.types.shape",
@@ -7015,7 +7110,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 50.0112,
+		popularity: 51.6700,
 	},
 	"css.types.shape.rect" => CSSFeature {
 		id: "css.types.shape.rect",
@@ -7034,7 +7129,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 50.0112,
+		popularity: 51.6700,
 	},
 	"css.properties.clip-path" => CSSFeature {
 		id: "css.properties.clip-path",
@@ -7053,7 +7148,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.4449,
+		popularity: 40.2224,
 	},
 	"css.properties.clip-path.basic_shape" => CSSFeature {
 		id: "css.properties.clip-path.basic_shape",
@@ -7072,7 +7167,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.4449,
+		popularity: 40.2224,
 	},
 	"css.properties.clip-path.html_elements" => CSSFeature {
 		id: "css.properties.clip-path.html_elements",
@@ -7091,7 +7186,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.4449,
+		popularity: 40.2224,
 	},
 	"css.properties.clip-path.path" => CSSFeature {
 		id: "css.properties.clip-path.path",
@@ -7110,7 +7205,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.4449,
+		popularity: 40.2224,
 	},
 	"css.properties.clip-path.svg_elements" => CSSFeature {
 		id: "css.properties.clip-path.svg_elements",
@@ -7129,7 +7224,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.4449,
+		popularity: 40.2224,
 	},
 	"css.properties.clip-path.is_animatable" => CSSFeature {
 		id: "css.properties.clip-path.is_animatable",
@@ -7224,7 +7319,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.9751,
+		popularity: 90.1607,
 	},
 	"css.types.color" => CSSFeature {
 		id: "css.types.color",
@@ -7243,7 +7338,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.9751,
+		popularity: 90.1607,
 	},
 	"css.properties.color-adjust" => CSSFeature {
 		id: "css.properties.color-adjust",
@@ -7357,7 +7452,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.5746,
+		popularity: 17.8217,
 	},
 	"css.properties.color-scheme.dark" => CSSFeature {
 		id: "css.properties.color-scheme.dark",
@@ -7376,7 +7471,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.5746,
+		popularity: 17.8217,
 	},
 	"css.properties.color-scheme.light" => CSSFeature {
 		id: "css.properties.color-scheme.light",
@@ -7395,7 +7490,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.5746,
+		popularity: 17.8217,
 	},
 	"css.properties.color-scheme.normal" => CSSFeature {
 		id: "css.properties.color-scheme.normal",
@@ -7414,7 +7509,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.5746,
+		popularity: 17.8217,
 	},
 	"css.properties.color-scheme.only" => CSSFeature {
 		id: "css.properties.color-scheme.only",
@@ -7433,7 +7528,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.5746,
+		popularity: 17.8217,
 	},
 	"css.at-rules.font-face.OpenType_COLRv0" => CSSFeature {
 		id: "css.at-rules.font-face.OpenType_COLRv0",
@@ -7775,7 +7870,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.8952,
+		popularity: 1.7404,
 	},
 	"css.properties.column-fill.auto" => CSSFeature {
 		id: "css.properties.column-fill.auto",
@@ -7794,7 +7889,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.8952,
+		popularity: 1.7404,
 	},
 	"css.properties.column-fill.balance" => CSSFeature {
 		id: "css.properties.column-fill.balance",
@@ -7813,7 +7908,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.8952,
+		popularity: 1.7404,
 	},
 	"css.selectors.column" => CSSFeature {
 		id: "css.selectors.column",
@@ -7870,7 +7965,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 0.9367,
+		popularity: 0.8191,
 	},
 	"css.properties.column-span.all" => CSSFeature {
 		id: "css.properties.column-span.all",
@@ -7889,7 +7984,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 0.9367,
+		popularity: 0.8191,
 	},
 	"css.properties.column-span.none" => CSSFeature {
 		id: "css.properties.column-span.none",
@@ -7908,7 +8003,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 0.9367,
+		popularity: 0.8191,
 	},
 	"css.types.gradient.conic-gradient" => CSSFeature {
 		id: "css.types.gradient.conic-gradient",
@@ -8003,7 +8098,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-containment"],
-		popularity: 19.0011,
+		popularity: 20.3009,
 	},
 	"css.properties.contain.content" => CSSFeature {
 		id: "css.properties.contain.content",
@@ -8022,7 +8117,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-containment"],
-		popularity: 19.0011,
+		popularity: 20.3009,
 	},
 	"css.properties.contain.none" => CSSFeature {
 		id: "css.properties.contain.none",
@@ -8041,7 +8136,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-containment"],
-		popularity: 19.0011,
+		popularity: 20.3009,
 	},
 	"css.properties.contain.strict" => CSSFeature {
 		id: "css.properties.contain.strict",
@@ -8060,7 +8155,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-containment"],
-		popularity: 19.0011,
+		popularity: 20.3009,
 	},
 	"css.properties.contain.inline-size" => CSSFeature {
 		id: "css.properties.contain.inline-size",
@@ -8098,7 +8193,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-block-size.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-block-size.none",
@@ -8117,7 +8212,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-height" => CSSFeature {
 		id: "css.properties.contain-intrinsic-height",
@@ -8136,7 +8231,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-height.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-height.none",
@@ -8155,7 +8250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-inline-size" => CSSFeature {
 		id: "css.properties.contain-intrinsic-inline-size",
@@ -8174,7 +8269,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-inline-size.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-inline-size.none",
@@ -8193,7 +8288,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-size" => CSSFeature {
 		id: "css.properties.contain-intrinsic-size",
@@ -8212,7 +8307,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-size.auto_none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-size.auto_none",
@@ -8231,7 +8326,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-size.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-size.none",
@@ -8250,7 +8345,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-width" => CSSFeature {
 		id: "css.properties.contain-intrinsic-width",
@@ -8269,7 +8364,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain-intrinsic-width.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-width.none",
@@ -8288,7 +8383,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.3814,
+		popularity: 6.5608,
 	},
 	"css.properties.contain.layout" => CSSFeature {
 		id: "css.properties.contain.layout",
@@ -8668,7 +8763,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.7204,
+		popularity: 81.5353,
 	},
 	"css.properties.content.element_replacement" => CSSFeature {
 		id: "css.properties.content.element_replacement",
@@ -8687,7 +8782,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.7204,
+		popularity: 81.5353,
 	},
 	"css.properties.content.gradient" => CSSFeature {
 		id: "css.properties.content.gradient",
@@ -8706,7 +8801,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.7204,
+		popularity: 81.5353,
 	},
 	"css.properties.content.none" => CSSFeature {
 		id: "css.properties.content.none",
@@ -8725,7 +8820,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.7204,
+		popularity: 81.5353,
 	},
 	"css.properties.content.none_applies_to_elements" => CSSFeature {
 		id: "css.properties.content.none_applies_to_elements",
@@ -8744,7 +8839,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.7204,
+		popularity: 81.5353,
 	},
 	"css.properties.content.normal" => CSSFeature {
 		id: "css.properties.content.normal",
@@ -8763,7 +8858,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.7204,
+		popularity: 81.5353,
 	},
 	"css.properties.content.url" => CSSFeature {
 		id: "css.properties.content.url",
@@ -8782,7 +8877,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.7204,
+		popularity: 81.5353,
 	},
 	"css.types.string" => CSSFeature {
 		id: "css.types.string",
@@ -8801,7 +8896,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.7204,
+		popularity: 81.5353,
 	},
 	"css.types.string.unicode_escaped_characters" => CSSFeature {
 		id: "css.types.string.unicode_escaped_characters",
@@ -8820,7 +8915,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.7204,
+		popularity: 81.5353,
 	},
 	"css.properties.content-visibility" => CSSFeature {
 		id: "css.properties.content-visibility",
@@ -8839,7 +8934,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &["https://caniuse.com/css-content-visibility"],
-		popularity: 5.9734,
+		popularity: 5.5284,
 	},
 	"css.properties.content-visibility.auto" => CSSFeature {
 		id: "css.properties.content-visibility.auto",
@@ -8858,7 +8953,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &["https://caniuse.com/css-content-visibility"],
-		popularity: 5.9734,
+		popularity: 5.5284,
 	},
 	"css.properties.content-visibility.hidden" => CSSFeature {
 		id: "css.properties.content-visibility.hidden",
@@ -8877,7 +8972,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &["https://caniuse.com/css-content-visibility"],
-		popularity: 5.9734,
+		popularity: 5.5284,
 	},
 	"css.properties.content-visibility.visible" => CSSFeature {
 		id: "css.properties.content-visibility.visible",
@@ -8896,7 +8991,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &["https://caniuse.com/css-content-visibility"],
-		popularity: 5.9734,
+		popularity: 5.5284,
 	},
 	"css.types.color.contrast-color" => CSSFeature {
 		id: "css.types.color.contrast-color",
@@ -8934,7 +9029,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-block-start-shape" => CSSFeature {
 		id: "css.properties.corner-block-start-shape",
@@ -8953,7 +9048,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-bottom-left-shape" => CSSFeature {
 		id: "css.properties.corner-bottom-left-shape",
@@ -8972,7 +9067,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-bottom-right-shape" => CSSFeature {
 		id: "css.properties.corner-bottom-right-shape",
@@ -8991,7 +9086,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-bottom-shape" => CSSFeature {
 		id: "css.properties.corner-bottom-shape",
@@ -9010,7 +9105,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-end-end-shape" => CSSFeature {
 		id: "css.properties.corner-end-end-shape",
@@ -9029,7 +9124,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-end-start-shape" => CSSFeature {
 		id: "css.properties.corner-end-start-shape",
@@ -9048,7 +9143,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-inline-end-shape" => CSSFeature {
 		id: "css.properties.corner-inline-end-shape",
@@ -9067,7 +9162,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-inline-start-shape" => CSSFeature {
 		id: "css.properties.corner-inline-start-shape",
@@ -9086,7 +9181,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-left-shape" => CSSFeature {
 		id: "css.properties.corner-left-shape",
@@ -9105,7 +9200,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-right-shape" => CSSFeature {
 		id: "css.properties.corner-right-shape",
@@ -9124,7 +9219,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-shape" => CSSFeature {
 		id: "css.properties.corner-shape",
@@ -9143,7 +9238,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-start-end-shape" => CSSFeature {
 		id: "css.properties.corner-start-end-shape",
@@ -9162,7 +9257,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-start-start-shape" => CSSFeature {
 		id: "css.properties.corner-start-start-shape",
@@ -9181,7 +9276,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-top-left-shape" => CSSFeature {
 		id: "css.properties.corner-top-left-shape",
@@ -9200,7 +9295,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-top-right-shape" => CSSFeature {
 		id: "css.properties.corner-top-right-shape",
@@ -9219,7 +9314,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.corner-top-shape" => CSSFeature {
 		id: "css.properties.corner-top-shape",
@@ -9238,7 +9333,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.types.corner-shape-value" => CSSFeature {
 		id: "css.types.corner-shape-value",
@@ -9257,7 +9352,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.types.corner-shape-value.bevel" => CSSFeature {
 		id: "css.types.corner-shape-value.bevel",
@@ -9276,7 +9371,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.types.corner-shape-value.notch" => CSSFeature {
 		id: "css.types.corner-shape-value.notch",
@@ -9295,7 +9390,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.types.corner-shape-value.round" => CSSFeature {
 		id: "css.types.corner-shape-value.round",
@@ -9314,7 +9409,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.types.corner-shape-value.scoop" => CSSFeature {
 		id: "css.types.corner-shape-value.scoop",
@@ -9333,7 +9428,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.types.corner-shape-value.square" => CSSFeature {
 		id: "css.types.corner-shape-value.square",
@@ -9352,7 +9447,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.types.corner-shape-value.squircle" => CSSFeature {
 		id: "css.types.corner-shape-value.squircle",
@@ -9371,7 +9466,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.types.corner-shape-value.superellipse" => CSSFeature {
 		id: "css.types.corner-shape-value.superellipse",
@@ -9390,7 +9485,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.types.superellipse" => CSSFeature {
 		id: "css.types.superellipse",
@@ -9409,7 +9504,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2367,
+		popularity: 0.1915,
 	},
 	"css.properties.counter-reset.reversed" => CSSFeature {
 		id: "css.properties.counter-reset.reversed",
@@ -9447,7 +9542,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,2),
 				},
 		caniuse: &[],
-		popularity: 0.3789,
+		popularity: 0.6093,
 	},
 	"css.properties.counter-set.list-item" => CSSFeature {
 		id: "css.properties.counter-set.list-item",
@@ -9466,7 +9561,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,2),
 				},
 		caniuse: &[],
-		popularity: 0.3789,
+		popularity: 0.6093,
 	},
 	"css.properties.counter-set.none" => CSSFeature {
 		id: "css.properties.counter-set.none",
@@ -9485,7 +9580,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,2),
 				},
 		caniuse: &[],
-		popularity: 0.3789,
+		popularity: 0.6093,
 	},
 	"css.at-rules.counter-style" => CSSFeature {
 		id: "css.at-rules.counter-style",
@@ -9998,7 +10093,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.alias" => CSSFeature {
 		id: "css.properties.cursor.alias",
@@ -10017,7 +10112,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.all-scroll" => CSSFeature {
 		id: "css.properties.cursor.all-scroll",
@@ -10036,7 +10131,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.auto" => CSSFeature {
 		id: "css.properties.cursor.auto",
@@ -10055,7 +10150,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.cell" => CSSFeature {
 		id: "css.properties.cursor.cell",
@@ -10074,7 +10169,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.col-resize" => CSSFeature {
 		id: "css.properties.cursor.col-resize",
@@ -10093,7 +10188,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.context-menu" => CSSFeature {
 		id: "css.properties.cursor.context-menu",
@@ -10112,7 +10207,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.copy" => CSSFeature {
 		id: "css.properties.cursor.copy",
@@ -10131,7 +10226,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.crosshair" => CSSFeature {
 		id: "css.properties.cursor.crosshair",
@@ -10150,7 +10245,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.default" => CSSFeature {
 		id: "css.properties.cursor.default",
@@ -10169,7 +10264,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.e-resize" => CSSFeature {
 		id: "css.properties.cursor.e-resize",
@@ -10188,7 +10283,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.ew-resize" => CSSFeature {
 		id: "css.properties.cursor.ew-resize",
@@ -10207,7 +10302,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.grab" => CSSFeature {
 		id: "css.properties.cursor.grab",
@@ -10226,7 +10321,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.grabbing" => CSSFeature {
 		id: "css.properties.cursor.grabbing",
@@ -10245,7 +10340,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.help" => CSSFeature {
 		id: "css.properties.cursor.help",
@@ -10264,7 +10359,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.move" => CSSFeature {
 		id: "css.properties.cursor.move",
@@ -10283,7 +10378,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.n-resize" => CSSFeature {
 		id: "css.properties.cursor.n-resize",
@@ -10302,7 +10397,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.ne-resize" => CSSFeature {
 		id: "css.properties.cursor.ne-resize",
@@ -10321,7 +10416,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.nesw-resize" => CSSFeature {
 		id: "css.properties.cursor.nesw-resize",
@@ -10340,7 +10435,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.no-drop" => CSSFeature {
 		id: "css.properties.cursor.no-drop",
@@ -10359,7 +10454,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.none" => CSSFeature {
 		id: "css.properties.cursor.none",
@@ -10378,7 +10473,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.not-allowed" => CSSFeature {
 		id: "css.properties.cursor.not-allowed",
@@ -10397,7 +10492,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.ns-resize" => CSSFeature {
 		id: "css.properties.cursor.ns-resize",
@@ -10416,7 +10511,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.nw-resize" => CSSFeature {
 		id: "css.properties.cursor.nw-resize",
@@ -10435,7 +10530,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.nwse-resize" => CSSFeature {
 		id: "css.properties.cursor.nwse-resize",
@@ -10454,7 +10549,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.pointer" => CSSFeature {
 		id: "css.properties.cursor.pointer",
@@ -10473,7 +10568,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.progress" => CSSFeature {
 		id: "css.properties.cursor.progress",
@@ -10492,7 +10587,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.row-resize" => CSSFeature {
 		id: "css.properties.cursor.row-resize",
@@ -10511,7 +10606,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.s-resize" => CSSFeature {
 		id: "css.properties.cursor.s-resize",
@@ -10530,7 +10625,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.se-resize" => CSSFeature {
 		id: "css.properties.cursor.se-resize",
@@ -10549,7 +10644,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.sw-resize" => CSSFeature {
 		id: "css.properties.cursor.sw-resize",
@@ -10568,7 +10663,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.text" => CSSFeature {
 		id: "css.properties.cursor.text",
@@ -10587,7 +10682,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.url" => CSSFeature {
 		id: "css.properties.cursor.url",
@@ -10606,7 +10701,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.url_positioning_syntax" => CSSFeature {
 		id: "css.properties.cursor.url_positioning_syntax",
@@ -10625,7 +10720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.vertical-text" => CSSFeature {
 		id: "css.properties.cursor.vertical-text",
@@ -10644,7 +10739,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.w-resize" => CSSFeature {
 		id: "css.properties.cursor.w-resize",
@@ -10663,7 +10758,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.wait" => CSSFeature {
 		id: "css.properties.cursor.wait",
@@ -10682,7 +10777,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.zoom-in" => CSSFeature {
 		id: "css.properties.cursor.zoom-in",
@@ -10701,7 +10796,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.cursor.zoom-out" => CSSFeature {
 		id: "css.properties.cursor.zoom-out",
@@ -10720,7 +10815,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 84.2385,
+		popularity: 84.4947,
 	},
 	"css.properties.text-overflow.string" => CSSFeature {
 		id: "css.properties.text-overflow.string",
@@ -10880,15 +10975,15 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "The ::details-content pseudo-element selects the expandable content of a <details> element, excluding the <summary>.",
 		spec: "https://drafts.csswg.org/css-pseudo-4/#details-content-pseudo",
 		groups: &["selectors"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,9,16).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(131,0),
 						chrome_android: BrowserVersion(131,0),
 						edge: BrowserVersion(131,0),
 						firefox: BrowserVersion(143,0),
 						firefox_android: BrowserVersion(143,0),
-						safari: BrowserVersion(0, 0),
-						safari_ios: BrowserVersion(0, 0),
+						safari: BrowserVersion(18,4),
+						safari_ios: BrowserVersion(18,4),
 				},
 		caniuse: &[],
 		popularity: 0.0000,
@@ -11005,7 +11100,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 92.2779,
+		popularity: 92.4733,
 	},
 	"css.properties.display.block" => CSSFeature {
 		id: "css.properties.display.block",
@@ -11024,7 +11119,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 92.2779,
+		popularity: 92.4733,
 	},
 	"css.properties.display.inline" => CSSFeature {
 		id: "css.properties.display.inline",
@@ -11043,7 +11138,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 92.2779,
+		popularity: 92.4733,
 	},
 	"css.properties.display.inline-block" => CSSFeature {
 		id: "css.properties.display.inline-block",
@@ -11062,7 +11157,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 92.2779,
+		popularity: 92.4733,
 	},
 	"css.properties.display.none" => CSSFeature {
 		id: "css.properties.display.none",
@@ -11081,7 +11176,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 92.2779,
+		popularity: 92.4733,
 	},
 	"css.properties.display.none.option_is_hidden" => CSSFeature {
 		id: "css.properties.display.none.option_is_hidden",
@@ -11100,7 +11195,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 92.2779,
+		popularity: 92.4733,
 	},
 	"css.properties.content-visibility.is_transitionable" => CSSFeature {
 		id: "css.properties.content-visibility.is_transitionable",
@@ -11689,7 +11784,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6839,
+		popularity: 0.8646,
 	},
 	"css.properties.dominant-baseline.alphabetic" => CSSFeature {
 		id: "css.properties.dominant-baseline.alphabetic",
@@ -11708,7 +11803,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6839,
+		popularity: 0.8646,
 	},
 	"css.properties.dominant-baseline.auto" => CSSFeature {
 		id: "css.properties.dominant-baseline.auto",
@@ -11727,7 +11822,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6839,
+		popularity: 0.8646,
 	},
 	"css.properties.dominant-baseline.central" => CSSFeature {
 		id: "css.properties.dominant-baseline.central",
@@ -11746,7 +11841,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6839,
+		popularity: 0.8646,
 	},
 	"css.properties.dominant-baseline.hanging" => CSSFeature {
 		id: "css.properties.dominant-baseline.hanging",
@@ -11765,7 +11860,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6839,
+		popularity: 0.8646,
 	},
 	"css.properties.dominant-baseline.ideographic" => CSSFeature {
 		id: "css.properties.dominant-baseline.ideographic",
@@ -11784,7 +11879,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6839,
+		popularity: 0.8646,
 	},
 	"css.properties.dominant-baseline.mathematical" => CSSFeature {
 		id: "css.properties.dominant-baseline.mathematical",
@@ -11803,7 +11898,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6839,
+		popularity: 0.8646,
 	},
 	"css.properties.dominant-baseline.middle" => CSSFeature {
 		id: "css.properties.dominant-baseline.middle",
@@ -11822,7 +11917,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6839,
+		popularity: 0.8646,
 	},
 	"css.at-rules.media.dynamic-range" => CSSFeature {
 		id: "css.at-rules.media.dynamic-range",
@@ -12069,7 +12164,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.8731,
+		popularity: 1.1180,
 	},
 	"css.properties.field-sizing.content" => CSSFeature {
 		id: "css.properties.field-sizing.content",
@@ -12088,7 +12183,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.8731,
+		popularity: 1.1180,
 	},
 	"css.properties.field-sizing.fixed" => CSSFeature {
 		id: "css.properties.field-sizing.fixed",
@@ -12107,7 +12202,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.8731,
+		popularity: 1.1180,
 	},
 	"css.selectors.file-selector-button" => CSSFeature {
 		id: "css.selectors.file-selector-button",
@@ -12145,7 +12240,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.blur" => CSSFeature {
 		id: "css.properties.filter.blur",
@@ -12164,7 +12259,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.brightness" => CSSFeature {
 		id: "css.properties.filter.brightness",
@@ -12183,7 +12278,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.contrast" => CSSFeature {
 		id: "css.properties.filter.contrast",
@@ -12202,7 +12297,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.drop-shadow" => CSSFeature {
 		id: "css.properties.filter.drop-shadow",
@@ -12221,7 +12316,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.grayscale" => CSSFeature {
 		id: "css.properties.filter.grayscale",
@@ -12240,7 +12335,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.hue-rotate" => CSSFeature {
 		id: "css.properties.filter.hue-rotate",
@@ -12259,7 +12354,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.invert" => CSSFeature {
 		id: "css.properties.filter.invert",
@@ -12278,7 +12373,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.opacity" => CSSFeature {
 		id: "css.properties.filter.opacity",
@@ -12297,7 +12392,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.saturate" => CSSFeature {
 		id: "css.properties.filter.saturate",
@@ -12316,7 +12411,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.properties.filter.sepia" => CSSFeature {
 		id: "css.properties.filter.sepia",
@@ -12335,7 +12430,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function" => CSSFeature {
 		id: "css.types.filter-function",
@@ -12354,7 +12449,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.blur" => CSSFeature {
 		id: "css.types.filter-function.blur",
@@ -12373,7 +12468,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.brightness" => CSSFeature {
 		id: "css.types.filter-function.brightness",
@@ -12392,7 +12487,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.contrast" => CSSFeature {
 		id: "css.types.filter-function.contrast",
@@ -12411,7 +12506,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.drop-shadow" => CSSFeature {
 		id: "css.types.filter-function.drop-shadow",
@@ -12430,7 +12525,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.grayscale" => CSSFeature {
 		id: "css.types.filter-function.grayscale",
@@ -12449,7 +12544,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.hue-rotate" => CSSFeature {
 		id: "css.types.filter-function.hue-rotate",
@@ -12468,7 +12563,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.invert" => CSSFeature {
 		id: "css.types.filter-function.invert",
@@ -12487,7 +12582,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.opacity" => CSSFeature {
 		id: "css.types.filter-function.opacity",
@@ -12506,7 +12601,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.saturate" => CSSFeature {
 		id: "css.types.filter-function.saturate",
@@ -12525,7 +12620,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.types.filter-function.sepia" => CSSFeature {
 		id: "css.types.filter-function.sepia",
@@ -12544,7 +12639,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 49.0140,
+		popularity: 48.5395,
 	},
 	"css.selectors.first-letter" => CSSFeature {
 		id: "css.selectors.first-letter",
@@ -14672,7 +14767,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &["https://caniuse.com/css-font-rendering-controls"],
-		popularity: 52.4474,
+		popularity: 50.1817,
 	},
 	"css.at-rules.font-face" => CSSFeature {
 		id: "css.at-rules.font-face",
@@ -14938,7 +15033,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 88.1749,
+		popularity: 88.1211,
 	},
 	"css.properties.font-family.math" => CSSFeature {
 		id: "css.properties.font-family.math",
@@ -15071,7 +15166,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-feature"],
-		popularity: 21.0026,
+		popularity: 21.2059,
 	},
 	"css.properties.font-feature-settings" => CSSFeature {
 		id: "css.properties.font-feature-settings",
@@ -15090,7 +15185,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-feature"],
-		popularity: 21.0026,
+		popularity: 21.2059,
 	},
 	"css.properties.font-feature-settings.normal" => CSSFeature {
 		id: "css.properties.font-feature-settings.normal",
@@ -15109,7 +15204,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-feature"],
-		popularity: 21.0026,
+		popularity: 21.2059,
 	},
 	"css.properties.font-kerning" => CSSFeature {
 		id: "css.properties.font-kerning",
@@ -15128,7 +15223,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/font-kerning"],
-		popularity: 1.5992,
+		popularity: 1.6608,
 	},
 	"css.properties.font-kerning.auto" => CSSFeature {
 		id: "css.properties.font-kerning.auto",
@@ -15147,7 +15242,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/font-kerning"],
-		popularity: 1.5992,
+		popularity: 1.6608,
 	},
 	"css.properties.font-kerning.none" => CSSFeature {
 		id: "css.properties.font-kerning.none",
@@ -15166,7 +15261,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/font-kerning"],
-		popularity: 1.5992,
+		popularity: 1.6608,
 	},
 	"css.properties.font-kerning.normal" => CSSFeature {
 		id: "css.properties.font-kerning.normal",
@@ -15185,7 +15280,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/font-kerning"],
-		popularity: 1.5992,
+		popularity: 1.6608,
 	},
 	"css.properties.font-language-override" => CSSFeature {
 		id: "css.properties.font-language-override",
@@ -15204,7 +15299,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0537,
+		popularity: 0.1670,
 	},
 	"css.at-rules.font-face.ascent-override" => CSSFeature {
 		id: "css.at-rules.font-face.ascent-override",
@@ -15280,7 +15375,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 1.8777,
+		popularity: 1.9432,
 	},
 	"css.properties.font-optical-sizing.auto" => CSSFeature {
 		id: "css.properties.font-optical-sizing.auto",
@@ -15299,7 +15394,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 1.8777,
+		popularity: 1.9432,
 	},
 	"css.properties.font-optical-sizing.none" => CSSFeature {
 		id: "css.properties.font-optical-sizing.none",
@@ -15318,7 +15413,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 1.8777,
+		popularity: 1.9432,
 	},
 	"css.at-rules.font-palette-values" => CSSFeature {
 		id: "css.at-rules.font-palette-values",
@@ -15337,7 +15432,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0352,
+		popularity: 0.0412,
 	},
 	"css.at-rules.font-palette-values.base-palette" => CSSFeature {
 		id: "css.at-rules.font-palette-values.base-palette",
@@ -15356,7 +15451,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0352,
+		popularity: 0.0412,
 	},
 	"css.at-rules.font-palette-values.font-family" => CSSFeature {
 		id: "css.at-rules.font-palette-values.font-family",
@@ -15375,7 +15470,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0352,
+		popularity: 0.0412,
 	},
 	"css.at-rules.font-palette-values.override-colors" => CSSFeature {
 		id: "css.at-rules.font-palette-values.override-colors",
@@ -15394,7 +15489,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0352,
+		popularity: 0.0412,
 	},
 	"css.properties.font-palette" => CSSFeature {
 		id: "css.properties.font-palette",
@@ -15413,7 +15508,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0352,
+		popularity: 0.0412,
 	},
 	"css.properties.font-palette.dark" => CSSFeature {
 		id: "css.properties.font-palette.dark",
@@ -15432,7 +15527,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0352,
+		popularity: 0.0412,
 	},
 	"css.properties.font-palette.light" => CSSFeature {
 		id: "css.properties.font-palette.light",
@@ -15451,7 +15546,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0352,
+		popularity: 0.0412,
 	},
 	"css.properties.font-palette.normal" => CSSFeature {
 		id: "css.properties.font-palette.normal",
@@ -15470,7 +15565,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0352,
+		popularity: 0.0412,
 	},
 	"css.properties.font-palette.animation_computed" => CSSFeature {
 		id: "css.properties.font-palette.animation_computed",
@@ -15660,7 +15755,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.6668,
+		popularity: 89.7432,
 	},
 	"css.properties.font-size.rem_values" => CSSFeature {
 		id: "css.properties.font-size.rem_values",
@@ -15679,7 +15774,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.6668,
+		popularity: 89.7432,
 	},
 	"css.properties.font-size.xxx-large" => CSSFeature {
 		id: "css.properties.font-size.xxx-large",
@@ -15698,7 +15793,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.6668,
+		popularity: 89.7432,
 	},
 	"css.at-rules.font-face.size-adjust" => CSSFeature {
 		id: "css.at-rules.font-face.size-adjust",
@@ -15717,7 +15812,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7156,
+		popularity: 1.7490,
 	},
 	"css.properties.font-size-adjust" => CSSFeature {
 		id: "css.properties.font-size-adjust",
@@ -15736,7 +15831,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7156,
+		popularity: 1.7490,
 	},
 	"css.properties.font-size-adjust.from-font" => CSSFeature {
 		id: "css.properties.font-size-adjust.from-font",
@@ -15755,7 +15850,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7156,
+		popularity: 1.7490,
 	},
 	"css.properties.font-size-adjust.none" => CSSFeature {
 		id: "css.properties.font-size-adjust.none",
@@ -15774,7 +15869,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7156,
+		popularity: 1.7490,
 	},
 	"css.properties.font-size-adjust.two-values" => CSSFeature {
 		id: "css.properties.font-size-adjust.two-values",
@@ -15793,7 +15888,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7156,
+		popularity: 1.7490,
 	},
 	"css.at-rules.font-face.font-stretch" => CSSFeature {
 		id: "css.at-rules.font-face.font-stretch",
@@ -15812,7 +15907,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/css-font-stretch"],
-		popularity: 24.2309,
+		popularity: 23.8959,
 	},
 	"css.properties.font-stretch" => CSSFeature {
 		id: "css.properties.font-stretch",
@@ -15831,7 +15926,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/css-font-stretch"],
-		popularity: 24.2309,
+		popularity: 23.8959,
 	},
 	"css.properties.font-stretch.percentage" => CSSFeature {
 		id: "css.properties.font-stretch.percentage",
@@ -15850,7 +15945,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/css-font-stretch"],
-		popularity: 24.2309,
+		popularity: 23.8959,
 	},
 	"css.properties.font.font-width_keyword_values" => CSSFeature {
 		id: "css.properties.font.font-width_keyword_values",
@@ -15869,7 +15964,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/css-font-stretch"],
-		popularity: 24.2309,
+		popularity: 23.8959,
 	},
 	"css.at-rules.font-face.font-style" => CSSFeature {
 		id: "css.at-rules.font-face.font-style",
@@ -15888,7 +15983,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 79.0741,
+		popularity: 79.0403,
 	},
 	"css.properties.font-style" => CSSFeature {
 		id: "css.properties.font-style",
@@ -15907,7 +16002,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 79.0741,
+		popularity: 79.0403,
 	},
 	"css.properties.font-style.italic" => CSSFeature {
 		id: "css.properties.font-style.italic",
@@ -15926,7 +16021,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 79.0741,
+		popularity: 79.0403,
 	},
 	"css.properties.font-style.normal" => CSSFeature {
 		id: "css.properties.font-style.normal",
@@ -15945,7 +16040,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 79.0741,
+		popularity: 79.0403,
 	},
 	"css.properties.font-style.oblique-angle" => CSSFeature {
 		id: "css.properties.font-style.oblique-angle",
@@ -15964,7 +16059,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 79.0741,
+		popularity: 79.0403,
 	},
 	"css.properties.font-synthesis" => CSSFeature {
 		id: "css.properties.font-synthesis",
@@ -15983,7 +16078,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4345,
+		popularity: 1.4924,
 	},
 	"css.properties.font-synthesis.position" => CSSFeature {
 		id: "css.properties.font-synthesis.position",
@@ -16002,7 +16097,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4345,
+		popularity: 1.4924,
 	},
 	"css.properties.font-synthesis.small-caps" => CSSFeature {
 		id: "css.properties.font-synthesis.small-caps",
@@ -16021,7 +16116,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4345,
+		popularity: 1.4924,
 	},
 	"css.properties.font-synthesis.style" => CSSFeature {
 		id: "css.properties.font-synthesis.style",
@@ -16040,7 +16135,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4345,
+		popularity: 1.4924,
 	},
 	"css.properties.font-synthesis.weight" => CSSFeature {
 		id: "css.properties.font-synthesis.weight",
@@ -16059,7 +16154,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4345,
+		popularity: 1.4924,
 	},
 	"css.properties.font-synthesis-position" => CSSFeature {
 		id: "css.properties.font-synthesis-position",
@@ -16135,7 +16230,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0138,
+		popularity: 0.0154,
 	},
 	"css.properties.font-synthesis-small-caps.auto" => CSSFeature {
 		id: "css.properties.font-synthesis-small-caps.auto",
@@ -16154,7 +16249,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0138,
+		popularity: 0.0154,
 	},
 	"css.properties.font-synthesis-small-caps.none" => CSSFeature {
 		id: "css.properties.font-synthesis-small-caps.none",
@@ -16173,7 +16268,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0138,
+		popularity: 0.0154,
 	},
 	"css.properties.font-synthesis-style" => CSSFeature {
 		id: "css.properties.font-synthesis-style",
@@ -16192,7 +16287,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0365,
+		popularity: 0.0348,
 	},
 	"css.properties.font-synthesis-style.auto" => CSSFeature {
 		id: "css.properties.font-synthesis-style.auto",
@@ -16211,7 +16306,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0365,
+		popularity: 0.0348,
 	},
 	"css.properties.font-synthesis-style.none" => CSSFeature {
 		id: "css.properties.font-synthesis-style.none",
@@ -16230,7 +16325,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0365,
+		popularity: 0.0348,
 	},
 	"css.properties.font-synthesis-weight" => CSSFeature {
 		id: "css.properties.font-synthesis-weight",
@@ -16249,7 +16344,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0805,
+		popularity: 0.0924,
 	},
 	"css.properties.font-synthesis-weight.auto" => CSSFeature {
 		id: "css.properties.font-synthesis-weight.auto",
@@ -16268,7 +16363,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0805,
+		popularity: 0.0924,
 	},
 	"css.properties.font-synthesis-weight.none" => CSSFeature {
 		id: "css.properties.font-synthesis-weight.none",
@@ -16287,7 +16382,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0805,
+		popularity: 0.0924,
 	},
 	"css.at-rules.font-face.font-variant" => CSSFeature {
 		id: "css.at-rules.font-face.font-variant",
@@ -16306,7 +16401,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant" => CSSFeature {
 		id: "css.properties.font-variant",
@@ -16325,7 +16420,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant.css_fonts_shorthand" => CSSFeature {
 		id: "css.properties.font-variant.css_fonts_shorthand",
@@ -16344,7 +16439,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant.greek_accented_characters" => CSSFeature {
 		id: "css.properties.font-variant.greek_accented_characters",
@@ -16363,7 +16458,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant.historical-forms" => CSSFeature {
 		id: "css.properties.font-variant.historical-forms",
@@ -16382,7 +16477,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant.none" => CSSFeature {
 		id: "css.properties.font-variant.none",
@@ -16401,7 +16496,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant.normal" => CSSFeature {
 		id: "css.properties.font-variant.normal",
@@ -16420,7 +16515,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant.sub" => CSSFeature {
 		id: "css.properties.font-variant.sub",
@@ -16439,7 +16534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant.super" => CSSFeature {
 		id: "css.properties.font-variant.super",
@@ -16458,7 +16553,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant.turkic_is" => CSSFeature {
 		id: "css.properties.font-variant.turkic_is",
@@ -16477,7 +16572,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.properties.font-variant.uppercase_eszett" => CSSFeature {
 		id: "css.properties.font-variant.uppercase_eszett",
@@ -16496,7 +16591,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 28.1699,
+		popularity: 28.0357,
 	},
 	"css.at-rules.font-feature-values" => CSSFeature {
 		id: "css.at-rules.font-feature-values",
@@ -16515,7 +16610,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.at-rules.font-feature-values.annotation" => CSSFeature {
 		id: "css.at-rules.font-feature-values.annotation",
@@ -16534,7 +16629,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.at-rules.font-feature-values.character-variant" => CSSFeature {
 		id: "css.at-rules.font-feature-values.character-variant",
@@ -16553,7 +16648,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.at-rules.font-feature-values.historical-forms" => CSSFeature {
 		id: "css.at-rules.font-feature-values.historical-forms",
@@ -16572,7 +16667,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.at-rules.font-feature-values.ornaments" => CSSFeature {
 		id: "css.at-rules.font-feature-values.ornaments",
@@ -16591,7 +16686,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.at-rules.font-feature-values.styleset" => CSSFeature {
 		id: "css.at-rules.font-feature-values.styleset",
@@ -16610,7 +16705,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.at-rules.font-feature-values.stylistic" => CSSFeature {
 		id: "css.at-rules.font-feature-values.stylistic",
@@ -16629,7 +16724,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.at-rules.font-feature-values.swash" => CSSFeature {
 		id: "css.at-rules.font-feature-values.swash",
@@ -16648,7 +16743,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-alternates" => CSSFeature {
 		id: "css.properties.font-variant-alternates",
@@ -16667,7 +16762,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-alternates.annotation" => CSSFeature {
 		id: "css.properties.font-variant-alternates.annotation",
@@ -16686,7 +16781,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-alternates.character_variant" => CSSFeature {
 		id: "css.properties.font-variant-alternates.character_variant",
@@ -16705,7 +16800,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-alternates.historical-forms" => CSSFeature {
 		id: "css.properties.font-variant-alternates.historical-forms",
@@ -16724,7 +16819,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-alternates.normal" => CSSFeature {
 		id: "css.properties.font-variant-alternates.normal",
@@ -16743,7 +16838,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-alternates.ornaments" => CSSFeature {
 		id: "css.properties.font-variant-alternates.ornaments",
@@ -16762,7 +16857,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-alternates.styleset" => CSSFeature {
 		id: "css.properties.font-variant-alternates.styleset",
@@ -16781,7 +16876,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-alternates.stylistic" => CSSFeature {
 		id: "css.properties.font-variant-alternates.stylistic",
@@ -16800,7 +16895,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-alternates.swash" => CSSFeature {
 		id: "css.properties.font-variant-alternates.swash",
@@ -16819,7 +16914,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2935,
+		popularity: 0.3429,
 	},
 	"css.properties.font-variant-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps",
@@ -16838,7 +16933,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.7216,
+		popularity: 0.8540,
 	},
 	"css.properties.font-variant-caps.all-petite-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.all-petite-caps",
@@ -16857,7 +16952,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.7216,
+		popularity: 0.8540,
 	},
 	"css.properties.font-variant-caps.all-small-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.all-small-caps",
@@ -16876,7 +16971,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.7216,
+		popularity: 0.8540,
 	},
 	"css.properties.font-variant-caps.normal" => CSSFeature {
 		id: "css.properties.font-variant-caps.normal",
@@ -16895,7 +16990,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.7216,
+		popularity: 0.8540,
 	},
 	"css.properties.font-variant-caps.petite-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.petite-caps",
@@ -16914,7 +17009,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.7216,
+		popularity: 0.8540,
 	},
 	"css.properties.font-variant-caps.small-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.small-caps",
@@ -16933,7 +17028,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.7216,
+		popularity: 0.8540,
 	},
 	"css.properties.font-variant-caps.titling-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.titling-caps",
@@ -16952,7 +17047,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.7216,
+		popularity: 0.8540,
 	},
 	"css.properties.font-variant-caps.unicase" => CSSFeature {
 		id: "css.properties.font-variant-caps.unicase",
@@ -16971,7 +17066,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.7216,
+		popularity: 0.8540,
 	},
 	"css.properties.font-variant-east-asian" => CSSFeature {
 		id: "css.properties.font-variant-east-asian",
@@ -16990,7 +17085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.full-width" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.full-width",
@@ -17009,7 +17104,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.jis04" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.jis04",
@@ -17028,7 +17123,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.jis78" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.jis78",
@@ -17047,7 +17142,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.jis83" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.jis83",
@@ -17066,7 +17161,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.jis90" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.jis90",
@@ -17085,7 +17180,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.normal" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.normal",
@@ -17104,7 +17199,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.proportional-width" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.proportional-width",
@@ -17123,7 +17218,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.ruby" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.ruby",
@@ -17142,7 +17237,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.simplified" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.simplified",
@@ -17161,7 +17256,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.traditional" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.traditional",
@@ -17180,7 +17275,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5363,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-emoji" => CSSFeature {
 		id: "css.properties.font-variant-emoji",
@@ -17199,7 +17294,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0476,
+		popularity: 0.0601,
 	},
 	"css.properties.font-variant-emoji.emoji" => CSSFeature {
 		id: "css.properties.font-variant-emoji.emoji",
@@ -17218,7 +17313,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0476,
+		popularity: 0.0601,
 	},
 	"css.properties.font-variant-emoji.normal" => CSSFeature {
 		id: "css.properties.font-variant-emoji.normal",
@@ -17237,7 +17332,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0476,
+		popularity: 0.0601,
 	},
 	"css.properties.font-variant-emoji.text" => CSSFeature {
 		id: "css.properties.font-variant-emoji.text",
@@ -17256,7 +17351,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0476,
+		popularity: 0.0601,
 	},
 	"css.properties.font-variant-emoji.unicode" => CSSFeature {
 		id: "css.properties.font-variant-emoji.unicode",
@@ -17275,7 +17370,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0476,
+		popularity: 0.0601,
 	},
 	"css.properties.font-variant-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures",
@@ -17294,7 +17389,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.common-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.common-ligatures",
@@ -17313,7 +17408,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.contextual" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.contextual",
@@ -17332,7 +17427,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.discretionary-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.discretionary-ligatures",
@@ -17351,7 +17446,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.historical-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.historical-ligatures",
@@ -17370,7 +17465,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.no-common-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.no-common-ligatures",
@@ -17389,7 +17484,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.no-contextual" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.no-contextual",
@@ -17408,7 +17503,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.no-discretionary-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.no-discretionary-ligatures",
@@ -17427,7 +17522,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.no-historical-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.no-historical-ligatures",
@@ -17446,7 +17541,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.none" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.none",
@@ -17465,7 +17560,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-ligatures.normal" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.normal",
@@ -17484,7 +17579,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.7733,
+		popularity: 7.0034,
 	},
 	"css.properties.font-variant-numeric" => CSSFeature {
 		id: "css.properties.font-variant-numeric",
@@ -17503,7 +17598,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-numeric.diagonal-fractions" => CSSFeature {
 		id: "css.properties.font-variant-numeric.diagonal-fractions",
@@ -17522,7 +17617,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-numeric.lining-nums" => CSSFeature {
 		id: "css.properties.font-variant-numeric.lining-nums",
@@ -17541,7 +17636,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-numeric.normal" => CSSFeature {
 		id: "css.properties.font-variant-numeric.normal",
@@ -17560,7 +17655,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-numeric.oldstyle-nums" => CSSFeature {
 		id: "css.properties.font-variant-numeric.oldstyle-nums",
@@ -17579,7 +17674,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-numeric.ordinal" => CSSFeature {
 		id: "css.properties.font-variant-numeric.ordinal",
@@ -17598,7 +17693,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-numeric.proportional-nums" => CSSFeature {
 		id: "css.properties.font-variant-numeric.proportional-nums",
@@ -17617,7 +17712,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-numeric.slashed-zero" => CSSFeature {
 		id: "css.properties.font-variant-numeric.slashed-zero",
@@ -17636,7 +17731,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-numeric.stacked-fractions" => CSSFeature {
 		id: "css.properties.font-variant-numeric.stacked-fractions",
@@ -17655,7 +17750,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-numeric.tabular-nums" => CSSFeature {
 		id: "css.properties.font-variant-numeric.tabular-nums",
@@ -17674,7 +17769,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6309,
+		popularity: 5.0272,
 	},
 	"css.properties.font-variant-position" => CSSFeature {
 		id: "css.properties.font-variant-position",
@@ -17693,7 +17788,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.2802,
+		popularity: 0.2997,
 	},
 	"css.properties.font-variant-position.normal" => CSSFeature {
 		id: "css.properties.font-variant-position.normal",
@@ -17712,7 +17807,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.2802,
+		popularity: 0.2997,
 	},
 	"css.properties.font-variant-position.sub" => CSSFeature {
 		id: "css.properties.font-variant-position.sub",
@@ -17731,7 +17826,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.2802,
+		popularity: 0.2997,
 	},
 	"css.properties.font-variant-position.super" => CSSFeature {
 		id: "css.properties.font-variant-position.super",
@@ -17750,7 +17845,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.2802,
+		popularity: 0.2997,
 	},
 	"css.at-rules.font-face.font-variation-settings" => CSSFeature {
 		id: "css.at-rules.font-face.font-variation-settings",
@@ -17769,7 +17864,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/variable-fonts"],
-		popularity: 16.9697,
+		popularity: 18.4137,
 	},
 	"css.properties.font-variation-settings" => CSSFeature {
 		id: "css.properties.font-variation-settings",
@@ -17788,7 +17883,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/variable-fonts"],
-		popularity: 16.9697,
+		popularity: 18.4137,
 	},
 	"css.at-rules.font-face.font-weight" => CSSFeature {
 		id: "css.at-rules.font-face.font-weight",
@@ -17807,7 +17902,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7549,
+		popularity: 87.9514,
 	},
 	"css.properties.font-weight" => CSSFeature {
 		id: "css.properties.font-weight",
@@ -17826,7 +17921,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7549,
+		popularity: 87.9514,
 	},
 	"css.properties.font-weight.bold" => CSSFeature {
 		id: "css.properties.font-weight.bold",
@@ -17845,7 +17940,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7549,
+		popularity: 87.9514,
 	},
 	"css.properties.font-weight.bolder" => CSSFeature {
 		id: "css.properties.font-weight.bolder",
@@ -17864,7 +17959,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7549,
+		popularity: 87.9514,
 	},
 	"css.properties.font-weight.lighter" => CSSFeature {
 		id: "css.properties.font-weight.lighter",
@@ -17883,7 +17978,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7549,
+		popularity: 87.9514,
 	},
 	"css.properties.font-weight.normal" => CSSFeature {
 		id: "css.properties.font-weight.normal",
@@ -17902,7 +17997,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7549,
+		popularity: 87.9514,
 	},
 	"css.properties.font-weight.number" => CSSFeature {
 		id: "css.properties.font-weight.number",
@@ -17921,7 +18016,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7549,
+		popularity: 87.9514,
 	},
 	"css.properties.font-width" => CSSFeature {
 		id: "css.properties.font-width",
@@ -19270,7 +19365,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.align-items.grid_context" => CSSFeature {
 		id: "css.properties.align-items.grid_context",
@@ -19289,7 +19384,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.align-items.grid_context.start_end" => CSSFeature {
 		id: "css.properties.align-items.grid_context.start_end",
@@ -19308,7 +19403,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.align-self.grid_context" => CSSFeature {
 		id: "css.properties.align-self.grid_context",
@@ -19327,7 +19422,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.column-gap.grid_context" => CSSFeature {
 		id: "css.properties.column-gap.grid_context",
@@ -19346,7 +19441,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.display.grid" => CSSFeature {
 		id: "css.properties.display.grid",
@@ -19365,7 +19460,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.display.inline-grid" => CSSFeature {
 		id: "css.properties.display.inline-grid",
@@ -19384,7 +19479,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.gap" => CSSFeature {
 		id: "css.properties.gap",
@@ -19403,7 +19498,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.gap.grid_context" => CSSFeature {
 		id: "css.properties.gap.grid_context",
@@ -19422,7 +19517,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.gap.grid_context.calc_values" => CSSFeature {
 		id: "css.properties.gap.grid_context.calc_values",
@@ -19441,7 +19536,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.gap.grid_context.percentage_values" => CSSFeature {
 		id: "css.properties.gap.grid_context.percentage_values",
@@ -19460,7 +19555,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.gap.normal" => CSSFeature {
 		id: "css.properties.gap.normal",
@@ -19479,7 +19574,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid" => CSSFeature {
 		id: "css.properties.grid",
@@ -19498,7 +19593,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-area" => CSSFeature {
 		id: "css.properties.grid-area",
@@ -19517,7 +19612,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-auto-columns" => CSSFeature {
 		id: "css.properties.grid-auto-columns",
@@ -19536,7 +19631,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-auto-flow" => CSSFeature {
 		id: "css.properties.grid-auto-flow",
@@ -19555,7 +19650,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-auto-flow.column" => CSSFeature {
 		id: "css.properties.grid-auto-flow.column",
@@ -19574,7 +19669,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-auto-flow.dense" => CSSFeature {
 		id: "css.properties.grid-auto-flow.dense",
@@ -19593,7 +19688,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-auto-flow.row" => CSSFeature {
 		id: "css.properties.grid-auto-flow.row",
@@ -19612,7 +19707,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-auto-rows" => CSSFeature {
 		id: "css.properties.grid-auto-rows",
@@ -19631,7 +19726,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-column" => CSSFeature {
 		id: "css.properties.grid-column",
@@ -19650,7 +19745,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-column-end" => CSSFeature {
 		id: "css.properties.grid-column-end",
@@ -19669,7 +19764,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-column-start" => CSSFeature {
 		id: "css.properties.grid-column-start",
@@ -19688,7 +19783,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-row" => CSSFeature {
 		id: "css.properties.grid-row",
@@ -19707,7 +19802,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-row-end" => CSSFeature {
 		id: "css.properties.grid-row-end",
@@ -19726,7 +19821,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-row-start" => CSSFeature {
 		id: "css.properties.grid-row-start",
@@ -19745,7 +19840,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template" => CSSFeature {
 		id: "css.properties.grid-template",
@@ -19764,7 +19859,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-areas" => CSSFeature {
 		id: "css.properties.grid-template-areas",
@@ -19783,7 +19878,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-areas.none" => CSSFeature {
 		id: "css.properties.grid-template-areas.none",
@@ -19802,7 +19897,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-columns" => CSSFeature {
 		id: "css.properties.grid-template-columns",
@@ -19821,7 +19916,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-columns.auto" => CSSFeature {
 		id: "css.properties.grid-template-columns.auto",
@@ -19840,7 +19935,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-columns.fit-content" => CSSFeature {
 		id: "css.properties.grid-template-columns.fit-content",
@@ -19859,7 +19954,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-columns.max-content" => CSSFeature {
 		id: "css.properties.grid-template-columns.max-content",
@@ -19878,7 +19973,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-columns.min-content" => CSSFeature {
 		id: "css.properties.grid-template-columns.min-content",
@@ -19897,7 +19992,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-columns.minmax" => CSSFeature {
 		id: "css.properties.grid-template-columns.minmax",
@@ -19916,7 +20011,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-columns.none" => CSSFeature {
 		id: "css.properties.grid-template-columns.none",
@@ -19935,7 +20030,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-columns.repeat" => CSSFeature {
 		id: "css.properties.grid-template-columns.repeat",
@@ -19954,7 +20049,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-rows" => CSSFeature {
 		id: "css.properties.grid-template-rows",
@@ -19973,7 +20068,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-rows.auto" => CSSFeature {
 		id: "css.properties.grid-template-rows.auto",
@@ -19992,7 +20087,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-rows.fit-content" => CSSFeature {
 		id: "css.properties.grid-template-rows.fit-content",
@@ -20011,7 +20106,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-rows.max-content" => CSSFeature {
 		id: "css.properties.grid-template-rows.max-content",
@@ -20030,7 +20125,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-rows.min-content" => CSSFeature {
 		id: "css.properties.grid-template-rows.min-content",
@@ -20049,7 +20144,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-rows.minmax" => CSSFeature {
 		id: "css.properties.grid-template-rows.minmax",
@@ -20068,7 +20163,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-rows.none" => CSSFeature {
 		id: "css.properties.grid-template-rows.none",
@@ -20087,7 +20182,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-rows.repeat" => CSSFeature {
 		id: "css.properties.grid-template-rows.repeat",
@@ -20106,7 +20201,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template.none" => CSSFeature {
 		id: "css.properties.grid-template.none",
@@ -20125,7 +20220,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.justify-content.grid_context" => CSSFeature {
 		id: "css.properties.justify-content.grid_context",
@@ -20144,7 +20239,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.justify-items.grid_context" => CSSFeature {
 		id: "css.properties.justify-items.grid_context",
@@ -20163,7 +20258,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.justify-self" => CSSFeature {
 		id: "css.properties.justify-self",
@@ -20182,7 +20277,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.justify-self.auto" => CSSFeature {
 		id: "css.properties.justify-self.auto",
@@ -20201,7 +20296,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.justify-self.grid_context" => CSSFeature {
 		id: "css.properties.justify-self.grid_context",
@@ -20220,7 +20315,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.justify-self.left" => CSSFeature {
 		id: "css.properties.justify-self.left",
@@ -20239,7 +20334,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.justify-self.normal" => CSSFeature {
 		id: "css.properties.justify-self.normal",
@@ -20258,7 +20353,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.justify-self.right" => CSSFeature {
 		id: "css.properties.justify-self.right",
@@ -20277,7 +20372,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.justify-self.stretch" => CSSFeature {
 		id: "css.properties.justify-self.stretch",
@@ -20296,7 +20391,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.place-content.grid_context" => CSSFeature {
 		id: "css.properties.place-content.grid_context",
@@ -20315,7 +20410,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.place-items.grid_context" => CSSFeature {
 		id: "css.properties.place-items.grid_context",
@@ -20334,7 +20429,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.place-self.grid_context" => CSSFeature {
 		id: "css.properties.place-self.grid_context",
@@ -20353,7 +20448,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.row-gap" => CSSFeature {
 		id: "css.properties.row-gap",
@@ -20372,7 +20467,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.row-gap.grid_context" => CSSFeature {
 		id: "css.properties.row-gap.grid_context",
@@ -20391,7 +20486,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.row-gap.normal" => CSSFeature {
 		id: "css.properties.row-gap.normal",
@@ -20410,7 +20505,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.types.flex" => CSSFeature {
 		id: "css.types.flex",
@@ -20429,7 +20524,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7128,
+		popularity: 0.6901,
 	},
 	"css.properties.grid-template-columns.animation" => CSSFeature {
 		id: "css.properties.grid-template-columns.animation",
@@ -20847,7 +20942,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 0.2026,
+		popularity: 0.3218,
 	},
 	"css.properties.hyphenate-character.auto" => CSSFeature {
 		id: "css.properties.hyphenate-character.auto",
@@ -20866,7 +20961,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 0.2026,
+		popularity: 0.3218,
 	},
 	"css.properties.hyphenate-limit-chars" => CSSFeature {
 		id: "css.properties.hyphenate-limit-chars",
@@ -20885,7 +20980,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1049,
+		popularity: 0.1082,
 	},
 	"css.properties.hyphenate-limit-chars.auto" => CSSFeature {
 		id: "css.properties.hyphenate-limit-chars.auto",
@@ -20904,7 +20999,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1049,
+		popularity: 0.1082,
 	},
 	"css.properties.hyphens" => CSSFeature {
 		id: "css.properties.hyphens",
@@ -20923,7 +21018,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.auto" => CSSFeature {
 		id: "css.properties.hyphens.auto",
@@ -20942,7 +21037,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_afrikaans" => CSSFeature {
 		id: "css.properties.hyphens.language_afrikaans",
@@ -20961,7 +21056,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_albanian" => CSSFeature {
 		id: "css.properties.hyphens.language_albanian",
@@ -20980,7 +21075,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_amharic" => CSSFeature {
 		id: "css.properties.hyphens.language_amharic",
@@ -20999,7 +21094,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_armenian" => CSSFeature {
 		id: "css.properties.hyphens.language_armenian",
@@ -21018,7 +21113,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_assamese" => CSSFeature {
 		id: "css.properties.hyphens.language_assamese",
@@ -21037,7 +21132,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_basque" => CSSFeature {
 		id: "css.properties.hyphens.language_basque",
@@ -21056,7 +21151,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_belarusian" => CSSFeature {
 		id: "css.properties.hyphens.language_belarusian",
@@ -21075,7 +21170,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_bengali" => CSSFeature {
 		id: "css.properties.hyphens.language_bengali",
@@ -21094,7 +21189,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_bosnian" => CSSFeature {
 		id: "css.properties.hyphens.language_bosnian",
@@ -21113,7 +21208,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_bulgarian" => CSSFeature {
 		id: "css.properties.hyphens.language_bulgarian",
@@ -21132,7 +21227,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_catalan" => CSSFeature {
 		id: "css.properties.hyphens.language_catalan",
@@ -21151,7 +21246,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_croatian" => CSSFeature {
 		id: "css.properties.hyphens.language_croatian",
@@ -21170,7 +21265,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_cyrillic_mongolian" => CSSFeature {
 		id: "css.properties.hyphens.language_cyrillic_mongolian",
@@ -21189,7 +21284,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_czech" => CSSFeature {
 		id: "css.properties.hyphens.language_czech",
@@ -21208,7 +21303,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_danish" => CSSFeature {
 		id: "css.properties.hyphens.language_danish",
@@ -21227,7 +21322,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_dutch" => CSSFeature {
 		id: "css.properties.hyphens.language_dutch",
@@ -21246,7 +21341,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_english" => CSSFeature {
 		id: "css.properties.hyphens.language_english",
@@ -21265,7 +21360,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_esperanto" => CSSFeature {
 		id: "css.properties.hyphens.language_esperanto",
@@ -21284,7 +21379,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_estonian" => CSSFeature {
 		id: "css.properties.hyphens.language_estonian",
@@ -21303,7 +21398,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_ethiopic_script_mul" => CSSFeature {
 		id: "css.properties.hyphens.language_ethiopic_script_mul",
@@ -21322,7 +21417,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_ethiopic_script_und" => CSSFeature {
 		id: "css.properties.hyphens.language_ethiopic_script_und",
@@ -21341,7 +21436,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_finnish" => CSSFeature {
 		id: "css.properties.hyphens.language_finnish",
@@ -21360,7 +21455,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_french" => CSSFeature {
 		id: "css.properties.hyphens.language_french",
@@ -21379,7 +21474,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_galician" => CSSFeature {
 		id: "css.properties.hyphens.language_galician",
@@ -21398,7 +21493,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_georgian" => CSSFeature {
 		id: "css.properties.hyphens.language_georgian",
@@ -21417,7 +21512,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_german_reformed_orthography" => CSSFeature {
 		id: "css.properties.hyphens.language_german_reformed_orthography",
@@ -21436,7 +21531,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_german_swiss_orthography" => CSSFeature {
 		id: "css.properties.hyphens.language_german_swiss_orthography",
@@ -21455,7 +21550,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_german_traditional_orthography" => CSSFeature {
 		id: "css.properties.hyphens.language_german_traditional_orthography",
@@ -21474,7 +21569,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_gujarati" => CSSFeature {
 		id: "css.properties.hyphens.language_gujarati",
@@ -21493,7 +21588,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_hindi" => CSSFeature {
 		id: "css.properties.hyphens.language_hindi",
@@ -21512,7 +21607,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_hungarian" => CSSFeature {
 		id: "css.properties.hyphens.language_hungarian",
@@ -21531,7 +21626,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_icelandic" => CSSFeature {
 		id: "css.properties.hyphens.language_icelandic",
@@ -21550,7 +21645,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_interlingua" => CSSFeature {
 		id: "css.properties.hyphens.language_interlingua",
@@ -21569,7 +21664,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_irish" => CSSFeature {
 		id: "css.properties.hyphens.language_irish",
@@ -21588,7 +21683,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_italian" => CSSFeature {
 		id: "css.properties.hyphens.language_italian",
@@ -21607,7 +21702,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_kannada" => CSSFeature {
 		id: "css.properties.hyphens.language_kannada",
@@ -21626,7 +21721,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_kurmanji" => CSSFeature {
 		id: "css.properties.hyphens.language_kurmanji",
@@ -21645,7 +21740,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_latin" => CSSFeature {
 		id: "css.properties.hyphens.language_latin",
@@ -21664,7 +21759,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_latvian" => CSSFeature {
 		id: "css.properties.hyphens.language_latvian",
@@ -21683,7 +21778,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_lithuanian" => CSSFeature {
 		id: "css.properties.hyphens.language_lithuanian",
@@ -21702,7 +21797,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_malayalam" => CSSFeature {
 		id: "css.properties.hyphens.language_malayalam",
@@ -21721,7 +21816,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_marathi" => CSSFeature {
 		id: "css.properties.hyphens.language_marathi",
@@ -21740,7 +21835,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_modern_greek" => CSSFeature {
 		id: "css.properties.hyphens.language_modern_greek",
@@ -21759,7 +21854,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_mongolian" => CSSFeature {
 		id: "css.properties.hyphens.language_mongolian",
@@ -21778,7 +21873,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_norwegian_nn" => CSSFeature {
 		id: "css.properties.hyphens.language_norwegian_nn",
@@ -21797,7 +21892,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_norwegian_no" => CSSFeature {
 		id: "css.properties.hyphens.language_norwegian_no",
@@ -21816,7 +21911,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_old_slavonic" => CSSFeature {
 		id: "css.properties.hyphens.language_old_slavonic",
@@ -21835,7 +21930,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_oriya" => CSSFeature {
 		id: "css.properties.hyphens.language_oriya",
@@ -21854,7 +21949,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_polish" => CSSFeature {
 		id: "css.properties.hyphens.language_polish",
@@ -21873,7 +21968,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_portuguese" => CSSFeature {
 		id: "css.properties.hyphens.language_portuguese",
@@ -21892,7 +21987,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_punjabi" => CSSFeature {
 		id: "css.properties.hyphens.language_punjabi",
@@ -21911,7 +22006,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_russian" => CSSFeature {
 		id: "css.properties.hyphens.language_russian",
@@ -21930,7 +22025,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_slovak" => CSSFeature {
 		id: "css.properties.hyphens.language_slovak",
@@ -21949,7 +22044,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_slovenian" => CSSFeature {
 		id: "css.properties.hyphens.language_slovenian",
@@ -21968,7 +22063,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_spanish" => CSSFeature {
 		id: "css.properties.hyphens.language_spanish",
@@ -21987,7 +22082,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_swedish" => CSSFeature {
 		id: "css.properties.hyphens.language_swedish",
@@ -22006,7 +22101,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_tamil" => CSSFeature {
 		id: "css.properties.hyphens.language_tamil",
@@ -22025,7 +22120,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_telugu" => CSSFeature {
 		id: "css.properties.hyphens.language_telugu",
@@ -22044,7 +22139,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_turkish" => CSSFeature {
 		id: "css.properties.hyphens.language_turkish",
@@ -22063,7 +22158,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_turkmen" => CSSFeature {
 		id: "css.properties.hyphens.language_turkmen",
@@ -22082,7 +22177,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_ukrainian" => CSSFeature {
 		id: "css.properties.hyphens.language_ukrainian",
@@ -22101,7 +22196,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_upper_sorbian" => CSSFeature {
 		id: "css.properties.hyphens.language_upper_sorbian",
@@ -22120,7 +22215,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.properties.hyphens.language_welsh" => CSSFeature {
 		id: "css.properties.hyphens.language_welsh",
@@ -22139,7 +22234,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.8042,
+		popularity: 11.2829,
 	},
 	"css.types.length.ic" => CSSFeature {
 		id: "css.types.length.ic",
@@ -22196,7 +22291,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css-image-orientation"],
-		popularity: 0.1951,
+		popularity: 0.3280,
 	},
 	"css.properties.image-orientation.from-image" => CSSFeature {
 		id: "css.properties.image-orientation.from-image",
@@ -22215,7 +22310,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css-image-orientation"],
-		popularity: 0.1951,
+		popularity: 0.3280,
 	},
 	"css.properties.image-orientation.none" => CSSFeature {
 		id: "css.properties.image-orientation.none",
@@ -22234,7 +22329,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css-image-orientation"],
-		popularity: 0.1951,
+		popularity: 0.3280,
 	},
 	"css.properties.image-rendering" => CSSFeature {
 		id: "css.properties.image-rendering",
@@ -22253,7 +22348,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/css-crisp-edges"],
-		popularity: 7.4658,
+		popularity: 7.0113,
 	},
 	"css.properties.image-rendering.auto" => CSSFeature {
 		id: "css.properties.image-rendering.auto",
@@ -22272,7 +22367,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/css-crisp-edges"],
-		popularity: 7.4658,
+		popularity: 7.0113,
 	},
 	"css.properties.image-rendering.pixelated" => CSSFeature {
 		id: "css.properties.image-rendering.pixelated",
@@ -22291,7 +22386,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/css-crisp-edges"],
-		popularity: 7.4658,
+		popularity: 7.0113,
 	},
 	"css.properties.background-image.image-set" => CSSFeature {
 		id: "css.properties.background-image.image-set",
@@ -22652,7 +22747,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0763,
+		popularity: 0.0691,
 	},
 	"css.properties.initial-letter.normal" => CSSFeature {
 		id: "css.properties.initial-letter.normal",
@@ -22671,7 +22766,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0763,
+		popularity: 0.0691,
 	},
 	"css.types.global_keywords.initial" => CSSFeature {
 		id: "css.types.global_keywords.initial",
@@ -22690,7 +22785,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-initial-value"],
-		popularity: 4.2294,
+		popularity: 5.3620,
 	},
 	"css.selectors.checked" => CSSFeature {
 		id: "css.selectors.checked",
@@ -22842,7 +22937,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0166,
+		popularity: 0.0179,
 	},
 	"css.properties.interactivity.auto" => CSSFeature {
 		id: "css.properties.interactivity.auto",
@@ -22861,7 +22956,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0166,
+		popularity: 0.0179,
 	},
 	"css.properties.interactivity.inert" => CSSFeature {
 		id: "css.properties.interactivity.inert",
@@ -22880,7 +22975,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0166,
+		popularity: 0.0179,
 	},
 	"css.properties.interpolate-size" => CSSFeature {
 		id: "css.properties.interpolate-size",
@@ -22899,7 +22994,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.2752,
+		popularity: 2.4216,
 	},
 	"css.properties.interpolate-size.allow-keywords" => CSSFeature {
 		id: "css.properties.interpolate-size.allow-keywords",
@@ -22918,7 +23013,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.2752,
+		popularity: 2.4216,
 	},
 	"css.properties.interpolate-size.numeric-only" => CSSFeature {
 		id: "css.properties.interpolate-size.numeric-only",
@@ -22937,7 +23032,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.2752,
+		popularity: 2.4216,
 	},
 	"css.at-rules.media.inverted-colors" => CSSFeature {
 		id: "css.at-rules.media.inverted-colors",
@@ -23013,7 +23108,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &[],
-		popularity: 12.7080,
+		popularity: 13.3387,
 	},
 	"css.types.color.lab" => CSSFeature {
 		id: "css.types.color.lab",
@@ -23355,7 +23450,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-letter-spacing"],
-		popularity: 66.7668,
+		popularity: 65.6508,
 	},
 	"css.properties.letter-spacing.normal" => CSSFeature {
 		id: "css.properties.letter-spacing.normal",
@@ -23374,7 +23469,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-letter-spacing"],
-		popularity: 66.7668,
+		popularity: 65.6508,
 	},
 	"css.types.length.lh" => CSSFeature {
 		id: "css.types.length.lh",
@@ -23431,7 +23526,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.2353,
+		popularity: 5.3438,
 	},
 	"css.properties.line-break.anywhere" => CSSFeature {
 		id: "css.properties.line-break.anywhere",
@@ -23450,7 +23545,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.2353,
+		popularity: 5.3438,
 	},
 	"css.properties.line-break.auto" => CSSFeature {
 		id: "css.properties.line-break.auto",
@@ -23469,7 +23564,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.2353,
+		popularity: 5.3438,
 	},
 	"css.properties.line-break.loose" => CSSFeature {
 		id: "css.properties.line-break.loose",
@@ -23488,7 +23583,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.2353,
+		popularity: 5.3438,
 	},
 	"css.properties.line-break.normal" => CSSFeature {
 		id: "css.properties.line-break.normal",
@@ -23507,7 +23602,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.2353,
+		popularity: 5.3438,
 	},
 	"css.properties.line-break.strict" => CSSFeature {
 		id: "css.properties.line-break.strict",
@@ -23526,7 +23621,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.2353,
+		popularity: 5.3438,
 	},
 	"css.properties.line-clamp" => CSSFeature {
 		id: "css.properties.line-clamp",
@@ -23545,7 +23640,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-line-clamp"],
-		popularity: 0.0024,
+		popularity: 0.0029,
 	},
 	"css.properties.line-clamp.none" => CSSFeature {
 		id: "css.properties.line-clamp.none",
@@ -23564,7 +23659,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-line-clamp"],
-		popularity: 0.0024,
+		popularity: 0.0029,
 	},
 	"css.properties.line-height" => CSSFeature {
 		id: "css.properties.line-height",
@@ -23583,7 +23678,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 86.1663,
+		popularity: 85.9222,
 	},
 	"css.properties.line-height.normal" => CSSFeature {
 		id: "css.properties.line-height.normal",
@@ -23602,7 +23697,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 86.1663,
+		popularity: 85.9222,
 	},
 	"css.types.easing-function.linear-function" => CSSFeature {
 		id: "css.types.easing-function.linear-function",
@@ -23773,7 +23868,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-image" => CSSFeature {
 		id: "css.properties.list-style-image",
@@ -23792,7 +23887,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-image.none" => CSSFeature {
 		id: "css.properties.list-style-image.none",
@@ -23811,7 +23906,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-position" => CSSFeature {
 		id: "css.properties.list-style-position",
@@ -23830,7 +23925,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-position.inside" => CSSFeature {
 		id: "css.properties.list-style-position.inside",
@@ -23849,7 +23944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-position.outside" => CSSFeature {
 		id: "css.properties.list-style-position.outside",
@@ -23868,7 +23963,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type" => CSSFeature {
 		id: "css.properties.list-style-type",
@@ -23887,7 +23982,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.arabic-indic" => CSSFeature {
 		id: "css.properties.list-style-type.arabic-indic",
@@ -23906,7 +24001,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.armenian" => CSSFeature {
 		id: "css.properties.list-style-type.armenian",
@@ -23925,7 +24020,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.bengali" => CSSFeature {
 		id: "css.properties.list-style-type.bengali",
@@ -23944,7 +24039,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.cambodian" => CSSFeature {
 		id: "css.properties.list-style-type.cambodian",
@@ -23963,7 +24058,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.circle" => CSSFeature {
 		id: "css.properties.list-style-type.circle",
@@ -23982,7 +24077,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.cjk-decimal" => CSSFeature {
 		id: "css.properties.list-style-type.cjk-decimal",
@@ -24001,7 +24096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.cjk-earthly-branch" => CSSFeature {
 		id: "css.properties.list-style-type.cjk-earthly-branch",
@@ -24020,7 +24115,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.cjk-heavenly-stem" => CSSFeature {
 		id: "css.properties.list-style-type.cjk-heavenly-stem",
@@ -24039,7 +24134,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.cjk-ideographic" => CSSFeature {
 		id: "css.properties.list-style-type.cjk-ideographic",
@@ -24058,7 +24153,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.decimal" => CSSFeature {
 		id: "css.properties.list-style-type.decimal",
@@ -24077,7 +24172,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.decimal-leading-zero" => CSSFeature {
 		id: "css.properties.list-style-type.decimal-leading-zero",
@@ -24096,7 +24191,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.devanagari" => CSSFeature {
 		id: "css.properties.list-style-type.devanagari",
@@ -24115,7 +24210,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.disc" => CSSFeature {
 		id: "css.properties.list-style-type.disc",
@@ -24134,7 +24229,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.disclosure-closed" => CSSFeature {
 		id: "css.properties.list-style-type.disclosure-closed",
@@ -24153,7 +24248,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.disclosure-open" => CSSFeature {
 		id: "css.properties.list-style-type.disclosure-open",
@@ -24172,7 +24267,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.ethiopic-numeric" => CSSFeature {
 		id: "css.properties.list-style-type.ethiopic-numeric",
@@ -24191,7 +24286,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.georgian" => CSSFeature {
 		id: "css.properties.list-style-type.georgian",
@@ -24210,7 +24305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.gujarati" => CSSFeature {
 		id: "css.properties.list-style-type.gujarati",
@@ -24229,7 +24324,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.gurmukhi" => CSSFeature {
 		id: "css.properties.list-style-type.gurmukhi",
@@ -24248,7 +24343,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.hebrew" => CSSFeature {
 		id: "css.properties.list-style-type.hebrew",
@@ -24267,7 +24362,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.hiragana" => CSSFeature {
 		id: "css.properties.list-style-type.hiragana",
@@ -24286,7 +24381,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.hiragana-iroha" => CSSFeature {
 		id: "css.properties.list-style-type.hiragana-iroha",
@@ -24305,7 +24400,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.japanese-formal" => CSSFeature {
 		id: "css.properties.list-style-type.japanese-formal",
@@ -24324,7 +24419,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.japanese-informal" => CSSFeature {
 		id: "css.properties.list-style-type.japanese-informal",
@@ -24343,7 +24438,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.kannada" => CSSFeature {
 		id: "css.properties.list-style-type.kannada",
@@ -24362,7 +24457,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.katakana" => CSSFeature {
 		id: "css.properties.list-style-type.katakana",
@@ -24381,7 +24476,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.katakana-iroha" => CSSFeature {
 		id: "css.properties.list-style-type.katakana-iroha",
@@ -24400,7 +24495,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.khmer" => CSSFeature {
 		id: "css.properties.list-style-type.khmer",
@@ -24419,7 +24514,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.korean-hangul-formal" => CSSFeature {
 		id: "css.properties.list-style-type.korean-hangul-formal",
@@ -24438,7 +24533,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.korean-hanja-formal" => CSSFeature {
 		id: "css.properties.list-style-type.korean-hanja-formal",
@@ -24457,7 +24552,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.korean-hanja-informal" => CSSFeature {
 		id: "css.properties.list-style-type.korean-hanja-informal",
@@ -24476,7 +24571,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.lao" => CSSFeature {
 		id: "css.properties.list-style-type.lao",
@@ -24495,7 +24590,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.lower-alpha" => CSSFeature {
 		id: "css.properties.list-style-type.lower-alpha",
@@ -24514,7 +24609,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.lower-armenian" => CSSFeature {
 		id: "css.properties.list-style-type.lower-armenian",
@@ -24533,7 +24628,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.lower-greek" => CSSFeature {
 		id: "css.properties.list-style-type.lower-greek",
@@ -24552,7 +24647,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.lower-latin" => CSSFeature {
 		id: "css.properties.list-style-type.lower-latin",
@@ -24571,7 +24666,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.lower-roman" => CSSFeature {
 		id: "css.properties.list-style-type.lower-roman",
@@ -24590,7 +24685,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.malayalam" => CSSFeature {
 		id: "css.properties.list-style-type.malayalam",
@@ -24609,7 +24704,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.mongolian" => CSSFeature {
 		id: "css.properties.list-style-type.mongolian",
@@ -24628,7 +24723,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.myanmar" => CSSFeature {
 		id: "css.properties.list-style-type.myanmar",
@@ -24647,7 +24742,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.none" => CSSFeature {
 		id: "css.properties.list-style-type.none",
@@ -24666,7 +24761,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.oriya" => CSSFeature {
 		id: "css.properties.list-style-type.oriya",
@@ -24685,7 +24780,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.persian" => CSSFeature {
 		id: "css.properties.list-style-type.persian",
@@ -24704,7 +24799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.simp-chinese-formal" => CSSFeature {
 		id: "css.properties.list-style-type.simp-chinese-formal",
@@ -24723,7 +24818,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.simp-chinese-informal" => CSSFeature {
 		id: "css.properties.list-style-type.simp-chinese-informal",
@@ -24742,7 +24837,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.square" => CSSFeature {
 		id: "css.properties.list-style-type.square",
@@ -24761,7 +24856,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.string" => CSSFeature {
 		id: "css.properties.list-style-type.string",
@@ -24780,7 +24875,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.symbols" => CSSFeature {
 		id: "css.properties.list-style-type.symbols",
@@ -24799,7 +24894,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.tamil" => CSSFeature {
 		id: "css.properties.list-style-type.tamil",
@@ -24818,7 +24913,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.telugu" => CSSFeature {
 		id: "css.properties.list-style-type.telugu",
@@ -24837,7 +24932,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.thai" => CSSFeature {
 		id: "css.properties.list-style-type.thai",
@@ -24856,7 +24951,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.tibetan" => CSSFeature {
 		id: "css.properties.list-style-type.tibetan",
@@ -24875,7 +24970,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.trad-chinese-formal" => CSSFeature {
 		id: "css.properties.list-style-type.trad-chinese-formal",
@@ -24894,7 +24989,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.trad-chinese-informal" => CSSFeature {
 		id: "css.properties.list-style-type.trad-chinese-informal",
@@ -24913,7 +25008,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.upper-alpha" => CSSFeature {
 		id: "css.properties.list-style-type.upper-alpha",
@@ -24932,7 +25027,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.upper-armenian" => CSSFeature {
 		id: "css.properties.list-style-type.upper-armenian",
@@ -24951,7 +25046,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.upper-latin" => CSSFeature {
 		id: "css.properties.list-style-type.upper-latin",
@@ -24970,7 +25065,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style-type.upper-roman" => CSSFeature {
 		id: "css.properties.list-style-type.upper-roman",
@@ -24989,7 +25084,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.list-style.symbols" => CSSFeature {
 		id: "css.properties.list-style.symbols",
@@ -25008,7 +25103,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 67.6432,
+		popularity: 67.2558,
 	},
 	"css.properties.block-size" => CSSFeature {
 		id: "css.properties.block-size",
@@ -26661,7 +26756,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin-bottom" => CSSFeature {
 		id: "css.properties.margin-bottom",
@@ -26680,7 +26775,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin-bottom.auto" => CSSFeature {
 		id: "css.properties.margin-bottom.auto",
@@ -26699,7 +26794,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin-left" => CSSFeature {
 		id: "css.properties.margin-left",
@@ -26718,7 +26813,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin-left.auto" => CSSFeature {
 		id: "css.properties.margin-left.auto",
@@ -26737,7 +26832,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin-right" => CSSFeature {
 		id: "css.properties.margin-right",
@@ -26756,7 +26851,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin-right.auto" => CSSFeature {
 		id: "css.properties.margin-right.auto",
@@ -26775,7 +26870,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin-top" => CSSFeature {
 		id: "css.properties.margin-top",
@@ -26794,7 +26889,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin-top.auto" => CSSFeature {
 		id: "css.properties.margin-top.auto",
@@ -26813,7 +26908,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin.auto" => CSSFeature {
 		id: "css.properties.margin.auto",
@@ -26832,7 +26927,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.5642,
+		popularity: 91.4837,
 	},
 	"css.properties.margin-trim" => CSSFeature {
 		id: "css.properties.margin-trim",
@@ -27003,7 +27098,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-marker-pseudo"],
-		popularity: 0.0462,
+		popularity: 0.0511,
 	},
 	"css.selectors.marker.animation_and_transition_support" => CSSFeature {
 		id: "css.selectors.marker.animation_and_transition_support",
@@ -27022,7 +27117,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-marker-pseudo"],
-		popularity: 0.0462,
+		popularity: 0.0511,
 	},
 	"css.properties.mask-border" => CSSFeature {
 		id: "css.properties.mask-border",
@@ -27155,7 +27250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &[],
-		popularity: 1.8706,
+		popularity: 2.0260,
 	},
 	"css.properties.mask-type.alpha" => CSSFeature {
 		id: "css.properties.mask-type.alpha",
@@ -27174,7 +27269,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &[],
-		popularity: 1.8706,
+		popularity: 2.0260,
 	},
 	"css.properties.mask-type.luminance" => CSSFeature {
 		id: "css.properties.mask-type.luminance",
@@ -27193,7 +27288,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &[],
-		popularity: 1.8706,
+		popularity: 2.0260,
 	},
 	"css.properties.mask" => CSSFeature {
 		id: "css.properties.mask",
@@ -28789,7 +28884,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-mixblendmode"],
-		popularity: 9.3789,
+		popularity: 9.2005,
 	},
 	"css.properties.mix-blend-mode.plus-darker" => CSSFeature {
 		id: "css.properties.mix-blend-mode.plus-darker",
@@ -28808,7 +28903,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-mixblendmode"],
-		popularity: 9.3789,
+		popularity: 9.2005,
 	},
 	"css.properties.mix-blend-mode.plus-lighter" => CSSFeature {
 		id: "css.properties.mix-blend-mode.plus-lighter",
@@ -28827,7 +28922,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-mixblendmode"],
-		popularity: 9.3789,
+		popularity: 9.2005,
 	},
 	"css.properties.mix-blend-mode.svg_elements" => CSSFeature {
 		id: "css.properties.mix-blend-mode.svg_elements",
@@ -28846,7 +28941,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-mixblendmode"],
-		popularity: 9.3789,
+		popularity: 9.2005,
 	},
 	"css.selectors.modal" => CSSFeature {
 		id: "css.selectors.modal",
@@ -30347,7 +30442,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 52.2185,
+		popularity: 49.0484,
 	},
 	"css.properties.object-fit.contain" => CSSFeature {
 		id: "css.properties.object-fit.contain",
@@ -30366,7 +30461,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 52.2185,
+		popularity: 49.0484,
 	},
 	"css.properties.object-fit.cover" => CSSFeature {
 		id: "css.properties.object-fit.cover",
@@ -30385,7 +30480,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 52.2185,
+		popularity: 49.0484,
 	},
 	"css.properties.object-fit.fill" => CSSFeature {
 		id: "css.properties.object-fit.fill",
@@ -30404,7 +30499,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 52.2185,
+		popularity: 49.0484,
 	},
 	"css.properties.object-fit.none" => CSSFeature {
 		id: "css.properties.object-fit.none",
@@ -30423,7 +30518,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 52.2185,
+		popularity: 49.0484,
 	},
 	"css.properties.object-fit.scale-down" => CSSFeature {
 		id: "css.properties.object-fit.scale-down",
@@ -30442,7 +30537,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 52.2185,
+		popularity: 49.0484,
 	},
 	"css.properties.object-position" => CSSFeature {
 		id: "css.properties.object-position",
@@ -30461,7 +30556,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &[],
-		popularity: 18.6168,
+		popularity: 17.0782,
 	},
 	"css.properties.object-view-box" => CSSFeature {
 		id: "css.properties.object-view-box",
@@ -30480,7 +30575,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0306,
+		popularity: 0.0330,
 	},
 	"css.properties.object-view-box.none" => CSSFeature {
 		id: "css.properties.object-view-box.none",
@@ -30499,7 +30594,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0306,
+		popularity: 0.0330,
 	},
 	"css.types.color.oklab" => CSSFeature {
 		id: "css.types.color.oklab",
@@ -30594,7 +30689,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-opacity"],
-		popularity: 86.5557,
+		popularity: 86.6762,
 	},
 	"css.properties.opacity.percentages" => CSSFeature {
 		id: "css.properties.opacity.percentages",
@@ -30613,7 +30708,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-opacity"],
-		popularity: 86.5557,
+		popularity: 86.6762,
 	},
 	"css.types.number" => CSSFeature {
 		id: "css.types.number",
@@ -30632,7 +30727,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-opacity"],
-		popularity: 86.5557,
+		popularity: 86.6762,
 	},
 	"css.types.number.scientific_notation" => CSSFeature {
 		id: "css.types.number.scientific_notation",
@@ -30651,7 +30746,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-opacity"],
-		popularity: 86.5557,
+		popularity: 86.6762,
 	},
 	"css.properties.fill-opacity" => CSSFeature {
 		id: "css.properties.fill-opacity",
@@ -30727,7 +30822,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 77.3577,
+		popularity: 77.6060,
 	},
 	"css.properties.outline-color" => CSSFeature {
 		id: "css.properties.outline-color",
@@ -31012,7 +31107,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 87.1143,
+		popularity: 87.1574,
 	},
 	"css.at-rules.media.overflow-inline" => CSSFeature {
 		id: "css.at-rules.media.overflow-inline",
@@ -31031,7 +31126,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 87.1143,
+		popularity: 87.1574,
 	},
 	"css.properties.overflow-anchor" => CSSFeature {
 		id: "css.properties.overflow-anchor",
@@ -31050,7 +31145,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-overflow-anchor"],
-		popularity: 5.9967,
+		popularity: 6.2421,
 	},
 	"css.properties.overflow-anchor.auto" => CSSFeature {
 		id: "css.properties.overflow-anchor.auto",
@@ -31069,7 +31164,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-overflow-anchor"],
-		popularity: 5.9967,
+		popularity: 6.2421,
 	},
 	"css.properties.overflow-anchor.none" => CSSFeature {
 		id: "css.properties.overflow-anchor.none",
@@ -31088,7 +31183,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-overflow-anchor"],
-		popularity: 5.9967,
+		popularity: 6.2421,
 	},
 	"css.properties.overflow-x.clip" => CSSFeature {
 		id: "css.properties.overflow-x.clip",
@@ -31183,7 +31278,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7595,
+		popularity: 1.3213,
 	},
 	"css.properties.overflow-clip-margin.border-box" => CSSFeature {
 		id: "css.properties.overflow-clip-margin.border-box",
@@ -31202,7 +31297,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7595,
+		popularity: 1.3213,
 	},
 	"css.properties.overflow-clip-margin.content-box" => CSSFeature {
 		id: "css.properties.overflow-clip-margin.content-box",
@@ -31221,7 +31316,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7595,
+		popularity: 1.3213,
 	},
 	"css.properties.overflow-clip-margin.padding-box" => CSSFeature {
 		id: "css.properties.overflow-clip-margin.padding-box",
@@ -31240,7 +31335,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7595,
+		popularity: 1.3213,
 	},
 	"css.types.overflow.overlay" => CSSFeature {
 		id: "css.types.overflow.overlay",
@@ -31601,7 +31696,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/wordwrap"],
-		popularity: 38.1046,
+		popularity: 39.0223,
 	},
 	"css.properties.overflow-wrap.anywhere" => CSSFeature {
 		id: "css.properties.overflow-wrap.anywhere",
@@ -31620,7 +31715,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/wordwrap"],
-		popularity: 38.1046,
+		popularity: 39.0223,
 	},
 	"css.properties.overflow-wrap.break-word" => CSSFeature {
 		id: "css.properties.overflow-wrap.break-word",
@@ -31639,7 +31734,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/wordwrap"],
-		popularity: 38.1046,
+		popularity: 39.0223,
 	},
 	"css.properties.overflow-wrap.normal" => CSSFeature {
 		id: "css.properties.overflow-wrap.normal",
@@ -31658,7 +31753,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/wordwrap"],
-		popularity: 38.1046,
+		popularity: 39.0223,
 	},
 	"css.properties.overlay" => CSSFeature {
 		id: "css.properties.overlay",
@@ -31677,7 +31772,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0350,
+		popularity: 0.0442,
 	},
 	"css.properties.overlay.auto" => CSSFeature {
 		id: "css.properties.overlay.auto",
@@ -31696,7 +31791,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0350,
+		popularity: 0.0442,
 	},
 	"css.properties.overlay.none" => CSSFeature {
 		id: "css.properties.overlay.none",
@@ -31715,7 +31810,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0350,
+		popularity: 0.0442,
 	},
 	"css.properties.overscroll-behavior" => CSSFeature {
 		id: "css.properties.overscroll-behavior",
@@ -31734,7 +31829,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-block" => CSSFeature {
 		id: "css.properties.overscroll-behavior-block",
@@ -31753,7 +31848,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-block.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior-block.auto",
@@ -31772,7 +31867,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-block.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior-block.contain",
@@ -31791,7 +31886,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-block.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior-block.none",
@@ -31810,7 +31905,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-inline" => CSSFeature {
 		id: "css.properties.overscroll-behavior-inline",
@@ -31829,7 +31924,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-inline.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior-inline.auto",
@@ -31848,7 +31943,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-inline.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior-inline.contain",
@@ -31867,7 +31962,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-inline.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior-inline.none",
@@ -31886,7 +31981,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-x" => CSSFeature {
 		id: "css.properties.overscroll-behavior-x",
@@ -31905,7 +32000,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-x.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior-x.auto",
@@ -31924,7 +32019,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-x.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior-x.contain",
@@ -31943,7 +32038,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-x.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior-x.none",
@@ -31962,7 +32057,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-y" => CSSFeature {
 		id: "css.properties.overscroll-behavior-y",
@@ -31981,7 +32076,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-y.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior-y.auto",
@@ -32000,7 +32095,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-y.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior-y.contain",
@@ -32019,7 +32114,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior-y.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior-y.none",
@@ -32038,7 +32133,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior.auto",
@@ -32057,7 +32152,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior.contain",
@@ -32076,7 +32171,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.overscroll-behavior.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior.none",
@@ -32095,7 +32190,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.5643,
+		popularity: 15.0208,
 	},
 	"css.properties.padding" => CSSFeature {
 		id: "css.properties.padding",
@@ -32114,7 +32209,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.4352,
+		popularity: 91.7591,
 	},
 	"css.properties.padding-bottom" => CSSFeature {
 		id: "css.properties.padding-bottom",
@@ -32133,7 +32228,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.4352,
+		popularity: 91.7591,
 	},
 	"css.properties.padding-left" => CSSFeature {
 		id: "css.properties.padding-left",
@@ -32152,7 +32247,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.4352,
+		popularity: 91.7591,
 	},
 	"css.properties.padding-right" => CSSFeature {
 		id: "css.properties.padding-right",
@@ -32171,7 +32266,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.4352,
+		popularity: 91.7591,
 	},
 	"css.properties.padding-top" => CSSFeature {
 		id: "css.properties.padding-top",
@@ -32190,7 +32285,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.4352,
+		popularity: 91.7591,
 	},
 	"css.properties.page-break-after" => CSSFeature {
 		id: "css.properties.page-break-after",
@@ -33121,7 +33216,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.5125,
+		popularity: 1.6789,
 	},
 	"css.properties.page" => CSSFeature {
 		id: "css.properties.page",
@@ -33634,7 +33729,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7846,
+		popularity: 0.7087,
 	},
 	"css.types.basic-shape.path" => CSSFeature {
 		id: "css.types.basic-shape.path",
@@ -33976,7 +34071,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &["https://caniuse.com/pointer-events"],
-		popularity: 68.6271,
+		popularity: 68.2911,
 	},
 	"css.properties.pointer-events.html_elements" => CSSFeature {
 		id: "css.properties.pointer-events.html_elements",
@@ -33995,7 +34090,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &["https://caniuse.com/pointer-events"],
-		popularity: 68.6271,
+		popularity: 68.2911,
 	},
 	"css.selectors.backdrop.popover" => CSSFeature {
 		id: "css.selectors.backdrop.popover",
@@ -34052,7 +34147,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 90.9842,
+		popularity: 91.5028,
 	},
 	"css.at-rules.media.prefers-color-scheme" => CSSFeature {
 		id: "css.at-rules.media.prefers-color-scheme",
@@ -34185,7 +34280,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 2.4092,
+		popularity: 2.8268,
 	},
 	"css.properties.print-color-adjust.economy" => CSSFeature {
 		id: "css.properties.print-color-adjust.economy",
@@ -34204,7 +34299,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 2.4092,
+		popularity: 2.8268,
 	},
 	"css.properties.print-color-adjust.exact" => CSSFeature {
 		id: "css.properties.print-color-adjust.exact",
@@ -34223,7 +34318,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 2.4092,
+		popularity: 2.8268,
 	},
 	"css.types.length.Q" => CSSFeature {
 		id: "css.types.length.Q",
@@ -34261,7 +34356,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,5),
 				},
 		caniuse: &[],
-		popularity: 9.2063,
+		popularity: 8.6844,
 	},
 	"css.properties.quotes.auto" => CSSFeature {
 		id: "css.properties.quotes.auto",
@@ -34280,7 +34375,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,5),
 				},
 		caniuse: &[],
-		popularity: 9.2063,
+		popularity: 8.6844,
 	},
 	"css.properties.quotes.none" => CSSFeature {
 		id: "css.properties.quotes.none",
@@ -34299,7 +34394,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,5),
 				},
 		caniuse: &[],
-		popularity: 9.2063,
+		popularity: 8.6844,
 	},
 	"css.types.length.rcap" => CSSFeature {
 		id: "css.types.length.rcap",
@@ -34394,7 +34489,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0295,
+		popularity: 0.0345,
 	},
 	"css.properties.reading-flow.flex-flow" => CSSFeature {
 		id: "css.properties.reading-flow.flex-flow",
@@ -34413,7 +34508,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0295,
+		popularity: 0.0345,
 	},
 	"css.properties.reading-flow.flex-visual" => CSSFeature {
 		id: "css.properties.reading-flow.flex-visual",
@@ -34432,7 +34527,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0295,
+		popularity: 0.0345,
 	},
 	"css.properties.reading-flow.grid-columns" => CSSFeature {
 		id: "css.properties.reading-flow.grid-columns",
@@ -34451,7 +34546,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0295,
+		popularity: 0.0345,
 	},
 	"css.properties.reading-flow.grid-order" => CSSFeature {
 		id: "css.properties.reading-flow.grid-order",
@@ -34470,7 +34565,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0295,
+		popularity: 0.0345,
 	},
 	"css.properties.reading-flow.grid-rows" => CSSFeature {
 		id: "css.properties.reading-flow.grid-rows",
@@ -34489,7 +34584,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0295,
+		popularity: 0.0345,
 	},
 	"css.properties.reading-flow.normal" => CSSFeature {
 		id: "css.properties.reading-flow.normal",
@@ -34508,7 +34603,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0295,
+		popularity: 0.0345,
 	},
 	"css.properties.reading-flow.source-order" => CSSFeature {
 		id: "css.properties.reading-flow.source-order",
@@ -34527,7 +34622,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0295,
+		popularity: 0.0345,
 	},
 	"css.properties.reading-order" => CSSFeature {
 		id: "css.properties.reading-order",
@@ -34546,7 +34641,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0295,
+		popularity: 0.0345,
 	},
 	"css.at-rules.property" => CSSFeature {
 		id: "css.at-rules.property",
@@ -34850,7 +34945,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-resize"],
-		popularity: 32.6130,
+		popularity: 34.1609,
 	},
 	"css.properties.resize.block" => CSSFeature {
 		id: "css.properties.resize.block",
@@ -34869,7 +34964,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-resize"],
-		popularity: 32.6130,
+		popularity: 34.1609,
 	},
 	"css.properties.resize.block_level_support" => CSSFeature {
 		id: "css.properties.resize.block_level_support",
@@ -34888,7 +34983,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-resize"],
-		popularity: 32.6130,
+		popularity: 34.1609,
 	},
 	"css.properties.resize.inline" => CSSFeature {
 		id: "css.properties.resize.inline",
@@ -34907,7 +35002,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-resize"],
-		popularity: 32.6130,
+		popularity: 34.1609,
 	},
 	"css.at-rules.media.resolution" => CSSFeature {
 		id: "css.at-rules.media.resolution",
@@ -35439,7 +35534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2023,
+		popularity: 0.1852,
 	},
 	"css.properties.ruby-align.center" => CSSFeature {
 		id: "css.properties.ruby-align.center",
@@ -35458,7 +35553,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2023,
+		popularity: 0.1852,
 	},
 	"css.properties.ruby-align.space-around" => CSSFeature {
 		id: "css.properties.ruby-align.space-around",
@@ -35477,7 +35572,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2023,
+		popularity: 0.1852,
 	},
 	"css.properties.ruby-align.space-between" => CSSFeature {
 		id: "css.properties.ruby-align.space-between",
@@ -35496,7 +35591,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2023,
+		popularity: 0.1852,
 	},
 	"css.properties.ruby-align.start" => CSSFeature {
 		id: "css.properties.ruby-align.start",
@@ -35515,7 +35610,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2023,
+		popularity: 0.1852,
 	},
 	"css.properties.ruby-overhang" => CSSFeature {
 		id: "css.properties.ruby-overhang",
@@ -35534,7 +35629,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.0001,
+		popularity: 0.0000,
 	},
 	"css.properties.ruby-overhang.auto" => CSSFeature {
 		id: "css.properties.ruby-overhang.auto",
@@ -35553,7 +35648,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.0001,
+		popularity: 0.0000,
 	},
 	"css.properties.ruby-overhang.none" => CSSFeature {
 		id: "css.properties.ruby-overhang.none",
@@ -35572,7 +35667,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.0001,
+		popularity: 0.0000,
 	},
 	"css.properties.ruby-position" => CSSFeature {
 		id: "css.properties.ruby-position",
@@ -35591,7 +35686,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2275,
+		popularity: 0.2236,
 	},
 	"css.properties.ruby-position.inter-character" => CSSFeature {
 		id: "css.properties.ruby-position.inter-character",
@@ -35610,7 +35705,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2275,
+		popularity: 0.2236,
 	},
 	"css.properties.ruby-position.over" => CSSFeature {
 		id: "css.properties.ruby-position.over",
@@ -35629,7 +35724,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2275,
+		popularity: 0.2236,
 	},
 	"css.properties.ruby-position.under" => CSSFeature {
 		id: "css.properties.ruby-position.under",
@@ -35648,7 +35743,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2275,
+		popularity: 0.2236,
 	},
 	"css.types.env" => CSSFeature {
 		id: "css.types.env",
@@ -35838,7 +35933,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-scroll-behavior"],
-		popularity: 18.7319,
+		popularity: 18.7551,
 	},
 	"css.properties.scroll-behavior.auto" => CSSFeature {
 		id: "css.properties.scroll-behavior.auto",
@@ -35857,7 +35952,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-scroll-behavior"],
-		popularity: 18.7319,
+		popularity: 18.7551,
 	},
 	"css.properties.scroll-behavior.smooth" => CSSFeature {
 		id: "css.properties.scroll-behavior.smooth",
@@ -35876,7 +35971,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-scroll-behavior"],
-		popularity: 18.7319,
+		popularity: 18.7551,
 	},
 	"css.selectors.scroll-button" => CSSFeature {
 		id: "css.selectors.scroll-button",
@@ -36655,7 +36750,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0221,
+		popularity: 0.0245,
 	},
 	"css.properties.scroll-initial-target.nearest" => CSSFeature {
 		id: "css.properties.scroll-initial-target.nearest",
@@ -36674,7 +36769,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0221,
+		popularity: 0.0245,
 	},
 	"css.properties.scroll-initial-target.none" => CSSFeature {
 		id: "css.properties.scroll-initial-target.none",
@@ -36693,7 +36788,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0221,
+		popularity: 0.0245,
 	},
 	"css.properties.scroll-marker-group" => CSSFeature {
 		id: "css.properties.scroll-marker-group",
@@ -37662,7 +37757,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 12.1825,
+		popularity: 14.6546,
 	},
 	"css.properties.scrollbar-color.auto" => CSSFeature {
 		id: "css.properties.scrollbar-color.auto",
@@ -37681,7 +37776,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 12.1825,
+		popularity: 14.6546,
 	},
 	"css.properties.scrollbar-gutter" => CSSFeature {
 		id: "css.properties.scrollbar-gutter",
@@ -37700,7 +37795,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 10.1907,
+		popularity: 10.8636,
 	},
 	"css.properties.scrollbar-gutter.auto" => CSSFeature {
 		id: "css.properties.scrollbar-gutter.auto",
@@ -37719,7 +37814,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 10.1907,
+		popularity: 10.8636,
 	},
 	"css.properties.scrollbar-gutter.stable" => CSSFeature {
 		id: "css.properties.scrollbar-gutter.stable",
@@ -37738,7 +37833,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 10.1907,
+		popularity: 10.8636,
 	},
 	"css.properties.scrollbar-width" => CSSFeature {
 		id: "css.properties.scrollbar-width",
@@ -37757,7 +37852,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 38.6686,
+		popularity: 37.1678,
 	},
 	"css.properties.scrollbar-width.auto" => CSSFeature {
 		id: "css.properties.scrollbar-width.auto",
@@ -37776,7 +37871,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 38.6686,
+		popularity: 37.1678,
 	},
 	"css.properties.scrollbar-width.none" => CSSFeature {
 		id: "css.properties.scrollbar-width.none",
@@ -37795,7 +37890,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 38.6686,
+		popularity: 37.1678,
 	},
 	"css.properties.scrollbar-width.thin" => CSSFeature {
 		id: "css.properties.scrollbar-width.thin",
@@ -37814,7 +37909,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 38.6686,
+		popularity: 37.1678,
 	},
 	"css.selectors.selection" => CSSFeature {
 		id: "css.selectors.selection",
@@ -38099,7 +38194,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-image-threshold.percentages" => CSSFeature {
 		id: "css.properties.shape-image-threshold.percentages",
@@ -38118,7 +38213,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-margin" => CSSFeature {
 		id: "css.properties.shape-margin",
@@ -38137,7 +38232,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-outside" => CSSFeature {
 		id: "css.properties.shape-outside",
@@ -38156,7 +38251,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-outside.circle" => CSSFeature {
 		id: "css.properties.shape-outside.circle",
@@ -38175,7 +38270,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-outside.gradient" => CSSFeature {
 		id: "css.properties.shape-outside.gradient",
@@ -38194,7 +38289,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-outside.image" => CSSFeature {
 		id: "css.properties.shape-outside.image",
@@ -38213,7 +38308,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-outside.inset" => CSSFeature {
 		id: "css.properties.shape-outside.inset",
@@ -38232,7 +38327,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-outside.none" => CSSFeature {
 		id: "css.properties.shape-outside.none",
@@ -38251,7 +38346,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-outside.path" => CSSFeature {
 		id: "css.properties.shape-outside.path",
@@ -38270,7 +38365,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.properties.shape-outside.polygon" => CSSFeature {
 		id: "css.properties.shape-outside.polygon",
@@ -38289,7 +38384,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.5000,
+		popularity: 0.5578,
 	},
 	"css.types.basic-shape" => CSSFeature {
 		id: "css.types.basic-shape",
@@ -38555,7 +38650,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 10.8238,
+		popularity: 11.5028,
 	},
 	"css.properties.speak-as" => CSSFeature {
 		id: "css.properties.speak-as",
@@ -40322,7 +40417,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css3-tabsize"],
-		popularity: 10.8784,
+		popularity: 11.3793,
 	},
 	"css.properties.tab-size.length" => CSSFeature {
 		id: "css.properties.tab-size.length",
@@ -40341,7 +40436,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css3-tabsize"],
-		popularity: 10.8784,
+		popularity: 11.3793,
 	},
 	"css.properties.border-collapse" => CSSFeature {
 		id: "css.properties.border-collapse",
@@ -40702,7 +40797,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 88.1301,
+		popularity: 87.9506,
 	},
 	"css.properties.text-align.center" => CSSFeature {
 		id: "css.properties.text-align.center",
@@ -40721,7 +40816,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 88.1301,
+		popularity: 87.9506,
 	},
 	"css.properties.text-align.end" => CSSFeature {
 		id: "css.properties.text-align.end",
@@ -40740,7 +40835,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 88.1301,
+		popularity: 87.9506,
 	},
 	"css.properties.text-align.justify" => CSSFeature {
 		id: "css.properties.text-align.justify",
@@ -40759,7 +40854,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 88.1301,
+		popularity: 87.9506,
 	},
 	"css.properties.text-align.left" => CSSFeature {
 		id: "css.properties.text-align.left",
@@ -40778,7 +40873,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 88.1301,
+		popularity: 87.9506,
 	},
 	"css.properties.text-align.match-parent" => CSSFeature {
 		id: "css.properties.text-align.match-parent",
@@ -40797,7 +40892,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 88.1301,
+		popularity: 87.9506,
 	},
 	"css.properties.text-align.right" => CSSFeature {
 		id: "css.properties.text-align.right",
@@ -40816,7 +40911,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 88.1301,
+		popularity: 87.9506,
 	},
 	"css.properties.text-align.start" => CSSFeature {
 		id: "css.properties.text-align.start",
@@ -40835,7 +40930,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 88.1301,
+		popularity: 87.9506,
 	},
 	"css.properties.text-align-last" => CSSFeature {
 		id: "css.properties.text-align-last",
@@ -40854,7 +40949,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-align-last"],
-		popularity: 2.6783,
+		popularity: 2.5206,
 	},
 	"css.properties.text-align-last.auto" => CSSFeature {
 		id: "css.properties.text-align-last.auto",
@@ -40873,7 +40968,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-align-last"],
-		popularity: 2.6783,
+		popularity: 2.5206,
 	},
 	"css.properties.text-autospace" => CSSFeature {
 		id: "css.properties.text-autospace",
@@ -40892,7 +40987,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.4922,
+		popularity: 1.6478,
 	},
 	"css.properties.text-autospace.auto" => CSSFeature {
 		id: "css.properties.text-autospace.auto",
@@ -40911,7 +41006,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.4922,
+		popularity: 1.6478,
 	},
 	"css.properties.text-autospace.ideograph-alpha" => CSSFeature {
 		id: "css.properties.text-autospace.ideograph-alpha",
@@ -40930,7 +41025,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.4922,
+		popularity: 1.6478,
 	},
 	"css.properties.text-autospace.ideograph-numeric" => CSSFeature {
 		id: "css.properties.text-autospace.ideograph-numeric",
@@ -40949,7 +41044,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.4922,
+		popularity: 1.6478,
 	},
 	"css.properties.text-autospace.insert" => CSSFeature {
 		id: "css.properties.text-autospace.insert",
@@ -40968,7 +41063,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.4922,
+		popularity: 1.6478,
 	},
 	"css.properties.text-autospace.no-autospace" => CSSFeature {
 		id: "css.properties.text-autospace.no-autospace",
@@ -40987,7 +41082,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.4922,
+		popularity: 1.6478,
 	},
 	"css.properties.text-autospace.normal" => CSSFeature {
 		id: "css.properties.text-autospace.normal",
@@ -41006,7 +41101,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.4922,
+		popularity: 1.6478,
 	},
 	"css.properties.text-autospace.punctuation" => CSSFeature {
 		id: "css.properties.text-autospace.punctuation",
@@ -41025,7 +41120,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.4922,
+		popularity: 1.6478,
 	},
 	"css.properties.text-autospace.replace" => CSSFeature {
 		id: "css.properties.text-autospace.replace",
@@ -41044,7 +41139,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.4922,
+		popularity: 1.6478,
 	},
 	"css.properties.text-box" => CSSFeature {
 		id: "css.properties.text-box",
@@ -41063,7 +41158,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.properties.text-box-edge" => CSSFeature {
 		id: "css.properties.text-box-edge",
@@ -41082,7 +41177,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.properties.text-box-edge.auto" => CSSFeature {
 		id: "css.properties.text-box-edge.auto",
@@ -41101,7 +41196,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.properties.text-box-trim" => CSSFeature {
 		id: "css.properties.text-box-trim",
@@ -41120,7 +41215,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.properties.text-box-trim.none" => CSSFeature {
 		id: "css.properties.text-box-trim.none",
@@ -41139,7 +41234,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.properties.text-box-trim.trim-both" => CSSFeature {
 		id: "css.properties.text-box-trim.trim-both",
@@ -41158,7 +41253,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.properties.text-box-trim.trim-end" => CSSFeature {
 		id: "css.properties.text-box-trim.trim-end",
@@ -41177,7 +41272,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.properties.text-box-trim.trim-start" => CSSFeature {
 		id: "css.properties.text-box-trim.trim-start",
@@ -41196,7 +41291,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.properties.text-box.normal" => CSSFeature {
 		id: "css.properties.text-box.normal",
@@ -41215,7 +41310,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.types.text-edge" => CSSFeature {
 		id: "css.types.text-edge",
@@ -41234,7 +41329,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.types.text-edge.alphabetic" => CSSFeature {
 		id: "css.types.text-edge.alphabetic",
@@ -41253,7 +41348,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.types.text-edge.cap" => CSSFeature {
 		id: "css.types.text-edge.cap",
@@ -41272,7 +41367,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.types.text-edge.ex" => CSSFeature {
 		id: "css.types.text-edge.ex",
@@ -41291,7 +41386,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.types.text-edge.text" => CSSFeature {
 		id: "css.types.text-edge.text",
@@ -41310,7 +41405,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1261,
+		popularity: 0.1220,
 	},
 	"css.properties.text-combine-upright" => CSSFeature {
 		id: "css.properties.text-combine-upright",
@@ -41329,7 +41424,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 0.2847,
+		popularity: 0.2788,
 	},
 	"css.properties.text-combine-upright.all" => CSSFeature {
 		id: "css.properties.text-combine-upright.all",
@@ -41348,7 +41443,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 0.2847,
+		popularity: 0.2788,
 	},
 	"css.properties.text-combine-upright.none" => CSSFeature {
 		id: "css.properties.text-combine-upright.none",
@@ -41367,7 +41462,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 0.2847,
+		popularity: 0.2788,
 	},
 	"css.properties.text-decoration" => CSSFeature {
 		id: "css.properties.text-decoration",
@@ -41386,7 +41481,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-color" => CSSFeature {
 		id: "css.properties.text-decoration-color",
@@ -41405,7 +41500,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-line" => CSSFeature {
 		id: "css.properties.text-decoration-line",
@@ -41424,7 +41519,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-line.grammar-error" => CSSFeature {
 		id: "css.properties.text-decoration-line.grammar-error",
@@ -41443,7 +41538,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-line.line-through" => CSSFeature {
 		id: "css.properties.text-decoration-line.line-through",
@@ -41462,7 +41557,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-line.none" => CSSFeature {
 		id: "css.properties.text-decoration-line.none",
@@ -41481,7 +41576,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-line.overline" => CSSFeature {
 		id: "css.properties.text-decoration-line.overline",
@@ -41500,7 +41595,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-line.spelling-error" => CSSFeature {
 		id: "css.properties.text-decoration-line.spelling-error",
@@ -41519,7 +41614,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-line.underline" => CSSFeature {
 		id: "css.properties.text-decoration-line.underline",
@@ -41538,7 +41633,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-skip" => CSSFeature {
 		id: "css.properties.text-decoration-skip",
@@ -41557,7 +41652,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-skip-ink" => CSSFeature {
 		id: "css.properties.text-decoration-skip-ink",
@@ -41576,7 +41671,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-skip-ink.all" => CSSFeature {
 		id: "css.properties.text-decoration-skip-ink.all",
@@ -41595,7 +41690,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-skip-ink.auto" => CSSFeature {
 		id: "css.properties.text-decoration-skip-ink.auto",
@@ -41614,7 +41709,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-skip-ink.none" => CSSFeature {
 		id: "css.properties.text-decoration-skip-ink.none",
@@ -41633,7 +41728,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-skip.auto" => CSSFeature {
 		id: "css.properties.text-decoration-skip.auto",
@@ -41652,7 +41747,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-skip.none" => CSSFeature {
 		id: "css.properties.text-decoration-skip.none",
@@ -41671,7 +41766,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-style" => CSSFeature {
 		id: "css.properties.text-decoration-style",
@@ -41690,7 +41785,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-style.wavy" => CSSFeature {
 		id: "css.properties.text-decoration-style.wavy",
@@ -41709,7 +41804,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-thickness" => CSSFeature {
 		id: "css.properties.text-decoration-thickness",
@@ -41728,7 +41823,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-thickness.auto" => CSSFeature {
 		id: "css.properties.text-decoration-thickness.auto",
@@ -41747,7 +41842,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-thickness.from-font" => CSSFeature {
 		id: "css.properties.text-decoration-thickness.from-font",
@@ -41766,7 +41861,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-thickness.percentage" => CSSFeature {
 		id: "css.properties.text-decoration-thickness.percentage",
@@ -41785,7 +41880,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration.includes_color-and-style" => CSSFeature {
 		id: "css.properties.text-decoration.includes_color-and-style",
@@ -41804,7 +41899,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration.includes_thickness" => CSSFeature {
 		id: "css.properties.text-decoration.includes_thickness",
@@ -41823,7 +41918,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.8663,
+		popularity: 83.6775,
 	},
 	"css.properties.text-decoration-line.blink" => CSSFeature {
 		id: "css.properties.text-decoration-line.blink",
@@ -41880,7 +41975,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-color" => CSSFeature {
 		id: "css.properties.text-emphasis-color",
@@ -41899,7 +41994,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-position" => CSSFeature {
 		id: "css.properties.text-emphasis-position",
@@ -41918,7 +42013,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-position.auto" => CSSFeature {
 		id: "css.properties.text-emphasis-position.auto",
@@ -41937,7 +42032,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-position.left" => CSSFeature {
 		id: "css.properties.text-emphasis-position.left",
@@ -41956,7 +42051,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-position.over" => CSSFeature {
 		id: "css.properties.text-emphasis-position.over",
@@ -41975,7 +42070,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-position.right" => CSSFeature {
 		id: "css.properties.text-emphasis-position.right",
@@ -41994,7 +42089,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-position.under" => CSSFeature {
 		id: "css.properties.text-emphasis-position.under",
@@ -42013,7 +42108,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-style" => CSSFeature {
 		id: "css.properties.text-emphasis-style",
@@ -42032,7 +42127,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-style.circle" => CSSFeature {
 		id: "css.properties.text-emphasis-style.circle",
@@ -42051,7 +42146,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-style.dot" => CSSFeature {
 		id: "css.properties.text-emphasis-style.dot",
@@ -42070,7 +42165,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-style.double-circle" => CSSFeature {
 		id: "css.properties.text-emphasis-style.double-circle",
@@ -42089,7 +42184,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-style.filled" => CSSFeature {
 		id: "css.properties.text-emphasis-style.filled",
@@ -42108,7 +42203,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-style.none" => CSSFeature {
 		id: "css.properties.text-emphasis-style.none",
@@ -42127,7 +42222,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-style.sesame" => CSSFeature {
 		id: "css.properties.text-emphasis-style.sesame",
@@ -42146,7 +42241,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-emphasis-style.triangle" => CSSFeature {
 		id: "css.properties.text-emphasis-style.triangle",
@@ -42165,7 +42260,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2112,
+		popularity: 0.3350,
 	},
 	"css.properties.text-indent" => CSSFeature {
 		id: "css.properties.text-indent",
@@ -42184,7 +42279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-indent"],
-		popularity: 35.7330,
+		popularity: 36.4291,
 	},
 	"css.properties.text-indent.each-line" => CSSFeature {
 		id: "css.properties.text-indent.each-line",
@@ -42336,7 +42431,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-orientation"],
-		popularity: 0.6295,
+		popularity: 0.6082,
 	},
 	"css.properties.text-orientation.mixed" => CSSFeature {
 		id: "css.properties.text-orientation.mixed",
@@ -42355,7 +42450,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-orientation"],
-		popularity: 0.6295,
+		popularity: 0.6082,
 	},
 	"css.properties.text-orientation.sideways" => CSSFeature {
 		id: "css.properties.text-orientation.sideways",
@@ -42374,7 +42469,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-orientation"],
-		popularity: 0.6295,
+		popularity: 0.6082,
 	},
 	"css.properties.text-orientation.upright" => CSSFeature {
 		id: "css.properties.text-orientation.upright",
@@ -42393,7 +42488,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-orientation"],
-		popularity: 0.6295,
+		popularity: 0.6082,
 	},
 	"css.properties.text-overflow" => CSSFeature {
 		id: "css.properties.text-overflow",
@@ -42412,7 +42507,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-overflow"],
-		popularity: 65.6972,
+		popularity: 64.7528,
 	},
 	"css.properties.text-overflow.clip" => CSSFeature {
 		id: "css.properties.text-overflow.clip",
@@ -42431,7 +42526,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-overflow"],
-		popularity: 65.6972,
+		popularity: 64.7528,
 	},
 	"css.properties.text-overflow.ellipsis" => CSSFeature {
 		id: "css.properties.text-overflow.ellipsis",
@@ -42450,7 +42545,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-overflow"],
-		popularity: 65.6972,
+		popularity: 64.7528,
 	},
 	"css.properties.text-overflow.two_value_syntax" => CSSFeature {
 		id: "css.properties.text-overflow.two_value_syntax",
@@ -42469,7 +42564,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-overflow"],
-		popularity: 65.6972,
+		popularity: 64.7528,
 	},
 	"css.properties.text-shadow" => CSSFeature {
 		id: "css.properties.text-shadow",
@@ -42488,7 +42583,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-textshadow"],
-		popularity: 45.3359,
+		popularity: 43.3796,
 	},
 	"css.properties.text-size-adjust" => CSSFeature {
 		id: "css.properties.text-size-adjust",
@@ -42507,7 +42602,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/text-size-adjust"],
-		popularity: 22.2072,
+		popularity: 21.4452,
 	},
 	"css.properties.text-size-adjust.auto" => CSSFeature {
 		id: "css.properties.text-size-adjust.auto",
@@ -42526,7 +42621,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/text-size-adjust"],
-		popularity: 22.2072,
+		popularity: 21.4452,
 	},
 	"css.properties.text-size-adjust.none" => CSSFeature {
 		id: "css.properties.text-size-adjust.none",
@@ -42545,7 +42640,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/text-size-adjust"],
-		popularity: 22.2072,
+		popularity: 21.4452,
 	},
 	"css.properties.text-size-adjust.percentages" => CSSFeature {
 		id: "css.properties.text-size-adjust.percentages",
@@ -42564,7 +42659,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/text-size-adjust"],
-		popularity: 22.2072,
+		popularity: 21.4452,
 	},
 	"css.properties.text-spacing-trim" => CSSFeature {
 		id: "css.properties.text-spacing-trim",
@@ -42583,7 +42678,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3709,
+		popularity: 1.8587,
 	},
 	"css.properties.text-spacing-trim.normal" => CSSFeature {
 		id: "css.properties.text-spacing-trim.normal",
@@ -42602,7 +42697,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3709,
+		popularity: 1.8587,
 	},
 	"css.properties.text-spacing-trim.space-all" => CSSFeature {
 		id: "css.properties.text-spacing-trim.space-all",
@@ -42621,7 +42716,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3709,
+		popularity: 1.8587,
 	},
 	"css.properties.text-spacing-trim.space-first" => CSSFeature {
 		id: "css.properties.text-spacing-trim.space-first",
@@ -42640,7 +42735,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3709,
+		popularity: 1.8587,
 	},
 	"css.properties.text-spacing-trim.trim-start" => CSSFeature {
 		id: "css.properties.text-spacing-trim.trim-start",
@@ -42659,7 +42754,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3709,
+		popularity: 1.8587,
 	},
 	"css.properties.-webkit-text-fill-color" => CSSFeature {
 		id: "css.properties.-webkit-text-fill-color",
@@ -42754,7 +42849,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.capitalize" => CSSFeature {
 		id: "css.properties.text-transform.capitalize",
@@ -42773,7 +42868,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.dutch_ij_digraph" => CSSFeature {
 		id: "css.properties.text-transform.dutch_ij_digraph",
@@ -42792,7 +42887,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.full-size-kana" => CSSFeature {
 		id: "css.properties.text-transform.full-size-kana",
@@ -42811,7 +42906,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.full-width" => CSSFeature {
 		id: "css.properties.text-transform.full-width",
@@ -42830,7 +42925,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.greek_accented_characters" => CSSFeature {
 		id: "css.properties.text-transform.greek_accented_characters",
@@ -42849,7 +42944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.lowercase" => CSSFeature {
 		id: "css.properties.text-transform.lowercase",
@@ -42868,7 +42963,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.lowercase_sigma" => CSSFeature {
 		id: "css.properties.text-transform.lowercase_sigma",
@@ -42887,7 +42982,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.none" => CSSFeature {
 		id: "css.properties.text-transform.none",
@@ -42906,7 +43001,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.turkic_is" => CSSFeature {
 		id: "css.properties.text-transform.turkic_is",
@@ -42925,7 +43020,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.uppercase" => CSSFeature {
 		id: "css.properties.text-transform.uppercase",
@@ -42944,7 +43039,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-transform.uppercase_eszett" => CSSFeature {
 		id: "css.properties.text-transform.uppercase_eszett",
@@ -42963,7 +43058,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.6412,
+		popularity: 71.9763,
 	},
 	"css.properties.text-underline-offset" => CSSFeature {
 		id: "css.properties.text-underline-offset",
@@ -42982,7 +43077,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 14.7911,
+		popularity: 14.3589,
 	},
 	"css.properties.text-underline-offset.auto" => CSSFeature {
 		id: "css.properties.text-underline-offset.auto",
@@ -43001,7 +43096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 14.7911,
+		popularity: 14.3589,
 	},
 	"css.properties.text-underline-offset.percentage" => CSSFeature {
 		id: "css.properties.text-underline-offset.percentage",
@@ -43020,7 +43115,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 14.7911,
+		popularity: 14.3589,
 	},
 	"css.properties.text-underline-position" => CSSFeature {
 		id: "css.properties.text-underline-position",
@@ -43039,7 +43134,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 3.9499,
+		popularity: 4.4688,
 	},
 	"css.properties.text-underline-position.auto" => CSSFeature {
 		id: "css.properties.text-underline-position.auto",
@@ -43058,7 +43153,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 3.9499,
+		popularity: 4.4688,
 	},
 	"css.properties.text-underline-position.from-font" => CSSFeature {
 		id: "css.properties.text-underline-position.from-font",
@@ -43077,7 +43172,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 3.9499,
+		popularity: 4.4688,
 	},
 	"css.properties.text-underline-position.left" => CSSFeature {
 		id: "css.properties.text-underline-position.left",
@@ -43096,7 +43191,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 3.9499,
+		popularity: 4.4688,
 	},
 	"css.properties.text-underline-position.right" => CSSFeature {
 		id: "css.properties.text-underline-position.right",
@@ -43115,7 +43210,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 3.9499,
+		popularity: 4.4688,
 	},
 	"css.properties.text-underline-position.under" => CSSFeature {
 		id: "css.properties.text-underline-position.under",
@@ -43134,7 +43229,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 3.9499,
+		popularity: 4.4688,
 	},
 	"css.properties.text-wrap" => CSSFeature {
 		id: "css.properties.text-wrap",
@@ -43153,7 +43248,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 18.7854,
+		popularity: 20.0779,
 	},
 	"css.properties.text-wrap.wrap" => CSSFeature {
 		id: "css.properties.text-wrap.wrap",
@@ -43172,7 +43267,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 18.7854,
+		popularity: 20.0779,
 	},
 	"css.properties.text-wrap.balance" => CSSFeature {
 		id: "css.properties.text-wrap.balance",
@@ -43210,7 +43305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 3.4922,
+		popularity: 3.4176,
 	},
 	"css.properties.text-wrap-mode.nowrap" => CSSFeature {
 		id: "css.properties.text-wrap-mode.nowrap",
@@ -43229,7 +43324,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 3.4922,
+		popularity: 3.4176,
 	},
 	"css.properties.text-wrap-mode.wrap" => CSSFeature {
 		id: "css.properties.text-wrap-mode.wrap",
@@ -43248,7 +43343,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 3.4922,
+		popularity: 3.4176,
 	},
 	"css.properties.text-wrap.nowrap" => CSSFeature {
 		id: "css.properties.text-wrap.nowrap",
@@ -43324,7 +43419,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1016,
+		popularity: 0.0909,
 	},
 	"css.properties.text-wrap-style.auto" => CSSFeature {
 		id: "css.properties.text-wrap-style.auto",
@@ -43343,7 +43438,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1016,
+		popularity: 0.0909,
 	},
 	"css.properties.text-wrap-style.balance" => CSSFeature {
 		id: "css.properties.text-wrap-style.balance",
@@ -43362,7 +43457,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1016,
+		popularity: 0.0909,
 	},
 	"css.properties.text-wrap-style.pretty" => CSSFeature {
 		id: "css.properties.text-wrap-style.pretty",
@@ -43381,7 +43476,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1016,
+		popularity: 0.0909,
 	},
 	"css.properties.text-wrap-style.stable" => CSSFeature {
 		id: "css.properties.text-wrap-style.stable",
@@ -43400,7 +43495,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1016,
+		popularity: 0.0909,
 	},
 	"css.selectors.future" => CSSFeature {
 		id: "css.selectors.future",
@@ -43457,7 +43552,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.touch-action.manipulation" => CSSFeature {
 		id: "css.properties.touch-action.manipulation",
@@ -43476,7 +43571,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.touch-action.none" => CSSFeature {
 		id: "css.properties.touch-action.none",
@@ -43495,7 +43590,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.touch-action.pan-down" => CSSFeature {
 		id: "css.properties.touch-action.pan-down",
@@ -43514,7 +43609,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.touch-action.pan-left" => CSSFeature {
 		id: "css.properties.touch-action.pan-left",
@@ -43533,7 +43628,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.touch-action.pan-right" => CSSFeature {
 		id: "css.properties.touch-action.pan-right",
@@ -43552,7 +43647,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.touch-action.pan-up" => CSSFeature {
 		id: "css.properties.touch-action.pan-up",
@@ -43571,7 +43666,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.touch-action.pan-x" => CSSFeature {
 		id: "css.properties.touch-action.pan-x",
@@ -43590,7 +43685,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.touch-action.pan-y" => CSSFeature {
 		id: "css.properties.touch-action.pan-y",
@@ -43609,7 +43704,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.touch-action.pinch-zoom" => CSSFeature {
 		id: "css.properties.touch-action.pinch-zoom",
@@ -43628,7 +43723,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 42.1965,
+		popularity: 41.0963,
 	},
 	"css.properties.transform-box" => CSSFeature {
 		id: "css.properties.transform-box",
@@ -43647,7 +43742,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 2.8964,
+		popularity: 3.4252,
 	},
 	"css.properties.transform-box.border-box" => CSSFeature {
 		id: "css.properties.transform-box.border-box",
@@ -43666,7 +43761,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 2.8964,
+		popularity: 3.4252,
 	},
 	"css.properties.transform-box.content-box" => CSSFeature {
 		id: "css.properties.transform-box.content-box",
@@ -43685,7 +43780,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 2.8964,
+		popularity: 3.4252,
 	},
 	"css.properties.transform-box.fill-box" => CSSFeature {
 		id: "css.properties.transform-box.fill-box",
@@ -43704,7 +43799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 2.8964,
+		popularity: 3.4252,
 	},
 	"css.properties.transform-box.stroke-box" => CSSFeature {
 		id: "css.properties.transform-box.stroke-box",
@@ -43723,7 +43818,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 2.8964,
+		popularity: 3.4252,
 	},
 	"css.properties.transform-box.view-box" => CSSFeature {
 		id: "css.properties.transform-box.view-box",
@@ -43742,7 +43837,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 2.8964,
+		popularity: 3.4252,
 	},
 	"css.properties.transform" => CSSFeature {
 		id: "css.properties.transform",
@@ -44730,7 +44825,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 0.4578,
+		popularity: 0.5736,
 	},
 	"css.properties.transition.transition-behavior" => CSSFeature {
 		id: "css.properties.transition.transition-behavior",
@@ -44749,7 +44844,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 0.4578,
+		popularity: 0.5736,
 	},
 	"css.properties.transition" => CSSFeature {
 		id: "css.properties.transition",
@@ -45300,7 +45395,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 66.1774,
+		popularity: 66.2449,
 	},
 	"css.properties.user-select.all" => CSSFeature {
 		id: "css.properties.user-select.all",
@@ -45319,7 +45414,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 66.1774,
+		popularity: 66.2449,
 	},
 	"css.properties.user-select.auto" => CSSFeature {
 		id: "css.properties.user-select.auto",
@@ -45338,7 +45433,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 66.1774,
+		popularity: 66.2449,
 	},
 	"css.properties.user-select.none" => CSSFeature {
 		id: "css.properties.user-select.none",
@@ -45357,7 +45452,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 66.1774,
+		popularity: 66.2449,
 	},
 	"css.properties.user-select.text" => CSSFeature {
 		id: "css.properties.user-select.text",
@@ -45376,7 +45471,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 66.1774,
+		popularity: 66.2449,
 	},
 	"css.properties.vertical-align" => CSSFeature {
 		id: "css.properties.vertical-align",
@@ -45395,7 +45490,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.6350,
+		popularity: 81.8009,
 	},
 	"css.properties.vertical-align.baseline" => CSSFeature {
 		id: "css.properties.vertical-align.baseline",
@@ -45414,7 +45509,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.6350,
+		popularity: 81.8009,
 	},
 	"css.properties.vertical-align.bottom" => CSSFeature {
 		id: "css.properties.vertical-align.bottom",
@@ -45433,7 +45528,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.6350,
+		popularity: 81.8009,
 	},
 	"css.properties.vertical-align.middle" => CSSFeature {
 		id: "css.properties.vertical-align.middle",
@@ -45452,7 +45547,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.6350,
+		popularity: 81.8009,
 	},
 	"css.properties.vertical-align.sub" => CSSFeature {
 		id: "css.properties.vertical-align.sub",
@@ -45471,7 +45566,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.6350,
+		popularity: 81.8009,
 	},
 	"css.properties.vertical-align.super" => CSSFeature {
 		id: "css.properties.vertical-align.super",
@@ -45490,7 +45585,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.6350,
+		popularity: 81.8009,
 	},
 	"css.properties.vertical-align.text-bottom" => CSSFeature {
 		id: "css.properties.vertical-align.text-bottom",
@@ -45509,7 +45604,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.6350,
+		popularity: 81.8009,
 	},
 	"css.properties.vertical-align.text-top" => CSSFeature {
 		id: "css.properties.vertical-align.text-top",
@@ -45528,7 +45623,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.6350,
+		popularity: 81.8009,
 	},
 	"css.properties.vertical-align.top" => CSSFeature {
 		id: "css.properties.vertical-align.top",
@@ -45547,7 +45642,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.6350,
+		popularity: 81.8009,
 	},
 	"css.properties.direction.vertical_slider_direction" => CSSFeature {
 		id: "css.properties.direction.vertical_slider_direction",
@@ -45623,7 +45718,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.0572,
+		popularity: 0.0631,
 	},
 	"css.properties.view-transition-class.none" => CSSFeature {
 		id: "css.properties.view-transition-class.none",
@@ -45642,7 +45737,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.0572,
+		popularity: 0.0631,
 	},
 	"css.properties.view-transition-name" => CSSFeature {
 		id: "css.properties.view-transition-name",
@@ -46136,7 +46231,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 75.7945,
+		popularity: 75.9642,
 	},
 	"css.properties.visibility.collapse" => CSSFeature {
 		id: "css.properties.visibility.collapse",
@@ -46155,7 +46250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 75.7945,
+		popularity: 75.9642,
 	},
 	"css.properties.visibility.hidden" => CSSFeature {
 		id: "css.properties.visibility.hidden",
@@ -46174,7 +46269,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 75.7945,
+		popularity: 75.9642,
 	},
 	"css.properties.visibility.visible" => CSSFeature {
 		id: "css.properties.visibility.visible",
@@ -46193,7 +46288,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 75.7945,
+		popularity: 75.9642,
 	},
 	"css.selectors.cue" => CSSFeature {
 		id: "css.selectors.cue",
@@ -46307,7 +46402,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space.break-spaces" => CSSFeature {
 		id: "css.properties.white-space.break-spaces",
@@ -46326,7 +46421,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space.normal" => CSSFeature {
 		id: "css.properties.white-space.normal",
@@ -46345,7 +46440,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space.nowrap" => CSSFeature {
 		id: "css.properties.white-space.nowrap",
@@ -46364,7 +46459,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space.pre" => CSSFeature {
 		id: "css.properties.white-space.pre",
@@ -46383,7 +46478,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space.pre-line" => CSSFeature {
 		id: "css.properties.white-space.pre-line",
@@ -46402,7 +46497,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space.pre-wrap" => CSSFeature {
 		id: "css.properties.white-space.pre-wrap",
@@ -46421,7 +46516,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space.shorthand_values" => CSSFeature {
 		id: "css.properties.white-space.shorthand_values",
@@ -46440,7 +46535,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space.svg_elements" => CSSFeature {
 		id: "css.properties.white-space.svg_elements",
@@ -46459,7 +46554,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space.textarea_support" => CSSFeature {
 		id: "css.properties.white-space.textarea_support",
@@ -46478,7 +46573,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2999,
+		popularity: 81.1637,
 	},
 	"css.properties.white-space-collapse" => CSSFeature {
 		id: "css.properties.white-space-collapse",
@@ -46497,7 +46592,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1948,
+		popularity: 1.4915,
 	},
 	"css.properties.white-space-collapse.break-spaces" => CSSFeature {
 		id: "css.properties.white-space-collapse.break-spaces",
@@ -46516,7 +46611,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1948,
+		popularity: 1.4915,
 	},
 	"css.properties.white-space-collapse.collapse" => CSSFeature {
 		id: "css.properties.white-space-collapse.collapse",
@@ -46535,7 +46630,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1948,
+		popularity: 1.4915,
 	},
 	"css.properties.white-space-collapse.preserve" => CSSFeature {
 		id: "css.properties.white-space-collapse.preserve",
@@ -46554,7 +46649,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1948,
+		popularity: 1.4915,
 	},
 	"css.properties.white-space-collapse.preserve-breaks" => CSSFeature {
 		id: "css.properties.white-space-collapse.preserve-breaks",
@@ -46573,7 +46668,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1948,
+		popularity: 1.4915,
 	},
 	"css.properties.white-space-collapse.preserve-spaces" => CSSFeature {
 		id: "css.properties.white-space-collapse.preserve-spaces",
@@ -46592,7 +46687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1948,
+		popularity: 1.4915,
 	},
 	"css.properties.orphans" => CSSFeature {
 		id: "css.properties.orphans",
@@ -46820,7 +46915,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/will-change"],
-		popularity: 37.0161,
+		popularity: 37.1138,
 	},
 	"css.properties.will-change.auto" => CSSFeature {
 		id: "css.properties.will-change.auto",
@@ -46839,7 +46934,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/will-change"],
-		popularity: 37.0161,
+		popularity: 37.1138,
 	},
 	"css.properties.will-change.contents" => CSSFeature {
 		id: "css.properties.will-change.contents",
@@ -46858,7 +46953,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/will-change"],
-		popularity: 37.0161,
+		popularity: 37.1138,
 	},
 	"css.properties.will-change.scroll-position" => CSSFeature {
 		id: "css.properties.will-change.scroll-position",
@@ -46877,7 +46972,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/will-change"],
-		popularity: 37.0161,
+		popularity: 37.1138,
 	},
 	"css.types.env.titlebar-area-height" => CSSFeature {
 		id: "css.types.env.titlebar-area-height",
@@ -46972,7 +47067,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/word-break"],
-		popularity: 55.8510,
+		popularity: 55.3359,
 	},
 	"css.properties.word-break.break-all" => CSSFeature {
 		id: "css.properties.word-break.break-all",
@@ -46991,7 +47086,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/word-break"],
-		popularity: 55.8510,
+		popularity: 55.3359,
 	},
 	"css.properties.word-break.keep-all" => CSSFeature {
 		id: "css.properties.word-break.keep-all",
@@ -47010,7 +47105,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/word-break"],
-		popularity: 55.8510,
+		popularity: 55.3359,
 	},
 	"css.properties.word-break.normal" => CSSFeature {
 		id: "css.properties.word-break.normal",
@@ -47029,7 +47124,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/word-break"],
-		popularity: 55.8510,
+		popularity: 55.3359,
 	},
 	"css.properties.word-break.auto-phrase" => CSSFeature {
 		id: "css.properties.word-break.auto-phrase",
@@ -47086,7 +47181,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 12.3387,
+		popularity: 12.1302,
 	},
 	"css.properties.word-spacing.normal" => CSSFeature {
 		id: "css.properties.word-spacing.normal",
@@ -47105,7 +47200,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 12.3387,
+		popularity: 12.1302,
 	},
 	"css.properties.writing-mode" => CSSFeature {
 		id: "css.properties.writing-mode",
@@ -47124,7 +47219,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.2783,
+		popularity: 6.8036,
 	},
 	"css.properties.writing-mode.horizontal-tb" => CSSFeature {
 		id: "css.properties.writing-mode.horizontal-tb",
@@ -47143,7 +47238,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.2783,
+		popularity: 6.8036,
 	},
 	"css.properties.writing-mode.sideways-lr" => CSSFeature {
 		id: "css.properties.writing-mode.sideways-lr",
@@ -47162,7 +47257,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.2783,
+		popularity: 6.8036,
 	},
 	"css.properties.writing-mode.sideways-rl" => CSSFeature {
 		id: "css.properties.writing-mode.sideways-rl",
@@ -47181,7 +47276,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.2783,
+		popularity: 6.8036,
 	},
 	"css.properties.writing-mode.vertical-lr" => CSSFeature {
 		id: "css.properties.writing-mode.vertical-lr",
@@ -47200,7 +47295,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.2783,
+		popularity: 6.8036,
 	},
 	"css.properties.writing-mode.vertical-rl" => CSSFeature {
 		id: "css.properties.writing-mode.vertical-rl",
@@ -47219,7 +47314,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.2783,
+		popularity: 6.8036,
 	},
 	"css.properties.writing-mode.lr" => CSSFeature {
 		id: "css.properties.writing-mode.lr",
@@ -47352,7 +47447,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.4338,
+		popularity: 85.2387,
 	},
 	"css.properties.z-index.auto" => CSSFeature {
 		id: "css.properties.z-index.auto",
@@ -47371,7 +47466,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.4338,
+		popularity: 85.2387,
 	},
 	"css.properties.z-index.negative_values" => CSSFeature {
 		id: "css.properties.z-index.negative_values",
@@ -47390,7 +47485,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.4338,
+		popularity: 85.2387,
 	},
 	"css.types.integer" => CSSFeature {
 		id: "css.types.integer",
@@ -47409,7 +47504,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.4338,
+		popularity: 85.2387,
 	},
 	"css.properties.zoom" => CSSFeature {
 		id: "css.properties.zoom",
@@ -47428,7 +47523,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,0),
 				},
 		caniuse: &["https://caniuse.com/css-zoom"],
-		popularity: 31.0991,
+		popularity: 31.2276,
 	},
 };
 
@@ -50285,6 +50380,13 @@ pub static SPECS: Map<&'static str, &'static [&'static str]> = phf_map! {
 	],
 	"https://drafts.csswg.org/css-ui-4/#insertion-caret" => &[
 		"css.properties.caret-color",
+	],
+	"https://drafts.csswg.org/css-ui-4/#propdef-caret-shape" => &[
+		"css.properties.caret-shape",
+		"css.properties.caret-shape.auto",
+		"css.properties.caret-shape.bar",
+		"css.properties.caret-shape.block",
+		"css.properties.caret-shape.underscore",
 	],
 	"https://drafts.csswg.org/css-cascade-5/" => &[
 		"css.at-rules.import.layer",

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -93,7 +93,7 @@ pub trait BooleanFeature<'a>: Sized {
 /// boolean_feature! {
 ///     /// A boolean media feature: `(test-feature)`
 ///     #[derive(ToCursors, ToSpan, Debug)]
-///     pub enum TestFeature<MyAtomSet::TestFeature>
+///     pub enum TestFeature{MyAtomSet::TestFeature}
 /// }
 ///
 /// // Test!
@@ -109,7 +109,7 @@ pub trait BooleanFeature<'a>: Sized {
 ///
 #[macro_export]
 macro_rules! boolean_feature {
-	($(#[$meta:meta])* $vis:vis enum $feature: ident<$feature_name: path>) => {
+	($(#[$meta:meta])* $vis:vis enum $feature: ident{$feature_name: path}) => {
 		$(#[$meta])*
 		$vis enum $feature {
 			WithValue($crate::T!['('], $crate::T![Ident], $crate::T![:], $crate::T![Any], $crate::T![')']),

--- a/crates/css_parse/src/traits/discrete_feature.rs
+++ b/crates/css_parse/src/traits/discrete_feature.rs
@@ -93,7 +93,7 @@ pub trait DiscreteFeature<'a>: Sized {
 /// discrete_feature! {
 ///     /// A discrete media feature: `(test-feature: big)`, `(test-feature: small)`
 ///     #[derive(ToCursors, ToSpan, Debug)]
-///     pub enum TestFeature<MyLangAtoms::TestFeature, T![Ident]>
+///     pub enum TestFeature{MyLangAtoms::TestFeature, T![Ident]}
 /// }
 ///
 /// // Test!
@@ -103,7 +103,7 @@ pub trait DiscreteFeature<'a>: Sized {
 ///
 #[macro_export]
 macro_rules! discrete_feature {
-	($(#[$meta:meta])* $vis:vis enum $feature: ident<$feature_name: path, $value: ty>) => {
+	($(#[$meta:meta])* $vis:vis enum $feature: ident{$feature_name: path, $value: ty}) => {
 		$(#[$meta])*
 		$vis enum $feature {
 			WithValue($crate::T!['('], $crate::T![Ident], $crate::T![:], $value, $crate::T![')']),

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -214,7 +214,7 @@ pub trait RangedFeature<'a>: Sized {
 /// ranged_feature! {
 ///   /// A ranged media feature: (thing: 1), or (1 <= thing < 10)
 ///   #[derive(ToCursors, ToSpan, Debug)]
-///   pub enum TestFeature<MyAtomSet::Thing, T![Number]>
+///   pub enum TestFeature{MyAtomSet::Thing, T![Number]}
 /// }
 ///
 /// // Test!
@@ -252,7 +252,7 @@ pub trait RangedFeature<'a>: Sized {
 /// ranged_feature! {
 ///   /// A ranged media feature: (thing: 1), or (1 <= thing < 10)
 ///   #[derive(Debug, ToCursors, ToSpan)]
-///   pub enum TestFeature<MyAtomSet::Thing | MyAtomSet::MinThing | MyAtomSet::MaxThing, T![Number]>
+///   pub enum TestFeature{MyAtomSet::Thing | MyAtomSet::MinThing | MyAtomSet::MaxThing, T![Number]}
 /// }
 ///
 /// // Test!
@@ -273,7 +273,7 @@ macro_rules! ranged_feature {
 	(@parse_call $p:ident, $feature_name:path, $min_name:path, $max_name:path) => {
 		Self::parse_ranged_feature($p, &$feature_name, Some(&$min_name), Some(&$max_name))
 	};
-	($(#[$meta:meta])* $vis:vis enum $feature: ident<$feature_name: path $(| $min_name: path | $max_name: path)?, $value: ty>) => {
+	($(#[$meta:meta])* $vis:vis enum $feature: ident{$feature_name: path $(| $min_name: path | $max_name: path)?, $value: ty}) => {
 		$(#[$meta])*
 		$vis enum $feature {
 			Left($crate::T!['('], T![Ident], $crate::Comparison, $value, $crate::T![')']),

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 css_lexer = { workspace = true }
-css_ast = { workspace = true, features = ["chromashift"] }
+css_ast = { workspace = true, features = ["chromashift", "visitable"] }
 css_parse = { workspace = true }
 csskit_lsp = { workspace = true }
 csskit_highlight = { workspace = true, features = ["ansi"] }

--- a/crates/csskit_highlight/Cargo.toml
+++ b/crates/csskit_highlight/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 bench = false
 
 [dependencies]
-css_ast = { workspace = true, features = ["chromashift"] }
+css_ast = { workspace = true, features = ["chromashift", "visitable"] }
 css_lexer = { workspace = true }
 css_parse = { workspace = true }
 chromashift = { workspace = true }

--- a/crates/csskit_lsp/Cargo.toml
+++ b/crates/csskit_lsp/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 
 [dependencies]
 css_parse = { workspace = true }
-css_ast = { workspace = true }
+css_ast = { workspace = true, features = ["visitable"] }
 css_lexer = { workspace = true }
 csskit_highlight = { workspace = true }
 

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -251,7 +251,7 @@ impl Def {
 
 	fn type_attributes(&self, derives_parse: bool, derives_visitable: bool) -> TokenStream {
 		let skip = if derives_visitable && self.should_skip_visit() {
-			quote! { #[visit(skip)] }
+			quote! { #[cfg_attr(feature = "visitable", visit(skip))] }
 		} else {
 			quote! {}
 		};
@@ -390,10 +390,9 @@ impl Def {
 					::csskit_derives::Peek,
 					::csskit_derives::ToCursors,
 					::csskit_derives::ToSpan,
-					::csskit_derives::Visitable,
 					Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 				#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-				#[visit(skip)]
+				#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(skip))]
 				pub enum #keyword_name {
 					#(#keywords)*
 				}
@@ -416,9 +415,9 @@ impl Def {
 						let generics = defs.get_generics();
 						let def = defs.generate_definition(vis, &ident, &generics, true, true);
 						quote! {
-							#[derive(::csskit_derives::Parse, ::csskit_derives::Peek, ::csskit_derives::ToSpan, ::csskit_derives::ToCursors, ::csskit_derives::Visitable, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+							#[derive(::csskit_derives::Parse, ::csskit_derives::Peek, ::csskit_derives::ToSpan, ::csskit_derives::ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 							#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-							#[visit(children)]
+							#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
 							#def
 						}
 					}

--- a/crates/csskit_proc_macro/src/syntax.rs
+++ b/crates/csskit_proc_macro/src/syntax.rs
@@ -6,14 +6,15 @@ use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Meta, Token
 use crate::def::*;
 use crate::generate::*;
 
-/// Check if derive(Visitable) is present in the attributes
 fn has_derive_of(attrs: &[Attribute], name: &'static str) -> bool {
 	for attr in attrs {
 		if attr.path().is_ident("derive") {
 			let nested = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated).unwrap_or_default();
 			for meta in nested {
 				match meta {
-					Meta::Path(path) if path.is_ident(name) => {
+					Meta::Path(path)
+						if path.is_ident(name) || path.segments.last().map(|s| s.ident == name).unwrap_or(false) =>
+					{
 						return true;
 					}
 					_ => {}

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none.snap
@@ -1,13 +1,14 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
+assertion_line: 352
 expression: pretty
 ---
 #[derive(Parse, Visitable)]
 enum Foo {
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Auto)]
     Auto(::css_parse::T![Ident]),
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::None)]
     None(::css_parse::T![Ident]),
 }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_multiplier_of_keywords.snap
@@ -7,7 +7,6 @@ expression: pretty
     ::csskit_derives::Peek,
     ::csskit_derives::ToCursors,
     ::csskit_derives::ToSpan,
-    ::csskit_derives::Visitable,
     Debug,
     Copy,
     Clone,
@@ -18,7 +17,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(skip))]
 pub enum FooKeywords {
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
@@ -26,4 +25,9 @@ pub enum FooKeywords {
     Bar(::css_parse::T![Ident]),
 }
 #[derive(Visitable, Parse)]
-struct Foo<'a>(#[visit(skip)] pub FooKeywords, #[visit(skip)] pub Option<FooKeywords>);
+struct Foo<'a>(
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    pub FooKeywords,
+    #[cfg_attr(feature = "visitable", visit(skip))]
+    pub Option<FooKeywords>,
+);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional2_keyword.snap
@@ -1,16 +1,17 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
+assertion_line: 275
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
 enum Foo {
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     Bar(
         Option<crate::Color>,
         Option<crate::Color>,
-        #[visit(skip)]
+        #[cfg_attr(feature = "visitable", visit(skip))]
         #[atom(CssAtomSet::Bar)]
         ::css_parse::T![Ident],
     ),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords.snap
@@ -1,17 +1,18 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
+assertion_line: 289
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
 #[parse(one_must_occur)]
 struct Foo {
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     pub foo: Option<::css_parse::T![Ident]>,
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Bar)]
     pub bar: Option<::css_parse::T![Ident]>,
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Baz)]
     pub baz: Option<::css_parse::T![Ident]>,
 }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords_with_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords_with_derive_parse.snap
@@ -1,17 +1,18 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
+assertion_line: 296
 expression: pretty
 ---
 #[derive(Parse, Visitable)]
 #[parse(one_must_occur)]
 struct Foo {
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     pub foo: Option<::css_parse::T![Ident]>,
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Bar)]
     pub bar: Option<::css_parse::T![Ident]>,
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Baz)]
     pub baz: Option<::css_parse::T![Ident]>,
 }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_keyword.snap
@@ -1,15 +1,16 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
+assertion_line: 261
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
 enum Foo {
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     Bar(
         Option<crate::Color>,
-        #[visit(skip)]
+        #[cfg_attr(feature = "visitable", visit(skip))]
         #[atom(CssAtomSet::Bar)]
         ::css_parse::T![Ident],
     ),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_last_keyword.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
+assertion_line: 268
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
 enum Foo {
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     Bar(
-        #[visit(skip)]
+        #[cfg_attr(feature = "visitable", visit(skip))]
         #[atom(CssAtomSet::Bar)]
         ::css_parse::T![Ident],
         Option<crate::Color>,

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_keywords.snap
@@ -7,7 +7,6 @@ expression: pretty
     ::csskit_derives::Peek,
     ::csskit_derives::ToCursors,
     ::csskit_derives::ToSpan,
-    ::csskit_derives::Visitable,
     Debug,
     Copy,
     Clone,
@@ -18,7 +17,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(skip))]
 pub enum FooKeywords {
     #[atom(CssAtomSet::Outset)]
     Outset(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_types.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_types.snap
@@ -7,7 +7,6 @@ expression: pretty
     ::csskit_derives::Peek,
     ::csskit_derives::ToSpan,
     ::csskit_derives::ToCursors,
-    ::csskit_derives::Visitable,
     Debug,
     Clone,
     PartialEq,
@@ -17,9 +16,9 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(children)]
+#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
 enum SingleFoo {
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     Bar(crate::Bar),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_just_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_just_keywords.snap
@@ -7,7 +7,6 @@ expression: pretty
     ::csskit_derives::Peek,
     ::csskit_derives::ToCursors,
     ::csskit_derives::ToSpan,
-    ::csskit_derives::Visitable,
     Debug,
     Copy,
     Clone,
@@ -18,7 +17,7 @@ expression: pretty
     Hash
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[visit(skip)]
+#[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(skip))]
 pub enum FooKeywords {
     #[atom(CssAtomSet::Outset)]
     Outset(::css_parse::T![Ident]),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_auto_color2_optimized.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
+assertion_line: 226
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
 enum Foo {
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     Color(crate::Color, crate::Color),

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_visitable_adds_attributes.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_visitable_adds_attributes.snap
@@ -1,13 +1,14 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
+assertion_line: 212
 expression: pretty
 ---
 #[derive(Parse, Visitable)]
 enum Foo {
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
-    #[visit(skip)]
+    #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Bar)]
     Bar(::css_parse::T![Ident]),
 }

--- a/crates/csskit_source_finder/src/lib.rs
+++ b/crates/csskit_source_finder/src/lib.rs
@@ -48,8 +48,11 @@ pub fn find_visitable_nodes(dir: &str, matches: &mut HashSet<String>, path_callb
 		.ignore_whitespace(true)
 		.build(
 			r#"
+			^\s*\#\[
+			# munch `cfg_atr(...,` and optional `derive(...)`.
+			(?:cfg_attr\([^,]+,\s*(?:derive\([^\)]+\),\s*)?)?
 			# match the #[visit] attribute
-			^\s*\#\[(visit)
+			(visit)
 			# munch the data between the attribute and the definition
 			.*?
 			(
@@ -58,8 +61,8 @@ pub fn find_visitable_nodes(dir: &str, matches: &mut HashSet<String>, path_callb
 			)
 			# munch any comments/attributes between this and our name (for macros)
 			(:?\n?\s*(:?\/\/|\#)[^\n]*)*
-			# finally grab the word (plus any lifetime definition)
-			\s*(\w*(:?<'a>)?)"#,
+			# finally grab the word (plus any generics)
+			\s*(\w*(:?<[^>]+>)?)"#,
 		)
 		.unwrap();
 	let mut searcher = SearcherBuilder::new().line_number(false).multi_line(true).build();

--- a/crates/csskit_transform/Cargo.toml
+++ b/crates/csskit_transform/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 bench = false
 
 [dependencies]
-css_ast = { workspace = true }
+css_ast = { workspace = true, features = ["visitable"] }
 
 [dev-dependencies]
 css_parse = { workspace = true }


### PR DESCRIPTION
The Visitable feature generates quite a lot of code which contributes to:

 - Slower build times
 - Difficulty debugging sometimes

In order to improve this, I set about making Visit gated behind a `visitable` feature flag. It was... a lot. I kind of
regret started it given how many files it touched, but it's done now and I'm not undoing it.