### PR TITLE
chromashift: Add ability to extract alpha, TryInto named color

### DIFF
--- a/crates/chromashift/src/a98_rgb.rs
+++ b/crates/chromashift/src/a98_rgb.rs
@@ -1,4 +1,4 @@
-use crate::{LinearRgb, round_dp};
+use crate::{LinearRgb, ToAlpha, round_dp};
 use core::fmt;
 
 /// An RGB colour space with defined chromacities.
@@ -23,6 +23,12 @@ impl A98Rgb {
 			blue: blue.clamp(0.0, 1.0),
 			alpha: alpha.clamp(0.0, 100.0),
 		}
+	}
+}
+
+impl ToAlpha for A98Rgb {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/channels.rs
+++ b/crates/chromashift/src/channels.rs
@@ -1,0 +1,15 @@
+/// Trait for extracting the alpha channel of a color.
+pub trait ToAlpha: Sized {
+	/// Returns a number between 0.0 (fully transparent) to 100.0 (fully opaque).
+	fn to_alpha(&self) -> f32;
+
+	/// Returns true if the alpha of this colour is 100.0
+	fn fully_opaque(&self) -> bool {
+		self.to_alpha() == 100.0
+	}
+
+	/// Returns true if the alpha of this colour is 0.0
+	fn fully_transparent(&self) -> bool {
+		self.to_alpha() == 0.0
+	}
+}

--- a/crates/chromashift/src/conversion.rs
+++ b/crates/chromashift/src/conversion.rs
@@ -191,6 +191,36 @@ simple_from!(Color to Oklch, via XyzD65);
 simple_from!(Color to Srgb, via XyzD65);
 simple_from!(Color to XyzD50, via XyzD65);
 
+macro_rules! impl_named_try_from_via_srgb {
+	($($ty:path),+ $(,)?) => {
+		$(
+			impl TryFrom<$ty> for Named {
+				type Error = ToNamedError;
+
+				fn try_from(value: $ty) -> Result<Self, Self::Error> {
+					Self::try_from(Srgb::from(value))
+				}
+			}
+		)+
+	};
+}
+
+impl_named_try_from_via_srgb!(
+	crate::A98Rgb,
+	crate::Hex,
+	crate::Hsv,
+	crate::Hsl,
+	crate::Hwb,
+	crate::Lab,
+	crate::Lch,
+	crate::LinearRgb,
+	crate::Oklab,
+	crate::Oklch,
+	crate::XyzD50,
+	crate::XyzD65,
+	crate::Color,
+);
+
 #[cfg(feature = "anstyle")]
 simple_from!(Color to anstyle::RgbColor, via Srgb);
 #[cfg(feature = "anstyle")]

--- a/crates/chromashift/src/hex.rs
+++ b/crates/chromashift/src/hex.rs
@@ -1,4 +1,4 @@
-use crate::Srgb;
+use crate::{Srgb, ToAlpha};
 use core::fmt;
 
 /// An Hex representation of the sRGB colour space.
@@ -29,6 +29,12 @@ impl Hex {
 
 	pub const fn has_alpha(&self) -> bool {
 		self.0 & 0xFF != 0xFF
+	}
+}
+
+impl ToAlpha for Hex {
+	fn to_alpha(&self) -> f32 {
+		((self.0 & 0xFF) as f32 / 255.0) * 100.0
 	}
 }
 

--- a/crates/chromashift/src/hsb.rs
+++ b/crates/chromashift/src/hsb.rs
@@ -1,4 +1,4 @@
-use crate::Srgb;
+use crate::{Srgb, ToAlpha};
 use core::fmt;
 
 /// An colour represented as Hue, Saturation, and Value expressed in the sRGB colour space.
@@ -23,6 +23,12 @@ impl Hsv {
 			value: value.clamp(0.0, 100.0),
 			alpha: alpha.clamp(0.0, 100.0),
 		}
+	}
+}
+
+impl ToAlpha for Hsv {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/hsl.rs
+++ b/crates/chromashift/src/hsl.rs
@@ -1,4 +1,4 @@
-use crate::{Srgb, round_dp};
+use crate::{Srgb, ToAlpha, round_dp};
 use core::fmt;
 
 /// An colour represented as Hue, Saturation, and Lightness expressed in the sRGB colour space.
@@ -23,6 +23,12 @@ impl Hsl {
 			lightness: lightness.clamp(0.0, 100.0),
 			alpha: alpha.clamp(0.0, 100.0),
 		}
+	}
+}
+
+impl ToAlpha for Hsl {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/hwb.rs
+++ b/crates/chromashift/src/hwb.rs
@@ -1,4 +1,4 @@
-use crate::{Hsv, round_dp};
+use crate::{Hsv, ToAlpha, round_dp};
 use core::fmt;
 
 /// An colour represented as Hue, Whiteness, and Blackness expressed in the sRGB colour space.
@@ -23,6 +23,12 @@ impl Hwb {
 			blackness: blackness.clamp(0.0, 100.0),
 			alpha: alpha.clamp(0.0, 100.0),
 		}
+	}
+}
+
+impl ToAlpha for Hwb {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/lab.rs
+++ b/crates/chromashift/src/lab.rs
@@ -1,4 +1,4 @@
-use crate::{XyzD50, round_dp};
+use crate::{ToAlpha, XyzD50, round_dp};
 use core::fmt;
 
 const D50X: f64 = 96.4220;
@@ -27,6 +27,12 @@ impl Lab {
 			b: b.clamp(-125.0, 125.0),
 			alpha: alpha.clamp(0.0, 100.0),
 		}
+	}
+}
+
+impl ToAlpha for Lab {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/lch.rs
+++ b/crates/chromashift/src/lch.rs
@@ -1,4 +1,4 @@
-use crate::{Lab, round_dp};
+use crate::{Lab, ToAlpha, round_dp};
 use core::fmt;
 
 /// A cylindrical colour space representing within the CIE colour space.
@@ -23,6 +23,12 @@ impl Lch {
 			hue: hue.rem_euclid(360.0),
 			alpha: alpha.clamp(0.0, 100.0),
 		}
+	}
+}
+
+impl ToAlpha for Lch {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/lib.rs
+++ b/crates/chromashift/src/lib.rs
@@ -2,6 +2,7 @@
 
 use core::fmt;
 mod a98_rgb;
+mod channels;
 mod conversion;
 mod distance;
 mod hex;
@@ -23,6 +24,7 @@ mod xyzd50;
 mod xyzd65;
 
 pub use a98_rgb::A98Rgb;
+pub use channels::ToAlpha;
 pub use distance::ColorDistance;
 pub use hex::Hex;
 pub use hsb::Hsv;
@@ -32,7 +34,7 @@ pub use lab::Lab;
 pub use lch::Lch;
 pub use linear_rgb::LinearRgb;
 pub use mix::{ColorMix, ColorMixPolar, HueInterpolation};
-pub use named::Named;
+pub use named::{Named, ToNamedError};
 pub use oklab::Oklab;
 pub use oklch::Oklch;
 pub use srgb::Srgb;
@@ -75,6 +77,27 @@ impl fmt::Display for Color {
 			Self::Srgb(s) => fmt::Display::fmt(s, f),
 			Self::XyzD50(x) => fmt::Display::fmt(x, f),
 			Self::XyzD65(x) => fmt::Display::fmt(x, f),
+		}
+	}
+}
+
+impl ToAlpha for Color {
+	fn to_alpha(&self) -> f32 {
+		match self {
+			Color::A98Rgb(a) => a.to_alpha(),
+			Color::Hex(h) => h.to_alpha(),
+			Color::Hsv(h) => h.to_alpha(),
+			Color::Hsl(h) => h.to_alpha(),
+			Color::Hwb(h) => h.to_alpha(),
+			Color::Lab(l) => l.to_alpha(),
+			Color::Lch(l) => l.to_alpha(),
+			Color::LinearRgb(l) => l.to_alpha(),
+			Color::Named(n) => n.to_alpha(),
+			Color::Oklab(o) => o.to_alpha(),
+			Color::Oklch(o) => o.to_alpha(),
+			Color::Srgb(s) => s.to_alpha(),
+			Color::XyzD50(x) => x.to_alpha(),
+			Color::XyzD65(x) => x.to_alpha(),
 		}
 	}
 }

