### PR TITLE
css_ast: Fix nightly build failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chromashift"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anstyle",
 ]
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "css_feature_data"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "browserslist-rs",
  "chrono",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "css_lexer"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "allocator-api2",
  "bitmask-enum",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "css_parse"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_derives"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "heck",
  "insta",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_proc_macro"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "css_lexer",
  "heck",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "derive_atom_set"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "heck",
  "itertools 0.14.0",

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -7,8 +7,6 @@ use css_parse::{
 	T,
 };
 use csskit_derives::{Parse, Peek, ToCursors, ToSpan};
-#[cfg(feature = "visitable")]
-use csskit_proc_macro::visit;
 
 mod features;
 pub use features::*;


### PR DESCRIPTION
The unused import was highlighted in nightly.