--- a/crates/chromashift/src/linear_rgb.rs
+++ b/crates/chromashift/src/linear_rgb.rs
@@ -1,4 +1,4 @@
-use crate::{XyzD65, round_dp};
+use crate::{ToAlpha, XyzD65, round_dp};
 use core::fmt;
 
 /// A device independent expression of RGB. No exactly defined chromacities.
@@ -23,6 +23,12 @@ impl LinearRgb {
 			blue: blue.clamp(0.0, 1.0),
 			alpha: alpha.clamp(0.0, 100.0),
 		}
+	}
+}
+
+impl ToAlpha for LinearRgb {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/named.rs
+++ b/crates/chromashift/src/named.rs
@@ -1,4 +1,4 @@
-use crate::Srgb;
+use crate::{Srgb, ToAlpha};
 use core::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -306,6 +306,12 @@ impl Named {
 			Named::Yellowgreen,
 		]
 		.into_iter()
+	}
+}
+
+impl ToAlpha for Named {
+	fn to_alpha(&self) -> f32 {
+		100.0
 	}
 }
 
@@ -617,5 +623,164 @@ impl From<Named> for Srgb {
 			Named::Yellowgreen => (154, 205, 50),
 		};
 		Srgb::new(red, green, blue, 100.0)
+	}
+}
+
+#[derive(Debug)]
+pub enum ToNamedError {
+	NotOpaque,
+	NoMatchingName,
+}
+
+impl TryFrom<Srgb> for Named {
+	type Error = ToNamedError;
+
+	fn try_from(value: Srgb) -> Result<Named, Self::Error> {
+		let Srgb { red, green, blue, alpha } = value;
+		if alpha != 100.0 {
+			Err(ToNamedError::NotOpaque)?;
+		}
+		match (red, green, blue) {
+			(240, 248, 255) => Ok(Named::Aliceblue),
+			(250, 235, 215) => Ok(Named::Antiquewhite),
+			(0, 255, 255) => Ok(Named::Aqua),
+			(127, 255, 212) => Ok(Named::Aquamarine),
+			(240, 255, 255) => Ok(Named::Azure),
+			(245, 245, 220) => Ok(Named::Beige),
+			(255, 228, 196) => Ok(Named::Bisque),
+			(0, 0, 0) => Ok(Named::Black),
+			(255, 235, 205) => Ok(Named::Blanchedalmond),
+			(0, 0, 255) => Ok(Named::Blue),
+			(138, 43, 226) => Ok(Named::Blueviolet),
+			(165, 42, 42) => Ok(Named::Brown),
+			(222, 184, 135) => Ok(Named::Burlywood),
+			(95, 158, 160) => Ok(Named::Cadetblue),
+			(127, 255, 0) => Ok(Named::Chartreuse),
+			(210, 105, 30) => Ok(Named::Chocolate),
+			(255, 127, 80) => Ok(Named::Coral),
+			(100, 149, 237) => Ok(Named::Cornflowerblue),
+			(255, 248, 220) => Ok(Named::Cornsilk),
+			(220, 20, 60) => Ok(Named::Crimson),
+			(0, 0, 139) => Ok(Named::Darkblue),
+			(0, 139, 139) => Ok(Named::Darkcyan),
+			(184, 134, 11) => Ok(Named::Darkgoldenrod),
+			(169, 169, 169) => Ok(Named::Darkgray),
+			(0, 100, 0) => Ok(Named::Darkgreen),
+			(189, 183, 107) => Ok(Named::Darkkhaki),
+			(139, 0, 139) => Ok(Named::Darkmagenta),
+			(85, 107, 47) => Ok(Named::Darkolivegreen),
+			(255, 140, 0) => Ok(Named::Darkorange),
+			(153, 50, 204) => Ok(Named::Darkorchid),
+			(139, 0, 0) => Ok(Named::Darkred),
+			(233, 150, 122) => Ok(Named::Darksalmon),
+			(143, 188, 143) => Ok(Named::Darkseagreen),
+			(72, 61, 139) => Ok(Named::Darkslateblue),
+			(47, 79, 79) => Ok(Named::Darkslategray),
+			(0, 206, 209) => Ok(Named::Darkturquoise),
+			(148, 0, 211) => Ok(Named::Darkviolet),
+			(255, 20, 147) => Ok(Named::Deeppink),
+			(0, 191, 255) => Ok(Named::Deepskyblue),
+			(105, 105, 105) => Ok(Named::Dimgray),
+			(30, 144, 255) => Ok(Named::Dodgerblue),
+			(178, 34, 34) => Ok(Named::Firebrick),
+			(255, 250, 240) => Ok(Named::Floralwhite),
+			(34, 139, 34) => Ok(Named::Forestgreen),
+			(255, 0, 255) => Ok(Named::Fuchsia),
+			(220, 220, 220) => Ok(Named::Gainsboro),
+			(248, 248, 255) => Ok(Named::Ghostwhite),
+			(255, 215, 0) => Ok(Named::Gold),
+			(218, 165, 32) => Ok(Named::Goldenrod),
+			(128, 128, 128) => Ok(Named::Gray),
+			(0, 128, 0) => Ok(Named::Green),
+			(173, 255, 47) => Ok(Named::Greenyellow),
+			(240, 255, 240) => Ok(Named::Honeydew),
+			(255, 105, 180) => Ok(Named::Hotpink),
+			(205, 92, 92) => Ok(Named::Indianred),
+			(75, 0, 130) => Ok(Named::Indigo),
+			(255, 255, 240) => Ok(Named::Ivory),
+			(240, 230, 140) => Ok(Named::Khaki),
+			(230, 230, 250) => Ok(Named::Lavender),
+			(255, 240, 245) => Ok(Named::Lavenderblush),
+			(124, 252, 0) => Ok(Named::Lawngreen),
+			(255, 250, 205) => Ok(Named::Lemonchiffon),
+			(173, 216, 230) => Ok(Named::Lightblue),
+			(240, 128, 128) => Ok(Named::Lightcoral),
+			(224, 255, 255) => Ok(Named::Lightcyan),
+			(250, 250, 210) => Ok(Named::Lightgoldenrodyellow),
+			(211, 211, 211) => Ok(Named::Lightgray),
+			(144, 238, 144) => Ok(Named::Lightgreen),
+			(255, 182, 193) => Ok(Named::Lightpink),
+			(255, 160, 122) => Ok(Named::Lightsalmon),
+			(32, 178, 170) => Ok(Named::Lightseagreen),
+			(135, 206, 250) => Ok(Named::Lightskyblue),
+			(119, 136, 153) => Ok(Named::Lightslategray),
+			(176, 196, 222) => Ok(Named::Lightsteelblue),
+			(255, 255, 224) => Ok(Named::Lightyellow),
+			(0, 255, 0) => Ok(Named::Lime),
+			(50, 205, 50) => Ok(Named::Limegreen),
+			(250, 240, 230) => Ok(Named::Linen),
+			(128, 0, 0) => Ok(Named::Maroon),
+			(102, 205, 170) => Ok(Named::Mediumaquamarine),
+			(0, 0, 205) => Ok(Named::Mediumblue),
+			(186, 85, 211) => Ok(Named::Mediumorchid),
+			(147, 112, 219) => Ok(Named::Mediumpurple),
+			(60, 179, 113) => Ok(Named::Mediumseagreen),
+			(123, 104, 238) => Ok(Named::Mediumslateblue),
+			(0, 250, 154) => Ok(Named::Mediumspringgreen),
+			(72, 209, 204) => Ok(Named::Mediumturquoise),
+			(199, 21, 133) => Ok(Named::Mediumvioletred),
+			(25, 25, 112) => Ok(Named::Midnightblue),
+			(245, 255, 250) => Ok(Named::Mintcream),
+			(255, 228, 225) => Ok(Named::Mistyrose),
+			(255, 228, 181) => Ok(Named::Moccasin),
+			(255, 222, 173) => Ok(Named::Navajowhite),
+			(0, 0, 128) => Ok(Named::Navy),
+			(253, 245, 230) => Ok(Named::Oldlace),
+			(128, 128, 0) => Ok(Named::Olive),
+			(107, 142, 35) => Ok(Named::Olivedrab),
+			(255, 165, 0) => Ok(Named::Orange),
+			(255, 69, 0) => Ok(Named::Orangered),
+			(218, 112, 214) => Ok(Named::Orchid),
+			(238, 232, 170) => Ok(Named::Palegoldenrod),
+			(152, 251, 152) => Ok(Named::Palegreen),
+			(175, 238, 238) => Ok(Named::Paleturquoise),
+			(219, 112, 147) => Ok(Named::Palevioletred),
+			(255, 239, 213) => Ok(Named::Papayawhip),
+			(255, 218, 185) => Ok(Named::Peachpuff),
+			(205, 133, 63) => Ok(Named::Peru),
+			(255, 192, 203) => Ok(Named::Pink),
+			(221, 160, 221) => Ok(Named::Plum),
+			(176, 224, 230) => Ok(Named::Powderblue),
+			(128, 0, 128) => Ok(Named::Purple),
+			(102, 51, 153) => Ok(Named::Rebeccapurple),
+			(255, 0, 0) => Ok(Named::Red),
+			(188, 143, 143) => Ok(Named::Rosybrown),
+			(65, 105, 225) => Ok(Named::Royalblue),
+			(139, 69, 19) => Ok(Named::Saddlebrown),
+			(250, 128, 114) => Ok(Named::Salmon),
+			(244, 164, 96) => Ok(Named::Sandybrown),
+			(46, 139, 87) => Ok(Named::Seagreen),
+			(255, 245, 238) => Ok(Named::Seashell),
+			(160, 82, 45) => Ok(Named::Sienna),
+			(192, 192, 192) => Ok(Named::Silver),
+			(135, 206, 235) => Ok(Named::Skyblue),
+			(106, 90, 205) => Ok(Named::Slateblue),
+			(112, 128, 144) => Ok(Named::Slategray),
+			(255, 250, 250) => Ok(Named::Snow),
+			(0, 255, 127) => Ok(Named::Springgreen),
+			(70, 130, 180) => Ok(Named::Steelblue),
+			(210, 180, 140) => Ok(Named::Tan),
+			(0, 128, 128) => Ok(Named::Teal),
+			(216, 191, 216) => Ok(Named::Thistle),
+			(255, 99, 71) => Ok(Named::Tomato),
+			(64, 224, 208) => Ok(Named::Turquoise),
+			(238, 130, 238) => Ok(Named::Violet),
+			(245, 222, 179) => Ok(Named::Wheat),
+			(255, 255, 255) => Ok(Named::White),
+			(245, 245, 245) => Ok(Named::Whitesmoke),
+			(255, 255, 0) => Ok(Named::Yellow),
+			(154, 205, 50) => Ok(Named::Yellowgreen),
+			_ => Err(ToNamedError::NoMatchingName),
+		}
 	}
 }

--- a/crates/chromashift/src/oklab.rs
+++ b/crates/chromashift/src/oklab.rs
@@ -1,4 +1,4 @@
-use crate::{XyzD65, round_dp};
+use crate::{ToAlpha, XyzD65, round_dp};
 use core::fmt;
 
 /// A more adequate expression of LAB, in the CIE colour space.
@@ -23,6 +23,12 @@ impl Oklab {
 			b: b.clamp(-128.0, 127.0),
 			alpha: alpha.clamp(0.0, 100.0),
 		}
+	}
+}
+
+impl ToAlpha for Oklab {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/oklch.rs
+++ b/crates/chromashift/src/oklch.rs
@@ -1,4 +1,4 @@
-use crate::{Oklab, round_dp};
+use crate::{Oklab, ToAlpha, round_dp};
 use core::fmt;
 
 /// A more adequate expression of LCH, in the CIE colour space.
@@ -23,6 +23,12 @@ impl Oklch {
 			hue: hue.rem_euclid(360.0),
 			alpha: alpha.clamp(0.0, 100.0),
 		}
+	}
+}
+
+impl ToAlpha for Oklch {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/srgb.rs
+++ b/crates/chromashift/src/srgb.rs
@@ -1,4 +1,4 @@
-use crate::LinearRgb;
+use crate::{LinearRgb, ToAlpha};
 use core::fmt;
 
 /// An RGB colour space with defined chromacities.
@@ -18,6 +18,12 @@ pub struct Srgb {
 impl Srgb {
 	pub fn new(red: u8, green: u8, blue: u8, alpha: f32) -> Self {
 		Self { red, green, blue, alpha: alpha.clamp(0.0, 100.0) }
+	}
+}
+
+impl ToAlpha for Srgb {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/tests.rs
+++ b/crates/chromashift/src/tests.rs
@@ -200,3 +200,27 @@ fn text_hex_display() {
 	assert_eq!(format!("{}", Hex::new(0x66339900)), "#6390");
 	assert_eq!(format!("{}", Hex::new(0x112233FF)), "#123");
 }
+
+#[test]
+fn named_try_from_other_spaces() {
+	let named = Named::Rebeccapurple;
+	let srgb = Srgb::new(102, 51, 153, 100.0);
+	assert_eq!(Named::try_from(srgb).unwrap(), named);
+	assert_eq!(Named::try_from(Hex::new(0x663399FF)).unwrap(), named);
+	assert_eq!(Named::try_from(Hsl::new(270.0, 50.0, 40.0, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(Hsv::new(270.0, 66.666_664, 60.0000004, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(Hwb::new(270.0, 19.9999996, 39.9999996, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(Lab::new(32.39271642, 38.42945581, -47.68554267, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(Lch::new(32.39271642, 61.24323680, 308.86510559, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(LinearRgb::new(0.13286832, 0.03310476, 0.31854683, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(Oklab::new(0.44027179, 0.08817676, -0.13386435, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(Oklch::new(0.44027179, 0.16029599, 303.37298848, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(A98Rgb::new(0.39940515, 0.21231660, 0.59441553, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(XyzD50::new(11.62668443, 7.26049173, 23.25379520, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(XyzD65::new(12.412, 7.493, 30.930, 100.0)).unwrap(), named);
+	assert_eq!(Named::try_from(Color::Srgb(srgb)).unwrap(), named);
+
+	let translucent = Hex::new(0x66339980);
+	assert!(matches!(Named::try_from(translucent), Err(ToNamedError::NotOpaque)));
+	assert!(matches!(Named::try_from(Color::Hex(translucent)), Err(ToNamedError::NotOpaque)));
+}

--- a/crates/chromashift/src/xyzd50.rs
+++ b/crates/chromashift/src/xyzd50.rs
@@ -1,4 +1,4 @@
-use crate::{XyzD65, round_dp};
+use crate::{ToAlpha, XyzD65, round_dp};
 use core::fmt;
 
 /// A colour expressed as X, Y and Z values, expressed in the CIE XYZ tristimulus colour space, with an explicit D50
@@ -19,6 +19,12 @@ pub struct XyzD50 {
 impl XyzD50 {
 	pub fn new(x: f64, y: f64, z: f64, alpha: f32) -> Self {
 		Self { x: x.clamp(0.0, 100.0), y: y.clamp(0.0, 100.0), z: z.clamp(0.0, 100.0), alpha: alpha.clamp(0.0, 100.0) }
+	}
+}
+
+impl ToAlpha for XyzD50 {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 

--- a/crates/chromashift/src/xyzd65.rs
+++ b/crates/chromashift/src/xyzd65.rs
@@ -1,4 +1,4 @@
-use crate::round_dp;
+use crate::{ToAlpha, round_dp};
 use core::fmt;
 
 /// A colour expressed as X, Y and Z values, expressed in the CIE XYZ tristimulus colour space, with an explicit D65
@@ -19,6 +19,12 @@ pub struct XyzD65 {
 impl XyzD65 {
 	pub fn new(x: f64, y: f64, z: f64, alpha: f32) -> Self {
 		Self { x: x.clamp(0.0, 100.0), y: y.clamp(0.0, 100.0), z: z.clamp(0.0, 100.0), alpha: alpha.clamp(0.0, 100.0) }
+	}
+}
+
+impl ToAlpha for XyzD65 {
+	fn to_alpha(&self) -> f32 {
+		self.alpha
 	}
 }
 


### PR DESCRIPTION
Working with chromashift a little and I noticed two issues which I wanted to improve: it can be a little clunky to get
an alpha channel from a `Color` as you first have to either match which colour you're referring to or convert it to a
known color (e.g. srgb) to then get the alpha. It would be much easier if there were a unilateral trait to simply get
the alpha from any colour or indeed the generic `Color` enum. Additionally I wanted to convert a colour to a named colour,
and this proved awkward to do as I would have to re-introduce the data from Named, or iterate and match (slow).

So this commit introduces those two improvements:

- The ToAlpha trait adds a `to_alpha(&self) -> f32` method to all colours, making it trivial to just get the alpha
	channel of the colour. This also adds convenience methods of `fully_opaque` and `fully_transparent`.
- Named now implements TryFrom<?>, where `?` is any of the colors, returning `Result<Named>`. If the colour was not
	fully opaque then it'll return `ToNamedError::NotOpaque`. If a named colour wasn't found then it'll return
	`ToNamedError::NoMatchingName`.
