### PR TITLE
generate-values: sort types lexicographically

### DIFF
--- a/.mise-tasks/generate-values/mod.ts
+++ b/.mise-tasks/generate-values/mod.ts
@@ -805,7 +805,7 @@ async function getSpec(name: string, index: Record<string, number[]>, descriptio
 		ignore.get(name)?.delete(prop);
 	}
 
-	const typeDefs = [...types.values()].map((table) => {
+	const typeDefs = [...types.values()].sort((a, b) => a.name.localeCompare(b.name)).map((table) => {
 		const enums: Map = enumOverrides.get(name);
 		const structs = structOverrides.get(name);
 		const manualParse = manualParseImpl.get(name);
@@ -1016,7 +1016,6 @@ ${typeDefs.join("\n")}
 
 		const dataFile: string[] = [];
 		dataFile.push("//! Auto-generated CSS features data");
-		dataFile.push("//! Generated on: " + new Date().toISOString());
 		dataFile.push("");
 		dataFile.push("use crate::*;");
 		dataFile.push("use phf::{phf_map, Map};");

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
 rust = { version = "1.90.0", components = "rustfmt,clippy", targets = "wasm32-unknown-unknown" }
 deno = "2.5.4"
-node = "24.10.0"
+node = "25.0.0"
 hyperfine = "latest"
 "cargo:cargo-insta" = "1.43.1"
 "cargo:cargo-expand" = "1.0.114"

--- a/crates/css_ast/src/values/align/mod.rs
+++ b/crates/css_ast/src/values/align/mod.rs
@@ -33,164 +33,6 @@ use impls::*;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum AlignContentStyleValue {}
 
-// /// Represents the style value for `justify-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-content).
-// ///
-// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-align-3/#justify-content
-// #[syntax(" normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "multicol containers, flex containers, and grid containers",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.justify-content"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum JustifyContentStyleValue {}
-
-// /// Represents the style value for `place-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-content).
-// ///
-// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'align-content'> <'justify-content'>?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-align-3/#place-content
-// #[syntax(" <'align-content'> <'justify-content'>? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "see individual properties",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.place-content"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct PlaceContentStyleValue;
-
-// /// Represents the style value for `justify-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-self).
-// ///
-// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-align-3/#justify-self
-// #[syntax(" auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "block-level boxes, absolutely-positioned boxes, and grid items",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.justify-self"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum JustifySelfStyleValue {}
-
-/// Represents the style value for `align-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#align-self).
-///
-/// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position>
-/// ```
-///
-// https://drafts.csswg.org/css-align-3/#align-self
-#[syntax(" auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "flex items, grid items, and absolutely-positioned boxes",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.align-self"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum AlignSelfStyleValue {}
-
-// /// Represents the style value for `place-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-self).
-// ///
-// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'align-self'> <'justify-self'>?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-align-3/#place-self
-// #[syntax(" <'align-self'> <'justify-self'>? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "see individual properties",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.place-self"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct PlaceSelfStyleValue;
-
-// /// Represents the style value for `justify-items` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-items).
-// ///
-// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-align-3/#justify-items
-// #[syntax(
-// 	" normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "legacy",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.justify-items"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum JustifyItemsStyleValue {}
-
 // /// Represents the style value for `align-items` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#align-items).
 // ///
 // /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
@@ -217,57 +59,31 @@ pub enum AlignSelfStyleValue {}
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum AlignItemsStyleValue {}
 
-// /// Represents the style value for `place-items` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-items).
-// ///
-// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'align-items'> <'justify-items'>?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-align-3/#place-items
-// #[syntax(" <'align-items'> <'justify-items'>? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.place-items"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct PlaceItemsStyleValue;
-
-/// Represents the style value for `row-gap` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#row-gap).
+/// Represents the style value for `align-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#align-self).
 ///
-/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+/// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// normal | <length-percentage [0,∞]>
+/// auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position>
 /// ```
 ///
-// https://drafts.csswg.org/css-align-3/#row-gap
-#[syntax(" normal | <length-percentage [0,∞]> ")]
+// https://drafts.csswg.org/css-align-3/#align-self
+#[syntax(" auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "normal",
-	applies_to = "multi-column containers, flex containers, grid containers",
+	initial = "auto",
+	applies_to = "flex items, grid items, and absolutely-positioned boxes",
 	inherited = "no",
-	percentages = "see § 8.3 percentages in gap properties",
+	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "by computed value type"
+	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-gap"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.align-self"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum RowGapStyleValue {}
+pub enum AlignSelfStyleValue {}
 
 /// Represents the style value for `column-gap` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#column-gap).
 ///
@@ -320,3 +136,187 @@ pub enum ColumnGapStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.gap"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct GapStyleValue;
+
+// /// Represents the style value for `justify-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-content).
+// ///
+// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-align-3/#justify-content
+// #[syntax(" normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "multicol containers, flex containers, and grid containers",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.justify-content"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum JustifyContentStyleValue {}
+
+// /// Represents the style value for `justify-items` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-items).
+// ///
+// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-align-3/#justify-items
+// #[syntax(
+// 	" normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "legacy",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.justify-items"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum JustifyItemsStyleValue {}
+
+// /// Represents the style value for `justify-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#justify-self).
+// ///
+// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-align-3/#justify-self
+// #[syntax(" auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "block-level boxes, absolutely-positioned boxes, and grid items",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.justify-self"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum JustifySelfStyleValue {}
+
+// /// Represents the style value for `place-content` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-content).
+// ///
+// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'align-content'> <'justify-content'>?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-align-3/#place-content
+// #[syntax(" <'align-content'> <'justify-content'>? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "see individual properties",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.place-content"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct PlaceContentStyleValue;
+
+// /// Represents the style value for `place-items` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-items).
+// ///
+// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'align-items'> <'justify-items'>?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-align-3/#place-items
+// #[syntax(" <'align-items'> <'justify-items'>? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.place-items"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct PlaceItemsStyleValue;
+
+// /// Represents the style value for `place-self` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#place-self).
+// ///
+// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'align-self'> <'justify-self'>?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-align-3/#place-self
+// #[syntax(" <'align-self'> <'justify-self'>? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "see individual properties",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.place-self"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct PlaceSelfStyleValue;
+
+/// Represents the style value for `row-gap` as defined in [css-align-3](https://drafts.csswg.org/css-align-3/#row-gap).
+///
+/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-align-3/#row-gap
+#[syntax(" normal | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "multi-column containers, flex containers, grid containers",
+	inherited = "no",
+	percentages = "see § 8.3 percentages in gap properties",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-gap"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum RowGapStyleValue {}

--- a/crates/css_ast/src/values/anchor_position/mod.rs
+++ b/crates/css_ast/src/values/anchor_position/mod.rs
@@ -111,6 +111,32 @@ pub struct PositionAnchorStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PositionAreaStyleValue;
 
+// /// Represents the style value for `position-try` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-try).
+// ///
+// /// Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'position-try-order'>? <'position-try-fallbacks'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-anchor-position-2/#position-try
+// #[syntax(" <'position-try-order'>? <'position-try-fallbacks'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position-try"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct PositionTryStyleValue;
+
 // /// Represents the style value for `position-try-fallbacks` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-try-fallbacks).
 // ///
 // /// Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.
@@ -162,32 +188,6 @@ pub struct PositionAreaStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position-try-order"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum PositionTryOrderStyleValue {}
-
-// /// Represents the style value for `position-try` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-try).
-// ///
-// /// Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'position-try-order'>? <'position-try-fallbacks'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-anchor-position-2/#position-try
-// #[syntax(" <'position-try-order'>? <'position-try-fallbacks'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position-try"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct PositionTryStyleValue;
 
 // /// Represents the style value for `position-visibility` as defined in [css-anchor-position-2](https://drafts.csswg.org/css-anchor-position-2/#position-visibility).
 // ///

--- a/crates/css_ast/src/values/animations/mod.rs
+++ b/crates/css_ast/src/values/animations/mod.rs
@@ -7,214 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `animation-name` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-name).
-///
-/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// [ none | <keyframes-name> ]#
-/// ```
-///
-// https://drafts.csswg.org/css-animations-2/#animation-name
-#[syntax(" [ none | <keyframes-name> ]# ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-name"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AnimationNameStyleValue<'a>;
-
-/// Represents the style value for `animation-duration` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-duration).
-///
-/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// [ auto | <time [0s,∞]> ]#
-/// ```
-///
-// https://drafts.csswg.org/css-animations-2/#animation-duration
-#[syntax(" [ auto | <time [0s,∞]> ]# ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-duration"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AnimationDurationStyleValue<'a>;
-
-/// Represents the style value for `animation-timing-function` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-timing-function).
-///
-/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <easing-function>#
-/// ```
-///
-// https://drafts.csswg.org/css-animations-2/#animation-timing-function
-#[syntax(" <easing-function># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "ease",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-timing-function"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AnimationTimingFunctionStyleValue<'a>;
-
-/// Represents the style value for `animation-iteration-count` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-iteration-count).
-///
-/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <single-animation-iteration-count>#
-/// ```
-///
-// https://drafts.csswg.org/css-animations-2/#animation-iteration-count
-#[syntax(" <single-animation-iteration-count># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "1",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-iteration-count"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AnimationIterationCountStyleValue<'a>;
-
-/// Represents the style value for `animation-direction` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-direction).
-///
-/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <single-animation-direction>#
-/// ```
-///
-// https://drafts.csswg.org/css-animations-2/#animation-direction
-#[syntax(" <single-animation-direction># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-direction"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AnimationDirectionStyleValue<'a>;
-
-/// Represents the style value for `animation-play-state` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-play-state).
-///
-/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <single-animation-play-state>#
-/// ```
-///
-// https://drafts.csswg.org/css-animations-2/#animation-play-state
-#[syntax(" <single-animation-play-state># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "running",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-play-state"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AnimationPlayStateStyleValue<'a>;
-
-/// Represents the style value for `animation-delay` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-delay).
-///
-/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <time>#
-/// ```
-///
-// https://drafts.csswg.org/css-animations-2/#animation-delay
-#[syntax(" <time># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0s",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-delay"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AnimationDelayStyleValue<'a>;
-
-/// Represents the style value for `animation-fill-mode` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-fill-mode).
-///
-/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <single-animation-fill-mode>#
-/// ```
-///
-// https://drafts.csswg.org/css-animations-2/#animation-fill-mode
-#[syntax(" <single-animation-fill-mode># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-fill-mode"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AnimationFillModeStyleValue<'a>;
-
 // /// Represents the style value for `animation` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation).
 // ///
 // /// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
@@ -267,6 +59,188 @@ pub struct AnimationFillModeStyleValue<'a>;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationCompositionStyleValue<'a>;
 
+/// Represents the style value for `animation-delay` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-delay).
+///
+/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <time>#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-delay
+#[syntax(" <time># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0s",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-delay"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AnimationDelayStyleValue<'a>;
+
+/// Represents the style value for `animation-direction` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-direction).
+///
+/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <single-animation-direction>#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-direction
+#[syntax(" <single-animation-direction># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-direction"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AnimationDirectionStyleValue<'a>;
+
+/// Represents the style value for `animation-duration` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-duration).
+///
+/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// [ auto | <time [0s,∞]> ]#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-duration
+#[syntax(" [ auto | <time [0s,∞]> ]# ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-duration"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AnimationDurationStyleValue<'a>;
+
+/// Represents the style value for `animation-fill-mode` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-fill-mode).
+///
+/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <single-animation-fill-mode>#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-fill-mode
+#[syntax(" <single-animation-fill-mode># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-fill-mode"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AnimationFillModeStyleValue<'a>;
+
+/// Represents the style value for `animation-iteration-count` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-iteration-count).
+///
+/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <single-animation-iteration-count>#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-iteration-count
+#[syntax(" <single-animation-iteration-count># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "1",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-iteration-count"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AnimationIterationCountStyleValue<'a>;
+
+/// Represents the style value for `animation-name` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-name).
+///
+/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// [ none | <keyframes-name> ]#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-name
+#[syntax(" [ none | <keyframes-name> ]# ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-name"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AnimationNameStyleValue<'a>;
+
+/// Represents the style value for `animation-play-state` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-play-state).
+///
+/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <single-animation-play-state>#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-play-state
+#[syntax(" <single-animation-play-state># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "running",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-play-state"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AnimationPlayStateStyleValue<'a>;
+
 /// Represents the style value for `animation-timeline` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-timeline).
 ///
 /// The animation-timeline, scroll-timeline, and view-timeline CSS properties advance animations based on the user's scroll position.
@@ -292,6 +266,56 @@ pub struct AnimationCompositionStyleValue<'a>;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-timeline"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationTimelineStyleValue<'a>;
+
+/// Represents the style value for `animation-timing-function` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-timing-function).
+///
+/// The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <easing-function>#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-timing-function
+#[syntax(" <easing-function># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "ease",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-timing-function"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AnimationTimingFunctionStyleValue<'a>;
+
+/// Represents the style value for `animation-trigger` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <single-animation-trigger>#
+/// ```
+///
+// https://drafts.csswg.org/css-animations-2/#animation-trigger
+#[syntax(" <single-animation-trigger># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AnimationTriggerStyleValue<'a>;
 
 /// Represents the style value for `animation-trigger-behavior` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-behavior).
 ///
@@ -321,6 +345,150 @@ pub struct AnimationTimelineStyleValue<'a>;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationTriggerBehaviorStyleValue<'a>;
 
+// /// Represents the style value for `animation-trigger-exit-range` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ <'animation-trigger-exit-range-start'> <'animation-trigger-exit-range-end'>? ]#
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range
+// #[syntax(" [ <'animation-trigger-exit-range-start'> <'animation-trigger-exit-range-end'>? ]# ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-exit-range"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct AnimationTriggerExitRangeStyleValue<'a>;
+
+// /// Represents the style value for `animation-trigger-exit-range-end` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-end).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-end
+// #[syntax(" [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "relative to the specified named timeline range if one was specified, else to the entire timeline",
+// 	canonical_order = "per grammar",
+// 	animation_type = "not animatable",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-exit-range-end"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct AnimationTriggerExitRangeEndStyleValue<'a>;
+
+// /// Represents the style value for `animation-trigger-exit-range-start` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-start).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-start
+// #[syntax(" [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "relative to the specified named timeline range if one was specified, else to the entire timeline",
+// 	canonical_order = "per grammar",
+// 	animation_type = "not animatable",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-exit-range-start"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct AnimationTriggerExitRangeStartStyleValue<'a>;
+
+// /// Represents the style value for `animation-trigger-range` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-range).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ <'animation-trigger-range-start'> <'animation-trigger-range-end'>? ]#
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-animations-2/#animation-trigger-range
+// #[syntax(" [ <'animation-trigger-range-start'> <'animation-trigger-range-end'>? ]# ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-range"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct AnimationTriggerRangeStyleValue<'a>;
+
+// /// Represents the style value for `animation-trigger-range-end` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-range-end).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-animations-2/#animation-trigger-range-end
+// #[syntax(" [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "relative to the specified named timeline range if one was specified, else to the entire timeline",
+// 	canonical_order = "per grammar",
+// 	animation_type = "not animatable",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-range-end"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct AnimationTriggerRangeEndStyleValue<'a>;
+
+// /// Represents the style value for `animation-trigger-range-start` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-range-start).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-animations-2/#animation-trigger-range-start
+// #[syntax(" [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "relative to the specified named timeline range if one was specified, else to the entire timeline",
+// 	canonical_order = "per grammar",
+// 	animation_type = "not animatable",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-range-start"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct AnimationTriggerRangeStartStyleValue<'a>;
+
 /// Represents the style value for `animation-trigger-timeline` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-timeline).
 ///
 /// The grammar is defined as:
@@ -348,171 +516,3 @@ pub struct AnimationTriggerBehaviorStyleValue<'a>;
 )]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct AnimationTriggerTimelineStyleValue<'a>;
-
-// /// Represents the style value for `animation-trigger-range` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-range).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ <'animation-trigger-range-start'> <'animation-trigger-range-end'>? ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-animations-2/#animation-trigger-range
-// #[syntax(" [ <'animation-trigger-range-start'> <'animation-trigger-range-end'>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-range"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct AnimationTriggerRangeStyleValue<'a>;
-
-// /// Represents the style value for `animation-trigger-range-start` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-range-start).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-animations-2/#animation-trigger-range-start
-// #[syntax(" [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "relative to the specified named timeline range if one was specified, else to the entire timeline",
-// 	canonical_order = "per grammar",
-// 	animation_type = "not animatable",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-range-start"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct AnimationTriggerRangeStartStyleValue<'a>;
-
-// /// Represents the style value for `animation-trigger-range-end` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-range-end).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-animations-2/#animation-trigger-range-end
-// #[syntax(" [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "relative to the specified named timeline range if one was specified, else to the entire timeline",
-// 	canonical_order = "per grammar",
-// 	animation_type = "not animatable",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-range-end"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct AnimationTriggerRangeEndStyleValue<'a>;
-
-// /// Represents the style value for `animation-trigger-exit-range` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ <'animation-trigger-exit-range-start'> <'animation-trigger-exit-range-end'>? ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range
-// #[syntax(" [ <'animation-trigger-exit-range-start'> <'animation-trigger-exit-range-end'>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-exit-range"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct AnimationTriggerExitRangeStyleValue<'a>;
-
-// /// Represents the style value for `animation-trigger-exit-range-start` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-start).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-start
-// #[syntax(" [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "relative to the specified named timeline range if one was specified, else to the entire timeline",
-// 	canonical_order = "per grammar",
-// 	animation_type = "not animatable",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-exit-range-start"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct AnimationTriggerExitRangeStartStyleValue<'a>;
-
-// /// Represents the style value for `animation-trigger-exit-range-end` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-end).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-animations-2/#animation-trigger-exit-range-end
-// #[syntax(" [ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "relative to the specified named timeline range if one was specified, else to the entire timeline",
-// 	canonical_order = "per grammar",
-// 	animation_type = "not animatable",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger-exit-range-end"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct AnimationTriggerExitRangeEndStyleValue<'a>;
-
-/// Represents the style value for `animation-trigger` as defined in [css-animations-2](https://drafts.csswg.org/css-animations-2/#animation-trigger).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <single-animation-trigger>#
-/// ```
-///
-// https://drafts.csswg.org/css-animations-2/#animation-trigger
-#[syntax(" <single-animation-trigger># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.animation-trigger"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AnimationTriggerStyleValue<'a>;

--- a/crates/css_ast/src/values/backgrounds/mod.rs
+++ b/crates/css_ast/src/values/backgrounds/mod.rs
@@ -7,6 +7,84 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+// /// Represents the style value for `background` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background).
+// ///
+// /// The background CSS property is a shorthand that sets several background properties at once.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <bg-layer>#? , <final-bg-layer>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-backgrounds-4/#background
+// #[syntax(" <bg-layer>#? , <final-bg-layer> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BackgroundStyleValue<'a>;
+
+/// Represents the style value for `background-attachment` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-attachment).
+///
+/// The background-attachment CSS property sets whether an element's background image or gradient moves as the element scrolls.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <attachment>#
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#background-attachment
+#[syntax(" <attachment># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "scroll",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-attachment"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BackgroundAttachmentStyleValue<'a>;
+
+/// Represents the style value for `background-clip` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-clip).
+///
+/// The background-clip CSS property sets the extent of the background: the padding box, the content box, or the default border box.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <bg-clip>#
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#background-clip
+#[syntax(" <bg-clip># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "border-box",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "repeatable list"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-clip"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BackgroundClipStyleValue<'a>;
+
 /// Represents the style value for `background-color` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-color).
 ///
 /// The background-color CSS property sets the fill color of an element, behind any content and background images or gradients.
@@ -59,57 +137,31 @@ pub struct BackgroundColorStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BackgroundImageStyleValue<'a>;
 
-/// Represents the style value for `background-repeat` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat).
+/// Represents the style value for `background-origin` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-origin).
 ///
-/// The background-repeat CSS property sets how a background image is tiled.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <repeat-style>#
-/// ```
-///
-// https://drafts.csswg.org/css-backgrounds-4/#background-repeat
-#[syntax(" <repeat-style># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "repeat",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BackgroundRepeatStyleValue<'a>;
-
-/// Represents the style value for `background-attachment` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-attachment).
-///
-/// The background-attachment CSS property sets whether an element's background image or gradient moves as the element scrolls.
+/// The background-origin CSS property sets the background starting position relative to the border and padding of an element.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <attachment>#
+/// <visual-box>#
 /// ```
 ///
-// https://drafts.csswg.org/css-backgrounds-4/#background-attachment
-#[syntax(" <attachment># ")]
+// https://drafts.csswg.org/css-backgrounds-4/#background-origin
+#[syntax(" <visual-box># ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "scroll",
+	initial = "padding-box",
 	applies_to = "all elements",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "discrete"
+	animation_type = "repeatable list"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-attachment"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-origin"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BackgroundAttachmentStyleValue<'a>;
+pub struct BackgroundOriginStyleValue<'a>;
 
 // /// Represents the style value for `background-position` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position).
 // ///
@@ -137,205 +189,53 @@ pub struct BackgroundAttachmentStyleValue<'a>;
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BackgroundPositionStyleValue<'a>;
 
-/// Represents the style value for `background-clip` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-clip).
-///
-/// The background-clip CSS property sets the extent of the background: the padding box, the content box, or the default border box.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <bg-clip>#
-/// ```
-///
-// https://drafts.csswg.org/css-backgrounds-4/#background-clip
-#[syntax(" <bg-clip># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "border-box",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "repeatable list"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-clip"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BackgroundClipStyleValue<'a>;
-
-/// Represents the style value for `background-origin` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-origin).
-///
-/// The background-origin CSS property sets the background starting position relative to the border and padding of an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box>#
-/// ```
-///
-// https://drafts.csswg.org/css-backgrounds-4/#background-origin
-#[syntax(" <visual-box># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "padding-box",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "repeatable list"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-origin"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BackgroundOriginStyleValue<'a>;
-
-/// Represents the style value for `background-size` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-size).
-///
-/// The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <bg-size>#
-/// ```
-///
-// https://drafts.csswg.org/css-backgrounds-4/#background-size
-#[syntax(" <bg-size># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "see text",
-	canonical_order = "per grammar",
-	animation_type = "repeatable list"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-size"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BackgroundSizeStyleValue<'a>;
-
-// /// Represents the style value for `background` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background).
-// ///
-// /// The background CSS property is a shorthand that sets several background properties at once.
+// /// Represents the style value for `background-position-block` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position-block).
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// <bg-layer>#? , <final-bg-layer>
+// /// [ center | [ [ start | end ]? <length-percentage>? ]! ]#
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-backgrounds-4/#background
-// #[syntax(" <bg-layer>#? , <final-bg-layer> ")]
+// // https://drafts.csswg.org/css-backgrounds-4/#background-position-block
+// #[syntax(" [ center | [ [ start | end ]? <length-percentage>? ]! ]# ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "see individual properties",
+// 	initial = "0%",
 //   applies_to = "all elements",
 // 	inherited = "no",
-// 	percentages = "see individual properties",
+// 	percentages = "refer to size of background positioning area minus size of background image",
 // 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
+// 	animation_type = "repeatable list",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-position-block"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BackgroundStyleValue<'a>;
+// pub enum BackgroundPositionBlockStyleValue<'a> {}
 
-/// Represents the style value for `background-repeat-x` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-x).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <repetition>#
-/// ```
-///
-// https://drafts.csswg.org/css-backgrounds-4/#background-repeat-x
-#[syntax(" <repetition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "repeat",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-x"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BackgroundRepeatXStyleValue<'a>;
-
-/// Represents the style value for `background-repeat-y` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-y).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <repetition>#
-/// ```
-///
-// https://drafts.csswg.org/css-backgrounds-4/#background-repeat-y
-#[syntax(" <repetition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "repeat",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-y"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BackgroundRepeatYStyleValue<'a>;
-
-/// Represents the style value for `background-repeat-block` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-block).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <repetition>#
-/// ```
-///
-// https://drafts.csswg.org/css-backgrounds-4/#background-repeat-block
-#[syntax(" <repetition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "repeat",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-block"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BackgroundRepeatBlockStyleValue<'a>;
-
-/// Represents the style value for `background-repeat-inline` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-inline).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <repetition>#
-/// ```
-///
-// https://drafts.csswg.org/css-backgrounds-4/#background-repeat-inline
-#[syntax(" <repetition># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "repeat",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-inline"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BackgroundRepeatInlineStyleValue<'a>;
+// /// Represents the style value for `background-position-inline` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position-inline).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ center | [ [ start | end ]? <length-percentage>? ]! ]#
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-backgrounds-4/#background-position-inline
+// #[syntax(" [ center | [ [ start | end ]? <length-percentage>? ]! ]# ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0%",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "refer to inline-size of background positioning area minus inline-size of background image",
+// 	canonical_order = "per grammar",
+// 	animation_type = "repeatable list",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-position-inline"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum BackgroundPositionInlineStyleValue<'a> {}
 
 // /// Represents the style value for `background-position-x` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position-x).
 // ///
@@ -389,50 +289,150 @@ pub struct BackgroundRepeatInlineStyleValue<'a>;
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum BackgroundPositionYStyleValue<'a> {}
 
-// /// Represents the style value for `background-position-inline` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position-inline).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ center | [ [ start | end ]? <length-percentage>? ]! ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-backgrounds-4/#background-position-inline
-// #[syntax(" [ center | [ [ start | end ]? <length-percentage>? ]! ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0%",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "refer to inline-size of background positioning area minus inline-size of background image",
-// 	canonical_order = "per grammar",
-// 	animation_type = "repeatable list",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-position-inline"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum BackgroundPositionInlineStyleValue<'a> {}
+/// Represents the style value for `background-repeat` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat).
+///
+/// The background-repeat CSS property sets how a background image is tiled.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <repeat-style>#
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#background-repeat
+#[syntax(" <repeat-style># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "repeat",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BackgroundRepeatStyleValue<'a>;
 
-// /// Represents the style value for `background-position-block` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-position-block).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ center | [ [ start | end ]? <length-percentage>? ]! ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-backgrounds-4/#background-position-block
-// #[syntax(" [ center | [ [ start | end ]? <length-percentage>? ]! ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0%",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "refer to size of background positioning area minus size of background image",
-// 	canonical_order = "per grammar",
-// 	animation_type = "repeatable list",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-position-block"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum BackgroundPositionBlockStyleValue<'a> {}
+/// Represents the style value for `background-repeat-block` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-block).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <repetition>#
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#background-repeat-block
+#[syntax(" <repetition># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "repeat",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-block"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BackgroundRepeatBlockStyleValue<'a>;
+
+/// Represents the style value for `background-repeat-inline` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-inline).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <repetition>#
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#background-repeat-inline
+#[syntax(" <repetition># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "repeat",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-inline"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BackgroundRepeatInlineStyleValue<'a>;
+
+/// Represents the style value for `background-repeat-x` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-x).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <repetition>#
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#background-repeat-x
+#[syntax(" <repetition># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "repeat",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-x"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BackgroundRepeatXStyleValue<'a>;
+
+/// Represents the style value for `background-repeat-y` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-repeat-y).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <repetition>#
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#background-repeat-y
+#[syntax(" <repetition># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "repeat",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-repeat-y"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BackgroundRepeatYStyleValue<'a>;
+
+/// Represents the style value for `background-size` as defined in [css-backgrounds-4](https://drafts.csswg.org/css-backgrounds-4/#background-size).
+///
+/// The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <bg-size>#
+/// ```
+///
+// https://drafts.csswg.org/css-backgrounds-4/#background-size
+#[syntax(" <bg-size># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "see text",
+	canonical_order = "per grammar",
+	animation_type = "repeatable list"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.background-size"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BackgroundSizeStyleValue<'a>;

--- a/crates/css_ast/src/values/borders/mod.rs
+++ b/crates/css_ast/src/values/borders/mod.rs
@@ -7,252 +7,18 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `border-top-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-color).
+/// Represents the style value for `border` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border).
 ///
 /// The border CSS property sets the color, style, and width of the line around an element.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <color> | <image-1D>
+/// <line-width> || <line-style> || <color>
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-top-color
-#[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see prose"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderTopColorStyleValue<'a> {}
-
-/// Represents the style value for `border-right-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-color).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <color> | <image-1D>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-right-color
-#[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see prose"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderRightColorStyleValue<'a> {}
-
-/// Represents the style value for `border-bottom-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-color).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <color> | <image-1D>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-bottom-color
-#[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see prose"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderBottomColorStyleValue<'a> {}
-
-/// Represents the style value for `border-left-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-color).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <color> | <image-1D>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-left-color
-#[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see prose"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderLeftColorStyleValue<'a> {}
-
-/// Represents the style value for `border-block-start-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-color).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <color> | <image-1D>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-start-color
-#[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see prose"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderBlockStartColorStyleValue<'a> {}
-
-/// Represents the style value for `border-block-end-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-color).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <color> | <image-1D>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-end-color
-#[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see prose"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderBlockEndColorStyleValue<'a> {}
-
-/// Represents the style value for `border-inline-start-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-color).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <color> | <image-1D>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-start-color
-#[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see prose"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderInlineStartColorStyleValue<'a> {}
-
-/// Represents the style value for `border-inline-end-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-color).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <color> | <image-1D>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-end-color
-#[syntax(" <color> | <image-1D> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see prose"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderInlineEndColorStyleValue<'a> {}
-
-// /// Represents the style value for `border-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-color).
-// ///
-// /// The border CSS property sets the color, style, and width of the line around an element.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ <color> | <image-1D> ]{1,4}
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-color
-// #[syntax(" [ <color> | <image-1D> ]{1,4} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-color"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderColorStyleValue<'a>;
-
-/// Represents the style value for `border-block-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-color).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'border-top-color'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-color
-#[syntax(" <'border-top-color'>{1,2} ")]
+// https://drafts.csswg.org/css-borders-4/#border
+#[syntax(" <line-width> || <line-style> || <color> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
@@ -263,815 +29,9 @@ pub enum BorderInlineEndColorStyleValue<'a> {}
 	animation_type = "see individual properties"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-color"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBlockColorStyleValue<'a>;
-
-/// Represents the style value for `border-inline-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-color).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'border-top-color'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-color
-#[syntax(" <'border-top-color'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineColorStyleValue<'a>;
-
-/// Represents the style value for `border-top-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-style).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-top-style
-#[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderTopStyleStyleValue;
-
-/// Represents the style value for `border-right-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-style).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-right-style
-#[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderRightStyleStyleValue;
-
-/// Represents the style value for `border-bottom-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-style).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-bottom-style
-#[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBottomStyleStyleValue;
-
-/// Represents the style value for `border-left-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-style).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-left-style
-#[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderLeftStyleStyleValue;
-
-/// Represents the style value for `border-block-start-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-style).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-start-style
-#[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBlockStartStyleStyleValue;
-
-/// Represents the style value for `border-block-end-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-style).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-end-style
-#[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBlockEndStyleStyleValue;
-
-/// Represents the style value for `border-inline-start-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-style).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-start-style
-#[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineStartStyleStyleValue;
-
-/// Represents the style value for `border-inline-end-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-style).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-end-style
-#[syntax(" <line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineEndStyleStyleValue;
-
-/// Represents the style value for `border-block-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-style).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'border-top-style'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-style
-#[syntax(" <'border-top-style'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBlockStyleStyleValue;
-
-/// Represents the style value for `border-inline-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-style).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'border-top-style'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-style
-#[syntax(" <'border-top-style'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineStyleStyleValue;
-
-/// Represents the style value for `border-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-style).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'border-top-style'>{1,4}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-style
-#[syntax(" <'border-top-style'>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderStyleStyleValue;
-
-/// Represents the style value for `border-top-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-width).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-top-width
-#[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderTopWidthStyleValue;
-
-/// Represents the style value for `border-right-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-width).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-right-width
-#[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderRightWidthStyleValue;
-
-/// Represents the style value for `border-bottom-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-width).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-bottom-width
-#[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBottomWidthStyleValue;
-
-/// Represents the style value for `border-left-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-width).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-left-width
-#[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderLeftWidthStyleValue;
-
-/// Represents the style value for `border-block-start-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-width).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-start-width
-#[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBlockStartWidthStyleValue;
-
-/// Represents the style value for `border-block-end-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-width).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-end-width
-#[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBlockEndWidthStyleValue;
-
-/// Represents the style value for `border-inline-start-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-width).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-start-width
-#[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineStartWidthStyleValue;
-
-/// Represents the style value for `border-inline-end-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-width).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-end-width
-#[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineEndWidthStyleValue;
-
-/// Represents the style value for `border-block-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-width).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'border-top-width'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-width
-#[syntax(" <'border-top-width'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBlockWidthStyleValue;
-
-/// Represents the style value for `border-inline-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-width).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'border-top-width'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-width
-#[syntax(" <'border-top-width'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineWidthStyleValue;
-
-/// Represents the style value for `border-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-width).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'border-top-width'>{1,4}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-width
-#[syntax(" <'border-top-width'>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderWidthStyleValue;
-
-/// Represents the style value for `border-top` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width> || <line-style> || <color>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-top
-#[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "See individual properties",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderTopStyleValue;
-
-/// Represents the style value for `border-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width> || <line-style> || <color>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-right
-#[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "See individual properties",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderRightStyleValue;
-
-/// Represents the style value for `border-bottom` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width> || <line-style> || <color>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-bottom
-#[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "See individual properties",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBottomStyleValue;
-
-/// Represents the style value for `border-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left).
-///
-/// The border CSS property sets the color, style, and width of the line around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width> || <line-style> || <color>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-left
-#[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "See individual properties",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderLeftStyleValue;
-
-/// Represents the style value for `border-block-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width> || <line-style> || <color>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-start
-#[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "See individual properties",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBlockStartStyleValue;
-
-/// Represents the style value for `border-block-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width> || <line-style> || <color>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-block-end
-#[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "See individual properties",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBlockEndStyleValue;
-
-/// Represents the style value for `border-inline-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width> || <line-style> || <color>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-start
-#[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "See individual properties",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineStartStyleValue;
-
-/// Represents the style value for `border-inline-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width> || <line-style> || <color>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-inline-end
-#[syntax(" <line-width> || <line-style> || <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "See individual properties",
-	applies_to = "all elements except ruby base containers and ruby annotation containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineEndStyleValue;
+pub struct BorderStyleValue;
 
 /// Represents the style value for `border-block` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block).
 ///
@@ -1099,18 +59,18 @@ pub struct BorderInlineEndStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBlockStyleValue;
 
-/// Represents the style value for `border-inline` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline).
+/// Represents the style value for `border-block-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-color).
 ///
 /// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <'border-block-start'>
+/// <'border-top-color'>{1,2}
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-inline
-#[syntax(" <'border-block-start'> ")]
+// https://drafts.csswg.org/css-borders-4/#border-block-color
+#[syntax(" <'border-top-color'>{1,2} ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "see individual properties",
@@ -1121,11 +81,319 @@ pub struct BorderBlockStyleValue;
 	animation_type = "see individual properties"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-color"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderInlineStyleValue;
+pub struct BorderBlockColorStyleValue<'a>;
 
-/// Represents the style value for `border` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border).
+/// Represents the style value for `border-block-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width> || <line-style> || <color>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-end
+#[syntax(" <line-width> || <line-style> || <color> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "See individual properties",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderBlockEndStyleValue;
+
+/// Represents the style value for `border-block-end-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-color).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <color> | <image-1D>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-end-color
+#[syntax(" <color> | <image-1D> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "currentcolor",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see prose"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderBlockEndColorStyleValue<'a> {}
+
+// /// Represents the style value for `border-block-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-radius).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-block-end-radius
+// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-radius"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderBlockEndRadiusStyleValue;
+
+/// Represents the style value for `border-block-end-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-style).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-style>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-end-style
+#[syntax(" <line-style> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderBlockEndStyleStyleValue;
+
+/// Represents the style value for `border-block-end-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-width).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-end-width
+#[syntax(" <line-width> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderBlockEndWidthStyleValue;
+
+/// Represents the style value for `border-block-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width> || <line-style> || <color>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-start
+#[syntax(" <line-width> || <line-style> || <color> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "See individual properties",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderBlockStartStyleValue;
+
+/// Represents the style value for `border-block-start-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-color).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <color> | <image-1D>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-start-color
+#[syntax(" <color> | <image-1D> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "currentcolor",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see prose"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderBlockStartColorStyleValue<'a> {}
+
+// /// Represents the style value for `border-block-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-radius).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-block-start-radius
+// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-radius"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderBlockStartRadiusStyleValue;
+
+/// Represents the style value for `border-block-start-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-style).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-style>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-start-style
+#[syntax(" <line-style> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderBlockStartStyleStyleValue;
+
+/// Represents the style value for `border-block-start-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-width).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-start-width
+#[syntax(" <line-width> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderBlockStartWidthStyleValue;
+
+/// Represents the style value for `border-block-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-style).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'border-top-style'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-style
+#[syntax(" <'border-top-style'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderBlockStyleStyleValue;
+
+/// Represents the style value for `border-block-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-width).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'border-top-width'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-block-width
+#[syntax(" <'border-top-width'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderBlockWidthStyleValue;
+
+/// Represents the style value for `border-bottom` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom).
 ///
 /// The border CSS property sets the color, style, and width of the line around an element.
 ///
@@ -1135,23 +403,49 @@ pub struct BorderInlineStyleValue;
 /// <line-width> || <line-style> || <color>
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border
+// https://drafts.csswg.org/css-borders-4/#border-bottom
 #[syntax(" <line-width> || <line-style> || <color> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
+	initial = "See individual properties",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "see individual properties"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderStyleValue;
+pub struct BorderBottomStyleValue;
 
-/// Represents the style value for `border-top-left-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-left-radius).
+/// Represents the style value for `border-bottom-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-color).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <color> | <image-1D>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-bottom-color
+#[syntax(" <color> | <image-1D> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "currentcolor",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see prose"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderBottomColorStyleValue<'a> {}
+
+/// Represents the style value for `border-bottom-left-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-left-radius).
 ///
 /// The border-radius CSS property rounds the corners of the border drawn around an element.
 ///
@@ -1161,7 +455,7 @@ pub struct BorderStyleValue;
 /// <length-percentage [0,∞]>{1,2}
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-top-left-radius
+// https://drafts.csswg.org/css-borders-4/#border-bottom-left-radius
 #[syntax(" <length-percentage [0,∞]>{1,2} ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
@@ -1173,35 +467,33 @@ pub struct BorderStyleValue;
 	animation_type = "by computed value"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-left-radius"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-left-radius"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderTopLeftRadiusStyleValue;
+pub struct BorderBottomLeftRadiusStyleValue;
 
-/// Represents the style value for `border-top-right-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-right-radius).
-///
-/// The border-radius CSS property rounds the corners of the border drawn around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length-percentage [0,∞]>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-top-right-radius
-#[syntax(" <length-percentage [0,∞]>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements (but see prose)",
-	inherited = "no",
-	percentages = "refer to corresponding dimension of the border box.",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-right-radius"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderTopRightRadiusStyleValue;
+// /// Represents the style value for `border-bottom-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-radius).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-bottom-radius
+// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-radius"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderBottomRadiusStyleValue;
 
 /// Represents the style value for `border-bottom-right-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-right-radius).
 ///
@@ -1233,109 +525,203 @@ pub struct BorderTopRightRadiusStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderBottomRightRadiusStyleValue;
 
-/// Represents the style value for `border-bottom-left-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-left-radius).
+/// Represents the style value for `border-bottom-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-style).
 ///
-/// The border-radius CSS property rounds the corners of the border drawn around an element.
+/// The border CSS property sets the color, style, and width of the line around an element.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <length-percentage [0,∞]>{1,2}
+/// <line-style>
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-bottom-left-radius
-#[syntax(" <length-percentage [0,∞]>{1,2} ")]
+// https://drafts.csswg.org/css-borders-4/#border-bottom-style
+#[syntax(" <line-style> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "0",
-	applies_to = "all elements (but see prose)",
+	initial = "none",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
 	inherited = "no",
-	percentages = "refer to corresponding dimension of the border box.",
+	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "by computed value"
+	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-left-radius"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-style"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderBottomLeftRadiusStyleValue;
+pub struct BorderBottomStyleStyleValue;
 
-/// Represents the style value for `border-start-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-start-start-radius).
+/// Represents the style value for `border-bottom-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-width).
 ///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+/// The border CSS property sets the color, style, and width of the line around an element.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <length-percentage [0,∞]>{1,2}
+/// <line-width>
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-start-start-radius
-#[syntax(" <length-percentage [0,∞]>{1,2} ")]
+// https://drafts.csswg.org/css-borders-4/#border-bottom-width
+#[syntax(" <line-width> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "0",
-	applies_to = "all elements (but see prose)",
+	initial = "medium",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
 	inherited = "no",
-	percentages = "refer to corresponding dimension of the border box.",
+	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "by computed value"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-start-start-radius"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-width"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderStartStartRadiusStyleValue;
+pub struct BorderBottomWidthStyleValue;
 
-/// Represents the style value for `border-start-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-start-end-radius).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+/// Represents the style value for `border-clip` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <length-percentage [0,∞]>{1,2}
+/// normal | [ <length-percentage [0,∞]> | <flex> ]+
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-start-end-radius
-#[syntax(" <length-percentage [0,∞]>{1,2} ")]
+// https://drafts.csswg.org/css-borders-4/#border-clip
+#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "0",
-	applies_to = "all elements (but see prose)",
+	initial = "normal",
+	applies_to = "all elements",
 	inherited = "no",
-	percentages = "refer to corresponding dimension of the border box.",
+	percentages = "refer to length of border-edge side",
 	canonical_order = "per grammar",
 	animation_type = "by computed value"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-start-end-radius"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderStartEndRadiusStyleValue;
+pub enum BorderClipStyleValue<'a> {}
 
-/// Represents the style value for `border-end-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-end-start-radius).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+/// Represents the style value for `border-clip-bottom` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-bottom).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <length-percentage [0,∞]>{1,2}
+/// normal | [ <length-percentage [0,∞]> | <flex> ]+
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-end-start-radius
-#[syntax(" <length-percentage [0,∞]>{1,2} ")]
+// https://drafts.csswg.org/css-borders-4/#border-clip-bottom
+#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "0",
-	applies_to = "all elements (but see prose)",
+	initial = "normal",
+	applies_to = "all elements",
 	inherited = "no",
-	percentages = "refer to corresponding dimension of the border box.",
+	percentages = "refer to length of border-edge side",
 	canonical_order = "per grammar",
 	animation_type = "by computed value"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-end-start-radius"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-bottom"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderEndStartRadiusStyleValue;
+pub enum BorderClipBottomStyleValue<'a> {}
+
+/// Represents the style value for `border-clip-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-left).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | [ <length-percentage [0,∞]> | <flex> ]+
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-clip-left
+#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "refer to length of border-edge side",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-left"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderClipLeftStyleValue<'a> {}
+
+/// Represents the style value for `border-clip-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-right).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | [ <length-percentage [0,∞]> | <flex> ]+
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-clip-right
+#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "refer to length of border-edge side",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-right"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderClipRightStyleValue<'a> {}
+
+/// Represents the style value for `border-clip-top` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-top).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | [ <length-percentage [0,∞]> | <flex> ]+
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-clip-top
+#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "refer to length of border-edge side",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-top"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderClipTopStyleValue<'a> {}
+
+// /// Represents the style value for `border-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-color).
+// ///
+// /// The border CSS property sets the color, style, and width of the line around an element.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ <color> | <image-1D> ]{1,4}
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-color
+// #[syntax(" [ <color> | <image-1D> ]{1,4} ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-color"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderColorStyleValue<'a>;
 
 /// Represents the style value for `border-end-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-end-end-radius).
 ///
@@ -1363,1151 +749,59 @@ pub struct BorderEndStartRadiusStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderEndEndRadiusStyleValue;
 
-// /// Represents the style value for `border-top-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-radius).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-top-radius
-// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-radius"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderTopRadiusStyleValue;
-
-// /// Represents the style value for `border-right-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-radius).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-right-radius
-// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-radius"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderRightRadiusStyleValue;
-
-// /// Represents the style value for `border-bottom-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-bottom-radius).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-bottom-radius
-// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-bottom-radius"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderBottomRadiusStyleValue;
-
-// /// Represents the style value for `border-left-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-radius).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-left-radius
-// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-radius"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderLeftRadiusStyleValue;
-
-// /// Represents the style value for `border-block-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-start-radius).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-block-start-radius
-// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-start-radius"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderBlockStartRadiusStyleValue;
-
-// /// Represents the style value for `border-block-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-block-end-radius).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-block-end-radius
-// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-block-end-radius"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderBlockEndRadiusStyleValue;
-
-// /// Represents the style value for `border-inline-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-radius).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-inline-start-radius
-// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-radius"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderInlineStartRadiusStyleValue;
-
-// /// Represents the style value for `border-inline-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-radius).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-inline-end-radius
-// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-radius"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderInlineEndRadiusStyleValue;
-
-// /// Represents the style value for `border-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-radius).
-// ///
-// /// The border-radius CSS property rounds the corners of the border drawn around an element.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-radius
-// #[syntax(" <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-radius"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderRadiusStyleValue;
-
-/// Represents the style value for `corner-top-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-left-shape).
+/// Represents the style value for `border-end-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-end-start-radius).
 ///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <corner-shape-value>
+/// <length-percentage [0,∞]>{1,2}
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#corner-top-left-shape
-#[syntax(" <corner-shape-value> ")]
+// https://drafts.csswg.org/css-borders-4/#border-end-start-radius
+#[syntax(" <length-percentage [0,∞]>{1,2} ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "round",
-	applies_to = "all elements where border-radius can apply",
+	initial = "0",
+	applies_to = "all elements (but see prose)",
 	inherited = "no",
-	percentages = "n/a",
+	percentages = "refer to corresponding dimension of the border box.",
 	canonical_order = "per grammar",
-	animation_type = "see superellipse interpolation"
+	animation_type = "by computed value"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-left-shape"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-end-start-radius"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerTopLeftShapeStyleValue;
+pub struct BorderEndStartRadiusStyleValue;
 
-/// Represents the style value for `corner-top-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-right-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <corner-shape-value>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-top-right-shape
-#[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "round",
-	applies_to = "all elements where border-radius can apply",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see superellipse interpolation"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-right-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerTopRightShapeStyleValue;
-
-/// Represents the style value for `corner-bottom-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-right-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <corner-shape-value>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-bottom-right-shape
-#[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "round",
-	applies_to = "all elements where border-radius can apply",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see superellipse interpolation"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-right-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerBottomRightShapeStyleValue;
-
-/// Represents the style value for `corner-bottom-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-left-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <corner-shape-value>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-bottom-left-shape
-#[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "round",
-	applies_to = "all elements where border-radius can apply",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see superellipse interpolation"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-left-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerBottomLeftShapeStyleValue;
-
-/// Represents the style value for `corner-start-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-start-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <corner-shape-value>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-start-start-shape
-#[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "round",
-	applies_to = "all elements where border-radius can apply",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see superellipse interpolation"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-start-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerStartStartShapeStyleValue;
-
-/// Represents the style value for `corner-start-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-end-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <corner-shape-value>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-start-end-shape
-#[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "round",
-	applies_to = "all elements where border-radius can apply",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see superellipse interpolation"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-end-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerStartEndShapeStyleValue;
-
-/// Represents the style value for `corner-end-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-start-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <corner-shape-value>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-end-start-shape
-#[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "round",
-	applies_to = "all elements where border-radius can apply",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see superellipse interpolation"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-start-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerEndStartShapeStyleValue;
-
-/// Represents the style value for `corner-end-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-end-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <corner-shape-value>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-end-end-shape
-#[syntax(" <corner-shape-value> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "round",
-	applies_to = "all elements where border-radius can apply",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see superellipse interpolation"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-end-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerEndEndShapeStyleValue;
-
-/// Represents the style value for `corner-top-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'corner-top-left-shape'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-top-shape
-#[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerTopShapeStyleValue;
-
-/// Represents the style value for `corner-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-right-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'corner-top-left-shape'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-right-shape
-#[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-right-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerRightShapeStyleValue;
-
-/// Represents the style value for `corner-bottom-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'corner-top-left-shape'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-bottom-shape
-#[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerBottomShapeStyleValue;
-
-/// Represents the style value for `corner-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-left-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'corner-top-left-shape'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-left-shape
-#[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-left-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerLeftShapeStyleValue;
-
-/// Represents the style value for `corner-block-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-start-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'corner-top-left-shape'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-block-start-shape
-#[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-start-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerBlockStartShapeStyleValue;
-
-/// Represents the style value for `corner-block-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-end-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'corner-top-left-shape'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-block-end-shape
-#[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-end-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerBlockEndShapeStyleValue;
-
-/// Represents the style value for `corner-inline-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-start-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'corner-top-left-shape'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-inline-start-shape
-#[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-start-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerInlineStartShapeStyleValue;
-
-/// Represents the style value for `corner-inline-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-end-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'corner-top-left-shape'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-inline-end-shape
-#[syntax(" <'corner-top-left-shape'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-end-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerInlineEndShapeStyleValue;
-
-/// Represents the style value for `corner-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-shape).
-///
-/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'corner-top-left-shape'>{1,4}
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#corner-shape
-#[syntax(" <'corner-top-left-shape'>{1,4} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "round",
-	applies_to = "all elements where border-radius can apply",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CornerShapeStyleValue;
-
-// /// Represents the style value for `corner-top-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-left).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-top-left
-// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-left"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerTopLeftStyleValue;
-
-// /// Represents the style value for `corner-top-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-right).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-top-right
-// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-right"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerTopRightStyleValue;
-
-// /// Represents the style value for `corner-bottom-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-left).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-bottom-left
-// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-left"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerBottomLeftStyleValue;
-
-// /// Represents the style value for `corner-bottom-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-right).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-bottom-right
-// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-right"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerBottomRightStyleValue;
-
-// /// Represents the style value for `corner-start-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-start).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-start-start
-// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-start"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerStartStartStyleValue;
-
-// /// Represents the style value for `corner-start-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-end).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-start-end
-// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-end"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerStartEndStyleValue;
-
-// /// Represents the style value for `corner-end-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-start).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-end-start
-// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-start"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerEndStartStyleValue;
-
-// /// Represents the style value for `corner-end-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-end).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-end-end
-// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-end"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerEndEndStyleValue;
-
-// /// Represents the style value for `corner-top` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-radius'> || <'corner-top-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-top
-// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerTopStyleValue;
-
-// /// Represents the style value for `corner-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-right).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-radius'> || <'corner-top-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-right
-// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-right"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerRightStyleValue;
-
-// /// Represents the style value for `corner-bottom` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-radius'> || <'corner-top-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-bottom
-// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerBottomStyleValue;
-
-// /// Represents the style value for `corner-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-left).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-radius'> || <'corner-top-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-left
-// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-left"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerLeftStyleValue;
-
-// /// Represents the style value for `corner-block-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-start).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-radius'> || <'corner-top-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-block-start
-// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-start"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerBlockStartStyleValue;
-
-// /// Represents the style value for `corner-block-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-end).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-radius'> || <'corner-top-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-block-end
-// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-end"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerBlockEndStyleValue;
-
-// /// Represents the style value for `corner-inline-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-start).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-radius'> || <'corner-top-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-inline-start
-// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-start"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerInlineStartStyleValue;
-
-// /// Represents the style value for `corner-inline-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-end).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-top-radius'> || <'corner-top-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner-inline-end
-// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-end"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerInlineEndStyleValue;
-
-// /// Represents the style value for `corner` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'border-radius'> || <'corner-shape'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#corner
-// #[syntax(" <'border-radius'> || <'corner-shape'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0",
-//   applies_to = "all elements (but see prose)",
-// 	inherited = "no",
-// 	percentages = "refer to corresponding dimension of the border box.",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct CornerStyleValue;
-
-/// Represents the style value for `border-image-source` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-source).
-///
-/// The border-image CSS property draws an image around an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <image>
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-image-source
-#[syntax(" none | <image> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "All elements, except internal table elements when border-collapse is collapse",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-source"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BorderImageSourceStyleValue<'a>;
-
-// /// Represents the style value for `border-image-slice` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-slice).
+// /// Represents the style value for `border-image` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image).
 // ///
 // /// The border-image CSS property draws an image around an element.
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// [<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?
+// /// <'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-borders-4/#border-image-slice
-// #[syntax(" [<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill? ")]
+// // https://drafts.csswg.org/css-borders-4/#border-image
+// #[syntax(
+// 	" <'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'> "
+// )]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "100%",
-//   applies_to = "All elements, except internal table elements when border-collapse is collapse",
+// 	initial = "See individual properties",
+//   applies_to = "See individual properties",
 // 	inherited = "no",
-// 	percentages = "refer to size of the border image",
+// 	percentages = "n/a",
 // 	canonical_order = "per grammar",
-// 	animation_type = "by computed value",
+// 	animation_type = "see individual properties",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-slice"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderImageSliceStyleValue;
-
-// /// Represents the style value for `border-image-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-width).
-// ///
-// /// The border-image CSS property draws an image around an element.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4}
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-borders-4/#border-image-width
-// #[syntax(" [ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "1",
-//   applies_to = "All elements, except internal table elements when border-collapse is collapse",
-// 	inherited = "no",
-// 	percentages = "relative to width/height of the border image area",
-// 	canonical_order = "per grammar",
-// 	animation_type = "by computed value",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-width"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderImageWidthStyleValue;
+// pub struct BorderImageStyleValue;
 
 /// Represents the style value for `border-image-outset` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-outset).
 ///
@@ -2561,33 +855,571 @@ pub struct BorderImageOutsetStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BorderImageRepeatStyleValue;
 
-// /// Represents the style value for `border-image` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image).
+// /// Represents the style value for `border-image-slice` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-slice).
 // ///
 // /// The border-image CSS property draws an image around an element.
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// <'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>
+// /// [<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill?
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-borders-4/#border-image
-// #[syntax(
-// 	" <'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'> "
-// )]
+// // https://drafts.csswg.org/css-borders-4/#border-image-slice
+// #[syntax(" [<number [0,∞]> | <percentage [0,∞]>]{1,4} && fill? ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "See individual properties",
-//   applies_to = "See individual properties",
+// 	initial = "100%",
+//   applies_to = "All elements, except internal table elements when border-collapse is collapse",
 // 	inherited = "no",
-// 	percentages = "n/a",
+// 	percentages = "refer to size of the border image",
+// 	canonical_order = "per grammar",
+// 	animation_type = "by computed value",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-slice"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderImageSliceStyleValue;
+
+/// Represents the style value for `border-image-source` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-source).
+///
+/// The border-image CSS property draws an image around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <image>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-image-source
+#[syntax(" none | <image> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "All elements, except internal table elements when border-collapse is collapse",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-source"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderImageSourceStyleValue<'a>;
+
+// /// Represents the style value for `border-image-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-image-width).
+// ///
+// /// The border-image CSS property draws an image around an element.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4}
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-image-width
+// #[syntax(" [ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4} ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "1",
+//   applies_to = "All elements, except internal table elements when border-collapse is collapse",
+// 	inherited = "no",
+// 	percentages = "relative to width/height of the border image area",
+// 	canonical_order = "per grammar",
+// 	animation_type = "by computed value",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image-width"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderImageWidthStyleValue;
+
+/// Represents the style value for `border-inline` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'border-block-start'>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline
+#[syntax(" <'border-block-start'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineStyleValue;
+
+/// Represents the style value for `border-inline-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-color).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'border-top-color'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-color
+#[syntax(" <'border-top-color'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineColorStyleValue<'a>;
+
+/// Represents the style value for `border-inline-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width> || <line-style> || <color>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-end
+#[syntax(" <line-width> || <line-style> || <color> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "See individual properties",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineEndStyleValue;
+
+/// Represents the style value for `border-inline-end-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-color).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <color> | <image-1D>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-end-color
+#[syntax(" <color> | <image-1D> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "currentcolor",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see prose"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderInlineEndColorStyleValue<'a> {}
+
+// /// Represents the style value for `border-inline-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-radius).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-inline-end-radius
+// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
 // 	canonical_order = "per grammar",
 // 	animation_type = "see individual properties",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-image"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-radius"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct BorderImageStyleValue;
+// pub struct BorderInlineEndRadiusStyleValue;
+
+/// Represents the style value for `border-inline-end-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-style).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-style>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-end-style
+#[syntax(" <line-style> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineEndStyleStyleValue;
+
+/// Represents the style value for `border-inline-end-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-end-width).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-end-width
+#[syntax(" <line-width> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-end-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineEndWidthStyleValue;
+
+/// Represents the style value for `border-inline-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width> || <line-style> || <color>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-start
+#[syntax(" <line-width> || <line-style> || <color> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "See individual properties",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineStartStyleValue;
+
+/// Represents the style value for `border-inline-start-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-color).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <color> | <image-1D>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-start-color
+#[syntax(" <color> | <image-1D> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "currentcolor",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see prose"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderInlineStartColorStyleValue<'a> {}
+
+// /// Represents the style value for `border-inline-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-radius).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-inline-start-radius
+// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-radius"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderInlineStartRadiusStyleValue;
+
+/// Represents the style value for `border-inline-start-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-style).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-style>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-start-style
+#[syntax(" <line-style> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineStartStyleStyleValue;
+
+/// Represents the style value for `border-inline-start-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-start-width).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-start-width
+#[syntax(" <line-width> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-start-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineStartWidthStyleValue;
+
+/// Represents the style value for `border-inline-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-style).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'border-top-style'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-style
+#[syntax(" <'border-top-style'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineStyleStyleValue;
+
+/// Represents the style value for `border-inline-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-inline-width).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'border-top-width'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-inline-width
+#[syntax(" <'border-top-width'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-inline-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderInlineWidthStyleValue;
+
+/// Represents the style value for `border-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width> || <line-style> || <color>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-left
+#[syntax(" <line-width> || <line-style> || <color> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "See individual properties",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderLeftStyleValue;
+
+/// Represents the style value for `border-left-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-color).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <color> | <image-1D>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-left-color
+#[syntax(" <color> | <image-1D> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "currentcolor",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see prose"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderLeftColorStyleValue<'a> {}
+
+// /// Represents the style value for `border-left-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-radius).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-left-radius
+// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-radius"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderLeftRadiusStyleValue;
+
+/// Represents the style value for `border-left-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-style).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-style>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-left-style
+#[syntax(" <line-style> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderLeftStyleStyleValue;
+
+/// Represents the style value for `border-left-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-left-width).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-left-width
+#[syntax(" <line-width> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-left-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderLeftWidthStyleValue;
 
 // /// Represents the style value for `border-limit` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-limit).
 // ///
@@ -2615,125 +1447,517 @@ pub struct BorderImageRepeatStyleValue;
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum BorderLimitStyleValue {}
 
-/// Represents the style value for `border-clip` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | [ <length-percentage [0,∞]> | <flex> ]+
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-clip
-#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "refer to length of border-edge side",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderClipStyleValue<'a> {}
+// /// Represents the style value for `border-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-radius).
+// ///
+// /// The border-radius CSS property rounds the corners of the border drawn around an element.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-radius
+// #[syntax(" <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-radius"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderRadiusStyleValue;
 
-/// Represents the style value for `border-clip-top` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-top).
+/// Represents the style value for `border-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// normal | [ <length-percentage [0,∞]> | <flex> ]+
+/// <line-width> || <line-style> || <color>
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-clip-top
-#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
+// https://drafts.csswg.org/css-borders-4/#border-right
+#[syntax(" <line-width> || <line-style> || <color> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "normal",
-	applies_to = "all elements",
+	initial = "See individual properties",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
 	inherited = "no",
-	percentages = "refer to length of border-edge side",
+	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "by computed value"
+	animation_type = "see individual properties"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-top"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderClipTopStyleValue<'a> {}
+pub struct BorderRightStyleValue;
 
-/// Represents the style value for `border-clip-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-right).
+/// Represents the style value for `border-right-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-color).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// normal | [ <length-percentage [0,∞]> | <flex> ]+
+/// <color> | <image-1D>
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-clip-right
-#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
+// https://drafts.csswg.org/css-borders-4/#border-right-color
+#[syntax(" <color> | <image-1D> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "normal",
-	applies_to = "all elements",
+	initial = "currentcolor",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
 	inherited = "no",
-	percentages = "refer to length of border-edge side",
+	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "by computed value"
+	animation_type = "see prose"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-right"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-color"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderClipRightStyleValue<'a> {}
+pub enum BorderRightColorStyleValue<'a> {}
 
-/// Represents the style value for `border-clip-bottom` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-bottom).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | [ <length-percentage [0,∞]> | <flex> ]+
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#border-clip-bottom
-#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "refer to length of border-edge side",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-bottom"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderClipBottomStyleValue<'a> {}
+// /// Represents the style value for `border-right-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-radius).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-right-radius
+// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-radius"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderRightRadiusStyleValue;
 
-/// Represents the style value for `border-clip-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-clip-left).
+/// Represents the style value for `border-right-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-style).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// normal | [ <length-percentage [0,∞]> | <flex> ]+
+/// <line-style>
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#border-clip-left
-#[syntax(" normal | [ <length-percentage [0,∞]> | <flex> ]+ ")]
+// https://drafts.csswg.org/css-borders-4/#border-right-style
+#[syntax(" <line-style> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "normal",
-	applies_to = "all elements",
+	initial = "none",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
 	inherited = "no",
-	percentages = "refer to length of border-edge side",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderRightStyleStyleValue;
+
+/// Represents the style value for `border-right-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-right-width).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-right-width
+#[syntax(" <line-width> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "by computed value"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-clip-left"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-right-width"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BorderClipLeftStyleValue<'a> {}
+pub struct BorderRightWidthStyleValue;
+
+// /// Represents the style value for `border-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-shape).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [ <basic-shape> <geometry-box>?]{1,2}
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-shape
+// #[syntax(" none | [ <basic-shape> <geometry-box>?]{1,2} ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "see prose",
+// 	canonical_order = "per grammar",
+// 	animation_type = "by computed value",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-shape"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum BorderShapeStyleValue {}
+
+/// Represents the style value for `border-start-end-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-start-end-radius).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length-percentage [0,∞]>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-start-end-radius
+#[syntax(" <length-percentage [0,∞]>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements (but see prose)",
+	inherited = "no",
+	percentages = "refer to corresponding dimension of the border box.",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-start-end-radius"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderStartEndRadiusStyleValue;
+
+/// Represents the style value for `border-start-start-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-start-start-radius).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length-percentage [0,∞]>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-start-start-radius
+#[syntax(" <length-percentage [0,∞]>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements (but see prose)",
+	inherited = "no",
+	percentages = "refer to corresponding dimension of the border box.",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-start-start-radius"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderStartStartRadiusStyleValue;
+
+/// Represents the style value for `border-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-style).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'border-top-style'>{1,4}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-style
+#[syntax(" <'border-top-style'>{1,4} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderStyleStyleValue;
+
+/// Represents the style value for `border-top` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width> || <line-style> || <color>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-top
+#[syntax(" <line-width> || <line-style> || <color> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "See individual properties",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderTopStyleValue;
+
+/// Represents the style value for `border-top-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-color).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <color> | <image-1D>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-top-color
+#[syntax(" <color> | <image-1D> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "currentcolor",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see prose"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BorderTopColorStyleValue<'a> {}
+
+/// Represents the style value for `border-top-left-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-left-radius).
+///
+/// The border-radius CSS property rounds the corners of the border drawn around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length-percentage [0,∞]>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-top-left-radius
+#[syntax(" <length-percentage [0,∞]>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements (but see prose)",
+	inherited = "no",
+	percentages = "refer to corresponding dimension of the border box.",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-left-radius"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderTopLeftRadiusStyleValue;
+
+// /// Represents the style value for `border-top-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-radius).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#border-top-radius
+// #[syntax(" <length-percentage [0,∞]>{1,2} [ / <length-percentage [0,∞]>{1,2} ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-radius"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct BorderTopRadiusStyleValue;
+
+/// Represents the style value for `border-top-right-radius` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-right-radius).
+///
+/// The border-radius CSS property rounds the corners of the border drawn around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length-percentage [0,∞]>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-top-right-radius
+#[syntax(" <length-percentage [0,∞]>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements (but see prose)",
+	inherited = "no",
+	percentages = "refer to corresponding dimension of the border box.",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-right-radius"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderTopRightRadiusStyleValue;
+
+/// Represents the style value for `border-top-style` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-style).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-style>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-top-style
+#[syntax(" <line-style> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderTopStyleStyleValue;
+
+/// Represents the style value for `border-top-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-top-width).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-top-width
+#[syntax(" <line-width> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "all elements except ruby base containers and ruby annotation containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-top-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderTopWidthStyleValue;
+
+/// Represents the style value for `border-width` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-width).
+///
+/// The border CSS property sets the color, style, and width of the line around an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'border-top-width'>{1,4}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#border-width
+#[syntax(" <'border-top-width'>{1,4} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BorderWidthStyleValue;
+
+/// Represents the style value for `box-shadow` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow).
+///
+/// The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <spread-shadow>#
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#box-shadow
+#[syntax(" <spread-shadow># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BoxShadowStyleValue<'a>;
+
+/// Represents the style value for `box-shadow-blur` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-blur).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length [0,∞]>#
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#box-shadow-blur
+#[syntax(" <length [0,∞]># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow-blur"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BoxShadowBlurStyleValue<'a>;
 
 /// Represents the style value for `box-shadow-color` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-color).
 ///
@@ -2783,19 +2007,19 @@ pub struct BoxShadowColorStyleValue<'a>;
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct BoxShadowOffsetStyleValue<'a>;
 
-/// Represents the style value for `box-shadow-blur` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-blur).
+/// Represents the style value for `box-shadow-position` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-position).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <length [0,∞]>#
+/// [ outset | inset ]#
 /// ```
 ///
-// https://drafts.csswg.org/css-borders-4/#box-shadow-blur
-#[syntax(" <length [0,∞]># ")]
+// https://drafts.csswg.org/css-borders-4/#box-shadow-position
+#[syntax(" [ outset | inset ]# ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "0",
+	initial = "outset",
 	applies_to = "all elements",
 	inherited = "no",
 	percentages = "n/a",
@@ -2803,9 +2027,9 @@ pub struct BoxShadowColorStyleValue<'a>;
 	animation_type = "by computed value"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow-blur"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow-position"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BoxShadowBlurStyleValue<'a>;
+pub struct BoxShadowPositionStyleValue<'a>;
 
 /// Represents the style value for `box-shadow-spread` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-spread).
 ///
@@ -2831,76 +2055,852 @@ pub struct BoxShadowBlurStyleValue<'a>;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BoxShadowSpreadStyleValue<'a>;
 
-/// Represents the style value for `box-shadow-position` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow-position).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// [ outset | inset ]#
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#box-shadow-position
-#[syntax(" [ outset | inset ]# ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "outset",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow-position"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BoxShadowPositionStyleValue<'a>;
-
-/// Represents the style value for `box-shadow` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#box-shadow).
-///
-/// The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <spread-shadow>#
-/// ```
-///
-// https://drafts.csswg.org/css-borders-4/#box-shadow
-#[syntax(" <spread-shadow># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-shadow"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BoxShadowStyleValue<'a>;
-
-// /// Represents the style value for `border-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#border-shape).
+// /// Represents the style value for `corner` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner).
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// none | [ <basic-shape> <geometry-box>?]{1,2}
+// /// <'border-radius'> || <'corner-shape'>
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-borders-4/#border-shape
-// #[syntax(" none | [ <basic-shape> <geometry-box>?]{1,2} ")]
+// // https://drafts.csswg.org/css-borders-4/#corner
+// #[syntax(" <'border-radius'> || <'corner-shape'> ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "none",
-//   applies_to = "all elements",
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
 // 	inherited = "no",
-// 	percentages = "see prose",
+// 	percentages = "refer to corresponding dimension of the border box.",
 // 	canonical_order = "per grammar",
-// 	animation_type = "by computed value",
+// 	animation_type = "see individual properties",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.border-shape"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum BorderShapeStyleValue {}
+// pub struct CornerStyleValue;
+
+// /// Represents the style value for `corner-block-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-end).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-radius'> || <'corner-top-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-block-end
+// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-end"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerBlockEndStyleValue;
+
+/// Represents the style value for `corner-block-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-end-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'corner-top-left-shape'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-block-end-shape
+#[syntax(" <'corner-top-left-shape'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-end-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerBlockEndShapeStyleValue;
+
+// /// Represents the style value for `corner-block-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-start).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-radius'> || <'corner-top-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-block-start
+// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-start"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerBlockStartStyleValue;
+
+/// Represents the style value for `corner-block-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-block-start-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'corner-top-left-shape'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-block-start-shape
+#[syntax(" <'corner-top-left-shape'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-block-start-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerBlockStartShapeStyleValue;
+
+// /// Represents the style value for `corner-bottom` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-radius'> || <'corner-top-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-bottom
+// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerBottomStyleValue;
+
+// /// Represents the style value for `corner-bottom-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-left).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-bottom-left
+// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-left"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerBottomLeftStyleValue;
+
+/// Represents the style value for `corner-bottom-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-left-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <corner-shape-value>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-bottom-left-shape
+#[syntax(" <corner-shape-value> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "round",
+	applies_to = "all elements where border-radius can apply",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see superellipse interpolation"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-left-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerBottomLeftShapeStyleValue;
+
+// /// Represents the style value for `corner-bottom-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-right).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-bottom-right
+// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-right"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerBottomRightStyleValue;
+
+/// Represents the style value for `corner-bottom-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-right-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <corner-shape-value>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-bottom-right-shape
+#[syntax(" <corner-shape-value> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "round",
+	applies_to = "all elements where border-radius can apply",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see superellipse interpolation"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-right-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerBottomRightShapeStyleValue;
+
+/// Represents the style value for `corner-bottom-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-bottom-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'corner-top-left-shape'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-bottom-shape
+#[syntax(" <'corner-top-left-shape'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-bottom-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerBottomShapeStyleValue;
+
+// /// Represents the style value for `corner-end-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-end).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-end-end
+// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-end"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerEndEndStyleValue;
+
+/// Represents the style value for `corner-end-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-end-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <corner-shape-value>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-end-end-shape
+#[syntax(" <corner-shape-value> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "round",
+	applies_to = "all elements where border-radius can apply",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see superellipse interpolation"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-end-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerEndEndShapeStyleValue;
+
+// /// Represents the style value for `corner-end-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-start).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-end-start
+// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-start"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerEndStartStyleValue;
+
+/// Represents the style value for `corner-end-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-end-start-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <corner-shape-value>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-end-start-shape
+#[syntax(" <corner-shape-value> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "round",
+	applies_to = "all elements where border-radius can apply",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see superellipse interpolation"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-end-start-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerEndStartShapeStyleValue;
+
+// /// Represents the style value for `corner-inline-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-end).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-radius'> || <'corner-top-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-inline-end
+// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-end"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerInlineEndStyleValue;
+
+/// Represents the style value for `corner-inline-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-end-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'corner-top-left-shape'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-inline-end-shape
+#[syntax(" <'corner-top-left-shape'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-end-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerInlineEndShapeStyleValue;
+
+// /// Represents the style value for `corner-inline-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-start).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-radius'> || <'corner-top-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-inline-start
+// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-start"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerInlineStartStyleValue;
+
+/// Represents the style value for `corner-inline-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-inline-start-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'corner-top-left-shape'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-inline-start-shape
+#[syntax(" <'corner-top-left-shape'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-inline-start-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerInlineStartShapeStyleValue;
+
+// /// Represents the style value for `corner-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-left).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-radius'> || <'corner-top-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-left
+// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-left"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerLeftStyleValue;
+
+/// Represents the style value for `corner-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-left-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'corner-top-left-shape'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-left-shape
+#[syntax(" <'corner-top-left-shape'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-left-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerLeftShapeStyleValue;
+
+// /// Represents the style value for `corner-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-right).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-radius'> || <'corner-top-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-right
+// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-right"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerRightStyleValue;
+
+/// Represents the style value for `corner-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-right-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'corner-top-left-shape'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-right-shape
+#[syntax(" <'corner-top-left-shape'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-right-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerRightShapeStyleValue;
+
+/// Represents the style value for `corner-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'corner-top-left-shape'>{1,4}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-shape
+#[syntax(" <'corner-top-left-shape'>{1,4} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "round",
+	applies_to = "all elements where border-radius can apply",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerShapeStyleValue;
+
+// /// Represents the style value for `corner-start-end` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-end).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-start-end
+// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-end"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerStartEndStyleValue;
+
+/// Represents the style value for `corner-start-end-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-end-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <corner-shape-value>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-start-end-shape
+#[syntax(" <corner-shape-value> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "round",
+	applies_to = "all elements where border-radius can apply",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see superellipse interpolation"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-end-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerStartEndShapeStyleValue;
+
+// /// Represents the style value for `corner-start-start` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-start).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-start-start
+// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-start"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerStartStartStyleValue;
+
+/// Represents the style value for `corner-start-start-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-start-start-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <corner-shape-value>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-start-start-shape
+#[syntax(" <corner-shape-value> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "round",
+	applies_to = "all elements where border-radius can apply",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see superellipse interpolation"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-start-start-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerStartStartShapeStyleValue;
+
+// /// Represents the style value for `corner-top` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-radius'> || <'corner-top-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-top
+// #[syntax(" <'border-top-radius'> || <'corner-top-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerTopStyleValue;
+
+// /// Represents the style value for `corner-top-left` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-left).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-top-left
+// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-left"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerTopLeftStyleValue;
+
+/// Represents the style value for `corner-top-left-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-left-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <corner-shape-value>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-top-left-shape
+#[syntax(" <corner-shape-value> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "round",
+	applies_to = "all elements where border-radius can apply",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see superellipse interpolation"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-left-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerTopLeftShapeStyleValue;
+
+// /// Represents the style value for `corner-top-right` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-right).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'border-top-left-radius'> || <'corner-top-left-shape'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-borders-4/#corner-top-right
+// #[syntax(" <'border-top-left-radius'> || <'corner-top-left-shape'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0",
+//   applies_to = "all elements (but see prose)",
+// 	inherited = "no",
+// 	percentages = "refer to corresponding dimension of the border box.",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-right"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct CornerTopRightStyleValue;
+
+/// Represents the style value for `corner-top-right-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-right-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <corner-shape-value>
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-top-right-shape
+#[syntax(" <corner-shape-value> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "round",
+	applies_to = "all elements where border-radius can apply",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see superellipse interpolation"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-right-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerTopRightShapeStyleValue;
+
+/// Represents the style value for `corner-top-shape` as defined in [css-borders-4](https://drafts.csswg.org/css-borders-4/#corner-top-shape).
+///
+/// The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'corner-top-left-shape'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-borders-4/#corner-top-shape
+#[syntax(" <'corner-top-left-shape'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.corner-top-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CornerTopShapeStyleValue;

--- a/crates/css_ast/src/values/box/mod.rs
+++ b/crates/css_ast/src/values/box/mod.rs
@@ -7,18 +7,18 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `margin-top` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-top).
+/// Represents the style value for `margin` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin).
 ///
 /// The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <length-percentage> | auto
+/// <'margin-top'>{1,4}
 /// ```
 ///
-// https://drafts.csswg.org/css-box-4/#margin-top
-#[syntax(" <length-percentage> | auto ")]
+// https://drafts.csswg.org/css-box-4/#margin
+#[syntax(" <'margin-top'>{1,4} ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
@@ -29,35 +29,9 @@ use impls::*;
 	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-top"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MarginTopStyleValue;
-
-/// Represents the style value for `margin-right` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-right).
-///
-/// The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length-percentage> | auto
-/// ```
-///
-// https://drafts.csswg.org/css-box-4/#margin-right
-#[syntax(" <length-percentage> | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements except internal table elements, ruby base containers, and ruby annotation containers",
-	inherited = "no",
-	percentages = "refer to logical width of containing block",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-right"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MarginRightStyleValue;
+pub struct MarginStyleValue;
 
 /// Represents the style value for `margin-bottom` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-bottom).
 ///
@@ -111,18 +85,18 @@ pub struct MarginBottomStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MarginLeftStyleValue;
 
-/// Represents the style value for `margin` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin).
+/// Represents the style value for `margin-right` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-right).
 ///
 /// The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <'margin-top'>{1,4}
+/// <length-percentage> | auto
 /// ```
 ///
-// https://drafts.csswg.org/css-box-4/#margin
-#[syntax(" <'margin-top'>{1,4} ")]
+// https://drafts.csswg.org/css-box-4/#margin-right
+#[syntax(" <length-percentage> | auto ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
@@ -133,22 +107,74 @@ pub struct MarginLeftStyleValue;
 	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-right"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MarginStyleValue;
+pub struct MarginRightStyleValue;
 
-/// Represents the style value for `padding-top` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding-top).
+/// Represents the style value for `margin-top` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-top).
+///
+/// The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length-percentage> | auto
+/// ```
+///
+// https://drafts.csswg.org/css-box-4/#margin-top
+#[syntax(" <length-percentage> | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements except internal table elements, ruby base containers, and ruby annotation containers",
+	inherited = "no",
+	percentages = "refer to logical width of containing block",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-top"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct MarginTopStyleValue;
+
+// /// Represents the style value for `margin-trim` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-trim).
+// ///
+// /// The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-box-4/#margin-trim
+// #[syntax(" none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "block containers, multi-column containers, flex containers, grid containers",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-trim"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum MarginTrimStyleValue {}
+
+/// Represents the style value for `padding` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding).
 ///
 /// The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <length-percentage [0,∞]>
+/// <'padding-top'>{1,4}
 /// ```
 ///
-// https://drafts.csswg.org/css-box-4/#padding-top
-#[syntax(" <length-percentage [0,∞]> ")]
+// https://drafts.csswg.org/css-box-4/#padding
+#[syntax(" <'padding-top'>{1,4} ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
@@ -159,35 +185,9 @@ pub struct MarginStyleValue;
 	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-top"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct PaddingTopStyleValue;
-
-/// Represents the style value for `padding-right` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding-right).
-///
-/// The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-box-4/#padding-right
-#[syntax(" <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements except: internal table elements other than table cells, ruby base containers, and ruby annotation containers",
-	inherited = "no",
-	percentages = "refer to logical width of containing block",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-right"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct PaddingRightStyleValue;
+pub struct PaddingStyleValue;
 
 /// Represents the style value for `padding-bottom` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding-bottom).
 ///
@@ -241,18 +241,18 @@ pub struct PaddingBottomStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingLeftStyleValue;
 
-/// Represents the style value for `padding` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding).
+/// Represents the style value for `padding-right` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding-right).
 ///
 /// The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <'padding-top'>{1,4}
+/// <length-percentage [0,∞]>
 /// ```
 ///
-// https://drafts.csswg.org/css-box-4/#padding
-#[syntax(" <'padding-top'>{1,4} ")]
+// https://drafts.csswg.org/css-box-4/#padding-right
+#[syntax(" <length-percentage [0,∞]> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
@@ -263,32 +263,32 @@ pub struct PaddingLeftStyleValue;
 	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-right"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct PaddingStyleValue;
+pub struct PaddingRightStyleValue;
 
-// /// Represents the style value for `margin-trim` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#margin-trim).
-// ///
-// /// The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-box-4/#margin-trim
-// #[syntax(" none | [ block || inline ] | [ block-start || inline-start || block-end || inline-end ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "block containers, multi-column containers, flex containers, grid containers",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-trim"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum MarginTrimStyleValue {}
+/// Represents the style value for `padding-top` as defined in [css-box-4](https://drafts.csswg.org/css-box-4/#padding-top).
+///
+/// The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-box-4/#padding-top
+#[syntax(" <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements except: internal table elements other than table cells, ruby base containers, and ruby annotation containers",
+	inherited = "no",
+	percentages = "refer to logical width of containing block",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-top"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct PaddingTopStyleValue;

--- a/crates/css_ast/src/values/break/mod.rs
+++ b/crates/css_ast/src/values/break/mod.rs
@@ -7,33 +7,31 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `break-before` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#break-before).
+/// Represents the style value for `box-decoration-break` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#box-decoration-break).
 ///
-/// In printed page layouts, the break-after, break-before, break-inside CSS properties control where printed pages start and end. Also known as pagination or page breaking.
+/// The box-decoration-break CSS property sets whether box decorations, such as borders or backgrounds, of an element divided across a page, column, or region wraps each fragment or splits across the break.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region
+/// slice | clone
 /// ```
 ///
-// https://drafts.csswg.org/css-break-4/#break-before
-#[syntax(
-	" auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region "
-)]
+// https://drafts.csswg.org/css-break-4/#box-decoration-break
+#[syntax(" slice | clone ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "auto",
-	applies_to = "block-level boxes, grid items, flex items, table row groups, table rows (but see prose)",
+	initial = "slice",
+	applies_to = "all elements",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.break-before"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-decoration-break"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BreakBeforeStyleValue {}
+pub enum BoxDecorationBreakStyleValue {}
 
 /// Represents the style value for `break-after` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#break-after).
 ///
@@ -63,6 +61,34 @@ pub enum BreakBeforeStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BreakAfterStyleValue {}
 
+/// Represents the style value for `break-before` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#break-before).
+///
+/// In printed page layouts, the break-after, break-before, break-inside CSS properties control where printed pages start and end. Also known as pagination or page breaking.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region
+/// ```
+///
+// https://drafts.csswg.org/css-break-4/#break-before
+#[syntax(
+	" auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region "
+)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "block-level boxes, grid items, flex items, table row groups, table rows (but see prose)",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.break-before"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BreakBeforeStyleValue {}
+
 /// Represents the style value for `break-inside` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#break-inside).
 ///
 /// In printed page layouts, the break-after, break-before, break-inside CSS properties control where printed pages start and end. Also known as pagination or page breaking.
@@ -88,6 +114,30 @@ pub enum BreakAfterStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.break-inside"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BreakInsideStyleValue {}
+
+/// Represents the style value for `margin-break` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#margin-break).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | keep | discard
+/// ```
+///
+// https://drafts.csswg.org/css-break-4/#margin-break
+#[syntax(" auto | keep | discard ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-break"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum MarginBreakStyleValue {}
 
 /// Represents the style value for `orphans` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#orphans).
 ///
@@ -140,53 +190,3 @@ pub struct OrphansStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.widows"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct WidowsStyleValue;
-
-/// Represents the style value for `box-decoration-break` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#box-decoration-break).
-///
-/// The box-decoration-break CSS property sets whether box decorations, such as borders or backgrounds, of an element divided across a page, column, or region wraps each fragment or splits across the break.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// slice | clone
-/// ```
-///
-// https://drafts.csswg.org/css-break-4/#box-decoration-break
-#[syntax(" slice | clone ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "slice",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-decoration-break"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BoxDecorationBreakStyleValue {}
-
-/// Represents the style value for `margin-break` as defined in [css-break-4](https://drafts.csswg.org/css-break-4/#margin-break).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | keep | discard
-/// ```
-///
-// https://drafts.csswg.org/css-break-4/#margin-break
-#[syntax(" auto | keep | discard ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-break"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum MarginBreakStyleValue {}

--- a/crates/css_ast/src/values/color_adjust/mod.rs
+++ b/crates/css_ast/src/values/color_adjust/mod.rs
@@ -7,6 +7,32 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+/// Represents the style value for `color-adjust` as defined in [css-color-adjust-1](https://drafts.csswg.org/css-color-adjust-1/#color-adjust).
+///
+/// The color-adjust shorthand CSS property allows multiple performance related color adjustments to be set at once. Setting the print-color-adjust CSS property directly is preferred, as it is the only such adjustment so far defined.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'print-color-adjust'>
+/// ```
+///
+// https://drafts.csswg.org/css-color-adjust-1/#color-adjust
+#[syntax(" <'print-color-adjust'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.color-adjust"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ColorAdjustStyleValue;
+
 // /// Represents the style value for `color-scheme` as defined in [css-color-adjust-1](https://drafts.csswg.org/css-color-adjust-1/#color-scheme).
 // ///
 // /// The color-scheme CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.
@@ -84,29 +110,3 @@ pub enum ForcedColorAdjustStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.print-color-adjust"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum PrintColorAdjustStyleValue {}
-
-/// Represents the style value for `color-adjust` as defined in [css-color-adjust-1](https://drafts.csswg.org/css-color-adjust-1/#color-adjust).
-///
-/// The color-adjust shorthand CSS property allows multiple performance related color adjustments to be set at once. Setting the print-color-adjust CSS property directly is preferred, as it is the only such adjustment so far defined.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'print-color-adjust'>
-/// ```
-///
-// https://drafts.csswg.org/css-color-adjust-1/#color-adjust
-#[syntax(" <'print-color-adjust'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.color-adjust"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ColorAdjustStyleValue;

--- a/crates/css_ast/src/values/conditional/mod.rs
+++ b/crates/css_ast/src/values/conditional/mod.rs
@@ -7,31 +7,31 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `container-type` as defined in [css-conditional-5](https://drafts.csswg.org/css-conditional-5/#container-type).
+// /// Represents the style value for `container` as defined in [css-conditional-5](https://drafts.csswg.org/css-conditional-5/#container).
 // ///
 // /// Container size queries with the @container at-rule apply styles to an element based on the dimensions of its container.
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// normal | [ [ size | inline-size ] || scroll-state ]
+// /// <'container-name'> [ / <'container-type'> ]?
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-conditional-5/#container-type
-// #[syntax(" normal | [ [ size | inline-size ] || scroll-state ] ")]
+// // https://drafts.csswg.org/css-conditional-5/#container
+// #[syntax(" <'container-name'> [ / <'container-type'> ]? ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
+// 	initial = "see individual properties",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
 // 	canonical_order = "per grammar",
-// 	animation_type = "not animatable",
+// 	animation_type = "see individual properties",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.container-type"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.container"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum ContainerTypeStyleValue {}
+// pub struct ContainerStyleValue;
 
 /// Represents the style value for `container-name` as defined in [css-conditional-5](https://drafts.csswg.org/css-conditional-5/#container-name).
 ///
@@ -59,28 +59,28 @@ use impls::*;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ContainerNameStyleValue<'a>;
 
-// /// Represents the style value for `container` as defined in [css-conditional-5](https://drafts.csswg.org/css-conditional-5/#container).
+// /// Represents the style value for `container-type` as defined in [css-conditional-5](https://drafts.csswg.org/css-conditional-5/#container-type).
 // ///
 // /// Container size queries with the @container at-rule apply styles to an element based on the dimensions of its container.
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// <'container-name'> [ / <'container-type'> ]?
+// /// normal | [ [ size | inline-size ] || scroll-state ]
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-conditional-5/#container
-// #[syntax(" <'container-name'> [ / <'container-type'> ]? ")]
+// // https://drafts.csswg.org/css-conditional-5/#container-type
+// #[syntax(" normal | [ [ size | inline-size ] || scroll-state ] ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
+// 	initial = "normal",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
 // 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
+// 	animation_type = "not animatable",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.container"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.container-type"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct ContainerStyleValue;
+// pub enum ContainerTypeStyleValue {}

--- a/crates/css_ast/src/values/content/mod.rs
+++ b/crates/css_ast/src/values/content/mod.rs
@@ -7,6 +7,78 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+/// Represents the style value for `bookmark-label` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-label).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <content-list>
+/// ```
+///
+// https://drafts.csswg.org/css-content-3/#bookmark-label
+#[syntax(" <content-list> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "content(text)",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bookmark-label"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BookmarkLabelStyleValue<'a>;
+
+/// Represents the style value for `bookmark-level` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-level).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <integer [1,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-content-3/#bookmark-level
+#[syntax(" none | <integer [1,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bookmark-level"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct BookmarkLevelStyleValue;
+
+/// Represents the style value for `bookmark-state` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-state).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// open | closed
+/// ```
+///
+// https://drafts.csswg.org/css-content-3/#bookmark-state
+#[syntax(" open | closed ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "open",
+	applies_to = "block-level elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bookmark-state"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BookmarkStateStyleValue {}
+
 // /// Represents the style value for `content` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#content).
 // ///
 // /// The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.
@@ -58,75 +130,3 @@ use impls::*;
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.quotes"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum QuotesStyleValue<'a> {}
-
-/// Represents the style value for `bookmark-level` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-level).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <integer [1,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-content-3/#bookmark-level
-#[syntax(" none | <integer [1,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bookmark-level"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BookmarkLevelStyleValue;
-
-/// Represents the style value for `bookmark-label` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-label).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <content-list>
-/// ```
-///
-// https://drafts.csswg.org/css-content-3/#bookmark-label
-#[syntax(" <content-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "content(text)",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bookmark-label"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BookmarkLabelStyleValue<'a>;
-
-/// Represents the style value for `bookmark-state` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-state).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// open | closed
-/// ```
-///
-// https://drafts.csswg.org/css-content-3/#bookmark-state
-#[syntax(" open | closed ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "open",
-	applies_to = "block-level elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bookmark-state"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BookmarkStateStyleValue {}

--- a/crates/css_ast/src/values/display/mod.rs
+++ b/crates/css_ast/src/values/display/mod.rs
@@ -61,32 +61,6 @@ use impls::*;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OrderStyleValue;
 
-/// Represents the style value for `visibility` as defined in [css-display-4](https://drafts.csswg.org/css-display-4/#visibility).
-///
-/// The visibility CSS property sets whether an element is shown. Invisible elements still affect the document layout.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// visible | hidden | force-hidden | collapse
-/// ```
-///
-// https://drafts.csswg.org/css-display-4/#visibility
-#[syntax(" visible | hidden | force-hidden | collapse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "visible",
-	applies_to = "all elements",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.visibility"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum VisibilityStyleValue {}
-
 /// Represents the style value for `reading-flow` as defined in [css-display-4](https://drafts.csswg.org/css-display-4/#reading-flow).
 ///
 /// The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.
@@ -138,3 +112,29 @@ pub enum ReadingFlowStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.reading-order"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ReadingOrderStyleValue;
+
+/// Represents the style value for `visibility` as defined in [css-display-4](https://drafts.csswg.org/css-display-4/#visibility).
+///
+/// The visibility CSS property sets whether an element is shown. Invisible elements still affect the document layout.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// visible | hidden | force-hidden | collapse
+/// ```
+///
+// https://drafts.csswg.org/css-display-4/#visibility
+#[syntax(" visible | hidden | force-hidden | collapse ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "visible",
+	applies_to = "all elements",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.visibility"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum VisibilityStyleValue {}

--- a/crates/css_ast/src/values/exclusions/mod.rs
+++ b/crates/css_ast/src/values/exclusions/mod.rs
@@ -24,7 +24,7 @@ use impls::*;
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "not animatable"
+	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-flow"))]
@@ -48,7 +48,7 @@ pub enum WrapFlowStyleValue {}
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "not animatable"
+	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-through"))]

--- a/crates/css_ast/src/values/flexbox/mod.rs
+++ b/crates/css_ast/src/values/flexbox/mod.rs
@@ -7,6 +7,58 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+// /// Represents the style value for `flex` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex).
+// ///
+// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-flexbox-1/#flex
+// #[syntax(" none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "0 1 auto",
+//   applies_to = "flex items",
+// 	inherited = "no",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "by computed value type",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FlexStyleValue {}
+
+/// Represents the style value for `flex-basis` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-basis).
+///
+/// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// content | <'width'>
+/// ```
+///
+// https://drafts.csswg.org/css-flexbox-1/#flex-basis
+#[syntax(" content | <'width'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "flex items",
+	inherited = "no",
+	percentages = "relative to the flex container’s inner main size",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-basis"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FlexBasisStyleValue {}
+
 /// Represents the style value for `flex-direction` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-direction).
 ///
 /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
@@ -33,32 +85,6 @@ use impls::*;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FlexDirectionStyleValue {}
 
-/// Represents the style value for `flex-wrap` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-wrap).
-///
-/// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// nowrap | wrap | wrap-reverse
-/// ```
-///
-// https://drafts.csswg.org/css-flexbox-1/#flex-wrap
-#[syntax(" nowrap | wrap | wrap-reverse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "nowrap",
-	applies_to = "flex containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-wrap"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FlexWrapStyleValue {}
-
 /// Represents the style value for `flex-flow` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-flow).
 ///
 /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
@@ -84,32 +110,6 @@ pub enum FlexWrapStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-flow"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FlexFlowStyleValue;
-
-// /// Represents the style value for `flex` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex).
-// ///
-// /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-flexbox-1/#flex
-// #[syntax(" none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "0 1 auto",
-//   applies_to = "flex items",
-// 	inherited = "no",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "by computed value type",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FlexStyleValue {}
 
 /// Represents the style value for `flex-grow` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-grow).
 ///
@@ -163,28 +163,28 @@ pub struct FlexGrowStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FlexShrinkStyleValue;
 
-/// Represents the style value for `flex-basis` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-basis).
+/// Represents the style value for `flex-wrap` as defined in [css-flexbox-1](https://drafts.csswg.org/css-flexbox-1/#flex-wrap).
 ///
 /// Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// content | <'width'>
+/// nowrap | wrap | wrap-reverse
 /// ```
 ///
-// https://drafts.csswg.org/css-flexbox-1/#flex-basis
-#[syntax(" content | <'width'> ")]
+// https://drafts.csswg.org/css-flexbox-1/#flex-wrap
+#[syntax(" nowrap | wrap | wrap-reverse ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "auto",
-	applies_to = "flex items",
+	initial = "nowrap",
+	applies_to = "flex containers",
 	inherited = "no",
-	percentages = "relative to the flex container’s inner main size",
+	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "by computed value type"
+	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-basis"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flex-wrap"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FlexBasisStyleValue {}
+pub enum FlexWrapStyleValue {}

--- a/crates/css_ast/src/values/fonts/mod.rs
+++ b/crates/css_ast/src/values/fonts/mod.rs
@@ -7,6 +7,34 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+// /// Represents the style value for `font` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font).
+// ///
+// /// The font CSS property shorthand sets multiple font properties, including style, weight, size, and font family.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font
+// #[syntax(
+// 	" [ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name> "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontStyleValue<'a> {}
+
 /// Represents the style value for `font-family` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-family).
 ///
 /// The font-family CSS property sets the desired font face for text, along with optional fallback font faces.
@@ -32,6 +60,586 @@ use impls::*;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-family"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FontFamilyStyleValue<'a>;
+
+// /// Represents the style value for `font-feature-settings` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-feature-settings).
+// ///
+// /// The font-feature-settings CSS property sets low-level OpenType feature tags for a font. When possible, use font-variant instead.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | <feature-tag-value>#
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-feature-settings
+// #[syntax(" normal | <feature-tag-value># ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-feature-settings"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontFeatureSettingsStyleValue<'a> {}
+
+/// Represents the style value for `font-kerning` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-kerning).
+///
+/// The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | normal | none
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-kerning
+#[syntax(" auto | normal | none ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-kerning"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontKerningStyleValue {}
+
+/// Represents the style value for `font-language-override` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-language-override).
+///
+/// The font-language-override CSS property sets which language-specific glyphs are displayed.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | <string>
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-language-override
+#[syntax(" normal | <string> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-language-override"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontLanguageOverrideStyleValue {}
+
+/// Represents the style value for `font-optical-sizing` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-optical-sizing).
+///
+/// The font-optical-sizing CSS property sets whether text rendering is optimized for viewing at different sizes.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | none
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-optical-sizing
+#[syntax(" auto | none ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-optical-sizing"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontOpticalSizingStyleValue {}
+
+// /// Represents the style value for `font-palette` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-palette).
+// ///
+// /// The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | light | dark | <palette-identifier> | <palette-mix()>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-palette
+// #[syntax(" normal | light | dark | <palette-identifier> | <palette-mix()> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "by computed value",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-palette"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontPaletteStyleValue {}
+
+/// Represents the style value for `font-size` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-size).
+///
+/// The font-size CSS property sets the text height.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <absolute-size> | <relative-size> | <length-percentage [0,∞]> | math
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-size
+#[syntax(" <absolute-size> | <relative-size> | <length-percentage [0,∞]> | math ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "refer to parent element’s font size",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-size"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontSizeStyleValue {}
+
+// /// Represents the style value for `font-size-adjust` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-size-adjust).
+// ///
+// /// The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number [0,∞]> ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-size-adjust
+// #[syntax(" none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number [0,∞]> ] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete if the keywords differ, otherwise by computed value type",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-size-adjust"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontSizeAdjustStyleValue {}
+
+/// Represents the style value for `font-style` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-style).
+///
+/// The font-style CSS property sets the text style, with normal, italic, and oblique options.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | italic | left | right | oblique <angle [-90deg,90deg]>?
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-style
+#[syntax(" normal | italic | left | right | oblique <angle [-90deg,90deg]>? ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type;normal animates as oblique 0deg"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontStyleStyleValue {}
+
+// /// Represents the style value for `font-synthesis` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis).
+// ///
+// /// The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [ weight || style || small-caps || position]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-synthesis
+// #[syntax(" none | [ weight || style || small-caps || position] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "weight style small-caps position",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontSynthesisStyleValue {}
+
+/// Represents the style value for `font-synthesis-position` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-position).
+///
+/// The font-synthesis-position CSS property sets whether or not the browser should synthesize subscript and superscript typefaces when they're missing from the font.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | none
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-synthesis-position
+#[syntax(" auto | none ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-position"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontSynthesisPositionStyleValue {}
+
+/// Represents the style value for `font-synthesis-small-caps` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-small-caps).
+///
+/// The font-synthesis-small-caps CSS property sets whether or not the browser should synthesize small caps typefaces when they're missing from the font.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | none
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-synthesis-small-caps
+#[syntax(" auto | none ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-small-caps"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontSynthesisSmallCapsStyleValue {}
+
+/// Represents the style value for `font-synthesis-style` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-style).
+///
+/// The font-synthesis-style CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | none | oblique-only
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-synthesis-style
+#[syntax(" auto | none | oblique-only ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontSynthesisStyleStyleValue {}
+
+/// Represents the style value for `font-synthesis-weight` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-weight).
+///
+/// The font-synthesis-weight CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | none
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-synthesis-weight
+#[syntax(" auto | none ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-weight"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontSynthesisWeightStyleValue {}
+
+// /// Represents the style value for `font-variant` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant).
+// ///
+// /// The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-variant
+// #[syntax(
+// 	" normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ] "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontVariantStyleValue<'a> {}
+
+// /// Represents the style value for `font-variant-alternates` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-alternates).
+// ///
+// /// The font-variant-alternates CSS property, along with the @font-feature-values at-rule, chooses when to use a font's alternate glyphs.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-variant-alternates
+// #[syntax(
+// 	" normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-alternates"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontVariantAlternatesStyleValue<'a> {}
+
+/// Represents the style value for `font-variant-caps` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-caps).
+///
+/// The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-variant-caps
+#[syntax(" normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-caps"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontVariantCapsStyleValue {}
+
+// /// Represents the style value for `font-variant-east-asian` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-east-asian).
+// ///
+// /// The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-variant-east-asian
+// #[syntax(" normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-east-asian"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontVariantEastAsianStyleValue {}
+
+/// Represents the style value for `font-variant-emoji` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-emoji).
+///
+/// The font-variant-emoji CSS property sets the default presentation for emoji characters.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | text | emoji | unicode
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-variant-emoji
+#[syntax(" normal | text | emoji | unicode ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-emoji"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontVariantEmojiStyleValue {}
+
+// /// Represents the style value for `font-variant-ligatures` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-ligatures).
+// ///
+// /// The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-variant-ligatures
+// #[syntax(
+// 	" normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-ligatures"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontVariantLigaturesStyleValue {}
+
+// /// Represents the style value for `font-variant-numeric` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-numeric).
+// ///
+// /// The font-variant-numeric CSS property sets how numeric characters are displayed. For example, you can align columns of numbers or use zeroes that have a slash.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-variant-numeric
+// #[syntax(
+// 	" normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-numeric"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontVariantNumericStyleValue {}
+
+/// Represents the style value for `font-variant-position` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-position).
+///
+/// The font-variant-position CSS property sets whether to use alternate glyphs for subscript and superscript text.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | sub | super
+/// ```
+///
+// https://drafts.csswg.org/css-fonts-5/#font-variant-position
+#[syntax(" normal | sub | super ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-position"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FontVariantPositionStyleValue {}
+
+// /// Represents the style value for `font-variation-settings` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variation-settings).
+// ///
+// /// The font-variation-settings CSS property sets an "axis of variability" on a variable font, such as weight, optical size, or a custom axis defined by the typeface designer. When possible, use other CSS font properties, such as font-weight: bold. Also known as variable fonts.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | [ <opentype-tag> <number> ]#
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-fonts-5/#font-variation-settings
+// #[syntax(" normal | [ <opentype-tag> <number> ]# ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements and text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see prose",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variation-settings"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FontVariationSettingsStyleValue<'a> {}
 
 /// Represents the style value for `font-weight` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-weight).
 ///
@@ -86,611 +694,3 @@ pub enum FontWeightStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-width"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FontWidthStyleValue {}
-
-/// Represents the style value for `font-style` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-style).
-///
-/// The font-style CSS property sets the text style, with normal, italic, and oblique options.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | italic | left | right | oblique <angle [-90deg,90deg]>?
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-style
-#[syntax(" normal | italic | left | right | oblique <angle [-90deg,90deg]>? ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type;normal animates as oblique 0deg"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontStyleStyleValue {}
-
-/// Represents the style value for `font-size` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-size).
-///
-/// The font-size CSS property sets the text height.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <absolute-size> | <relative-size> | <length-percentage [0,∞]> | math
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-size
-#[syntax(" <absolute-size> | <relative-size> | <length-percentage [0,∞]> | math ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "refer to parent element’s font size",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-size"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontSizeStyleValue {}
-
-// /// Represents the style value for `font-size-adjust` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-size-adjust).
-// ///
-// /// The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number [0,∞]> ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-size-adjust
-// #[syntax(" none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number [0,∞]> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete if the keywords differ, otherwise by computed value type",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-size-adjust"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontSizeAdjustStyleValue {}
-
-// /// Represents the style value for `font` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font).
-// ///
-// /// The font CSS property shorthand sets multiple font properties, including style, weight, size, and font family.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font
-// #[syntax(
-// 	" [ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name> "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontStyleValue<'a> {}
-
-/// Represents the style value for `font-synthesis-weight` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-weight).
-///
-/// The font-synthesis-weight CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | none
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-synthesis-weight
-#[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-weight"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontSynthesisWeightStyleValue {}
-
-/// Represents the style value for `font-synthesis-style` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-style).
-///
-/// The font-synthesis-style CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | none | oblique-only
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-synthesis-style
-#[syntax(" auto | none | oblique-only ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontSynthesisStyleStyleValue {}
-
-/// Represents the style value for `font-synthesis-small-caps` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-small-caps).
-///
-/// The font-synthesis-small-caps CSS property sets whether or not the browser should synthesize small caps typefaces when they're missing from the font.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | none
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-synthesis-small-caps
-#[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-small-caps"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontSynthesisSmallCapsStyleValue {}
-
-/// Represents the style value for `font-synthesis-position` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis-position).
-///
-/// The font-synthesis-position CSS property sets whether or not the browser should synthesize subscript and superscript typefaces when they're missing from the font.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | none
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-synthesis-position
-#[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis-position"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontSynthesisPositionStyleValue {}
-
-// /// Represents the style value for `font-synthesis` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-synthesis).
-// ///
-// /// The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [ weight || style || small-caps || position]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-synthesis
-// #[syntax(" none | [ weight || style || small-caps || position] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "weight style small-caps position",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-synthesis"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontSynthesisStyleValue {}
-
-/// Represents the style value for `font-kerning` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-kerning).
-///
-/// The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | normal | none
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-kerning
-#[syntax(" auto | normal | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-kerning"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontKerningStyleValue {}
-
-// /// Represents the style value for `font-variant-ligatures` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-ligatures).
-// ///
-// /// The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-variant-ligatures
-// #[syntax(
-// 	" normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-ligatures"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontVariantLigaturesStyleValue {}
-
-/// Represents the style value for `font-variant-position` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-position).
-///
-/// The font-variant-position CSS property sets whether to use alternate glyphs for subscript and superscript text.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | sub | super
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-variant-position
-#[syntax(" normal | sub | super ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-position"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontVariantPositionStyleValue {}
-
-/// Represents the style value for `font-variant-caps` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-caps).
-///
-/// The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-variant-caps
-#[syntax(" normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-caps"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontVariantCapsStyleValue {}
-
-// /// Represents the style value for `font-variant-numeric` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-numeric).
-// ///
-// /// The font-variant-numeric CSS property sets how numeric characters are displayed. For example, you can align columns of numbers or use zeroes that have a slash.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-variant-numeric
-// #[syntax(
-// 	" normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-numeric"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontVariantNumericStyleValue {}
-
-// /// Represents the style value for `font-variant-alternates` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-alternates).
-// ///
-// /// The font-variant-alternates CSS property, along with the @font-feature-values at-rule, chooses when to use a font's alternate glyphs.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-variant-alternates
-// #[syntax(
-// 	" normal | [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-alternates"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontVariantAlternatesStyleValue<'a> {}
-
-// /// Represents the style value for `font-variant-east-asian` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-east-asian).
-// ///
-// /// The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-variant-east-asian
-// #[syntax(" normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-east-asian"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontVariantEastAsianStyleValue {}
-
-// /// Represents the style value for `font-variant` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant).
-// ///
-// /// The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-variant
-// #[syntax(
-// 	" normal | none | [ [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ] || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || [ stylistic(<feature-value-name>) || historical-forms || styleset(<feature-value-name>#) || character-variant(<feature-value-name>#) || swash(<feature-value-name>) || ornaments(<feature-value-name>) || annotation(<feature-value-name>) ] || [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ] || [ <east-asian-variant-values> || <east-asian-width-values> || ruby ] || [ sub | super ] || [ text | emoji | unicode ] ] "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontVariantStyleValue<'a> {}
-
-// /// Represents the style value for `font-feature-settings` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-feature-settings).
-// ///
-// /// The font-feature-settings CSS property sets low-level OpenType feature tags for a font. When possible, use font-variant instead.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | <feature-tag-value>#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-feature-settings
-// #[syntax(" normal | <feature-tag-value># ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-feature-settings"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontFeatureSettingsStyleValue<'a> {}
-
-/// Represents the style value for `font-language-override` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-language-override).
-///
-/// The font-language-override CSS property sets which language-specific glyphs are displayed.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | <string>
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-language-override
-#[syntax(" normal | <string> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-language-override"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontLanguageOverrideStyleValue {}
-
-/// Represents the style value for `font-optical-sizing` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-optical-sizing).
-///
-/// The font-optical-sizing CSS property sets whether text rendering is optimized for viewing at different sizes.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | none
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-optical-sizing
-#[syntax(" auto | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-optical-sizing"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontOpticalSizingStyleValue {}
-
-// /// Represents the style value for `font-variation-settings` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variation-settings).
-// ///
-// /// The font-variation-settings CSS property sets an "axis of variability" on a variable font, such as weight, optical size, or a custom axis defined by the typeface designer. When possible, use other CSS font properties, such as font-weight: bold. Also known as variable fonts.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | [ <opentype-tag> <number> ]#
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-variation-settings
-// #[syntax(" normal | [ <opentype-tag> <number> ]# ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see prose",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variation-settings"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontVariationSettingsStyleValue<'a> {}
-
-// /// Represents the style value for `font-palette` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-palette).
-// ///
-// /// The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | light | dark | <palette-identifier> | <palette-mix()>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-fonts-5/#font-palette
-// #[syntax(" normal | light | dark | <palette-identifier> | <palette-mix()> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements and text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "by computed value",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-palette"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FontPaletteStyleValue {}
-
-/// Represents the style value for `font-variant-emoji` as defined in [css-fonts-5](https://drafts.csswg.org/css-fonts-5/#font-variant-emoji).
-///
-/// The font-variant-emoji CSS property sets the default presentation for emoji characters.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | text | emoji | unicode
-/// ```
-///
-// https://drafts.csswg.org/css-fonts-5/#font-variant-emoji
-#[syntax(" normal | text | emoji | unicode ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.font-variant-emoji"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FontVariantEmojiStyleValue {}

--- a/crates/css_ast/src/values/forms/mod.rs
+++ b/crates/css_ast/src/values/forms/mod.rs
@@ -33,30 +33,6 @@ use impls::*;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FieldSizingStyleValue {}
 
-/// Represents the style value for `slider-orientation` as defined in [css-forms-1](https://drafts.csswg.org/css-forms-1/#slider-orientation).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | left-to-right | right-to-left | top-to-bottom | bottom-to-top
-/// ```
-///
-// https://drafts.csswg.org/css-forms-1/#slider-orientation
-#[syntax(" auto | left-to-right | right-to-left | top-to-bottom | bottom-to-top ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.slider-orientation"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum SliderOrientationStyleValue {}
-
 /// Represents the style value for `input-security` as defined in [css-forms-1](https://drafts.csswg.org/css-forms-1/#input-security).
 ///
 /// The grammar is defined as:
@@ -80,3 +56,27 @@ pub enum SliderOrientationStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.input-security"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum InputSecurityStyleValue {}
+
+/// Represents the style value for `slider-orientation` as defined in [css-forms-1](https://drafts.csswg.org/css-forms-1/#slider-orientation).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | left-to-right | right-to-left | top-to-bottom | bottom-to-top
+/// ```
+///
+// https://drafts.csswg.org/css-forms-1/#slider-orientation
+#[syntax(" auto | left-to-right | right-to-left | top-to-bottom | bottom-to-top ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.slider-orientation"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum SliderOrientationStyleValue {}

--- a/crates/css_ast/src/values/gaps/mod.rs
+++ b/crates/css_ast/src/values/gaps/mod.rs
@@ -7,6 +7,32 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+/// Represents the style value for `column-rule` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule).
+///
+/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <gap-rule-list> | <gap-auto-rule-list>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#column-rule
+#[syntax(" <gap-rule-list> | <gap-auto-rule-list> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ColumnRuleStyleValue {}
+
 /// Represents the style value for `column-rule-break` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-break).
 ///
 /// The grammar is defined as:
@@ -31,53 +57,31 @@ use impls::*;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnRuleBreakStyleValue {}
 
-/// Represents the style value for `row-rule-break` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-break).
+/// Represents the style value for `column-rule-color` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-color).
+///
+/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// none | spanning-item | intersection
+/// <line-color-list> | <auto-line-color-list>
 /// ```
 ///
-// https://drafts.csswg.org/css-gaps-1/#row-rule-break
-#[syntax(" none | spanning-item | intersection ")]
+// https://drafts.csswg.org/css-gaps-1/#column-rule-color
+#[syntax(" <line-color-list> | <auto-line-color-list> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "spanning-item",
+	initial = "currentcolor",
 	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "discrete"
+	animation_type = "repeatable list, see § 3.4.1 interpolation behavior."
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-break"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-color"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum RowRuleBreakStyleValue {}
-
-/// Represents the style value for `rule-break` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-break).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'column-rule-break'>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#rule-break
-#[syntax(" <'column-rule-break'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "Same as column-rule-break and row-rule-break",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-break"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct RuleBreakStyleValue;
+pub enum ColumnRuleColorStyleValue {}
 
 /// Represents the style value for `column-rule-outset` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-outset).
 ///
@@ -103,6 +107,130 @@ pub struct RuleBreakStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ColumnRuleOutsetStyleValue;
 
+/// Represents the style value for `column-rule-style` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-style).
+///
+/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-style-list> | <auto-line-style-list>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#column-rule-style
+#[syntax(" <line-style-list> | <auto-line-style-list> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ColumnRuleStyleStyleValue {}
+
+/// Represents the style value for `column-rule-width` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-width).
+///
+/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width-list> | <auto-line-width-list>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#column-rule-width
+#[syntax(" <line-width-list> | <auto-line-width-list> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "repeatable list, see § 3.4.1 interpolation behavior."
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ColumnRuleWidthStyleValue<'a> {}
+
+/// Represents the style value for `row-rule` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <gap-rule-list> | <gap-auto-rule-list>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#row-rule
+#[syntax(" <gap-rule-list> | <gap-auto-rule-list> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum RowRuleStyleValue {}
+
+/// Represents the style value for `row-rule-break` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-break).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | spanning-item | intersection
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#row-rule-break
+#[syntax(" none | spanning-item | intersection ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "spanning-item",
+	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-break"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum RowRuleBreakStyleValue {}
+
+/// Represents the style value for `row-rule-color` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-color).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-color-list> | <auto-line-color-list>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#row-rule-color
+#[syntax(" <line-color-list> | <auto-line-color-list> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "currentcolor",
+	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "repeatable list, see § 3.4.1 interpolation behavior."
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum RowRuleColorStyleValue {}
+
 /// Represents the style value for `row-rule-outset` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-outset).
 ///
 /// The grammar is defined as:
@@ -126,6 +254,126 @@ pub struct ColumnRuleOutsetStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-outset"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RowRuleOutsetStyleValue;
+
+/// Represents the style value for `row-rule-style` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-style).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-style-list> | <auto-line-style-list>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#row-rule-style
+#[syntax(" <line-style-list> | <auto-line-style-list> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum RowRuleStyleStyleValue {}
+
+/// Represents the style value for `row-rule-width` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-width).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width-list> | <auto-line-width-list>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#row-rule-width
+#[syntax(" <line-width-list> | <auto-line-width-list> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "repeatable list, see § 3.4.1 interpolation behavior."
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum RowRuleWidthStyleValue<'a> {}
+
+/// Represents the style value for `rule` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'column-rule'>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#rule
+#[syntax(" <'column-rule'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "Same as column-rule and row-rule",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct RuleStyleValue;
+
+/// Represents the style value for `rule-break` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-break).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'column-rule-break'>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#rule-break
+#[syntax(" <'column-rule-break'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "Same as column-rule-break and row-rule-break",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-break"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct RuleBreakStyleValue;
+
+/// Represents the style value for `rule-color` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-color).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'column-rule-color'>
+/// ```
+///
+// https://drafts.csswg.org/css-gaps-1/#rule-color
+#[syntax(" <'column-rule-color'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "Same as column-rule-color and row-rule-color",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct RuleColorStyleValue;
 
 /// Represents the style value for `rule-outset` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-outset).
 ///
@@ -175,230 +423,6 @@ pub struct RuleOutsetStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RuleOverlapStyleValue {}
 
-/// Represents the style value for `column-rule-color` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-color).
-///
-/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-color-list> | <auto-line-color-list>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#column-rule-color
-#[syntax(" <line-color-list> | <auto-line-color-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "repeatable list, see § 3.4.1 interpolation behavior."
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ColumnRuleColorStyleValue {}
-
-/// Represents the style value for `row-rule-color` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-color).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-color-list> | <auto-line-color-list>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#row-rule-color
-#[syntax(" <line-color-list> | <auto-line-color-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "repeatable list, see § 3.4.1 interpolation behavior."
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum RowRuleColorStyleValue {}
-
-/// Represents the style value for `column-rule-style` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-style).
-///
-/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style-list> | <auto-line-style-list>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#column-rule-style
-#[syntax(" <line-style-list> | <auto-line-style-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ColumnRuleStyleStyleValue {}
-
-/// Represents the style value for `row-rule-style` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-style).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-style-list> | <auto-line-style-list>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#row-rule-style
-#[syntax(" <line-style-list> | <auto-line-style-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum RowRuleStyleStyleValue {}
-
-/// Represents the style value for `column-rule-width` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule-width).
-///
-/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width-list> | <auto-line-width-list>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#column-rule-width
-#[syntax(" <line-width-list> | <auto-line-width-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "repeatable list, see § 3.4.1 interpolation behavior."
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ColumnRuleWidthStyleValue<'a> {}
-
-/// Represents the style value for `row-rule-width` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule-width).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width-list> | <auto-line-width-list>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#row-rule-width
-#[syntax(" <line-width-list> | <auto-line-width-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "grid containers, flex containers, multicol containers, and masonry containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "repeatable list, see § 3.4.1 interpolation behavior."
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum RowRuleWidthStyleValue<'a> {}
-
-/// Represents the style value for `column-rule` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#column-rule).
-///
-/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <gap-rule-list> | <gap-auto-rule-list>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#column-rule
-#[syntax(" <gap-rule-list> | <gap-auto-rule-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-rule"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ColumnRuleStyleValue {}
-
-/// Represents the style value for `row-rule` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#row-rule).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <gap-rule-list> | <gap-auto-rule-list>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#row-rule
-#[syntax(" <gap-rule-list> | <gap-auto-rule-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.row-rule"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum RowRuleStyleValue {}
-
-/// Represents the style value for `rule-color` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-color).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'column-rule-color'>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#rule-color
-#[syntax(" <'column-rule-color'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "Same as column-rule-color and row-rule-color",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct RuleColorStyleValue;
-
 /// Represents the style value for `rule-style` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule-style).
 ///
 /// The grammar is defined as:
@@ -446,27 +470,3 @@ pub struct RuleStyleStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule-width"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct RuleWidthStyleValue<'a>;
-
-/// Represents the style value for `rule` as defined in [css-gaps-1](https://drafts.csswg.org/css-gaps-1/#rule).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'column-rule'>
-/// ```
-///
-// https://drafts.csswg.org/css-gaps-1/#rule
-#[syntax(" <'column-rule'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "Same as column-rule and row-rule",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rule"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct RuleStyleValue;

--- a/crates/css_ast/src/values/gcpm/mod.rs
+++ b/crates/css_ast/src/values/gcpm/mod.rs
@@ -7,53 +7,29 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `string-set` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#string-set).
+// /// Represents the style value for `copy-into` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#copy-into).
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// [ <custom-ident> <content-list> ]# | none
+// /// none |  [ [ <custom-ident>  <content-level>] [,  <custom-ident>  <content-level>]*  ]?
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-gcpm-4/#string-set
-// #[syntax(" [ <custom-ident> <content-list> ]# | none ")]
+// // https://drafts.csswg.org/css-gcpm-4/#copy-into
+// #[syntax(" none |  [ [ <custom-ident>  <content-level>] [,  <custom-ident>  <content-level>]*  ]? ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
-//   applies_to = "all elements, but not pseudo-elements",
+//   applies_to = "all elements and pseudo-elements, but not ::first-line or ::first-letter.",
 // 	inherited = "no",
 // 	percentages = "n/a",
 // 	canonical_order = "per grammar",
 // 	animation_type = "discrete",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.string-set"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.copy-into"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum StringSetStyleValue<'a> {}
-
-/// Represents the style value for `running` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#running).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <custom-ident>
-/// ```
-///
-// https://drafts.csswg.org/css-gcpm-4/#running
-#[syntax(" <custom-ident> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.running"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct RunningStyleValue;
+// pub enum CopyIntoStyleValue {}
 
 /// Represents the style value for `footnote-display` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#footnote-display).
 ///
@@ -103,26 +79,50 @@ pub enum FootnoteDisplayStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FootnotePolicyStyleValue {}
 
-// /// Represents the style value for `copy-into` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#copy-into).
+/// Represents the style value for `running` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#running).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <custom-ident>
+/// ```
+///
+// https://drafts.csswg.org/css-gcpm-4/#running
+#[syntax(" <custom-ident> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.running"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct RunningStyleValue;
+
+// /// Represents the style value for `string-set` as defined in [css-gcpm-4](https://drafts.csswg.org/css-gcpm-4/#string-set).
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// none |  [ [ <custom-ident>  <content-level>] [,  <custom-ident>  <content-level>]*  ]?
+// /// [ <custom-ident> <content-list> ]# | none
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-gcpm-4/#copy-into
-// #[syntax(" none |  [ [ <custom-ident>  <content-level>] [,  <custom-ident>  <content-level>]*  ]? ")]
+// // https://drafts.csswg.org/css-gcpm-4/#string-set
+// #[syntax(" [ <custom-ident> <content-list> ]# | none ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
-//   applies_to = "all elements and pseudo-elements, but not ::first-line or ::first-letter.",
+//   applies_to = "all elements, but not pseudo-elements",
 // 	inherited = "no",
 // 	percentages = "n/a",
 // 	canonical_order = "per grammar",
 // 	animation_type = "discrete",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.copy-into"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.string-set"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum CopyIntoStyleValue {}
+// pub enum StringSetStyleValue<'a> {}

--- a/crates/css_ast/src/values/grid/mod.rs
+++ b/crates/css_ast/src/values/grid/mod.rs
@@ -7,6 +7,348 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+// /// Represents the style value for `grid` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid).
+// ///
+// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'grid-template'> | <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? | [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-grid-3/#grid
+// #[syntax(
+// 	" <'grid-template'> | <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? | [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'> "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "grid containers",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum GridStyleValue {}
+
+// /// Represents the style value for `grid-area` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-area).
+// ///
+// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <grid-line> [ / <grid-line> ]{0,3}
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-grid-3/#grid-area
+// #[syntax(" <grid-line> [ / <grid-line> ]{0,3} ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-area"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct GridAreaStyleValue;
+
+/// Represents the style value for `grid-auto-columns` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-auto-columns).
+///
+/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <track-size>+
+/// ```
+///
+// https://drafts.csswg.org/css-grid-3/#grid-auto-columns
+#[syntax(" <track-size>+ ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "grid containers",
+	inherited = "no",
+	percentages = "see track sizing",
+	canonical_order = "per grammar",
+	animation_type = "if the list lengths match, by computed value type per item; discrete otherwise"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-auto-columns"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct GridAutoColumnsStyleValue<'a>;
+
+// /// Represents the style value for `grid-auto-flow` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-auto-flow).
+// ///
+// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ row | column ] || dense
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-grid-3/#grid-auto-flow
+// #[syntax(" [ row | column ] || dense ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "row",
+//   applies_to = "grid containers",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-auto-flow"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct GridAutoFlowStyleValue;
+
+/// Represents the style value for `grid-auto-rows` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-auto-rows).
+///
+/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <track-size>+
+/// ```
+///
+// https://drafts.csswg.org/css-grid-3/#grid-auto-rows
+#[syntax(" <track-size>+ ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "grid containers",
+	inherited = "no",
+	percentages = "see track sizing",
+	canonical_order = "per grammar",
+	animation_type = "if the list lengths match, by computed value type per item; discrete otherwise"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-auto-rows"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct GridAutoRowsStyleValue<'a>;
+
+// /// Represents the style value for `grid-column` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-column).
+// ///
+// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <grid-line> [ / <grid-line> ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-grid-3/#grid-column
+// #[syntax(" <grid-line> [ / <grid-line> ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-column"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct GridColumnStyleValue;
+
+/// Represents the style value for `grid-column-end` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-column-end).
+///
+/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <grid-line>
+/// ```
+///
+// https://drafts.csswg.org/css-grid-3/#grid-column-end
+#[syntax(" <grid-line> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-column-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct GridColumnEndStyleValue;
+
+/// Represents the style value for `grid-column-start` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-column-start).
+///
+/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <grid-line>
+/// ```
+///
+// https://drafts.csswg.org/css-grid-3/#grid-column-start
+#[syntax(" <grid-line> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-column-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct GridColumnStartStyleValue;
+
+// /// Represents the style value for `grid-row` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-row).
+// ///
+// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <grid-line> [ / <grid-line> ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-grid-3/#grid-row
+// #[syntax(" <grid-line> [ / <grid-line> ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-row"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct GridRowStyleValue;
+
+/// Represents the style value for `grid-row-end` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-row-end).
+///
+/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <grid-line>
+/// ```
+///
+// https://drafts.csswg.org/css-grid-3/#grid-row-end
+#[syntax(" <grid-line> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-row-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct GridRowEndStyleValue;
+
+/// Represents the style value for `grid-row-start` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-row-start).
+///
+/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <grid-line>
+/// ```
+///
+// https://drafts.csswg.org/css-grid-3/#grid-row-start
+#[syntax(" <grid-line> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-row-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct GridRowStartStyleValue;
+
+// /// Represents the style value for `grid-template` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-template).
+// ///
+// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-grid-3/#grid-template
+// #[syntax(
+// 	" none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]? "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "grid containers",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-template"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum GridTemplateStyleValue<'a> {}
+
+/// Represents the style value for `grid-template-areas` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-template-areas).
+///
+/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <string>+
+/// ```
+///
+// https://drafts.csswg.org/css-grid-3/#grid-template-areas
+#[syntax(" none | <string>+ ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "grid containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-template-areas"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct GridTemplateAreasStyleValue<'a>;
+
 // /// Represents the style value for `grid-template-columns` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-template-columns).
 // ///
 // /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
@@ -59,371 +401,29 @@ use impls::*;
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum GridTemplateRowsStyleValue {}
 
-/// Represents the style value for `grid-template-areas` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-template-areas).
-///
-/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <string>+
-/// ```
-///
-// https://drafts.csswg.org/css-grid-3/#grid-template-areas
-#[syntax(" none | <string>+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "grid containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-template-areas"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct GridTemplateAreasStyleValue<'a>;
-
-// /// Represents the style value for `grid-template` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-template).
-// ///
-// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
+// /// Represents the style value for `item-cross` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-cross).
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?
+// /// [ auto | nowrap | wrap ] || [ normal | reverse ] | wrap-reverse
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-grid-3/#grid-template
-// #[syntax(
-// 	" none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]? "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "grid containers",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-template"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum GridTemplateStyleValue<'a> {}
-
-/// Represents the style value for `grid-auto-columns` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-auto-columns).
-///
-/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <track-size>+
-/// ```
-///
-// https://drafts.csswg.org/css-grid-3/#grid-auto-columns
-#[syntax(" <track-size>+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "grid containers",
-	inherited = "no",
-	percentages = "see track sizing",
-	canonical_order = "per grammar",
-	animation_type = "if the list lengths match, by computed value type per item; discrete otherwise"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-auto-columns"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct GridAutoColumnsStyleValue<'a>;
-
-/// Represents the style value for `grid-auto-rows` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-auto-rows).
-///
-/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <track-size>+
-/// ```
-///
-// https://drafts.csswg.org/css-grid-3/#grid-auto-rows
-#[syntax(" <track-size>+ ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "grid containers",
-	inherited = "no",
-	percentages = "see track sizing",
-	canonical_order = "per grammar",
-	animation_type = "if the list lengths match, by computed value type per item; discrete otherwise"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-auto-rows"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct GridAutoRowsStyleValue<'a>;
-
-// /// Represents the style value for `grid-auto-flow` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-auto-flow).
-// ///
-// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ row | column ] || dense
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-grid-3/#grid-auto-flow
-// #[syntax(" [ row | column ] || dense ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "row",
-//   applies_to = "grid containers",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-auto-flow"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct GridAutoFlowStyleValue;
-
-// /// Represents the style value for `grid` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid).
-// ///
-// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'grid-template'> | <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? | [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-grid-3/#grid
-// #[syntax(
-// 	" <'grid-template'> | <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? | [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'> "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "grid containers",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum GridStyleValue {}
-
-/// Represents the style value for `grid-row-start` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-row-start).
-///
-/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <grid-line>
-/// ```
-///
-// https://drafts.csswg.org/css-grid-3/#grid-row-start
-#[syntax(" <grid-line> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-row-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct GridRowStartStyleValue;
-
-/// Represents the style value for `grid-column-start` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-column-start).
-///
-/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <grid-line>
-/// ```
-///
-// https://drafts.csswg.org/css-grid-3/#grid-column-start
-#[syntax(" <grid-line> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-column-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct GridColumnStartStyleValue;
-
-/// Represents the style value for `grid-row-end` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-row-end).
-///
-/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <grid-line>
-/// ```
-///
-// https://drafts.csswg.org/css-grid-3/#grid-row-end
-#[syntax(" <grid-line> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-row-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct GridRowEndStyleValue;
-
-/// Represents the style value for `grid-column-end` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-column-end).
-///
-/// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <grid-line>
-/// ```
-///
-// https://drafts.csswg.org/css-grid-3/#grid-column-end
-#[syntax(" <grid-line> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-column-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct GridColumnEndStyleValue;
-
-// /// Represents the style value for `grid-row` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-row).
-// ///
-// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <grid-line> [ / <grid-line> ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-grid-3/#grid-row
-// #[syntax(" <grid-line> [ / <grid-line> ]? ")]
+// // https://drafts.csswg.org/css-grid-3/#item-cross
+// #[syntax(" [ auto | nowrap | wrap ] || [ normal | reverse ] | wrap-reverse ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "auto",
-//   applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
+//   applies_to = "flex containers, grid containers, masonry containers",
 // 	inherited = "no",
 // 	percentages = "n/a",
 // 	canonical_order = "per grammar",
 // 	animation_type = "discrete",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-row"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-cross"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct GridRowStyleValue;
-
-// /// Represents the style value for `grid-column` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-column).
-// ///
-// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <grid-line> [ / <grid-line> ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-grid-3/#grid-column
-// #[syntax(" <grid-line> [ / <grid-line> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-column"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct GridColumnStyleValue;
-
-// /// Represents the style value for `grid-area` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#grid-area).
-// ///
-// /// CSS grid is a two-dimensional layout system, which lays content out in rows and columns.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <grid-line> [ / <grid-line> ]{0,3}
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-grid-3/#grid-area
-// #[syntax(" <grid-line> [ / <grid-line> ]{0,3} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "grid items and absolutely-positioned boxes whose containing block is a grid container",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.grid-area"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct GridAreaStyleValue;
-
-/// Represents the style value for `item-tolerance` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-tolerance).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | <length-percentage> | infinite
-/// ```
-///
-// https://drafts.csswg.org/css-grid-3/#item-tolerance
-#[syntax(" normal | <length-percentage> | infinite ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "masonry containers",
-	inherited = "no",
-	percentages = "relative to the grid-axis content box size of the masonry container",
-	canonical_order = "per grammar",
-	animation_type = "as length"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-tolerance"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ItemToleranceStyleValue {}
+// pub enum ItemCrossStyleValue {}
 
 /// Represents the style value for `item-direction` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-direction).
 ///
@@ -448,6 +448,78 @@ pub enum ItemToleranceStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-direction"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ItemDirectionStyleValue {}
+
+// /// Represents the style value for `item-flow` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-flow).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'item-direction'> || <'item-wrap'> || <'item-pack'> || <'item-tolerance'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-grid-3/#item-flow
+// #[syntax(" <'item-direction'> || <'item-wrap'> || <'item-pack'> || <'item-tolerance'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-flow"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct ItemFlowStyleValue;
+
+// /// Represents the style value for `item-pack` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-pack).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | dense || balance
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-grid-3/#item-pack
+// #[syntax(" normal | dense || balance ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "flex containers, grid containers, masonry containers",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-pack"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum ItemPackStyleValue {}
+
+/// Represents the style value for `item-tolerance` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-tolerance).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | <length-percentage> | infinite
+/// ```
+///
+// https://drafts.csswg.org/css-grid-3/#item-tolerance
+#[syntax(" normal | <length-percentage> | infinite ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "masonry containers",
+	inherited = "no",
+	percentages = "relative to the grid-axis content box size of the masonry container",
+	canonical_order = "per grammar",
+	animation_type = "as length"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-tolerance"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ItemToleranceStyleValue {}
 
 /// Represents the style value for `item-track` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-track).
 ///
@@ -496,75 +568,3 @@ pub enum ItemTrackStyleValue {}
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-wrap"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum ItemWrapStyleValue {}
-
-// /// Represents the style value for `item-cross` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-cross).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ auto | nowrap | wrap ] || [ normal | reverse ] | wrap-reverse
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-grid-3/#item-cross
-// #[syntax(" [ auto | nowrap | wrap ] || [ normal | reverse ] | wrap-reverse ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "flex containers, grid containers, masonry containers",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-cross"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum ItemCrossStyleValue {}
-
-// /// Represents the style value for `item-pack` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-pack).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | dense || balance
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-grid-3/#item-pack
-// #[syntax(" normal | dense || balance ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "flex containers, grid containers, masonry containers",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-pack"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum ItemPackStyleValue {}
-
-// /// Represents the style value for `item-flow` as defined in [css-grid-3](https://drafts.csswg.org/css-grid-3/#item-flow).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// <'item-direction'> || <'item-wrap'> || <'item-pack'> || <'item-tolerance'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-grid-3/#item-flow
-// #[syntax(" <'item-direction'> || <'item-wrap'> || <'item-pack'> || <'item-tolerance'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.item-flow"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct ItemFlowStyleValue;

--- a/crates/css_ast/src/values/images/mod.rs
+++ b/crates/css_ast/src/values/images/mod.rs
@@ -7,58 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `object-fit` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#object-fit).
-// ///
-// /// The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// fill | none | [contain | cover] || scale-down
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-images-5/#object-fit
-// #[syntax(" fill | none | [contain | cover] || scale-down ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "fill",
-//   applies_to = "replaced elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.object-fit"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum ObjectFitStyleValue {}
-
-/// Represents the style value for `object-position` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#object-position).
-///
-/// The object-position CSS property places images, videos, and other replaced elements within their boxes.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <position>
-/// ```
-///
-// https://drafts.csswg.org/css-images-5/#object-position
-#[syntax(" <position> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "50% 50%",
-	applies_to = "replaced elements",
-	inherited = "no",
-	percentages = "refer to width and height of element itself",
-	canonical_order = "the horizontal component of the <position>, followed by the vertical component",
-	animation_type = "as for background-position"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.object-position"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ObjectPositionStyleValue;
-
 // /// Represents the style value for `image-orientation` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#image-orientation).
 // ///
 // /// The image-orientation CSS property corrects the rotation of an image using the image's metadata, such as EXIF.
@@ -134,6 +82,58 @@ pub enum ImageRenderingStyleValue {}
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.image-resolution"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ImageResolutionStyleValue;
+
+// /// Represents the style value for `object-fit` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#object-fit).
+// ///
+// /// The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// fill | none | [contain | cover] || scale-down
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-images-5/#object-fit
+// #[syntax(" fill | none | [contain | cover] || scale-down ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "fill",
+//   applies_to = "replaced elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.object-fit"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum ObjectFitStyleValue {}
+
+/// Represents the style value for `object-position` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#object-position).
+///
+/// The object-position CSS property places images, videos, and other replaced elements within their boxes.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <position>
+/// ```
+///
+// https://drafts.csswg.org/css-images-5/#object-position
+#[syntax(" <position> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "50% 50%",
+	applies_to = "replaced elements",
+	inherited = "no",
+	percentages = "refer to width and height of element itself",
+	canonical_order = "the horizontal component of the <position>, followed by the vertical component",
+	animation_type = "as for background-position"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.object-position"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ObjectPositionStyleValue;
 
 /// Represents the style value for `object-view-box` as defined in [css-images-5](https://drafts.csswg.org/css-images-5/#object-view-box).
 ///

--- a/crates/css_ast/src/values/inline/mod.rs
+++ b/crates/css_ast/src/values/inline/mod.rs
@@ -7,84 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `dominant-baseline` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#dominant-baseline).
-///
-/// The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top
-/// ```
-///
-// https://drafts.csswg.org/css-inline-3/#dominant-baseline
-#[syntax(" auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "block containers, inline boxes, table rows, grid containers, flex containers, and SVG text content elements",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.dominant-baseline"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum DominantBaselineStyleValue {}
-
-// /// Represents the style value for `vertical-align` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#vertical-align).
-// ///
-// /// The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ first | last] || <'alignment-baseline'> || <'baseline-shift'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-inline-3/#vertical-align
-// #[syntax(" [ first | last] || <'alignment-baseline'> || <'baseline-shift'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "baseline",
-//   applies_to = "see individual properties",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.vertical-align"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct VerticalAlignStyleValue;
-
-/// Represents the style value for `baseline-source` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#baseline-source).
-///
-/// The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | first | last
-/// ```
-///
-// https://drafts.csswg.org/css-inline-3/#baseline-source
-#[syntax(" auto | first | last ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "inline-level boxes",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.baseline-source"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BaselineSourceStyleValue {}
-
 /// Represents the style value for `alignment-baseline` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#alignment-baseline).
 ///
 /// The alignment-baseline CSS property sets which baseline of an element is aligned with the corresponding baseline of its parent.
@@ -137,157 +59,57 @@ pub enum AlignmentBaselineStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BaselineShiftStyleValue {}
 
-/// Represents the style value for `line-height` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#line-height).
+/// Represents the style value for `baseline-source` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#baseline-source).
 ///
-/// The line-height CSS property sets the spacing between text baselines, oriented to the horizontal or vertical writing mode.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | <number [0,∞]> | <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-inline-3/#line-height
-#[syntax(" normal | <number [0,∞]> | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "non-replaced inline boxes and SVG text content elements",
-	inherited = "yes",
-	percentages = "computed relative to 1em",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-height"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum LineHeightStyleValue {}
-
-/// Represents the style value for `line-fit-edge` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#line-fit-edge).
+/// The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// leading | <text-edge>
+/// auto | first | last
 /// ```
 ///
-// https://drafts.csswg.org/css-inline-3/#line-fit-edge
-#[syntax(" leading | <text-edge> ")]
+// https://drafts.csswg.org/css-inline-3/#baseline-source
+#[syntax(" auto | first | last ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "leading",
-	applies_to = "inline boxes",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-fit-edge"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum LineFitEdgeStyleValue {}
-
-// /// Represents the style value for `text-box` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#text-box).
-// ///
-// /// The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | <'text-box-trim'> || <'text-box-edge'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-inline-3/#text-box
-// #[syntax(" normal | <'text-box-trim'> || <'text-box-edge'> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "block containers, multi-column containers, and inline boxes",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-box"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum TextBoxStyleValue {}
-
-/// Represents the style value for `text-box-trim` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#text-box-trim).
-///
-/// The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | trim-start | trim-end | trim-both
-/// ```
-///
-// https://drafts.csswg.org/css-inline-3/#text-box-trim
-#[syntax(" none | trim-start | trim-end | trim-both ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "block containers, multi-column containers, and inline boxes",
+	initial = "auto",
+	applies_to = "inline-level boxes",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-box-trim"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.baseline-source"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TextBoxTrimStyleValue {}
+pub enum BaselineSourceStyleValue {}
 
-/// Represents the style value for `text-box-edge` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#text-box-edge).
+/// Represents the style value for `dominant-baseline` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#dominant-baseline).
 ///
-/// The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.
+/// The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | <text-edge>
+/// auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top
 /// ```
 ///
-// https://drafts.csswg.org/css-inline-3/#text-box-edge
-#[syntax(" auto | <text-edge> ")]
+// https://drafts.csswg.org/css-inline-3/#dominant-baseline
+#[syntax(" auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
-	applies_to = "block containers and inline boxes",
+	applies_to = "block containers, inline boxes, table rows, grid containers, flex containers, and SVG text content elements",
 	inherited = "yes",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-box-edge"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.dominant-baseline"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TextBoxEdgeStyleValue;
-
-/// Represents the style value for `inline-sizing` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#inline-sizing).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | stretch
-/// ```
-///
-// https://drafts.csswg.org/css-inline-3/#inline-sizing
-#[syntax(" normal | stretch ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "inline boxes, but not ruby container boxes nor internal ruby boxes",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inline-sizing"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum InlineSizingStyleValue {}
+pub enum DominantBaselineStyleValue {}
 
 // /// Represents the style value for `initial-letter` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#initial-letter).
 // ///
@@ -362,3 +184,181 @@ pub enum InlineSizingStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.initial-letter-wrap"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum InitialLetterWrapStyleValue {}
+
+/// Represents the style value for `inline-sizing` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#inline-sizing).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | stretch
+/// ```
+///
+// https://drafts.csswg.org/css-inline-3/#inline-sizing
+#[syntax(" normal | stretch ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "inline boxes, but not ruby container boxes nor internal ruby boxes",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inline-sizing"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum InlineSizingStyleValue {}
+
+/// Represents the style value for `line-fit-edge` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#line-fit-edge).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// leading | <text-edge>
+/// ```
+///
+// https://drafts.csswg.org/css-inline-3/#line-fit-edge
+#[syntax(" leading | <text-edge> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "leading",
+	applies_to = "inline boxes",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-fit-edge"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum LineFitEdgeStyleValue {}
+
+/// Represents the style value for `line-height` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#line-height).
+///
+/// The line-height CSS property sets the spacing between text baselines, oriented to the horizontal or vertical writing mode.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | <number [0,∞]> | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-inline-3/#line-height
+#[syntax(" normal | <number [0,∞]> | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "non-replaced inline boxes and SVG text content elements",
+	inherited = "yes",
+	percentages = "computed relative to 1em",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-height"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum LineHeightStyleValue {}
+
+// /// Represents the style value for `text-box` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#text-box).
+// ///
+// /// The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | <'text-box-trim'> || <'text-box-edge'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-inline-3/#text-box
+// #[syntax(" normal | <'text-box-trim'> || <'text-box-edge'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "block containers, multi-column containers, and inline boxes",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-box"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum TextBoxStyleValue {}
+
+/// Represents the style value for `text-box-edge` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#text-box-edge).
+///
+/// The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <text-edge>
+/// ```
+///
+// https://drafts.csswg.org/css-inline-3/#text-box-edge
+#[syntax(" auto | <text-edge> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "block containers and inline boxes",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-box-edge"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TextBoxEdgeStyleValue;
+
+/// Represents the style value for `text-box-trim` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#text-box-trim).
+///
+/// The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | trim-start | trim-end | trim-both
+/// ```
+///
+// https://drafts.csswg.org/css-inline-3/#text-box-trim
+#[syntax(" none | trim-start | trim-end | trim-both ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "block containers, multi-column containers, and inline boxes",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-box-trim"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum TextBoxTrimStyleValue {}
+
+// /// Represents the style value for `vertical-align` as defined in [css-inline-3](https://drafts.csswg.org/css-inline-3/#vertical-align).
+// ///
+// /// The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ first | last] || <'alignment-baseline'> || <'baseline-shift'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-inline-3/#vertical-align
+// #[syntax(" [ first | last] || <'alignment-baseline'> || <'baseline-shift'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "baseline",
+//   applies_to = "see individual properties",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.vertical-align"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct VerticalAlignStyleValue;

--- a/crates/css_ast/src/values/line_grid/mod.rs
+++ b/crates/css_ast/src/values/line_grid/mod.rs
@@ -7,6 +7,30 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+/// Represents the style value for `box-snap` as defined in [css-line-grid-1](https://drafts.csswg.org/css-line-grid-1/#box-snap).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | block-start | block-end | center | baseline | last-baseline
+/// ```
+///
+// https://drafts.csswg.org/css-line-grid-1/#box-snap
+#[syntax(" none | block-start | block-end | center | baseline | last-baseline ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "block-level boxes and internal table elements except table cells",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-snap"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BoxSnapStyleValue {}
+
 /// Represents the style value for `line-grid` as defined in [css-line-grid-1](https://drafts.csswg.org/css-line-grid-1/#line-grid).
 ///
 /// The grammar is defined as:
@@ -54,27 +78,3 @@ pub enum LineGridStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-snap"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum LineSnapStyleValue {}
-
-/// Represents the style value for `box-snap` as defined in [css-line-grid-1](https://drafts.csswg.org/css-line-grid-1/#box-snap).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | block-start | block-end | center | baseline | last-baseline
-/// ```
-///
-// https://drafts.csswg.org/css-line-grid-1/#box-snap
-#[syntax(" none | block-start | block-end | center | baseline | last-baseline ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "block-level boxes and internal table elements except table cells",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.box-snap"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BoxSnapStyleValue {}

--- a/crates/css_ast/src/values/lists/mod.rs
+++ b/crates/css_ast/src/values/lists/mod.rs
@@ -7,133 +7,31 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `list-style-image` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style-image).
-///
-/// The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <image> | none
-/// ```
-///
-// https://drafts.csswg.org/css-lists-3/#list-style-image
-#[syntax(" <image> | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "list items",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style-image"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ListStyleImageStyleValue<'a>;
-
-/// Represents the style value for `list-style-type` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style-type).
-///
-/// The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <counter-style> | <string> | none
-/// ```
-///
-// https://drafts.csswg.org/css-lists-3/#list-style-type
-#[syntax(" <counter-style> | <string> | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "disc",
-	applies_to = "list items",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style-type"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ListStyleTypeStyleValue<'a> {}
-
-/// Represents the style value for `list-style-position` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style-position).
-///
-/// The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// inside | outside
-/// ```
-///
-// https://drafts.csswg.org/css-lists-3/#list-style-position
-#[syntax(" inside | outside ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "outside",
-	applies_to = "list items",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style-position"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ListStylePositionStyleValue {}
-
-// /// Represents the style value for `list-style` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style).
+// /// Represents the style value for `counter-increment` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#counter-increment).
 // ///
-// /// The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.
+// /// The counter-reset and counter-increment CSS properties and the counter() and counters() functions automatically number headings or ordered list items.
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// <'list-style-position'> || <'list-style-image'> || <'list-style-type'>
+// /// [ <counter-name> <integer>? ]+ | none
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-lists-3/#list-style
-// #[syntax(" <'list-style-position'> || <'list-style-image'> || <'list-style-type'> ")]
+// // https://drafts.csswg.org/css-lists-3/#counter-increment
+// #[syntax(" [ <counter-name> <integer>? ]+ | none ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "list items",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
+// 	initial = "none",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
 // 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
+// 	animation_type = "by computed value type",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.counter-increment"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct ListStyleStyleValue;
-
-/// Represents the style value for `marker-side` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#marker-side).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// match-self | match-parent
-/// ```
-///
-// https://drafts.csswg.org/css-lists-3/#marker-side
-#[syntax(" match-self | match-parent ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "match-self",
-	applies_to = "list items",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.marker-side"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum MarkerSideStyleValue {}
+// pub enum CounterIncrementStyleValue<'a> {}
 
 // /// Represents the style value for `counter-reset` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#counter-reset).
 // ///
@@ -161,32 +59,6 @@ pub enum MarkerSideStyleValue {}
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum CounterResetStyleValue<'a> {}
 
-// /// Represents the style value for `counter-increment` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#counter-increment).
-// ///
-// /// The counter-reset and counter-increment CSS properties and the counter() and counters() functions automatically number headings or ordered list items.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ <counter-name> <integer>? ]+ | none
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-lists-3/#counter-increment
-// #[syntax(" [ <counter-name> <integer>? ]+ | none ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "by computed value type",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.counter-increment"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum CounterIncrementStyleValue<'a> {}
-
 // /// Represents the style value for `counter-set` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#counter-set).
 // ///
 // /// The counter-set CSS property creates (and optionally sets a value for) a counter, the numbers for a series of headings or ordered list items.
@@ -212,3 +84,131 @@ pub enum MarkerSideStyleValue {}
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.counter-set"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum CounterSetStyleValue<'a> {}
+
+// /// Represents the style value for `list-style` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style).
+// ///
+// /// The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'list-style-position'> || <'list-style-image'> || <'list-style-type'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-lists-3/#list-style
+// #[syntax(" <'list-style-position'> || <'list-style-image'> || <'list-style-type'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "list items",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct ListStyleStyleValue;
+
+/// Represents the style value for `list-style-image` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style-image).
+///
+/// The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <image> | none
+/// ```
+///
+// https://drafts.csswg.org/css-lists-3/#list-style-image
+#[syntax(" <image> | none ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "list items",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style-image"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ListStyleImageStyleValue<'a>;
+
+/// Represents the style value for `list-style-position` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style-position).
+///
+/// The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// inside | outside
+/// ```
+///
+// https://drafts.csswg.org/css-lists-3/#list-style-position
+#[syntax(" inside | outside ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "outside",
+	applies_to = "list items",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style-position"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ListStylePositionStyleValue {}
+
+/// Represents the style value for `list-style-type` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#list-style-type).
+///
+/// The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <counter-style> | <string> | none
+/// ```
+///
+// https://drafts.csswg.org/css-lists-3/#list-style-type
+#[syntax(" <counter-style> | <string> | none ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "disc",
+	applies_to = "list items",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.list-style-type"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ListStyleTypeStyleValue<'a> {}
+
+/// Represents the style value for `marker-side` as defined in [css-lists-3](https://drafts.csswg.org/css-lists-3/#marker-side).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// match-self | match-parent
+/// ```
+///
+// https://drafts.csswg.org/css-lists-3/#marker-side
+#[syntax(" match-self | match-parent ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "match-self",
+	applies_to = "list items",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.marker-side"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum MarkerSideStyleValue {}

--- a/crates/css_ast/src/values/logical/mod.rs
+++ b/crates/css_ast/src/values/logical/mod.rs
@@ -59,57 +59,161 @@ pub struct BlockSizeStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InlineSizeStyleValue;
 
-/// Represents the style value for `min-block-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#min-block-size).
+/// Represents the style value for `margin-block` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block).
 ///
 /// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <'min-width'>
+/// <'margin-top'>{1,2}
 /// ```
 ///
-// https://drafts.csswg.org/css-logical-1/#min-block-size
-#[syntax(" <'min-width'> ")]
+// https://drafts.csswg.org/css-logical-1/#margin-block
+#[syntax(" <'margin-top'>{1,2} ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "0",
-	applies_to = "same as height and width",
-	inherited = "no",
-	percentages = "as for the corresponding physical property",
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
 	canonical_order = "per grammar",
-	animation_type = "by computed value type"
+	animation_type = "see individual properties"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-block-size"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-block"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MinBlockSizeStyleValue;
+pub struct MarginBlockStyleValue;
 
-/// Represents the style value for `min-inline-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#min-inline-size).
+/// Represents the style value for `margin-block-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block-end).
 ///
 /// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <'min-width'>
+/// <'margin-top'>
 /// ```
 ///
-// https://drafts.csswg.org/css-logical-1/#min-inline-size
-#[syntax(" <'min-width'> ")]
+// https://drafts.csswg.org/css-logical-1/#margin-block-end
+#[syntax(" <'margin-top'> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
-	applies_to = "same as height and width",
+	applies_to = "Same as margin-top",
 	inherited = "no",
 	percentages = "as for the corresponding physical property",
 	canonical_order = "per grammar",
 	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-inline-size"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-block-end"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MinInlineSizeStyleValue;
+pub struct MarginBlockEndStyleValue;
+
+/// Represents the style value for `margin-block-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block-start).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'margin-top'>
+/// ```
+///
+// https://drafts.csswg.org/css-logical-1/#margin-block-start
+#[syntax(" <'margin-top'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "Same as margin-top",
+	inherited = "no",
+	percentages = "as for the corresponding physical property",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-block-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct MarginBlockStartStyleValue;
+
+/// Represents the style value for `margin-inline` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-inline).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'margin-top'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-logical-1/#margin-inline
+#[syntax(" <'margin-top'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-inline"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct MarginInlineStyleValue;
+
+/// Represents the style value for `margin-inline-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-inline-end).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'margin-top'>
+/// ```
+///
+// https://drafts.csswg.org/css-logical-1/#margin-inline-end
+#[syntax(" <'margin-top'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "Same as margin-top",
+	inherited = "no",
+	percentages = "as for the corresponding physical property",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-inline-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct MarginInlineEndStyleValue;
+
+/// Represents the style value for `margin-inline-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-inline-start).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'margin-top'>
+/// ```
+///
+// https://drafts.csswg.org/css-logical-1/#margin-inline-start
+#[syntax(" <'margin-top'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "Same as margin-top",
+	inherited = "no",
+	percentages = "as for the corresponding physical property",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-inline-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct MarginInlineStartStyleValue;
 
 /// Represents the style value for `max-block-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#max-block-size).
 ///
@@ -163,265 +267,57 @@ pub struct MaxBlockSizeStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct MaxInlineSizeStyleValue;
 
-/// Represents the style value for `margin-block-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block-start).
+/// Represents the style value for `min-block-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#min-block-size).
 ///
 /// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <'margin-top'>
+/// <'min-width'>
 /// ```
 ///
-// https://drafts.csswg.org/css-logical-1/#margin-block-start
-#[syntax(" <'margin-top'> ")]
+// https://drafts.csswg.org/css-logical-1/#min-block-size
+#[syntax(" <'min-width'> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
-	applies_to = "Same as margin-top",
+	applies_to = "same as height and width",
 	inherited = "no",
 	percentages = "as for the corresponding physical property",
 	canonical_order = "per grammar",
 	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-block-start"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-block-size"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MarginBlockStartStyleValue;
+pub struct MinBlockSizeStyleValue;
 
-/// Represents the style value for `margin-block-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block-end).
+/// Represents the style value for `min-inline-size` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#min-inline-size).
 ///
 /// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <'margin-top'>
+/// <'min-width'>
 /// ```
 ///
-// https://drafts.csswg.org/css-logical-1/#margin-block-end
-#[syntax(" <'margin-top'> ")]
+// https://drafts.csswg.org/css-logical-1/#min-inline-size
+#[syntax(" <'min-width'> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "0",
-	applies_to = "Same as margin-top",
+	applies_to = "same as height and width",
 	inherited = "no",
 	percentages = "as for the corresponding physical property",
 	canonical_order = "per grammar",
 	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-block-end"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-inline-size"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MarginBlockEndStyleValue;
-
-/// Represents the style value for `margin-inline-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-inline-start).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'margin-top'>
-/// ```
-///
-// https://drafts.csswg.org/css-logical-1/#margin-inline-start
-#[syntax(" <'margin-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "Same as margin-top",
-	inherited = "no",
-	percentages = "as for the corresponding physical property",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-inline-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MarginInlineStartStyleValue;
-
-/// Represents the style value for `margin-inline-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-inline-end).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'margin-top'>
-/// ```
-///
-// https://drafts.csswg.org/css-logical-1/#margin-inline-end
-#[syntax(" <'margin-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "Same as margin-top",
-	inherited = "no",
-	percentages = "as for the corresponding physical property",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-inline-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MarginInlineEndStyleValue;
-
-/// Represents the style value for `margin-block` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-block).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'margin-top'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-logical-1/#margin-block
-#[syntax(" <'margin-top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-block"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MarginBlockStyleValue;
-
-/// Represents the style value for `margin-inline` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#margin-inline).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'margin-top'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-logical-1/#margin-inline
-#[syntax(" <'margin-top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.margin-inline"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MarginInlineStyleValue;
-
-/// Represents the style value for `padding-block-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-block-start).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'padding-top'>
-/// ```
-///
-// https://drafts.csswg.org/css-logical-1/#padding-block-start
-#[syntax(" <'padding-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "Same as padding-top",
-	inherited = "no",
-	percentages = "as for the corresponding physical property",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-block-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct PaddingBlockStartStyleValue;
-
-/// Represents the style value for `padding-block-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-block-end).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'padding-top'>
-/// ```
-///
-// https://drafts.csswg.org/css-logical-1/#padding-block-end
-#[syntax(" <'padding-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "Same as padding-top",
-	inherited = "no",
-	percentages = "as for the corresponding physical property",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-block-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct PaddingBlockEndStyleValue;
-
-/// Represents the style value for `padding-inline-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-inline-start).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'padding-top'>
-/// ```
-///
-// https://drafts.csswg.org/css-logical-1/#padding-inline-start
-#[syntax(" <'padding-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "Same as padding-top",
-	inherited = "no",
-	percentages = "as for the corresponding physical property",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-inline-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct PaddingInlineStartStyleValue;
-
-/// Represents the style value for `padding-inline-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-inline-end).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'padding-top'>
-/// ```
-///
-// https://drafts.csswg.org/css-logical-1/#padding-inline-end
-#[syntax(" <'padding-top'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "Same as padding-top",
-	inherited = "no",
-	percentages = "as for the corresponding physical property",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-inline-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct PaddingInlineEndStyleValue;
+pub struct MinInlineSizeStyleValue;
 
 /// Represents the style value for `padding-block` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-block).
 ///
@@ -449,6 +345,58 @@ pub struct PaddingInlineEndStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingBlockStyleValue;
 
+/// Represents the style value for `padding-block-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-block-end).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'padding-top'>
+/// ```
+///
+// https://drafts.csswg.org/css-logical-1/#padding-block-end
+#[syntax(" <'padding-top'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "Same as padding-top",
+	inherited = "no",
+	percentages = "as for the corresponding physical property",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-block-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct PaddingBlockEndStyleValue;
+
+/// Represents the style value for `padding-block-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-block-start).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'padding-top'>
+/// ```
+///
+// https://drafts.csswg.org/css-logical-1/#padding-block-start
+#[syntax(" <'padding-top'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "Same as padding-top",
+	inherited = "no",
+	percentages = "as for the corresponding physical property",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-block-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct PaddingBlockStartStyleValue;
+
 /// Represents the style value for `padding-inline` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-inline).
 ///
 /// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
@@ -474,3 +422,55 @@ pub struct PaddingBlockStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-inline"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PaddingInlineStyleValue;
+
+/// Represents the style value for `padding-inline-end` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-inline-end).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'padding-top'>
+/// ```
+///
+// https://drafts.csswg.org/css-logical-1/#padding-inline-end
+#[syntax(" <'padding-top'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "Same as padding-top",
+	inherited = "no",
+	percentages = "as for the corresponding physical property",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-inline-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct PaddingInlineEndStyleValue;
+
+/// Represents the style value for `padding-inline-start` as defined in [css-logical-1](https://drafts.csswg.org/css-logical-1/#padding-inline-start).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'padding-top'>
+/// ```
+///
+// https://drafts.csswg.org/css-logical-1/#padding-inline-start
+#[syntax(" <'padding-top'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "Same as padding-top",
+	inherited = "no",
+	percentages = "as for the corresponding physical property",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.padding-inline-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct PaddingInlineStartStyleValue;

--- a/crates/css_ast/src/values/multicol/mod.rs
+++ b/crates/css_ast/src/values/multicol/mod.rs
@@ -7,32 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `column-width` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-width).
-///
-/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-multicol-2/#column-width
-#[syntax(" auto | <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "block containers except table wrapper boxes",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ColumnWidthStyleValue;
-
 /// Represents the style value for `column-count` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-count).
 ///
 /// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
@@ -58,58 +32,6 @@ pub struct ColumnWidthStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-count"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ColumnCountStyleValue;
-
-// /// Represents the style value for `columns` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#columns).
-// ///
-// /// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ <'column-width'> || <'column-count'> ] [ / <'column-height'> ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-multicol-2/#columns
-// #[syntax(" [ <'column-width'> || <'column-count'> ] [ / <'column-height'> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.columns"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct ColumnsStyleValue;
-
-/// Represents the style value for `column-span` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-span).
-///
-/// The column-span CSS property controls whether a child element extends across all columns of a multi-column parent.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <integer [1,∞]> | all | auto
-/// ```
-///
-// https://drafts.csswg.org/css-multicol-2/#column-span
-#[syntax(" none | <integer [1,∞]> | all | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "in-flow block-level elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-span"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ColumnSpanStyleValue {}
 
 /// Represents the style value for `column-fill` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-fill).
 ///
@@ -161,6 +83,58 @@ pub enum ColumnFillStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ColumnHeightStyleValue;
 
+/// Represents the style value for `column-span` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-span).
+///
+/// The column-span CSS property controls whether a child element extends across all columns of a multi-column parent.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <integer [1,∞]> | all | auto
+/// ```
+///
+// https://drafts.csswg.org/css-multicol-2/#column-span
+#[syntax(" none | <integer [1,∞]> | all | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "in-flow block-level elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-span"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ColumnSpanStyleValue {}
+
+/// Represents the style value for `column-width` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-width).
+///
+/// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-multicol-2/#column-width
+#[syntax(" auto | <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "block containers except table wrapper boxes",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ColumnWidthStyleValue;
+
 /// Represents the style value for `column-wrap` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#column-wrap).
 ///
 /// The grammar is defined as:
@@ -184,3 +158,29 @@ pub struct ColumnHeightStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.column-wrap"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ColumnWrapStyleValue {}
+
+// /// Represents the style value for `columns` as defined in [css-multicol-2](https://drafts.csswg.org/css-multicol-2/#columns).
+// ///
+// /// Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ <'column-width'> || <'column-count'> ] [ / <'column-height'> ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-multicol-2/#columns
+// #[syntax(" [ <'column-width'> || <'column-count'> ] [ / <'column-height'> ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.columns"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct ColumnsStyleValue;

--- a/crates/css_ast/src/values/nav/mod.rs
+++ b/crates/css_ast/src/values/nav/mod.rs
@@ -7,6 +7,30 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+/// Represents the style value for `spatial-navigation-action` as defined in [css-nav-1](https://drafts.csswg.org/css-nav-1/#spatial-navigation-action).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | focus | scroll
+/// ```
+///
+// https://drafts.csswg.org/css-nav-1/#spatial-navigation-action
+#[syntax(" auto | focus | scroll ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.spatial-navigation-action"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum SpatialNavigationActionStyleValue {}
+
 /// Represents the style value for `spatial-navigation-contain` as defined in [css-nav-1](https://drafts.csswg.org/css-nav-1/#spatial-navigation-contain).
 ///
 /// The grammar is defined as:
@@ -34,30 +58,6 @@ use impls::*;
 )]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum SpatialNavigationContainStyleValue {}
-
-/// Represents the style value for `spatial-navigation-action` as defined in [css-nav-1](https://drafts.csswg.org/css-nav-1/#spatial-navigation-action).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | focus | scroll
-/// ```
-///
-// https://drafts.csswg.org/css-nav-1/#spatial-navigation-action
-#[syntax(" auto | focus | scroll ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.spatial-navigation-action"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum SpatialNavigationActionStyleValue {}
 
 /// Represents the style value for `spatial-navigation-function` as defined in [css-nav-1](https://drafts.csswg.org/css-nav-1/#spatial-navigation-function).
 ///

--- a/crates/css_ast/src/values/overflow/mod.rs
+++ b/crates/css_ast/src/values/overflow/mod.rs
@@ -7,6 +7,504 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+/// Represents the style value for `-webkit-line-clamp` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#-webkit-line-clamp).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <integer [1,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#-webkit-line-clamp
+#[syntax(" none | <integer [1,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.-webkit-line-clamp"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct WebkitLineClampStyleValue;
+
+/// Represents the style value for `block-ellipsis` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#block-ellipsis).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// no-ellipsis | auto | <string>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#block-ellipsis
+#[syntax(" no-ellipsis | auto | <string> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "no-ellipsis",
+	applies_to = "block containers",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-ellipsis"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BlockEllipsisStyleValue {}
+
+/// Represents the style value for `continue` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#continue).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | discard | collapse
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#continue
+#[syntax(" auto | discard | collapse ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "block containers and multicol containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.continue"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ContinueStyleValue {}
+
+// /// Represents the style value for `line-clamp` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#line-clamp).
+// ///
+// /// The line-clamp CSS property limits the text in a block container to a certain number of lines. The prefixed -webkit-line-clamp is widely supported but only works with -webkit-box-orient: vertical in combination with display: -webkit-box or display: -webkit-inline-box.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [<integer [1,∞]> || <'block-ellipsis'>] -webkit-legacy?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-overflow-5/#line-clamp
+// #[syntax(" none | [<integer [1,∞]> || <'block-ellipsis'>] -webkit-legacy? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-clamp"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum LineClampStyleValue {}
+
+/// Represents the style value for `max-lines` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#max-lines).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <integer [1,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#max-lines
+#[syntax(" none | <integer [1,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "block containers which are also either line-clamp containers or fragmentation containers that capture region breaks",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-lines"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct MaxLinesStyleValue;
+
+/// Represents the style value for `overflow` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow).
+///
+/// The overflow CSS property sets the behavior for when content doesn't fit in an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'overflow-block'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow
+#[syntax(" <'overflow-block'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "visible",
+	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], and grid containers [CSS3-GRID-LAYOUT]",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowStyleValue;
+
+/// Represents the style value for `overflow-block` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-block).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// visible | hidden | clip | scroll | auto
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-block
+#[syntax(" visible | hidden | clip | scroll | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "visible",
+	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], grid containers [CSS3-GRID-LAYOUT]",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-block"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum OverflowBlockStyleValue {}
+
+/// Represents the style value for `overflow-clip-margin` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin).
+///
+/// The overflow-clip-margin CSS property sets how far overflow content may appear outside the bounds of an element before it's clipped by effects such as overflow: clip.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-clip-margin"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-block` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.overflow-clip-margin-block")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginBlockStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-block-end` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-end).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-end
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.overflow-clip-margin-block-end")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginBlockEndStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-block-start` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-start).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-start
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.overflow-clip-margin-block-start")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginBlockStartStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-bottom` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-bottom).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-bottom
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.overflow-clip-margin-bottom")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginBottomStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-inline` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.overflow-clip-margin-inline")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginInlineStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-inline-end` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-end).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-end
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.overflow-clip-margin-inline-end")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginInlineEndStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-inline-start` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-start).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-start
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.overflow-clip-margin-inline-start")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginInlineStartStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-left` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-left).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-left
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-clip-margin-left"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginLeftStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-right` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-right).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-right
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.overflow-clip-margin-right")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginRightStyleValue;
+
+/// Represents the style value for `overflow-clip-margin-top` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-top).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <visual-box> || <length [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-top
+#[syntax(" <visual-box> || <length [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0px",
+	applies_to = "boxes to which overflow applies",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-clip-margin-top"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OverflowClipMarginTopStyleValue;
+
+/// Represents the style value for `overflow-inline` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-inline).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// visible | hidden | clip | scroll | auto
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#overflow-inline
+#[syntax(" visible | hidden | clip | scroll | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "visible",
+	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], grid containers [CSS3-GRID-LAYOUT]",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-inline"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum OverflowInlineStyleValue {}
+
 /// Represents the style value for `overflow-x` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-x).
 ///
 /// The overflow CSS property sets the behavior for when content doesn't fit in an element.
@@ -59,110 +557,6 @@ pub enum OverflowXStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverflowYStyleValue {}
 
-/// Represents the style value for `overflow-block` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-block).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// visible | hidden | clip | scroll | auto
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-block
-#[syntax(" visible | hidden | clip | scroll | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "visible",
-	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], grid containers [CSS3-GRID-LAYOUT]",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-block"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum OverflowBlockStyleValue {}
-
-/// Represents the style value for `overflow-inline` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-inline).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// visible | hidden | clip | scroll | auto
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-inline
-#[syntax(" visible | hidden | clip | scroll | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "visible",
-	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], grid containers [CSS3-GRID-LAYOUT]",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-inline"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum OverflowInlineStyleValue {}
-
-/// Represents the style value for `overflow` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow).
-///
-/// The overflow CSS property sets the behavior for when content doesn't fit in an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'overflow-block'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow
-#[syntax(" <'overflow-block'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "visible",
-	applies_to = "block containers [CSS2], flex containers [CSS3-FLEXBOX], and grid containers [CSS3-GRID-LAYOUT]",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowStyleValue;
-
-/// Represents the style value for `overflow-clip-margin` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin).
-///
-/// The overflow-clip-margin CSS property sets how far overflow content may appear outside the bounds of an element before it's clipped by effects such as overflow: clip.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-clip-margin"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginStyleValue;
-
 /// Represents the style value for `scroll-behavior` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scroll-behavior).
 ///
 /// The scroll-behavior CSS property controls whether scrolling is smooth or snaps, for scroll actions not performed by the user such as those triggered by navigation.
@@ -188,6 +582,56 @@ pub struct OverflowClipMarginStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-behavior"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ScrollBehaviorStyleValue {}
+
+/// Represents the style value for `scroll-marker-group` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scroll-marker-group).
+///
+/// A scroll container can be navigated by activating ::scroll-marker pseudo-elements which appear in a generated ::scroll-marker-group pseudo-element, either before or after the scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | before | after
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#scroll-marker-group
+#[syntax(" none | before | after ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-marker-group"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ScrollMarkerGroupStyleValue {}
+
+/// Represents the style value for `scroll-target-group` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scroll-target-group).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | auto
+/// ```
+///
+// https://drafts.csswg.org/css-overflow-5/#scroll-target-group
+#[syntax(" none | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-target-group"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ScrollTargetGroupStyleValue {}
 
 // /// Represents the style value for `scrollbar-gutter` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scrollbar-gutter).
 // ///
@@ -240,447 +684,3 @@ pub enum ScrollBehaviorStyleValue {}
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-overflow"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TextOverflowStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-top` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-top).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-top
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-clip-margin-top"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginTopStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-right` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-right).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-right
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.overflow-clip-margin-right")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginRightStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-bottom` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-bottom).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-bottom
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.overflow-clip-margin-bottom")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginBottomStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-left` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-left).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-left
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overflow-clip-margin-left"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginLeftStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-block-start` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-start).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-start
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.overflow-clip-margin-block-start")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginBlockStartStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-inline-start` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-start).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-start
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.overflow-clip-margin-inline-start")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginInlineStartStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-block-end` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-end).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block-end
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.overflow-clip-margin-block-end")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginBlockEndStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-inline-end` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-end).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline-end
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "per computed value if the <visual-box> values match; otherwise discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.overflow-clip-margin-inline-end")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginInlineEndStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-inline` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-inline
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.overflow-clip-margin-inline")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginInlineStyleValue;
-
-/// Represents the style value for `overflow-clip-margin-block` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <visual-box> || <length [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#overflow-clip-margin-block
-#[syntax(" <visual-box> || <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0px",
-	applies_to = "boxes to which overflow applies",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.overflow-clip-margin-block")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OverflowClipMarginBlockStyleValue;
-
-/// Represents the style value for `block-ellipsis` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#block-ellipsis).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// no-ellipsis | auto | <string>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#block-ellipsis
-#[syntax(" no-ellipsis | auto | <string> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "no-ellipsis",
-	applies_to = "block containers",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-ellipsis"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BlockEllipsisStyleValue {}
-
-// /// Represents the style value for `line-clamp` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#line-clamp).
-// ///
-// /// The line-clamp CSS property limits the text in a block container to a certain number of lines. The prefixed -webkit-line-clamp is widely supported but only works with -webkit-box-orient: vertical in combination with display: -webkit-box or display: -webkit-inline-box.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [<integer [1,∞]> || <'block-ellipsis'>] -webkit-legacy?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-overflow-5/#line-clamp
-// #[syntax(" none | [<integer [1,∞]> || <'block-ellipsis'>] -webkit-legacy? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-clamp"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum LineClampStyleValue {}
-
-/// Represents the style value for `-webkit-line-clamp` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#-webkit-line-clamp).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <integer [1,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#-webkit-line-clamp
-#[syntax(" none | <integer [1,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.-webkit-line-clamp"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct WebkitLineClampStyleValue;
-
-/// Represents the style value for `max-lines` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#max-lines).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <integer [1,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#max-lines
-#[syntax(" none | <integer [1,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "block containers which are also either line-clamp containers or fragmentation containers that capture region breaks",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-lines"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct MaxLinesStyleValue;
-
-/// Represents the style value for `continue` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#continue).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | discard | collapse
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#continue
-#[syntax(" auto | discard | collapse ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "block containers and multicol containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.continue"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ContinueStyleValue {}
-
-/// Represents the style value for `scroll-target-group` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scroll-target-group).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | auto
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#scroll-target-group
-#[syntax(" none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-target-group"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ScrollTargetGroupStyleValue {}
-
-/// Represents the style value for `scroll-marker-group` as defined in [css-overflow-5](https://drafts.csswg.org/css-overflow-5/#scroll-marker-group).
-///
-/// A scroll container can be navigated by activating ::scroll-marker pseudo-elements which appear in a generated ::scroll-marker-group pseudo-element, either before or after the scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | before | after
-/// ```
-///
-// https://drafts.csswg.org/css-overflow-5/#scroll-marker-group
-#[syntax(" none | before | after ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-marker-group"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ScrollMarkerGroupStyleValue {}

--- a/crates/css_ast/src/values/overscroll/mod.rs
+++ b/crates/css_ast/src/values/overscroll/mod.rs
@@ -33,6 +33,62 @@ use impls::*;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OverscrollBehaviorStyleValue;
 
+/// Represents the style value for `overscroll-behavior-block` as defined in [css-overscroll-1](https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-block).
+///
+/// The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// contain | none | auto
+/// ```
+///
+// https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-block
+#[syntax(" contain | none | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll container elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overscroll-behavior-block"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum OverscrollBehaviorBlockStyleValue {}
+
+/// Represents the style value for `overscroll-behavior-inline` as defined in [css-overscroll-1](https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-inline).
+///
+/// The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// contain | none | auto
+/// ```
+///
+// https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-inline
+#[syntax(" contain | none | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll container elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.overscroll-behavior-inline")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum OverscrollBehaviorInlineStyleValue {}
+
 /// Represents the style value for `overscroll-behavior-x` as defined in [css-overscroll-1](https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-x).
 ///
 /// The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.
@@ -84,59 +140,3 @@ pub enum OverscrollBehaviorXStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overscroll-behavior-y"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverscrollBehaviorYStyleValue {}
-
-/// Represents the style value for `overscroll-behavior-inline` as defined in [css-overscroll-1](https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-inline).
-///
-/// The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// contain | none | auto
-/// ```
-///
-// https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-inline
-#[syntax(" contain | none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll container elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.overscroll-behavior-inline")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum OverscrollBehaviorInlineStyleValue {}
-
-/// Represents the style value for `overscroll-behavior-block` as defined in [css-overscroll-1](https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-block).
-///
-/// The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// contain | none | auto
-/// ```
-///
-// https://drafts.csswg.org/css-overscroll-1/#overscroll-behavior-block
-#[syntax(" contain | none | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll container elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overscroll-behavior-block"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum OverscrollBehaviorBlockStyleValue {}

--- a/crates/css_ast/src/values/page_floats/mod.rs
+++ b/crates/css_ast/src/values/page_floats/mod.rs
@@ -7,29 +7,33 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `float-reference` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#float-reference).
+/// Represents the style value for `clear` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#clear).
+///
+/// The float CSS property aligns an element to either side of its container, allowing text and inline elements to flow around it. The clear CSS property sets whether an element is moved below floating elements that proceed it.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// inline | column | region | page
+/// inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none
 /// ```
 ///
-// https://drafts.csswg.org/css-page-floats-3/#float-reference
-#[syntax(" inline | column | region | page ")]
+// https://drafts.csswg.org/css-page-floats-3/#clear
+#[syntax(
+	" inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none "
+)]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "inline",
-	applies_to = "all elements.",
+	initial = "none",
+	applies_to = "block-level elements, floats, regions, pages",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.float-reference"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.clear"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum FloatReferenceStyleValue {}
+pub enum ClearStyleValue {}
 
 /// Represents the style value for `float` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#float).
 ///
@@ -58,34 +62,6 @@ pub enum FloatReferenceStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.float"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum FloatStyleValue {}
-
-/// Represents the style value for `clear` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#clear).
-///
-/// The float CSS property aligns an element to either side of its container, allowing text and inline elements to flow around it. The clear CSS property sets whether an element is moved below floating elements that proceed it.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none
-/// ```
-///
-// https://drafts.csswg.org/css-page-floats-3/#clear
-#[syntax(
-	" inline-start | inline-end | block-start | block-end | left | right | top | bottom | both-inline | both-block | both | none "
-)]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "block-level elements, floats, regions, pages",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.clear"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ClearStyleValue {}
 
 /// Represents the style value for `float-defer` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#float-defer).
 ///
@@ -134,3 +110,27 @@ pub enum FloatDeferStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.float-offset"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FloatOffsetStyleValue;
+
+/// Represents the style value for `float-reference` as defined in [css-page-floats-3](https://drafts.csswg.org/css-page-floats-3/#float-reference).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// inline | column | region | page
+/// ```
+///
+// https://drafts.csswg.org/css-page-floats-3/#float-reference
+#[syntax(" inline | column | region | page ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "inline",
+	applies_to = "all elements.",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.float-reference"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum FloatReferenceStyleValue {}

--- a/crates/css_ast/src/values/position/mod.rs
+++ b/crates/css_ast/src/values/position/mod.rs
@@ -7,84 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `position` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#position).
-///
-/// The position CSS property sets the origin position of an element to an element, the element's scrollport, or the viewport.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// static | relative | absolute | sticky | fixed
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#position
-#[syntax(" static | relative | absolute | sticky | fixed ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "static",
-	applies_to = "all elements except table-column-group and table-column",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum PositionStyleValue {}
-
-/// Represents the style value for `top` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#top).
-///
-/// The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#top
-#[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "positioned elements",
-	inherited = "no",
-	percentages = "refer to size of containing block; see prose",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.top"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TopStyleValue;
-
-/// Represents the style value for `right` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#right).
-///
-/// The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#right
-#[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "positioned elements",
-	inherited = "no",
-	percentages = "refer to size of containing block; see prose",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.right"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct RightStyleValue;
-
 /// Represents the style value for `bottom` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#bottom).
 ///
 /// The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.
@@ -110,188 +32,6 @@ pub struct RightStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.bottom"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct BottomStyleValue;
-
-/// Represents the style value for `left` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#left).
-///
-/// The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#left
-#[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "positioned elements",
-	inherited = "no",
-	percentages = "refer to size of containing block; see prose",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.left"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct LeftStyleValue;
-
-/// Represents the style value for `inset-block-start` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block-start).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#inset-block-start
-#[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "positioned elements",
-	inherited = "no",
-	percentages = "refer to size of containing block; see prose",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-block-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct InsetBlockStartStyleValue;
-
-/// Represents the style value for `inset-inline-start` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline-start).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#inset-inline-start
-#[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "positioned elements",
-	inherited = "no",
-	percentages = "refer to size of containing block; see prose",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-inline-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct InsetInlineStartStyleValue;
-
-/// Represents the style value for `inset-block-end` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block-end).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#inset-block-end
-#[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "positioned elements",
-	inherited = "no",
-	percentages = "refer to size of containing block; see prose",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-block-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct InsetBlockEndStyleValue;
-
-/// Represents the style value for `inset-inline-end` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline-end).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#inset-inline-end
-#[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "positioned elements",
-	inherited = "no",
-	percentages = "refer to size of containing block; see prose",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-inline-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct InsetInlineEndStyleValue;
-
-/// Represents the style value for `inset-block` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'top'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#inset-block
-#[syntax(" <'top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "positioned elements",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-block"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct InsetBlockStyleValue;
-
-/// Represents the style value for `inset-inline` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline).
-///
-/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'top'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-position-4/#inset-inline
-#[syntax(" <'top'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "positioned elements",
-	inherited = "no",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-inline"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct InsetInlineStyleValue;
 
 /// Represents the style value for `inset` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset).
 ///
@@ -319,6 +59,188 @@ pub struct InsetInlineStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct InsetStyleValue;
 
+/// Represents the style value for `inset-block` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'top'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#inset-block
+#[syntax(" <'top'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "positioned elements",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-block"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct InsetBlockStyleValue;
+
+/// Represents the style value for `inset-block-end` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block-end).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#inset-block-end
+#[syntax(" auto | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "positioned elements",
+	inherited = "no",
+	percentages = "refer to size of containing block; see prose",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-block-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct InsetBlockEndStyleValue;
+
+/// Represents the style value for `inset-block-start` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-block-start).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#inset-block-start
+#[syntax(" auto | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "positioned elements",
+	inherited = "no",
+	percentages = "refer to size of containing block; see prose",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-block-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct InsetBlockStartStyleValue;
+
+/// Represents the style value for `inset-inline` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'top'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#inset-inline
+#[syntax(" <'top'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "positioned elements",
+	inherited = "no",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-inline"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct InsetInlineStyleValue;
+
+/// Represents the style value for `inset-inline-end` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline-end).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#inset-inline-end
+#[syntax(" auto | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "positioned elements",
+	inherited = "no",
+	percentages = "refer to size of containing block; see prose",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-inline-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct InsetInlineEndStyleValue;
+
+/// Represents the style value for `inset-inline-start` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#inset-inline-start).
+///
+/// CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#inset-inline-start
+#[syntax(" auto | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "positioned elements",
+	inherited = "no",
+	percentages = "refer to size of containing block; see prose",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.inset-inline-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct InsetInlineStartStyleValue;
+
+/// Represents the style value for `left` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#left).
+///
+/// The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#left
+#[syntax(" auto | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "positioned elements",
+	inherited = "no",
+	percentages = "refer to size of containing block; see prose",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.left"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct LeftStyleValue;
+
 /// Represents the style value for `overlay` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#overlay).
 ///
 /// The overlay CSS property, used as an allow-discrete CSS transition, prevents a top layer element, such as a popover or a <dialog>, from being removed from the top layer before it has finished animating. You can't set the value of the overlay property; only use it as transition property.
@@ -344,3 +266,81 @@ pub struct InsetStyleValue;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.overlay"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverlayStyleValue {}
+
+/// Represents the style value for `position` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#position).
+///
+/// The position CSS property sets the origin position of an element to an element, the element's scrollport, or the viewport.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// static | relative | absolute | sticky | fixed
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#position
+#[syntax(" static | relative | absolute | sticky | fixed ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "static",
+	applies_to = "all elements except table-column-group and table-column",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.position"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum PositionStyleValue {}
+
+/// Represents the style value for `right` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#right).
+///
+/// The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#right
+#[syntax(" auto | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "positioned elements",
+	inherited = "no",
+	percentages = "refer to size of containing block; see prose",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.right"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct RightStyleValue;
+
+/// Represents the style value for `top` as defined in [css-position-4](https://drafts.csswg.org/css-position-4/#top).
+///
+/// The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-position-4/#top
+#[syntax(" auto | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "positioned elements",
+	inherited = "no",
+	percentages = "refer to size of containing block; see prose",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.top"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TopStyleValue;

--- a/crates/css_ast/src/values/regions/mod.rs
+++ b/crates/css_ast/src/values/regions/mod.rs
@@ -7,30 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `flow-into` as defined in [css-regions-1](https://drafts.csswg.org/css-regions-1/#flow-into).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | <custom-ident> [element | content]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-regions-1/#flow-into
-// #[syntax(" none | <custom-ident> [element | content]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "All elements, but not pseudo-elements such as ::first-line, ::first-letter, ::before or ::after.",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "not animatable",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flow-into"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum FlowIntoStyleValue {}
-
 /// Represents the style value for `flow-from` as defined in [css-regions-1](https://drafts.csswg.org/css-regions-1/#flow-from).
 ///
 /// The grammar is defined as:
@@ -54,6 +30,30 @@ use impls::*;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flow-from"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct FlowFromStyleValue;
+
+// /// Represents the style value for `flow-into` as defined in [css-regions-1](https://drafts.csswg.org/css-regions-1/#flow-into).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | <custom-ident> [element | content]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-regions-1/#flow-into
+// #[syntax(" none | <custom-ident> [element | content]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "All elements, but not pseudo-elements such as ::first-line, ::first-letter, ::before or ::after.",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "not animatable",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.flow-into"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum FlowIntoStyleValue {}
 
 /// Represents the style value for `region-fragment` as defined in [css-regions-1](https://drafts.csswg.org/css-regions-1/#region-fragment).
 ///

--- a/crates/css_ast/src/values/rhythm/mod.rs
+++ b/crates/css_ast/src/values/rhythm/mod.rs
@@ -7,53 +7,29 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `block-step-size` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step-size).
+/// Represents the style value for `block-step` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// none | <length [0,∞]>
+/// <'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'>
 /// ```
 ///
-// https://drafts.csswg.org/css-rhythm-1/#block-step-size
-#[syntax(" none | <length [0,∞]> ")]
+// https://drafts.csswg.org/css-rhythm-1/#block-step
+#[syntax(" <'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "none",
+	initial = "see individual properties",
 	applies_to = "block-level boxes",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "by computed value type"
+	animation_type = "see individual properties"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step-size"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BlockStepSizeStyleValue;
-
-/// Represents the style value for `block-step-insert` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step-insert).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// margin-box | padding-box | content-box
-/// ```
-///
-// https://drafts.csswg.org/css-rhythm-1/#block-step-insert
-#[syntax(" margin-box | padding-box | content-box ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "margin-box",
-	applies_to = "block-level boxes",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step-insert"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BlockStepInsertStyleValue {}
+pub struct BlockStepStyleValue;
 
 /// Represents the style value for `block-step-align` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step-align).
 ///
@@ -79,6 +55,30 @@ pub enum BlockStepInsertStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BlockStepAlignStyleValue {}
 
+/// Represents the style value for `block-step-insert` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step-insert).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// margin-box | padding-box | content-box
+/// ```
+///
+// https://drafts.csswg.org/css-rhythm-1/#block-step-insert
+#[syntax(" margin-box | padding-box | content-box ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "margin-box",
+	applies_to = "block-level boxes",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step-insert"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum BlockStepInsertStyleValue {}
+
 /// Represents the style value for `block-step-round` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step-round).
 ///
 /// The grammar is defined as:
@@ -103,29 +103,29 @@ pub enum BlockStepAlignStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BlockStepRoundStyleValue {}
 
-/// Represents the style value for `block-step` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step).
+/// Represents the style value for `block-step-size` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#block-step-size).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'>
+/// none | <length [0,∞]>
 /// ```
 ///
-// https://drafts.csswg.org/css-rhythm-1/#block-step
-#[syntax(" <'block-step-size'> || <'block-step-insert'> || <'block-step-align'> || <'block-step-round'> ")]
+// https://drafts.csswg.org/css-rhythm-1/#block-step-size
+#[syntax(" none | <length [0,∞]> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "see individual properties",
+	initial = "none",
 	applies_to = "block-level boxes",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "see individual properties"
+	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.block-step-size"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct BlockStepStyleValue;
+pub struct BlockStepSizeStyleValue;
 
 /// Represents the style value for `line-height-step` as defined in [css-rhythm-1](https://drafts.csswg.org/css-rhythm-1/#line-height-step).
 ///

--- a/crates/css_ast/src/values/ruby/mod.rs
+++ b/crates/css_ast/src/values/ruby/mod.rs
@@ -7,56 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `ruby-position` as defined in [css-ruby-1](https://drafts.csswg.org/css-ruby-1/#ruby-position).
-// ///
-// /// The ruby-position CSS property sets the position of a ruby annotation in relation to its base text. Annotations can display over, under, or interleaved with the base text.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ alternate || [ over | under ] ] | inter-character
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-ruby-1/#ruby-position
-// #[syntax(" [ alternate || [ over | under ] ] | inter-character ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "alternate",
-//   applies_to = "ruby annotation containers",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.ruby-position"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum RubyPositionStyleValue {}
-
-/// Represents the style value for `ruby-merge` as defined in [css-ruby-1](https://drafts.csswg.org/css-ruby-1/#ruby-merge).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// separate | merge | auto
-/// ```
-///
-// https://drafts.csswg.org/css-ruby-1/#ruby-merge
-#[syntax(" separate | merge | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "separate",
-	applies_to = "interlinear ruby annotation containers",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.ruby-merge"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum RubyMergeStyleValue {}
-
 /// Represents the style value for `ruby-align` as defined in [css-ruby-1](https://drafts.csswg.org/css-ruby-1/#ruby-align).
 ///
 /// The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.
@@ -83,6 +33,30 @@ pub enum RubyMergeStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RubyAlignStyleValue {}
 
+/// Represents the style value for `ruby-merge` as defined in [css-ruby-1](https://drafts.csswg.org/css-ruby-1/#ruby-merge).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// separate | merge | auto
+/// ```
+///
+// https://drafts.csswg.org/css-ruby-1/#ruby-merge
+#[syntax(" separate | merge | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "separate",
+	applies_to = "interlinear ruby annotation containers",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.ruby-merge"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum RubyMergeStyleValue {}
+
 /// Represents the style value for `ruby-overhang` as defined in [css-ruby-1](https://drafts.csswg.org/css-ruby-1/#ruby-overhang).
 ///
 /// The ruby-overhang CSS property sets whether ruby annotations may overlap adjacent text.
@@ -108,3 +82,29 @@ pub enum RubyAlignStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.ruby-overhang"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum RubyOverhangStyleValue {}
+
+// /// Represents the style value for `ruby-position` as defined in [css-ruby-1](https://drafts.csswg.org/css-ruby-1/#ruby-position).
+// ///
+// /// The ruby-position CSS property sets the position of a ruby annotation in relation to its base text. Annotations can display over, under, or interleaved with the base text.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ alternate || [ over | under ] ] | inter-character
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-ruby-1/#ruby-position
+// #[syntax(" [ alternate || [ over | under ] ] | inter-character ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "alternate",
+//   applies_to = "ruby annotation containers",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.ruby-position"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum RubyPositionStyleValue {}

--- a/crates/css_ast/src/values/scroll_snap/mod.rs
+++ b/crates/css_ast/src/values/scroll_snap/mod.rs
@@ -7,31 +7,321 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `scroll-snap-type` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-type).
-// ///
-// /// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [ x | y | block | inline | both ] [ mandatory | proximity ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-type
-// #[syntax(" none | [ x | y | block | inline | both ] [ mandatory | proximity ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-snap-type"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum ScrollSnapTypeStyleValue {}
+/// Represents the style value for `scroll-initial-target` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-initial-target).
+///
+/// The scroll-initial-target: nearest CSS declaration sets the initial scroll position of its scroll container to the top of the element, much like scrolling to a URL fragment.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | nearest
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-initial-target
+#[syntax(" none | nearest ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "none"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-initial-target"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum ScrollInitialTargetStyleValue {}
+
+/// Represents the style value for `scroll-margin` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>{1,4}
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin
+#[syntax(" <length>{1,4} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginStyleValue;
+
+/// Represents the style value for `scroll-margin-block` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block
+#[syntax(" <length>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-block"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginBlockStyleValue;
+
+/// Represents the style value for `scroll-margin-block-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-end).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-end
+#[syntax(" <length> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-block-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginBlockEndStyleValue;
+
+/// Represents the style value for `scroll-margin-block-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-start).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-start
+#[syntax(" <length> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-block-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginBlockStartStyleValue;
+
+/// Represents the style value for `scroll-margin-bottom` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-bottom).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-bottom
+#[syntax(" <length> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-bottom"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginBottomStyleValue;
+
+/// Represents the style value for `scroll-margin-inline` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline
+#[syntax(" <length>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-inline"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginInlineStyleValue;
+
+/// Represents the style value for `scroll-margin-inline-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-end).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-end
+#[syntax(" <length> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-inline-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginInlineEndStyleValue;
+
+/// Represents the style value for `scroll-margin-inline-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-start).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-start
+#[syntax(" <length> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.scroll-margin-inline-start")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginInlineStartStyleValue;
+
+/// Represents the style value for `scroll-margin-left` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-left).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-left
+#[syntax(" <length> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-left"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginLeftStyleValue;
+
+/// Represents the style value for `scroll-margin-right` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-right).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-right
+#[syntax(" <length> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-right"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginRightStyleValue;
+
+/// Represents the style value for `scroll-margin-top` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-top).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-top
+#[syntax(" <length> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-top"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollMarginTopStyleValue;
 
 /// Represents the style value for `scroll-padding` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding).
 ///
@@ -59,31 +349,273 @@ use impls::*;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ScrollPaddingStyleValue;
 
-/// Represents the style value for `scroll-margin` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin).
+/// Represents the style value for `scroll-padding-block` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block).
 ///
 /// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <length>{1,4}
+/// [ auto | <length-percentage [0,∞]> ]{1,2}
 /// ```
 ///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin
-#[syntax(" <length>{1,4} ")]
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block
+#[syntax(" [ auto | <length-percentage [0,∞]> ]{1,2} ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "0",
-	applies_to = "all elements",
+	initial = "auto",
+	applies_to = "scroll containers",
 	inherited = "no",
-	percentages = "n/a",
+	percentages = "relative to the scroll container’s scrollport",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-block"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollPaddingBlockStyleValue;
+
+/// Represents the style value for `scroll-padding-block-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-end).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-end
+#[syntax(" auto | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "relative to the scroll container’s scrollport",
 	canonical_order = "per grammar",
 	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-block-end"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginStyleValue;
+pub struct ScrollPaddingBlockEndStyleValue;
+
+/// Represents the style value for `scroll-padding-block-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-start).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-start
+#[syntax(" auto | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "relative to the scroll container’s scrollport",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.scroll-padding-block-start")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollPaddingBlockStartStyleValue;
+
+/// Represents the style value for `scroll-padding-bottom` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-bottom).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-bottom
+#[syntax(" auto | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "relative to the scroll container’s scrollport",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-bottom"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollPaddingBottomStyleValue;
+
+/// Represents the style value for `scroll-padding-inline` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// [ auto | <length-percentage [0,∞]> ]{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline
+#[syntax(" [ auto | <length-percentage [0,∞]> ]{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "relative to the scroll container’s scrollport",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-inline"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollPaddingInlineStyleValue;
+
+/// Represents the style value for `scroll-padding-inline-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-end).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-end
+#[syntax(" auto | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "relative to the scroll container’s scrollport",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-inline-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollPaddingInlineEndStyleValue;
+
+/// Represents the style value for `scroll-padding-inline-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-start).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-start
+#[syntax(" auto | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "relative to the scroll container’s scrollport",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.scroll-padding-inline-start")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollPaddingInlineStartStyleValue;
+
+/// Represents the style value for `scroll-padding-left` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-left).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-left
+#[syntax(" auto | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "relative to the scroll container’s scrollport",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-left"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollPaddingLeftStyleValue;
+
+/// Represents the style value for `scroll-padding-right` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-right).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-right
+#[syntax(" auto | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "relative to the scroll container’s scrollport",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-right"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollPaddingRightStyleValue;
+
+/// Represents the style value for `scroll-padding-top` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-top).
+///
+/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]>
+/// ```
+///
+// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-top
+#[syntax(" auto | <length-percentage [0,∞]> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "scroll containers",
+	inherited = "no",
+	percentages = "relative to the scroll container’s scrollport",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-top"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScrollPaddingTopStyleValue;
 
 /// Represents the style value for `scroll-snap-align` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-align).
 ///
@@ -137,560 +669,28 @@ pub struct ScrollSnapAlignStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ScrollSnapStopStyleValue {}
 
-/// Represents the style value for `scroll-padding-top` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-top).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-top
-#[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-top"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingTopStyleValue;
-
-/// Represents the style value for `scroll-padding-right` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-right).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-right
-#[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-right"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingRightStyleValue;
-
-/// Represents the style value for `scroll-padding-bottom` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-bottom).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-bottom
-#[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-bottom"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingBottomStyleValue;
-
-/// Represents the style value for `scroll-padding-left` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-left).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-left
-#[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-left"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingLeftStyleValue;
-
-/// Represents the style value for `scroll-padding-inline-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-start).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-start
-#[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.scroll-padding-inline-start")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingInlineStartStyleValue;
-
-/// Represents the style value for `scroll-padding-block-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-start).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-start
-#[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.scroll-padding-block-start")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingBlockStartStyleValue;
-
-/// Represents the style value for `scroll-padding-inline-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-end).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline-end
-#[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-inline-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingInlineEndStyleValue;
-
-/// Represents the style value for `scroll-padding-block-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-end).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block-end
-#[syntax(" auto | <length-percentage [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-block-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingBlockEndStyleValue;
-
-/// Represents the style value for `scroll-padding-block` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// [ auto | <length-percentage [0,∞]> ]{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-block
-#[syntax(" [ auto | <length-percentage [0,∞]> ]{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-block"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingBlockStyleValue;
-
-/// Represents the style value for `scroll-padding-inline` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// [ auto | <length-percentage [0,∞]> ]{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-padding-inline
-#[syntax(" [ auto | <length-percentage [0,∞]> ]{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "scroll containers",
-	inherited = "no",
-	percentages = "relative to the scroll container’s scrollport",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-padding-inline"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollPaddingInlineStyleValue;
-
-/// Represents the style value for `scroll-margin-top` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-top).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-top
-#[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-top"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginTopStyleValue;
-
-/// Represents the style value for `scroll-margin-right` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-right).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-right
-#[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-right"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginRightStyleValue;
-
-/// Represents the style value for `scroll-margin-bottom` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-bottom).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-bottom
-#[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-bottom"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginBottomStyleValue;
-
-/// Represents the style value for `scroll-margin-left` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-left).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-left
-#[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-left"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginLeftStyleValue;
-
-/// Represents the style value for `scroll-margin-block-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-start).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-start
-#[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-block-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginBlockStartStyleValue;
-
-/// Represents the style value for `scroll-margin-inline-start` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-start).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-start
-#[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.scroll-margin-inline-start")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginInlineStartStyleValue;
-
-/// Represents the style value for `scroll-margin-block-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-end).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block-end
-#[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-block-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginBlockEndStyleValue;
-
-/// Represents the style value for `scroll-margin-inline-end` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-end).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline-end
-#[syntax(" <length> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-inline-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginInlineEndStyleValue;
-
-/// Represents the style value for `scroll-margin-block` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-block
-#[syntax(" <length>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-block"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginBlockStyleValue;
-
-/// Represents the style value for `scroll-margin-inline` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline).
-///
-/// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-margin-inline
-#[syntax(" <length>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-margin-inline"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScrollMarginInlineStyleValue;
-
-/// Represents the style value for `scroll-initial-target` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-initial-target).
-///
-/// The scroll-initial-target: nearest CSS declaration sets the initial scroll position of its scroll container to the top of the element, much like scrolling to a URL fragment.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | nearest
-/// ```
-///
-// https://drafts.csswg.org/css-scroll-snap-2/#scroll-initial-target
-#[syntax(" none | nearest ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "none"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-initial-target"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ScrollInitialTargetStyleValue {}
+// /// Represents the style value for `scroll-snap-type` as defined in [css-scroll-snap-2](https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-type).
+// ///
+// /// CSS scroll snap controls the panning and scrolling behavior within a scroll container.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [ x | y | block | inline | both ] [ mandatory | proximity ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-scroll-snap-2/#scroll-snap-type
+// #[syntax(" none | [ x | y | block | inline | both ] [ mandatory | proximity ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scroll-snap-type"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum ScrollSnapTypeStyleValue {}

--- a/crates/css_ast/src/values/shapes/mod.rs
+++ b/crates/css_ast/src/values/shapes/mod.rs
@@ -7,32 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `shape-outside` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-outside).
-// ///
-// /// The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [ <basic-shape> || <shape-box> ] | <image>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-shapes-2/#shape-outside
-// #[syntax(" none | [ <basic-shape> || <shape-box> ] | <image> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "floats and initial letter boxes",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "as defined for <basic-shape>, otherwise discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-outside"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum ShapeOutsideStyleValue<'a> {}
-
 /// Represents the style value for `shape-image-threshold` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-image-threshold).
 ///
 /// The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.
@@ -58,6 +32,30 @@ use impls::*;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-image-threshold"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ShapeImageThresholdStyleValue;
+
+// /// Represents the style value for `shape-inside` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-inside).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// auto | outside-shape | [ <basic-shape> || shape-box ] | <image> | display
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-shapes-2/#shape-inside
+// #[syntax(" auto | outside-shape | [ <basic-shape> || shape-box ] | <image> | display ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "block-level elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "as defined for <basic-shape>, otherwise discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-inside"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum ShapeInsideStyleValue<'a> {}
 
 /// Represents the style value for `shape-margin` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-margin).
 ///
@@ -85,29 +83,31 @@ pub struct ShapeImageThresholdStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct ShapeMarginStyleValue;
 
-// /// Represents the style value for `shape-inside` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-inside).
+// /// Represents the style value for `shape-outside` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-outside).
+// ///
+// /// The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// auto | outside-shape | [ <basic-shape> || shape-box ] | <image> | display
+// /// none | [ <basic-shape> || <shape-box> ] | <image>
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-shapes-2/#shape-inside
-// #[syntax(" auto | outside-shape | [ <basic-shape> || shape-box ] | <image> | display ")]
+// // https://drafts.csswg.org/css-shapes-2/#shape-outside
+// #[syntax(" none | [ <basic-shape> || <shape-box> ] | <image> ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "auto",
-//   applies_to = "block-level elements",
+// 	initial = "none",
+//   applies_to = "floats and initial letter boxes",
 // 	inherited = "no",
 // 	percentages = "n/a",
 // 	canonical_order = "per grammar",
 // 	animation_type = "as defined for <basic-shape>, otherwise discrete",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-inside"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.shape-outside"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum ShapeInsideStyleValue<'a> {}
+// pub enum ShapeOutsideStyleValue<'a> {}
 
 /// Represents the style value for `shape-padding` as defined in [css-shapes-2](https://drafts.csswg.org/css-shapes-2/#shape-padding).
 ///

--- a/crates/css_ast/src/values/sizing/mod.rs
+++ b/crates/css_ast/src/values/sizing/mod.rs
@@ -7,173 +7,31 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#width).
+/// Represents the style value for `aspect-ratio` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#aspect-ratio).
 ///
-/// The width and height CSS properties set the preferred physical size of an element.
+/// The aspect-ratio CSS property controls the width-to-height ratio of elements. For <img> and <video> elements, the width and height attributes used together with height: auto control the aspect ratio while the image/video is loading.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
+/// auto || <ratio>
 /// ```
 ///
-// https://drafts.csswg.org/css-sizing-4/#width
-#[syntax(
-	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
-)]
+// https://drafts.csswg.org/css-sizing-4/#aspect-ratio
+#[syntax(" auto || <ratio> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
-	applies_to = "all elements except non-replaced inlines",
+	applies_to = "all elements except inline boxes and internal ruby or table boxes",
 	inherited = "no",
-	percentages = "relative to width/height of containing block",
+	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "by computed value type, recursing into fit-content()"
+	animation_type = "by computed value"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.width"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.aspect-ratio"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum WidthStyleValue {}
-
-/// Represents the style value for `height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#height).
-///
-/// The width and height CSS properties set the preferred physical size of an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
-/// ```
-///
-// https://drafts.csswg.org/css-sizing-4/#height
-#[syntax(
-	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
-)]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements except non-replaced inlines",
-	inherited = "no",
-	percentages = "relative to width/height of containing block",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type, recursing into fit-content()"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.height"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum HeightStyleValue {}
-
-/// Represents the style value for `min-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-width).
-///
-/// The min-width, min-height, max-width, and max-height CSS properties set the minimum and maximum size of an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
-/// ```
-///
-// https://drafts.csswg.org/css-sizing-4/#min-width
-#[syntax(
-	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
-)]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements that accept width or height",
-	inherited = "no",
-	percentages = "relative to width/height of containing block",
-	canonical_order = "per grammar",
-	animation_type = "by computed value, recursing into fit-content()"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum MinWidthStyleValue {}
-
-/// Represents the style value for `min-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-height).
-///
-/// The min-width, min-height, max-width, and max-height CSS properties set the minimum and maximum size of an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
-/// ```
-///
-// https://drafts.csswg.org/css-sizing-4/#min-height
-#[syntax(
-	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
-)]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements that accept width or height",
-	inherited = "no",
-	percentages = "relative to width/height of containing block",
-	canonical_order = "per grammar",
-	animation_type = "by computed value, recursing into fit-content()"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-height"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum MinHeightStyleValue {}
-
-/// Represents the style value for `max-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#max-width).
-///
-/// The min-width, min-height, max-width, and max-height CSS properties set the minimum and maximum size of an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
-/// ```
-///
-// https://drafts.csswg.org/css-sizing-4/#max-width
-#[syntax(
-	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
-)]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements that accept width or height",
-	inherited = "no",
-	percentages = "relative to width/height of containing block",
-	canonical_order = "per grammar",
-	animation_type = "by computed value, recursing into fit-content()"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum MaxWidthStyleValue {}
-
-/// Represents the style value for `max-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#max-height).
-///
-/// The min-width, min-height, max-width, and max-height CSS properties set the minimum and maximum size of an element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
-/// ```
-///
-// https://drafts.csswg.org/css-sizing-4/#max-height
-#[syntax(
-	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
-)]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements that accept width or height",
-	inherited = "no",
-	percentages = "relative to width/height of containing block",
-	canonical_order = "per grammar",
-	animation_type = "by computed value, recursing into fit-content()"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-height"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum MaxHeightStyleValue {}
+pub struct AspectRatioStyleValue;
 
 /// Represents the style value for `box-sizing` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#box-sizing).
 ///
@@ -201,33 +59,7 @@ pub enum MaxHeightStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum BoxSizingStyleValue {}
 
-/// Represents the style value for `aspect-ratio` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#aspect-ratio).
-///
-/// The aspect-ratio CSS property controls the width-to-height ratio of elements. For <img> and <video> elements, the width and height attributes used together with height: auto control the aspect ratio while the image/video is loading.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto || <ratio>
-/// ```
-///
-// https://drafts.csswg.org/css-sizing-4/#aspect-ratio
-#[syntax(" auto || <ratio> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements except inline boxes and internal ruby or table boxes",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.aspect-ratio"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AspectRatioStyleValue;
-
-// /// Represents the style value for `contain-intrinsic-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-width).
+// /// Represents the style value for `contain-intrinsic-block-size` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-block-size).
 // ///
 // /// The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.
 // ///
@@ -237,7 +69,7 @@ pub struct AspectRatioStyleValue;
 // /// auto? [ none | <length [0,∞]> ]
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-width
+// // https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-block-size
 // #[syntax(" auto? [ none | <length [0,∞]> ] ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
@@ -249,9 +81,9 @@ pub struct AspectRatioStyleValue;
 // 	animation_type = "by computed value type",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-width"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-block-size"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct ContainIntrinsicWidthStyleValue;
+// pub struct ContainIntrinsicBlockSizeStyleValue;
 
 // /// Represents the style value for `contain-intrinsic-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-height).
 // ///
@@ -278,32 +110,6 @@ pub struct AspectRatioStyleValue;
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-height"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ContainIntrinsicHeightStyleValue;
-
-// /// Represents the style value for `contain-intrinsic-block-size` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-block-size).
-// ///
-// /// The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// auto? [ none | <length [0,∞]> ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-block-size
-// #[syntax(" auto? [ none | <length [0,∞]> ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "elements with size containment",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "by computed value type",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-block-size"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct ContainIntrinsicBlockSizeStyleValue;
 
 // /// Represents the style value for `contain-intrinsic-inline-size` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-inline-size).
 // ///
@@ -357,6 +163,144 @@ pub struct AspectRatioStyleValue;
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct ContainIntrinsicSizeStyleValue;
 
+// /// Represents the style value for `contain-intrinsic-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-width).
+// ///
+// /// The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// auto? [ none | <length [0,∞]> ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-sizing-4/#contain-intrinsic-width
+// #[syntax(" auto? [ none | <length [0,∞]> ] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "elements with size containment",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "by computed value type",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.contain-intrinsic-width"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct ContainIntrinsicWidthStyleValue;
+
+/// Represents the style value for `height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#height).
+///
+/// The width and height CSS properties set the preferred physical size of an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
+/// ```
+///
+// https://drafts.csswg.org/css-sizing-4/#height
+#[syntax(
+	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
+)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements except non-replaced inlines",
+	inherited = "no",
+	percentages = "relative to width/height of containing block",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type, recursing into fit-content()"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.height"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum HeightStyleValue {}
+
+/// Represents the style value for `max-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#max-height).
+///
+/// The min-width, min-height, max-width, and max-height CSS properties set the minimum and maximum size of an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
+/// ```
+///
+// https://drafts.csswg.org/css-sizing-4/#max-height
+#[syntax(
+	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
+)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements that accept width or height",
+	inherited = "no",
+	percentages = "relative to width/height of containing block",
+	canonical_order = "per grammar",
+	animation_type = "by computed value, recursing into fit-content()"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-height"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum MaxHeightStyleValue {}
+
+/// Represents the style value for `max-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#max-width).
+///
+/// The min-width, min-height, max-width, and max-height CSS properties set the minimum and maximum size of an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
+/// ```
+///
+// https://drafts.csswg.org/css-sizing-4/#max-width
+#[syntax(
+	" none | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
+)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements that accept width or height",
+	inherited = "no",
+	percentages = "relative to width/height of containing block",
+	canonical_order = "per grammar",
+	animation_type = "by computed value, recursing into fit-content()"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.max-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum MaxWidthStyleValue {}
+
+/// Represents the style value for `min-height` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-height).
+///
+/// The min-width, min-height, max-width, and max-height CSS properties set the minimum and maximum size of an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
+/// ```
+///
+// https://drafts.csswg.org/css-sizing-4/#min-height
+#[syntax(
+	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
+)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements that accept width or height",
+	inherited = "no",
+	percentages = "relative to width/height of containing block",
+	canonical_order = "per grammar",
+	animation_type = "by computed value, recursing into fit-content()"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-height"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum MinHeightStyleValue {}
+
 // /// Represents the style value for `min-intrinsic-sizing` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-intrinsic-sizing).
 // ///
 // /// The grammar is defined as:
@@ -380,3 +324,59 @@ pub struct AspectRatioStyleValue;
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-intrinsic-sizing"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum MinIntrinsicSizingStyleValue {}
+
+/// Represents the style value for `min-width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#min-width).
+///
+/// The min-width, min-height, max-width, and max-height CSS properties set the minimum and maximum size of an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
+/// ```
+///
+// https://drafts.csswg.org/css-sizing-4/#min-width
+#[syntax(
+	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
+)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements that accept width or height",
+	inherited = "no",
+	percentages = "relative to width/height of containing block",
+	canonical_order = "per grammar",
+	animation_type = "by computed value, recursing into fit-content()"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.min-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum MinWidthStyleValue {}
+
+/// Represents the style value for `width` as defined in [css-sizing-4](https://drafts.csswg.org/css-sizing-4/#width).
+///
+/// The width and height CSS properties set the preferred physical size of an element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain
+/// ```
+///
+// https://drafts.csswg.org/css-sizing-4/#width
+#[syntax(
+	" auto | <length-percentage [0,∞]> | min-content | max-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | stretch | fit-content | contain "
+)]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements except non-replaced inlines",
+	inherited = "no",
+	percentages = "relative to width/height of containing block",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type, recursing into fit-content()"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum WidthStyleValue {}

--- a/crates/css_ast/src/values/speech/mod.rs
+++ b/crates/css_ast/src/values/speech/mod.rs
@@ -7,53 +7,221 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `voice-volume` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-volume).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-speech-1/#voice-volume
-// #[syntax(" silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "medium",
-//   applies_to = "all elements",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "not animatable",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-volume"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum VoiceVolumeStyleValue {}
-
-/// Represents the style value for `voice-balance` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-balance).
+/// Represents the style value for `cue` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#cue).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <number> | left | center | right | leftwards | rightwards
+/// <'cue-before'> <'cue-after'>?
 /// ```
 ///
-// https://drafts.csswg.org/css-speech-1/#voice-balance
-#[syntax(" <number> | left | center | right | leftwards | rightwards ")]
+// https://drafts.csswg.org/css-speech-1/#cue
+#[syntax(" <'cue-before'> <'cue-after'>? ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "center",
+	initial = "see individual properties",
 	applies_to = "all elements",
-	inherited = "yes",
+	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "not animatable"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-balance"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cue"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum VoiceBalanceStyleValue {}
+pub struct CueStyleValue;
+
+/// Represents the style value for `cue-after` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#cue-after).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <uri> <decibel>? | none
+/// ```
+///
+// https://drafts.csswg.org/css-speech-1/#cue-after
+#[syntax(" <uri> <decibel>? | none ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cue-after"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CueAfterStyleValue;
+
+/// Represents the style value for `cue-before` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#cue-before).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <uri> <decibel>? | none
+/// ```
+///
+// https://drafts.csswg.org/css-speech-1/#cue-before
+#[syntax(" <uri> <decibel>? | none ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cue-before"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CueBeforeStyleValue;
+
+/// Represents the style value for `pause` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#pause).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'pause-before'> <'pause-after'>?
+/// ```
+///
+// https://drafts.csswg.org/css-speech-1/#pause
+#[syntax(" <'pause-before'> <'pause-after'>? ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pause"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct PauseStyleValue;
+
+/// Represents the style value for `pause-after` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#pause-after).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong
+/// ```
+///
+// https://drafts.csswg.org/css-speech-1/#pause-after
+#[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pause-after"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum PauseAfterStyleValue {}
+
+/// Represents the style value for `pause-before` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#pause-before).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong
+/// ```
+///
+// https://drafts.csswg.org/css-speech-1/#pause-before
+#[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pause-before"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum PauseBeforeStyleValue {}
+
+/// Represents the style value for `rest` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#rest).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'rest-before'> <'rest-after'>?
+/// ```
+///
+// https://drafts.csswg.org/css-speech-1/#rest
+#[syntax(" <'rest-before'> <'rest-after'>? ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rest"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct RestStyleValue;
+
+/// Represents the style value for `rest-after` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#rest-after).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong
+/// ```
+///
+// https://drafts.csswg.org/css-speech-1/#rest-after
+#[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rest-after"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum RestAfterStyleValue {}
+
+/// Represents the style value for `rest-before` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#rest-before).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong
+/// ```
+///
+// https://drafts.csswg.org/css-speech-1/#rest-before
+#[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rest-before"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum RestBeforeStyleValue {}
 
 /// Represents the style value for `speak` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#speak).
 ///
@@ -107,43 +275,43 @@ pub enum SpeakStyleValue {}
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum SpeakAsStyleValue {}
 
-/// Represents the style value for `pause-before` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#pause-before).
+/// Represents the style value for `voice-balance` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-balance).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong
+/// <number> | left | center | right | leftwards | rightwards
 /// ```
 ///
-// https://drafts.csswg.org/css-speech-1/#pause-before
-#[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
+// https://drafts.csswg.org/css-speech-1/#voice-balance
+#[syntax(" <number> | left | center | right | leftwards | rightwards ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "none",
+	initial = "center",
 	applies_to = "all elements",
-	inherited = "no",
+	inherited = "yes",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "not animatable"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pause-before"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-balance"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum PauseBeforeStyleValue {}
+pub enum VoiceBalanceStyleValue {}
 
-/// Represents the style value for `pause-after` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#pause-after).
+/// Represents the style value for `voice-duration` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-duration).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong
+/// auto | <time [0s,∞]>
 /// ```
 ///
-// https://drafts.csswg.org/css-speech-1/#pause-after
-#[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
+// https://drafts.csswg.org/css-speech-1/#voice-duration
+#[syntax(" auto | <time [0s,∞]> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "none",
+	initial = "auto",
 	applies_to = "all elements",
 	inherited = "no",
 	percentages = "n/a",
@@ -151,177 +319,9 @@ pub enum PauseBeforeStyleValue {}
 	animation_type = "not animatable"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pause-after"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-duration"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum PauseAfterStyleValue {}
-
-/// Represents the style value for `pause` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#pause).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'pause-before'> <'pause-after'>?
-/// ```
-///
-// https://drafts.csswg.org/css-speech-1/#pause
-#[syntax(" <'pause-before'> <'pause-after'>? ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.pause"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct PauseStyleValue;
-
-/// Represents the style value for `rest-before` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#rest-before).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong
-/// ```
-///
-// https://drafts.csswg.org/css-speech-1/#rest-before
-#[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rest-before"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum RestBeforeStyleValue {}
-
-/// Represents the style value for `rest-after` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#rest-after).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong
-/// ```
-///
-// https://drafts.csswg.org/css-speech-1/#rest-after
-#[syntax(" <time [0s,∞]> | none | x-weak | weak | medium | strong | x-strong ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rest-after"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum RestAfterStyleValue {}
-
-/// Represents the style value for `rest` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#rest).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'rest-before'> <'rest-after'>?
-/// ```
-///
-// https://drafts.csswg.org/css-speech-1/#rest
-#[syntax(" <'rest-before'> <'rest-after'>? ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rest"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct RestStyleValue;
-
-/// Represents the style value for `cue-before` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#cue-before).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <uri> <decibel>? | none
-/// ```
-///
-// https://drafts.csswg.org/css-speech-1/#cue-before
-#[syntax(" <uri> <decibel>? | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cue-before"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CueBeforeStyleValue;
-
-/// Represents the style value for `cue-after` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#cue-after).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <uri> <decibel>? | none
-/// ```
-///
-// https://drafts.csswg.org/css-speech-1/#cue-after
-#[syntax(" <uri> <decibel>? | none ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cue-after"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CueAfterStyleValue;
-
-/// Represents the style value for `cue` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#cue).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'cue-before'> <'cue-after'>?
-/// ```
-///
-// https://drafts.csswg.org/css-speech-1/#cue
-#[syntax(" <'cue-before'> <'cue-after'>? ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cue"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CueStyleValue;
+pub struct VoiceDurationStyleValue;
 
 // /// Represents the style value for `voice-family` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-family).
 // ///
@@ -346,30 +346,6 @@ pub struct CueStyleValue;
 // #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-family"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum VoiceFamilyStyleValue {}
-
-// /// Represents the style value for `voice-rate` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-rate).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-speech-1/#voice-rate
-// #[syntax(" [normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "all elements",
-// 	inherited = "yes",
-// 	percentages = "refer to default value",
-// 	canonical_order = "per grammar",
-// 	animation_type = "not animatable",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-rate"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct VoiceRateStyleValue;
 
 // /// Represents the style value for `voice-pitch` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-pitch).
 // ///
@@ -423,6 +399,30 @@ pub struct CueStyleValue;
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum VoiceRangeStyleValue {}
 
+// /// Represents the style value for `voice-rate` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-rate).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-speech-1/#voice-rate
+// #[syntax(" [normal | x-slow | slow | medium | fast | x-fast] || <percentage [0,∞]> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "all elements",
+// 	inherited = "yes",
+// 	percentages = "refer to default value",
+// 	canonical_order = "per grammar",
+// 	animation_type = "not animatable",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-rate"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct VoiceRateStyleValue;
+
 /// Represents the style value for `voice-stress` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-stress).
 ///
 /// The grammar is defined as:
@@ -447,26 +447,26 @@ pub struct CueStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum VoiceStressStyleValue {}
 
-/// Represents the style value for `voice-duration` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-duration).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <time [0s,∞]>
-/// ```
-///
-// https://drafts.csswg.org/css-speech-1/#voice-duration
-#[syntax(" auto | <time [0s,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-duration"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct VoiceDurationStyleValue;
+// /// Represents the style value for `voice-volume` as defined in [css-speech-1](https://drafts.csswg.org/css-speech-1/#voice-volume).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-speech-1/#voice-volume
+// #[syntax(" silent | [[x-soft | soft | medium | loud | x-loud] || <decibel>] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "medium",
+//   applies_to = "all elements",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "not animatable",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.voice-volume"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum VoiceVolumeStyleValue {}

--- a/crates/css_ast/src/values/tables/mod.rs
+++ b/crates/css_ast/src/values/tables/mod.rs
@@ -7,32 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `table-layout` as defined in [css-tables-3](https://drafts.csswg.org/css-tables-3/#table-layout).
-///
-/// The <table> HTML element, with several related elements, represents tabular data in rows and columns of cells.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | fixed
-/// ```
-///
-// https://drafts.csswg.org/css-tables-3/#table-layout
-#[syntax(" auto | fixed ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "table grid boxes",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.table-layout"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TableLayoutStyleValue {}
-
 /// Represents the style value for `border-collapse` as defined in [css-tables-3](https://drafts.csswg.org/css-tables-3/#border-collapse).
 ///
 /// The <table> HTML element, with several related elements, represents tabular data in rows and columns of cells.
@@ -136,3 +110,29 @@ pub enum CaptionSideStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.empty-cells"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum EmptyCellsStyleValue {}
+
+/// Represents the style value for `table-layout` as defined in [css-tables-3](https://drafts.csswg.org/css-tables-3/#table-layout).
+///
+/// The <table> HTML element, with several related elements, represents tabular data in rows and columns of cells.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | fixed
+/// ```
+///
+// https://drafts.csswg.org/css-tables-3/#table-layout
+#[syntax(" auto | fixed ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "table grid boxes",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.table-layout"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum TableLayoutStyleValue {}

--- a/crates/css_ast/src/values/text/mod.rs
+++ b/crates/css_ast/src/values/text/mod.rs
@@ -7,137 +7,155 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `text-transform` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-transform).
+// /// Represents the style value for `hanging-punctuation` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hanging-punctuation).
 // ///
-// /// The text-transform CSS property sets text case and capitalization.
+// /// The hanging-punctuation CSS property puts punctuation characters outside of the box to align the text with the rest of the document.
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto
+// /// none | [ first || [ force-end | allow-end ] || last ]
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-text-4/#text-transform
-// #[syntax(" none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto ")]
+// // https://drafts.csswg.org/css-text-4/#hanging-punctuation
+// #[syntax(" none | [ first || [ force-end | allow-end ] || last ] ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
 // 	initial = "none",
 //   applies_to = "text",
 // 	inherited = "yes",
 // 	percentages = "n/a",
-// 	canonical_order = "n/a",
+// 	canonical_order = "per grammar",
 // 	animation_type = "discrete",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-transform"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hanging-punctuation"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum TextTransformStyleValue {}
+// pub enum HangingPunctuationStyleValue {}
 
-// /// Represents the style value for `white-space` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#white-space).
-// ///
-// /// The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'> || <'white-space-trim'>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-4/#white-space
-// #[syntax(
-// 	" normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'> || <'white-space-trim'> "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "normal",
-//   applies_to = "text",
-// 	inherited = "see individual properties",
-// 	percentages = "n/a",
-// 	canonical_order = "n/a",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.white-space"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum WhiteSpaceStyleValue {}
-
-/// Represents the style value for `tab-size` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#tab-size).
+/// Represents the style value for `hyphenate-character` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-character).
 ///
-/// The tab-size CSS property sets the width of the tab character.
+/// The hyphenate-character CSS property sets the character or string to use at the end of a line before a line break.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <number [0,∞]> | <length [0,∞]>
+/// auto | <string>
 /// ```
 ///
-// https://drafts.csswg.org/css-text-4/#tab-size
-#[syntax(" <number [0,∞]> | <length [0,∞]> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "8",
-	applies_to = "text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "n/a",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.tab-size"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TabSizeStyleValue;
-
-/// Represents the style value for `word-break` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-break).
-///
-/// The word-break CSS property sets how lines break within words.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | break-all | keep-all | manual | auto-phrase | break-word
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#word-break
-#[syntax(" normal | break-all | keep-all | manual | auto-phrase | break-word ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "n/a",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-break"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum WordBreakStyleValue {}
-
-/// Represents the style value for `line-break` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#line-break).
-///
-/// The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | loose | normal | strict | anywhere
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#line-break
-#[syntax(" auto | loose | normal | strict | anywhere ")]
+// https://drafts.csswg.org/css-text-4/#hyphenate-character
+#[syntax(" auto | <string> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
 	applies_to = "text",
 	inherited = "yes",
 	percentages = "n/a",
-	canonical_order = "n/a",
+	canonical_order = "per grammar",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-break"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-character"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum LineBreakStyleValue {}
+pub struct HyphenateCharacterStyleValue;
+
+// /// Represents the style value for `hyphenate-limit-chars` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-chars).
+// ///
+// /// The hyphenate-limit-chars CSS property sets the number of characters in a word before it is hyphenated and the minimum number of characters on either side of the hyphen.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ auto | <integer> ]{1,3}
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-4/#hyphenate-limit-chars
+// #[syntax(" [ auto | <integer> ]{1,3} ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "by computed value type",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-chars"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct HyphenateLimitCharsStyleValue;
+
+/// Represents the style value for `hyphenate-limit-last` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-last).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | always | column | page | spread
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#hyphenate-limit-last
+#[syntax(" none | always | column | page | spread ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "block containers",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-last"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum HyphenateLimitLastStyleValue {}
+
+/// Represents the style value for `hyphenate-limit-lines` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-lines).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// no-limit | <integer>
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#hyphenate-limit-lines
+#[syntax(" no-limit | <integer> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "no-limit",
+	applies_to = "block containers",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-lines"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum HyphenateLimitLinesStyleValue {}
+
+/// Represents the style value for `hyphenate-limit-zone` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-zone).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#hyphenate-limit-zone
+#[syntax(" <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "block containers",
+	inherited = "yes",
+	percentages = "refers to length of the line box",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-zone"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct HyphenateLimitZoneStyleValue;
 
 /// Represents the style value for `hyphens` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphens).
 ///
@@ -165,6 +183,82 @@ pub enum LineBreakStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum HyphensStyleValue {}
 
+/// Represents the style value for `letter-spacing` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#letter-spacing).
+///
+/// The letter-spacing CSS property controls the amount of space between each letter in an element or block of text.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#letter-spacing
+#[syntax(" normal | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "inline boxes and text",
+	inherited = "yes",
+	percentages = "relative to computed font-size, i.e. 1em",
+	canonical_order = "n/a",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.letter-spacing"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum LetterSpacingStyleValue {}
+
+/// Represents the style value for `line-break` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#line-break).
+///
+/// The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | loose | normal | strict | anywhere
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#line-break
+#[syntax(" auto | loose | normal | strict | anywhere ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "n/a",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-break"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum LineBreakStyleValue {}
+
+/// Represents the style value for `line-padding` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#line-padding).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#line-padding
+#[syntax(" <length> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "inline boxes",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-padding"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct LinePaddingStyleValue;
+
 /// Represents the style value for `overflow-wrap` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#overflow-wrap).
 ///
 /// The overflow-wrap CSS property breaks a line of text onto multiple lines inside the targeted element in an otherwise unbreakable place to prevent overflow. The legacy property is word-wrap.
@@ -191,29 +285,31 @@ pub enum HyphensStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum OverflowWrapStyleValue {}
 
-/// Represents the style value for `word-wrap` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-wrap).
+/// Represents the style value for `tab-size` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#tab-size).
+///
+/// The tab-size CSS property sets the width of the tab character.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// normal | break-word | anywhere
+/// <number [0,∞]> | <length [0,∞]>
 /// ```
 ///
-// https://drafts.csswg.org/css-text-4/#word-wrap
-#[syntax(" normal | break-word | anywhere ")]
+// https://drafts.csswg.org/css-text-4/#tab-size
+#[syntax(" <number [0,∞]> | <length [0,∞]> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "normal",
+	initial = "8",
 	applies_to = "text",
 	inherited = "yes",
 	percentages = "n/a",
 	canonical_order = "n/a",
-	animation_type = "discrete"
+	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-wrap"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.tab-size"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum WordWrapStyleValue {}
+pub struct TabSizeStyleValue;
 
 /// Represents the style value for `text-align` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-align).
 ///
@@ -291,83 +387,55 @@ pub enum TextAlignAllStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextAlignLastStyleValue {}
 
-// /// Represents the style value for `text-justify` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-justify).
-// ///
-// /// The text-justify CSS property sets the justification method of text when text-align: justify is set.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ auto | none | inter-word | inter-character | ruby ] || no-compress
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-4/#text-justify
-// #[syntax(" [ auto | none | inter-word | inter-character | ruby ] || no-compress ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "n/a",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-justify"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct TextJustifyStyleValue;
-
-/// Represents the style value for `word-spacing` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-spacing).
+/// Represents the style value for `text-autospace` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-autospace).
 ///
-/// The word-spacing CSS property sets the amount of white space between words.
+/// The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// normal | <length-percentage>
+/// normal | <autospace> | auto
 /// ```
 ///
-// https://drafts.csswg.org/css-text-4/#word-spacing
-#[syntax(" normal | <length-percentage> ")]
+// https://drafts.csswg.org/css-text-4/#text-autospace
+#[syntax(" normal | <autospace> | auto ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "normal",
 	applies_to = "text",
 	inherited = "yes",
-	percentages = "relative to computed font-size, i.e. 1em",
-	canonical_order = "n/a",
-	animation_type = "by computed value type"
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-spacing"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-autospace"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum WordSpacingStyleValue {}
+pub enum TextAutospaceStyleValue {}
 
-/// Represents the style value for `letter-spacing` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#letter-spacing).
-///
-/// The letter-spacing CSS property controls the amount of space between each letter in an element or block of text.
+/// Represents the style value for `text-group-align` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-group-align).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// normal | <length-percentage>
+/// none | start | end | left | right | center
 /// ```
 ///
-// https://drafts.csswg.org/css-text-4/#letter-spacing
-#[syntax(" normal | <length-percentage> ")]
+// https://drafts.csswg.org/css-text-4/#text-group-align
+#[syntax(" none | start | end | left | right | center ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "normal",
-	applies_to = "inline boxes and text",
-	inherited = "yes",
-	percentages = "relative to computed font-size, i.e. 1em",
-	canonical_order = "n/a",
-	animation_type = "by computed value type"
+	initial = "none",
+	applies_to = "block containers",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.letter-spacing"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-group-align"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum LetterSpacingStyleValue {}
+pub enum TextGroupAlignStyleValue {}
 
 // /// Represents the style value for `text-indent` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-indent).
 // ///
@@ -395,45 +463,45 @@ pub enum LetterSpacingStyleValue {}
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TextIndentStyleValue;
 
-// /// Represents the style value for `hanging-punctuation` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hanging-punctuation).
+// /// Represents the style value for `text-justify` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-justify).
 // ///
-// /// The hanging-punctuation CSS property puts punctuation characters outside of the box to align the text with the rest of the document.
+// /// The text-justify CSS property sets the justification method of text when text-align: justify is set.
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// none | [ first || [ force-end | allow-end ] || last ]
+// /// [ auto | none | inter-word | inter-character | ruby ] || no-compress
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-text-4/#hanging-punctuation
-// #[syntax(" none | [ first || [ force-end | allow-end ] || last ] ")]
+// // https://drafts.csswg.org/css-text-4/#text-justify
+// #[syntax(" [ auto | none | inter-word | inter-character | ruby ] || no-compress ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "none",
+// 	initial = "auto",
 //   applies_to = "text",
 // 	inherited = "yes",
 // 	percentages = "n/a",
-// 	canonical_order = "per grammar",
+// 	canonical_order = "n/a",
 // 	animation_type = "discrete",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hanging-punctuation"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-justify"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum HangingPunctuationStyleValue {}
+// pub struct TextJustifyStyleValue;
 
-// /// Represents the style value for `word-space-transform` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-space-transform).
+// /// Represents the style value for `text-spacing` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-spacing).
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// none | [ space | ideographic-space ] && auto-phrase?
+// /// none | auto | <spacing-trim> || <autospace>
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-text-4/#word-space-transform
-// #[syntax(" none | [ space | ideographic-space ] && auto-phrase? ")]
+// // https://drafts.csswg.org/css-text-4/#text-spacing
+// #[syntax(" none | auto | <spacing-trim> || <autospace> ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "none",
+// 	initial = "see individual properties",
 //   applies_to = "text",
 // 	inherited = "yes",
 // 	percentages = "n/a",
@@ -441,9 +509,167 @@ pub enum LetterSpacingStyleValue {}
 // 	animation_type = "discrete",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-space-transform"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-spacing"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum WordSpaceTransformStyleValue {}
+// pub enum TextSpacingStyleValue {}
+
+/// Represents the style value for `text-spacing-trim` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-spacing-trim).
+///
+/// The text-spacing-trim CSS property controls spacing around CJK characters, avoiding excessive whitespace when using full-width punctuation characters.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <spacing-trim> | auto
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#text-spacing-trim
+#[syntax(" <spacing-trim> | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-spacing-trim"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TextSpacingTrimStyleValue;
+
+// /// Represents the style value for `text-transform` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-transform).
+// ///
+// /// The text-transform CSS property sets text case and capitalization.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-4/#text-transform
+// #[syntax(" none | [capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "n/a",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-transform"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum TextTransformStyleValue {}
+
+/// Represents the style value for `text-wrap` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-wrap).
+///
+/// The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'text-wrap-mode'> || <'text-wrap-style'>
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#text-wrap
+#[syntax(" <'text-wrap-mode'> || <'text-wrap-style'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "wrap",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-wrap"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TextWrapStyleValue;
+
+/// Represents the style value for `text-wrap-mode` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-wrap-mode).
+///
+/// The text-wrap-mode CSS property sets whether lines may wrap with the values wrap and nowrap. It is a longhand property for both white-space and text-wrap.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// wrap | nowrap
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#text-wrap-mode
+#[syntax(" wrap | nowrap ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "wrap",
+	applies_to = "text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-wrap-mode"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum TextWrapModeStyleValue {}
+
+/// Represents the style value for `text-wrap-style` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-wrap-style).
+///
+/// The text-wrap-style CSS property sets how lines break in text that overflows the container. It can also be set with the text-wrap shorthand.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | balance | stable | pretty | avoid-orphans
+/// ```
+///
+// https://drafts.csswg.org/css-text-4/#text-wrap-style
+#[syntax(" auto | balance | stable | pretty | avoid-orphans ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "block containers hat establish an inline formatting context",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-wrap-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum TextWrapStyleStyleValue {}
+
+// /// Represents the style value for `white-space` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#white-space).
+// ///
+// /// The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'> || <'white-space-trim'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-4/#white-space
+// #[syntax(
+// 	" normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'> || <'white-space-trim'> "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "normal",
+//   applies_to = "text",
+// 	inherited = "see individual properties",
+// 	percentages = "n/a",
+// 	canonical_order = "n/a",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.white-space"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum WhiteSpaceStyleValue {}
 
 /// Represents the style value for `white-space-collapse` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#white-space-collapse).
 ///
@@ -495,79 +721,105 @@ pub enum WhiteSpaceCollapseStyleValue {}
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub enum WhiteSpaceTrimStyleValue {}
 
-/// Represents the style value for `text-wrap-mode` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-wrap-mode).
+/// Represents the style value for `word-break` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-break).
 ///
-/// The text-wrap-mode CSS property sets whether lines may wrap with the values wrap and nowrap. It is a longhand property for both white-space and text-wrap.
+/// The word-break CSS property sets how lines break within words.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// wrap | nowrap
+/// normal | break-all | keep-all | manual | auto-phrase | break-word
 /// ```
 ///
-// https://drafts.csswg.org/css-text-4/#text-wrap-mode
-#[syntax(" wrap | nowrap ")]
+// https://drafts.csswg.org/css-text-4/#word-break
+#[syntax(" normal | break-all | keep-all | manual | auto-phrase | break-word ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "wrap",
+	initial = "normal",
 	applies_to = "text",
 	inherited = "yes",
 	percentages = "n/a",
-	canonical_order = "per grammar",
+	canonical_order = "n/a",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-wrap-mode"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-break"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TextWrapModeStyleValue {}
+pub enum WordBreakStyleValue {}
 
-/// Represents the style value for `wrap-inside` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#wrap-inside).
+// /// Represents the style value for `word-space-transform` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-space-transform).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [ space | ideographic-space ] && auto-phrase?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-4/#word-space-transform
+// #[syntax(" none | [ space | ideographic-space ] && auto-phrase? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-space-transform"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum WordSpaceTransformStyleValue {}
+
+/// Represents the style value for `word-spacing` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-spacing).
+///
+/// The word-spacing CSS property sets the amount of white space between words.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | avoid
+/// normal | <length-percentage>
 /// ```
 ///
-// https://drafts.csswg.org/css-text-4/#wrap-inside
-#[syntax(" auto | avoid ")]
+// https://drafts.csswg.org/css-text-4/#word-spacing
+#[syntax(" normal | <length-percentage> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "auto",
-	applies_to = "inline boxes",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
+	initial = "normal",
+	applies_to = "text",
+	inherited = "yes",
+	percentages = "relative to computed font-size, i.e. 1em",
+	canonical_order = "n/a",
+	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-inside"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-spacing"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum WrapInsideStyleValue {}
+pub enum WordSpacingStyleValue {}
 
-/// Represents the style value for `wrap-before` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#wrap-before).
+/// Represents the style value for `word-wrap` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#word-wrap).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | avoid | avoid-line | avoid-flex | line | flex
+/// normal | break-word | anywhere
 /// ```
 ///
-// https://drafts.csswg.org/css-text-4/#wrap-before
-#[syntax(" auto | avoid | avoid-line | avoid-flex | line | flex ")]
+// https://drafts.csswg.org/css-text-4/#word-wrap
+#[syntax(" normal | break-word | anywhere ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "auto",
-	applies_to = "inline-level boxes and flex items",
-	inherited = "no",
+	initial = "normal",
+	applies_to = "text",
+	inherited = "yes",
 	percentages = "n/a",
-	canonical_order = "per grammar",
+	canonical_order = "n/a",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-before"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.word-wrap"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum WrapBeforeStyleValue {}
+pub enum WordWrapStyleValue {}
 
 /// Represents the style value for `wrap-after` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#wrap-after).
 ///
@@ -593,302 +845,50 @@ pub enum WrapBeforeStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum WrapAfterStyleValue {}
 
-/// Represents the style value for `text-wrap-style` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-wrap-style).
-///
-/// The text-wrap-style CSS property sets how lines break in text that overflows the container. It can also be set with the text-wrap shorthand.
+/// Represents the style value for `wrap-before` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#wrap-before).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// auto | balance | stable | pretty | avoid-orphans
+/// auto | avoid | avoid-line | avoid-flex | line | flex
 /// ```
 ///
-// https://drafts.csswg.org/css-text-4/#text-wrap-style
-#[syntax(" auto | balance | stable | pretty | avoid-orphans ")]
+// https://drafts.csswg.org/css-text-4/#wrap-before
+#[syntax(" auto | avoid | avoid-line | avoid-flex | line | flex ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",
-	applies_to = "block containers hat establish an inline formatting context",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-wrap-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TextWrapStyleStyleValue {}
-
-/// Represents the style value for `text-wrap` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-wrap).
-///
-/// The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'text-wrap-mode'> || <'text-wrap-style'>
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#text-wrap
-#[syntax(" <'text-wrap-mode'> || <'text-wrap-style'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "wrap",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-wrap"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TextWrapStyleValue;
-
-/// Represents the style value for `hyphenate-character` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-character).
-///
-/// The hyphenate-character CSS property sets the character or string to use at the end of a line before a line break.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <string>
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#hyphenate-character
-#[syntax(" auto | <string> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-character"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct HyphenateCharacterStyleValue;
-
-/// Represents the style value for `hyphenate-limit-zone` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-zone).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#hyphenate-limit-zone
-#[syntax(" <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "block containers",
-	inherited = "yes",
-	percentages = "refers to length of the line box",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-zone"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct HyphenateLimitZoneStyleValue;
-
-// /// Represents the style value for `hyphenate-limit-chars` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-chars).
-// ///
-// /// The hyphenate-limit-chars CSS property sets the number of characters in a word before it is hyphenated and the minimum number of characters on either side of the hyphen.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ auto | <integer> ]{1,3}
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-4/#hyphenate-limit-chars
-// #[syntax(" [ auto | <integer> ]{1,3} ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "by computed value type",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-chars"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct HyphenateLimitCharsStyleValue;
-
-/// Represents the style value for `hyphenate-limit-lines` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-lines).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// no-limit | <integer>
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#hyphenate-limit-lines
-#[syntax(" no-limit | <integer> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "no-limit",
-	applies_to = "block containers",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-lines"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum HyphenateLimitLinesStyleValue {}
-
-/// Represents the style value for `hyphenate-limit-last` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#hyphenate-limit-last).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | always | column | page | spread
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#hyphenate-limit-last
-#[syntax(" none | always | column | page | spread ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "block containers",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.hyphenate-limit-last"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum HyphenateLimitLastStyleValue {}
-
-/// Represents the style value for `text-group-align` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-group-align).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | start | end | left | right | center
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#text-group-align
-#[syntax(" none | start | end | left | right | center ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "block containers",
+	applies_to = "inline-level boxes and flex items",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-group-align"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-before"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TextGroupAlignStyleValue {}
+pub enum WrapBeforeStyleValue {}
 
-/// Represents the style value for `line-padding` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#line-padding).
+/// Represents the style value for `wrap-inside` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#wrap-inside).
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <length>
+/// auto | avoid
 /// ```
 ///
-// https://drafts.csswg.org/css-text-4/#line-padding
-#[syntax(" <length> ")]
+// https://drafts.csswg.org/css-text-4/#wrap-inside
+#[syntax(" auto | avoid ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "0",
+	initial = "auto",
 	applies_to = "inline boxes",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.line-padding"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct LinePaddingStyleValue;
-
-/// Represents the style value for `text-autospace` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-autospace).
-///
-/// The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | <autospace> | auto
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#text-autospace
-#[syntax(" normal | <autospace> | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "text",
-	inherited = "yes",
+	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-autospace"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.wrap-inside"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TextAutospaceStyleValue {}
-
-/// Represents the style value for `text-spacing-trim` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-spacing-trim).
-///
-/// The text-spacing-trim CSS property controls spacing around CJK characters, avoiding excessive whitespace when using full-width punctuation characters.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <spacing-trim> | auto
-/// ```
-///
-// https://drafts.csswg.org/css-text-4/#text-spacing-trim
-#[syntax(" <spacing-trim> | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-spacing-trim"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TextSpacingTrimStyleValue;
-
-// /// Represents the style value for `text-spacing` as defined in [css-text-4](https://drafts.csswg.org/css-text-4/#text-spacing).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | auto | <spacing-trim> || <autospace>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-4/#text-spacing
-// #[syntax(" none | auto | <spacing-trim> || <autospace> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-spacing"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum TextSpacingStyleValue {}
+pub enum WrapInsideStyleValue {}

--- a/crates/css_ast/src/values/text_decor/mod.rs
+++ b/crates/css_ast/src/values/text_decor/mod.rs
@@ -7,84 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-// /// Represents the style value for `text-decoration-line` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-line).
-// ///
-// /// The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-decor-4/#text-decoration-line
-// #[syntax(" none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "all elements",
-// 	inherited = "no (but see prose, above)",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-line"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum TextDecorationLineStyleValue {}
-
-/// Represents the style value for `text-decoration-style` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-style).
-///
-/// The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// solid | double | dotted | dashed | wavy
-/// ```
-///
-// https://drafts.csswg.org/css-text-decor-4/#text-decoration-style
-#[syntax(" solid | double | dotted | dashed | wavy ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "solid",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TextDecorationStyleStyleValue {}
-
-/// Represents the style value for `text-decoration-color` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-color).
-///
-/// The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <color>
-/// ```
-///
-// https://drafts.csswg.org/css-text-decor-4/#text-decoration-color
-#[syntax(" <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "currentcolor",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TextDecorationColorStyleValue;
-
 // /// Represents the style value for `text-decoration` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration).
 // ///
 // /// The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.
@@ -113,61 +35,9 @@ pub struct TextDecorationColorStyleValue;
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 // pub struct TextDecorationStyleValue;
 
-// /// Represents the style value for `text-underline-position` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-underline-position).
-// ///
-// /// The text-underline-position CSS property sets the position of underlines on text. For example, text-underline-position: under places the underline below the text, avoiding crossing descenders. The underline may be further adjusted by the text-underline-offset property.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// auto | [ from-font | under ] || [ left | right ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-decor-4/#text-underline-position
-// #[syntax(" auto | [ from-font | under ] || [ left | right ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "all elements",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-underline-position"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum TextUnderlinePositionStyleValue {}
-
-// /// Represents the style value for `text-emphasis-style` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-style).
-// ///
-// /// The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-decor-4/#text-emphasis-style
-// #[syntax(" none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "text",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-style"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum TextEmphasisStyleStyleValue {}
-
-/// Represents the style value for `text-emphasis-color` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-color).
+/// Represents the style value for `text-decoration-color` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-color).
 ///
-/// The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.
+/// The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.
 ///
 /// The grammar is defined as:
 ///
@@ -175,175 +45,47 @@ pub struct TextDecorationColorStyleValue;
 /// <color>
 /// ```
 ///
-// https://drafts.csswg.org/css-text-decor-4/#text-emphasis-color
+// https://drafts.csswg.org/css-text-decor-4/#text-decoration-color
 #[syntax(" <color> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "currentcolor",
-	applies_to = "text",
-	inherited = "yes",
+	applies_to = "all elements",
+	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "by computed value type"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-color"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-color"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TextEmphasisColorStyleValue;
+pub struct TextDecorationColorStyleValue;
 
-// /// Represents the style value for `text-emphasis` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis).
+// /// Represents the style value for `text-decoration-line` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-line).
 // ///
-// /// The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.
+// /// The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.
 // ///
 // /// The grammar is defined as:
 // ///
 // /// ```text,ignore
-// /// <'text-emphasis-style'> || <'text-emphasis-color'>
+// /// none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error
 // /// ```
 // ///
-// // https://drafts.csswg.org/css-text-decor-4/#text-emphasis
-// #[syntax(" <'text-emphasis-style'> || <'text-emphasis-color'> ")]
+// // https://drafts.csswg.org/css-text-decor-4/#text-decoration-line
+// #[syntax(" none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error ")]
 // #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // #[style_value(
-// 	initial = "see individual properties",
-//   applies_to = "see individual properties",
-// 	inherited = "see individual properties",
-// 	percentages = "see individual properties",
-// 	canonical_order = "per grammar",
-// 	animation_type = "see individual properties",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct TextEmphasisStyleValue;
-
-// /// Represents the style value for `text-emphasis-position` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-position).
-// ///
-// /// The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ over | under ] && [ right | left ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-decor-4/#text-emphasis-position
-// #[syntax(" [ over | under ] && [ right | left ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "over right",
-//   applies_to = "text",
-// 	inherited = "yes",
+// 	initial = "none",
+//   applies_to = "all elements",
+// 	inherited = "no (but see prose, above)",
 // 	percentages = "n/a",
 // 	canonical_order = "per grammar",
 // 	animation_type = "discrete",
 // )]
 // #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-position"))]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-line"))]
 // #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct TextEmphasisPositionStyleValue;
-
-/// Represents the style value for `text-shadow` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-shadow).
-///
-/// The text-shadow CSS property sets the position and styles of shadow on text.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <shadow>#
-/// ```
-///
-// https://drafts.csswg.org/css-text-decor-4/#text-shadow
-#[syntax(" none | <shadow># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "as shadow list"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-shadow"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TextShadowStyleValue<'a>;
-
-/// Represents the style value for `text-decoration-thickness` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness).
-///
-/// The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | from-font | <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness
-#[syntax(" auto | from-font | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-thickness"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TextDecorationThicknessStyleValue {}
-
-/// Represents the style value for `text-underline-offset` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-underline-offset).
-///
-/// The text-underline-offset CSS property shifts underlines on text from the initial position by a given distance. The initial position is affected by the text-underline-position property.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <length-percentage>
-/// ```
-///
-// https://drafts.csswg.org/css-text-decor-4/#text-underline-offset
-#[syntax(" auto | <length-percentage> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-underline-offset"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TextUnderlineOffsetStyleValue;
-
-/// Represents the style value for `text-decoration-trim` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-trim).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <length>{1,2} | auto
-/// ```
-///
-// https://drafts.csswg.org/css-text-decor-4/#text-decoration-trim
-#[syntax(" <length>{1,2} | auto ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-trim"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TextDecorationTrimStyleValue;
+// pub enum TextDecorationLineStyleValue {}
 
 /// Represents the style value for `text-decoration-skip` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip).
 ///
@@ -371,30 +113,6 @@ pub struct TextDecorationTrimStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextDecorationSkipStyleValue {}
 
-// /// Represents the style value for `text-decoration-skip-self` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-self).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// auto | skip-all | [ skip-underline || skip-overline || skip-line-through ] | no-skip
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-self
-// #[syntax(" auto | skip-all | [ skip-underline || skip-overline || skip-line-through ] | no-skip ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "all elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip-self"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum TextDecorationSkipSelfStyleValue {}
-
 /// Represents the style value for `text-decoration-skip-box` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-box).
 ///
 /// The grammar is defined as:
@@ -418,30 +136,6 @@ pub enum TextDecorationSkipStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip-box"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextDecorationSkipBoxStyleValue {}
-
-// /// Represents the style value for `text-decoration-skip-spaces` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-spaces).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | all | [ start || end ]
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-spaces
-// #[syntax(" none | all | [ start || end ] ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "start end",
-//   applies_to = "all elements",
-// 	inherited = "yes",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip-spaces"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum TextDecorationSkipSpacesStyleValue {}
 
 /// Represents the style value for `text-decoration-skip-ink` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-ink).
 ///
@@ -469,6 +163,208 @@ pub enum TextDecorationSkipBoxStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextDecorationSkipInkStyleValue {}
 
+// /// Represents the style value for `text-decoration-skip-self` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-self).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// auto | skip-all | [ skip-underline || skip-overline || skip-line-through ] | no-skip
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-self
+// #[syntax(" auto | skip-all | [ skip-underline || skip-overline || skip-line-through ] | no-skip ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "all elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip-self"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum TextDecorationSkipSelfStyleValue {}
+
+// /// Represents the style value for `text-decoration-skip-spaces` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-spaces).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | all | [ start || end ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-spaces
+// #[syntax(" none | all | [ start || end ] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "start end",
+//   applies_to = "all elements",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-skip-spaces"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum TextDecorationSkipSpacesStyleValue {}
+
+/// Represents the style value for `text-decoration-style` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-style).
+///
+/// The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// solid | double | dotted | dashed | wavy
+/// ```
+///
+// https://drafts.csswg.org/css-text-decor-4/#text-decoration-style
+#[syntax(" solid | double | dotted | dashed | wavy ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "solid",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum TextDecorationStyleStyleValue {}
+
+/// Represents the style value for `text-decoration-thickness` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness).
+///
+/// The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | from-font | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness
+#[syntax(" auto | from-font | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-thickness"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum TextDecorationThicknessStyleValue {}
+
+/// Represents the style value for `text-decoration-trim` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-decoration-trim).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <length>{1,2} | auto
+/// ```
+///
+// https://drafts.csswg.org/css-text-decor-4/#text-decoration-trim
+#[syntax(" <length>{1,2} | auto ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-decoration-trim"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TextDecorationTrimStyleValue;
+
+// /// Represents the style value for `text-emphasis` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis).
+// ///
+// /// The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// <'text-emphasis-style'> || <'text-emphasis-color'>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-decor-4/#text-emphasis
+// #[syntax(" <'text-emphasis-style'> || <'text-emphasis-color'> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "see individual properties",
+//   applies_to = "see individual properties",
+// 	inherited = "see individual properties",
+// 	percentages = "see individual properties",
+// 	canonical_order = "per grammar",
+// 	animation_type = "see individual properties",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct TextEmphasisStyleValue;
+
+/// Represents the style value for `text-emphasis-color` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-color).
+///
+/// The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <color>
+/// ```
+///
+// https://drafts.csswg.org/css-text-decor-4/#text-emphasis-color
+#[syntax(" <color> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "currentcolor",
+	applies_to = "text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TextEmphasisColorStyleValue;
+
+// /// Represents the style value for `text-emphasis-position` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-position).
+// ///
+// /// The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ over | under ] && [ right | left ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-decor-4/#text-emphasis-position
+// #[syntax(" [ over | under ] && [ right | left ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "over right",
+//   applies_to = "text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-position"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct TextEmphasisPositionStyleValue;
+
 /// Represents the style value for `text-emphasis-skip` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-skip).
 ///
 /// The grammar is defined as:
@@ -492,3 +388,107 @@ pub enum TextDecorationSkipInkStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-skip"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TextEmphasisSkipStyleValue;
+
+// /// Represents the style value for `text-emphasis-style` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-emphasis-style).
+// ///
+// /// The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-decor-4/#text-emphasis-style
+// #[syntax(" none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "text",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-emphasis-style"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum TextEmphasisStyleStyleValue {}
+
+/// Represents the style value for `text-shadow` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-shadow).
+///
+/// The text-shadow CSS property sets the position and styles of shadow on text.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <shadow>#
+/// ```
+///
+// https://drafts.csswg.org/css-text-decor-4/#text-shadow
+#[syntax(" none | <shadow># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "as shadow list"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-shadow"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TextShadowStyleValue<'a>;
+
+/// Represents the style value for `text-underline-offset` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-underline-offset).
+///
+/// The text-underline-offset CSS property shifts underlines on text from the initial position by a given distance. The initial position is affected by the text-underline-position property.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <length-percentage>
+/// ```
+///
+// https://drafts.csswg.org/css-text-decor-4/#text-underline-offset
+#[syntax(" auto | <length-percentage> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-underline-offset"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TextUnderlineOffsetStyleValue;
+
+// /// Represents the style value for `text-underline-position` as defined in [css-text-decor-4](https://drafts.csswg.org/css-text-decor-4/#text-underline-position).
+// ///
+// /// The text-underline-position CSS property sets the position of underlines on text. For example, text-underline-position: under places the underline below the text, avoiding crossing descenders. The underline may be further adjusted by the text-underline-offset property.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// auto | [ from-font | under ] || [ left | right ]
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-text-decor-4/#text-underline-position
+// #[syntax(" auto | [ from-font | under ] || [ left | right ] ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "all elements",
+// 	inherited = "yes",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-underline-position"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum TextUnderlinePositionStyleValue {}

--- a/crates/css_ast/src/values/transforms/mod.rs
+++ b/crates/css_ast/src/values/transforms/mod.rs
@@ -7,179 +7,21 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `transform` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform).
-///
-/// The transform CSS property and its 2D transform functions allow rotating, scaling, skewing, and translating an element. Arbitrary 2D transforms are also possible using a transformation matrix.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <transform-list>
-/// ```
-///
-// https://drafts.csswg.org/css-transforms-2/#transform
-#[syntax(" none | <transform-list> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "transformable elements",
-	inherited = "no",
-	percentages = "refer to the size of reference box",
-	canonical_order = "per grammar",
-	animation_type = "transform list, see interpolation rules"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TransformStyleValue<'a>;
-
-// /// Represents the style value for `transform-origin` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-origin).
-// ///
-// /// The transform CSS property and its 2D transform functions allow rotating, scaling, skewing, and translating an element. Arbitrary 2D transforms are also possible using a transformation matrix.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// [ left | center | right | top | bottom | <length-percentage> ] |   [ left | center | right | <length-percentage> ]  [ top | center | bottom | <length-percentage> ] <length>? |  [ [ center | left | right ] && [ center | top | bottom ] ] <length>?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-transforms-2/#transform-origin
-// #[syntax(
-// 	" [ left | center | right | top | bottom | <length-percentage> ] |   [ left | center | right | <length-percentage> ]  [ top | center | bottom | <length-percentage> ] <length>? |  [ [ center | left | right ] && [ center | top | bottom ] ] <length>? "
-// )]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "50% 50%",
-//   applies_to = "transformable elements",
-// 	inherited = "no",
-// 	percentages = "refer to the size of reference box",
-// 	canonical_order = "per grammar",
-// 	animation_type = "by computed value",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform-origin"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum TransformOriginStyleValue {}
-
-/// Represents the style value for `transform-box` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-box).
-///
-/// The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// content-box | border-box | fill-box | stroke-box | view-box
-/// ```
-///
-// https://drafts.csswg.org/css-transforms-2/#transform-box
-#[syntax(" content-box | border-box | fill-box | stroke-box | view-box ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "view-box",
-	applies_to = "transformable elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform-box"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TransformBoxStyleValue {}
-
-// /// Represents the style value for `translate` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#translate).
-// ///
-// /// The translate, rotate, and scale CSS properties apply single transformations independently, as opposed to applying multiple transformations with the transform CSS property.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | <length-percentage> [ <length-percentage> <length>? ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-transforms-2/#translate
-// #[syntax(" none | <length-percentage> [ <length-percentage> <length>? ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "transformable elements",
-// 	inherited = "no",
-// 	percentages = "relative to the width of the reference box (for the first value) or the height (for the second value)",
-// 	canonical_order = "per grammar",
-// 	animation_type = "by computed value, but see below for none",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.translate"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub struct TranslateStyleValue;
-
-// /// Represents the style value for `rotate` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#rotate).
-// ///
-// /// The translate, rotate, and scale CSS properties apply single transformations independently, as opposed to applying multiple transformations with the transform CSS property.
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// none | <angle> | [ x | y | z | <number>{3} ] && <angle>
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-transforms-2/#rotate
-// #[syntax(" none | <angle> | [ x | y | z | <number>{3} ] && <angle> ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "none",
-//   applies_to = "transformable elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "as slerp, but see below for none",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rotate"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum RotateStyleValue {}
-
-/// Represents the style value for `scale` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#scale).
-///
-/// The translate, rotate, and scale CSS properties apply single transformations independently, as opposed to applying multiple transformations with the transform CSS property.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | [ <number> | <percentage> ]{1,3}
-/// ```
-///
-// https://drafts.csswg.org/css-transforms-2/#scale
-#[syntax(" none | [ <number> | <percentage> ]{1,3} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "transformable elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value, but see below for none"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scale"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ScaleStyleValue;
-
-/// Represents the style value for `transform-style` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-style).
+/// Represents the style value for `backface-visibility` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#backface-visibility).
 ///
 /// The transform CSS property and its 3D transform functions allow rotations and other transforms in three dimensions, including perspective transforms.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// flat | preserve-3d
+/// visible | hidden
 /// ```
 ///
-// https://drafts.csswg.org/css-transforms-2/#transform-style
-#[syntax(" flat | preserve-3d ")]
+// https://drafts.csswg.org/css-transforms-2/#backface-visibility
+#[syntax(" visible | hidden ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "flat",
+	initial = "visible",
 	applies_to = "transformable elements",
 	inherited = "no",
 	percentages = "n/a",
@@ -187,9 +29,9 @@ pub struct ScaleStyleValue;
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform-style"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.backface-visibility"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TransformStyleStyleValue {}
+pub enum BackfaceVisibilityStyleValue {}
 
 /// Represents the style value for `perspective` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#perspective).
 ///
@@ -243,21 +85,99 @@ pub struct PerspectiveStyleValue;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct PerspectiveOriginStyleValue;
 
-/// Represents the style value for `backface-visibility` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#backface-visibility).
+// /// Represents the style value for `rotate` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#rotate).
+// ///
+// /// The translate, rotate, and scale CSS properties apply single transformations independently, as opposed to applying multiple transformations with the transform CSS property.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | <angle> | [ x | y | z | <number>{3} ] && <angle>
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-transforms-2/#rotate
+// #[syntax(" none | <angle> | [ x | y | z | <number>{3} ] && <angle> ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "transformable elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "as slerp, but see below for none",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.rotate"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum RotateStyleValue {}
+
+/// Represents the style value for `scale` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#scale).
 ///
-/// The transform CSS property and its 3D transform functions allow rotations and other transforms in three dimensions, including perspective transforms.
+/// The translate, rotate, and scale CSS properties apply single transformations independently, as opposed to applying multiple transformations with the transform CSS property.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// visible | hidden
+/// none | [ <number> | <percentage> ]{1,3}
 /// ```
 ///
-// https://drafts.csswg.org/css-transforms-2/#backface-visibility
-#[syntax(" visible | hidden ")]
+// https://drafts.csswg.org/css-transforms-2/#scale
+#[syntax(" none | [ <number> | <percentage> ]{1,3} ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
-	initial = "visible",
+	initial = "none",
+	applies_to = "transformable elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value, but see below for none"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.scale"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ScaleStyleValue;
+
+/// Represents the style value for `transform` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform).
+///
+/// The transform CSS property and its 2D transform functions allow rotating, scaling, skewing, and translating an element. Arbitrary 2D transforms are also possible using a transformation matrix.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <transform-list>
+/// ```
+///
+// https://drafts.csswg.org/css-transforms-2/#transform
+#[syntax(" none | <transform-list> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "transformable elements",
+	inherited = "no",
+	percentages = "refer to the size of reference box",
+	canonical_order = "per grammar",
+	animation_type = "transform list, see interpolation rules"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TransformStyleValue<'a>;
+
+/// Represents the style value for `transform-box` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-box).
+///
+/// The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// content-box | border-box | fill-box | stroke-box | view-box
+/// ```
+///
+// https://drafts.csswg.org/css-transforms-2/#transform-box
+#[syntax(" content-box | border-box | fill-box | stroke-box | view-box ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "view-box",
 	applies_to = "transformable elements",
 	inherited = "no",
 	percentages = "n/a",
@@ -265,6 +185,86 @@ pub struct PerspectiveOriginStyleValue;
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.backface-visibility"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform-box"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum BackfaceVisibilityStyleValue {}
+pub enum TransformBoxStyleValue {}
+
+// /// Represents the style value for `transform-origin` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-origin).
+// ///
+// /// The transform CSS property and its 2D transform functions allow rotating, scaling, skewing, and translating an element. Arbitrary 2D transforms are also possible using a transformation matrix.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// [ left | center | right | top | bottom | <length-percentage> ] |   [ left | center | right | <length-percentage> ]  [ top | center | bottom | <length-percentage> ] <length>? |  [ [ center | left | right ] && [ center | top | bottom ] ] <length>?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-transforms-2/#transform-origin
+// #[syntax(
+// 	" [ left | center | right | top | bottom | <length-percentage> ] |   [ left | center | right | <length-percentage> ]  [ top | center | bottom | <length-percentage> ] <length>? |  [ [ center | left | right ] && [ center | top | bottom ] ] <length>? "
+// )]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "50% 50%",
+//   applies_to = "transformable elements",
+// 	inherited = "no",
+// 	percentages = "refer to the size of reference box",
+// 	canonical_order = "per grammar",
+// 	animation_type = "by computed value",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform-origin"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum TransformOriginStyleValue {}
+
+/// Represents the style value for `transform-style` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#transform-style).
+///
+/// The transform CSS property and its 3D transform functions allow rotations and other transforms in three dimensions, including perspective transforms.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// flat | preserve-3d
+/// ```
+///
+// https://drafts.csswg.org/css-transforms-2/#transform-style
+#[syntax(" flat | preserve-3d ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "flat",
+	applies_to = "transformable elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transform-style"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum TransformStyleStyleValue {}
+
+// /// Represents the style value for `translate` as defined in [css-transforms-2](https://drafts.csswg.org/css-transforms-2/#translate).
+// ///
+// /// The translate, rotate, and scale CSS properties apply single transformations independently, as opposed to applying multiple transformations with the transform CSS property.
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// none | <length-percentage> [ <length-percentage> <length>? ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-transforms-2/#translate
+// #[syntax(" none | <length-percentage> [ <length-percentage> <length>? ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "none",
+//   applies_to = "transformable elements",
+// 	inherited = "no",
+// 	percentages = "relative to the width of the reference box (for the first value) or the height (for the second value)",
+// 	canonical_order = "per grammar",
+// 	animation_type = "by computed value, but see below for none",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.translate"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub struct TranslateStyleValue;

--- a/crates/css_ast/src/values/transitions/mod.rs
+++ b/crates/css_ast/src/values/transitions/mod.rs
@@ -7,114 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `transition-property` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-property).
-///
-/// The transition shorthand CSS property sets how changes to an element's styles may occur over time. Transitions can be applied to specific CSS properties, all properties, or none.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <single-transition-property>#
-/// ```
-///
-// https://drafts.csswg.org/css-transitions-2/#transition-property
-#[syntax(" none | <single-transition-property># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "all",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-property"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TransitionPropertyStyleValue<'a>;
-
-/// Represents the style value for `transition-duration` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-duration).
-///
-/// The transition shorthand CSS property sets how changes to an element's styles may occur over time. Transitions can be applied to specific CSS properties, all properties, or none.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <time [0s,∞]>#
-/// ```
-///
-// https://drafts.csswg.org/css-transitions-2/#transition-duration
-#[syntax(" <time [0s,∞]># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0s",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-duration"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TransitionDurationStyleValue<'a>;
-
-/// Represents the style value for `transition-timing-function` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-timing-function).
-///
-/// The transition shorthand CSS property sets how changes to an element's styles may occur over time. Transitions can be applied to specific CSS properties, all properties, or none.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <easing-function>#
-/// ```
-///
-// https://drafts.csswg.org/css-transitions-2/#transition-timing-function
-#[syntax(" <easing-function># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "ease",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(
-	feature = "css_feature_data",
-	derive(ToCSSFeature),
-	css_feature("css.properties.transition-timing-function")
-)]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TransitionTimingFunctionStyleValue<'a>;
-
-/// Represents the style value for `transition-delay` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-delay).
-///
-/// The transition shorthand CSS property sets how changes to an element's styles may occur over time. Transitions can be applied to specific CSS properties, all properties, or none.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <time>#
-/// ```
-///
-// https://drafts.csswg.org/css-transitions-2/#transition-delay
-#[syntax(" <time># ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "0s",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-delay"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct TransitionDelayStyleValue<'a>;
-
 /// Represents the style value for `transition` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition).
 ///
 /// The transition shorthand CSS property sets how changes to an element's styles may occur over time. Transitions can be applied to specific CSS properties, all properties, or none.
@@ -166,3 +58,111 @@ pub struct TransitionStyleValue<'a>;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-behavior"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct TransitionBehaviorStyleValue<'a>;
+
+/// Represents the style value for `transition-delay` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-delay).
+///
+/// The transition shorthand CSS property sets how changes to an element's styles may occur over time. Transitions can be applied to specific CSS properties, all properties, or none.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <time>#
+/// ```
+///
+// https://drafts.csswg.org/css-transitions-2/#transition-delay
+#[syntax(" <time># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0s",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-delay"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TransitionDelayStyleValue<'a>;
+
+/// Represents the style value for `transition-duration` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-duration).
+///
+/// The transition shorthand CSS property sets how changes to an element's styles may occur over time. Transitions can be applied to specific CSS properties, all properties, or none.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <time [0s,∞]>#
+/// ```
+///
+// https://drafts.csswg.org/css-transitions-2/#transition-duration
+#[syntax(" <time [0s,∞]># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "0s",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-duration"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TransitionDurationStyleValue<'a>;
+
+/// Represents the style value for `transition-property` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-property).
+///
+/// The transition shorthand CSS property sets how changes to an element's styles may occur over time. Transitions can be applied to specific CSS properties, all properties, or none.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <single-transition-property>#
+/// ```
+///
+// https://drafts.csswg.org/css-transitions-2/#transition-property
+#[syntax(" none | <single-transition-property># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "all",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.transition-property"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TransitionPropertyStyleValue<'a>;
+
+/// Represents the style value for `transition-timing-function` as defined in [css-transitions-2](https://drafts.csswg.org/css-transitions-2/#transition-timing-function).
+///
+/// The transition shorthand CSS property sets how changes to an element's styles may occur over time. Transitions can be applied to specific CSS properties, all properties, or none.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <easing-function>#
+/// ```
+///
+// https://drafts.csswg.org/css-transitions-2/#transition-timing-function
+#[syntax(" <easing-function># ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "ease",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(
+	feature = "css_feature_data",
+	derive(ToCSSFeature),
+	css_feature("css.properties.transition-timing-function")
+)]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct TransitionTimingFunctionStyleValue<'a>;

--- a/crates/css_ast/src/values/ui/mod.rs
+++ b/crates/css_ast/src/values/ui/mod.rs
@@ -7,6 +7,378 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
+/// Represents the style value for `accent-color` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#accent-color).
+///
+/// The accent-color CSS property sets a color for checkboxes, radio buttons, and other form controls.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <color>
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#accent-color
+#[syntax(" auto | <color> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.accent-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct AccentColorStyleValue;
+
+/// Represents the style value for `appearance` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#appearance).
+///
+/// The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | auto | base | base-select | <compat-auto> | <compat-special>
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#appearance
+#[syntax(" none | auto | base | base-select | <compat-auto> | <compat-special> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.appearance"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum AppearanceStyleValue {}
+
+/// Represents the style value for `caret` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'caret-color'> || <'caret-animation'> || <'caret-shape'>
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#caret
+#[syntax(" <'caret-color'> || <'caret-animation'> || <'caret-shape'> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "text or elements that accept text input",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CaretStyleValue;
+
+/// Represents the style value for `caret-animation` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret-animation).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | manual
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#caret-animation
+#[syntax(" auto | manual ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "text or elements that accept text input",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret-animation"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum CaretAnimationStyleValue {}
+
+/// Represents the style value for `caret-color` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret-color).
+///
+/// The caret-color CSS property sets the color of the text insertion pointer in a text input.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | <color>
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#caret-color
+#[syntax(" auto | <color> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "text or elements that accept text input",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret-color"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CaretColorStyleValue;
+
+/// Represents the style value for `caret-shape` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret-shape).
+///
+/// The caret-shape CSS property controls the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | bar | block | underscore
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#caret-shape
+#[syntax(" auto | bar | block | underscore ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "text or elements that accept text input",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret-shape"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum CaretShapeStyleValue {}
+
+/// Represents the style value for `cursor` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#cursor).
+///
+/// The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <cursor-image>#? <cursor-predefined>
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#cursor
+#[syntax(" <cursor-image>#? <cursor-predefined> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cursor"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct CursorStyleValue<'a>;
+
+/// Represents the style value for `interactivity` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interactivity).
+///
+/// The interactivity: inert CSS declaration makes an element and its descendants inert, like when using the inert HTML attribute. Inert elements can't be focused or clicked, their text can't be selected or found using the browser's find-in-page feature.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | inert
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#interactivity
+#[syntax(" auto | inert ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interactivity"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum InteractivityStyleValue {}
+
+/// Represents the style value for `interest-delay` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interest-delay).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <'interest-delay-start'>{1,2}
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#interest-delay
+#[syntax(" <'interest-delay-start'>{1,2} ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "see individual properties",
+	applies_to = "see individual properties",
+	inherited = "see individual properties",
+	percentages = "see individual properties",
+	canonical_order = "per grammar",
+	animation_type = "see individual properties"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interest-delay"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct InterestDelayStyleValue;
+
+/// Represents the style value for `interest-delay-end` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interest-delay-end).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | <time>
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#interest-delay-end
+#[syntax(" normal | <time> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interest-delay-end"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum InterestDelayEndStyleValue {}
+
+/// Represents the style value for `interest-delay-start` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interest-delay-start).
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | <time>
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#interest-delay-start
+#[syntax(" normal | <time> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value type"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interest-delay-start"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum InterestDelayStartStyleValue {}
+
+// /// Represents the style value for `nav-down` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-down).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// auto | <id> [ current | root | <target-name> ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-ui-4/#nav-down
+// #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "all enabled elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-down"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum NavDownStyleValue {}
+
+// /// Represents the style value for `nav-left` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-left).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// auto | <id> [ current | root | <target-name> ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-ui-4/#nav-left
+// #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "all enabled elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-left"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum NavLeftStyleValue {}
+
+// /// Represents the style value for `nav-right` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-right).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// auto | <id> [ current | root | <target-name> ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-ui-4/#nav-right
+// #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "all enabled elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-right"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum NavRightStyleValue {}
+
+// /// Represents the style value for `nav-up` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-up).
+// ///
+// /// The grammar is defined as:
+// ///
+// /// ```text,ignore
+// /// auto | <id> [ current | root | <target-name> ]?
+// /// ```
+// ///
+// // https://drafts.csswg.org/css-ui-4/#nav-up
+// #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
+// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// #[style_value(
+// 	initial = "auto",
+//   applies_to = "all enabled elements",
+// 	inherited = "no",
+// 	percentages = "n/a",
+// 	canonical_order = "per grammar",
+// 	animation_type = "discrete",
+// )]
+// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-up"))]
+// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+// pub enum NavUpStyleValue {}
+
 /// Represents the style value for `outline` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline).
 ///
 /// The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.
@@ -32,58 +404,6 @@ use impls::*;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OutlineStyleValue<'a>;
-
-/// Represents the style value for `outline-width` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline-width).
-///
-/// The outline-color, outline-style, and outline-width and outline-offset CSS properties style a line around an element, outside of the border.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <line-width>
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#outline-width
-#[syntax(" <line-width> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "medium",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline-width"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OutlineWidthStyleValue;
-
-/// Represents the style value for `outline-style` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline-style).
-///
-/// The outline-color, outline-style, and outline-width and outline-offset CSS properties style a line around an element, outside of the border.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <outline-line-style>
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#outline-style
-#[syntax(" auto | <outline-line-style> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline-style"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct OutlineStyleStyleValue;
 
 /// Represents the style value for `outline-color` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline-color).
 ///
@@ -137,279 +457,57 @@ pub enum OutlineColorStyleValue<'a> {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub struct OutlineOffsetStyleValue;
 
-/// Represents the style value for `resize` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#resize).
+/// Represents the style value for `outline-style` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline-style).
 ///
-/// The resize CSS property sets whether an element can be resized by the user, and on which axes.
+/// The outline-color, outline-style, and outline-width and outline-offset CSS properties style a line around an element, outside of the border.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// none | both | horizontal | vertical | block | inline
+/// auto | <outline-line-style>
 /// ```
 ///
-// https://drafts.csswg.org/css-ui-4/#resize
-#[syntax(" none | both | horizontal | vertical | block | inline ")]
+// https://drafts.csswg.org/css-ui-4/#outline-style
+#[syntax(" auto | <outline-line-style> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
-	applies_to = "elements that are scroll containers and optionally replaced elements such as images, videos, and iframes",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.resize"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum ResizeStyleValue {}
-
-/// Represents the style value for `cursor` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#cursor).
-///
-/// The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <cursor-image>#? <cursor-predefined>
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#cursor
-#[syntax(" <cursor-image>#? <cursor-predefined> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
 	applies_to = "all elements",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.cursor"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CursorStyleValue<'a>;
-
-/// Represents the style value for `caret-color` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret-color).
-///
-/// The caret-color CSS property sets the color of the text insertion pointer in a text input.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <color>
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#caret-color
-#[syntax(" auto | <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "text or elements that accept text input",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CaretColorStyleValue;
-
-/// Represents the style value for `caret-animation` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret-animation).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | manual
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#caret-animation
-#[syntax(" auto | manual ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "text or elements that accept text input",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret-animation"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum CaretAnimationStyleValue {}
-
-/// Represents the style value for `caret-shape` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret-shape).
-///
-/// The caret-shape CSS property controls the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | bar | block | underscore
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#caret-shape
-#[syntax(" auto | bar | block | underscore ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "text or elements that accept text input",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret-shape"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum CaretShapeStyleValue {}
-
-/// Represents the style value for `caret` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#caret).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'caret-color'> || <'caret-animation'> || <'caret-shape'>
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#caret
-#[syntax(" <'caret-color'> || <'caret-animation'> || <'caret-shape'> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "text or elements that accept text input",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.caret"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct CaretStyleValue;
-
-// /// Represents the style value for `nav-up` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-up).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// auto | <id> [ current | root | <target-name> ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-ui-4/#nav-up
-// #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "all enabled elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-up"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum NavUpStyleValue {}
-
-// /// Represents the style value for `nav-right` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-right).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// auto | <id> [ current | root | <target-name> ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-ui-4/#nav-right
-// #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "all enabled elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-right"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum NavRightStyleValue {}
-
-// /// Represents the style value for `nav-down` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-down).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// auto | <id> [ current | root | <target-name> ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-ui-4/#nav-down
-// #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "all enabled elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-down"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum NavDownStyleValue {}
-
-// /// Represents the style value for `nav-left` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#nav-left).
-// ///
-// /// The grammar is defined as:
-// ///
-// /// ```text,ignore
-// /// auto | <id> [ current | root | <target-name> ]?
-// /// ```
-// ///
-// // https://drafts.csswg.org/css-ui-4/#nav-left
-// #[syntax(" auto | <id> [ current | root | <target-name> ]? ")]
-// #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// #[style_value(
-// 	initial = "auto",
-//   applies_to = "all enabled elements",
-// 	inherited = "no",
-// 	percentages = "n/a",
-// 	canonical_order = "per grammar",
-// 	animation_type = "discrete",
-// )]
-// #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-// #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.nav-left"))]
-// #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-// pub enum NavLeftStyleValue {}
-
-/// Represents the style value for `user-select` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#user-select).
-///
-/// The user-select CSS property controls which elements can be selected by the user.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | text | none | contain | all
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#user-select
-#[syntax(" auto | text | none | contain | all ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements, and optionally to the ::before and ::after pseudo-elements",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
-	animation_type = "discrete"
+	animation_type = "by computed value"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.user-select"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline-style"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum UserSelectStyleValue {}
+pub struct OutlineStyleStyleValue;
+
+/// Represents the style value for `outline-width` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#outline-width).
+///
+/// The outline-color, outline-style, and outline-width and outline-offset CSS properties style a line around an element, outside of the border.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// <line-width>
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#outline-width
+#[syntax(" <line-width> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "medium",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "by computed value"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.outline-width"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct OutlineWidthStyleValue;
 
 /// Represents the style value for `pointer-events` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#pointer-events).
 ///
@@ -437,152 +535,54 @@ pub enum UserSelectStyleValue {}
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum PointerEventsStyleValue {}
 
-/// Represents the style value for `interactivity` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interactivity).
+/// Represents the style value for `resize` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#resize).
 ///
-/// The interactivity: inert CSS declaration makes an element and its descendants inert, like when using the inert HTML attribute. Inert elements can't be focused or clicked, their text can't be selected or found using the browser's find-in-page feature.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | inert
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#interactivity
-#[syntax(" auto | inert ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interactivity"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum InteractivityStyleValue {}
-
-/// Represents the style value for `interest-delay-start` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interest-delay-start).
+/// The resize CSS property sets whether an element can be resized by the user, and on which axes.
 ///
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// normal | <time>
+/// none | both | horizontal | vertical | block | inline
 /// ```
 ///
-// https://drafts.csswg.org/css-ui-4/#interest-delay-start
-#[syntax(" normal | <time> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interest-delay-start"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum InterestDelayStartStyleValue {}
-
-/// Represents the style value for `interest-delay-end` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interest-delay-end).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | <time>
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#interest-delay-end
-#[syntax(" normal | <time> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interest-delay-end"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum InterestDelayEndStyleValue {}
-
-/// Represents the style value for `interest-delay` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#interest-delay).
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// <'interest-delay-start'>{1,2}
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#interest-delay
-#[syntax(" <'interest-delay-start'>{1,2} ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "see individual properties",
-	applies_to = "see individual properties",
-	inherited = "see individual properties",
-	percentages = "see individual properties",
-	canonical_order = "per grammar",
-	animation_type = "see individual properties"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.interest-delay"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct InterestDelayStyleValue;
-
-/// Represents the style value for `accent-color` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#accent-color).
-///
-/// The accent-color CSS property sets a color for checkboxes, radio buttons, and other form controls.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// auto | <color>
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#accent-color
-#[syntax(" auto | <color> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "auto",
-	applies_to = "all elements",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "by computed value type"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.accent-color"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct AccentColorStyleValue;
-
-/// Represents the style value for `appearance` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#appearance).
-///
-/// The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | auto | base | base-select | <compat-auto> | <compat-special>
-/// ```
-///
-// https://drafts.csswg.org/css-ui-4/#appearance
-#[syntax(" none | auto | base | base-select | <compat-auto> | <compat-special> ")]
+// https://drafts.csswg.org/css-ui-4/#resize
+#[syntax(" none | both | horizontal | vertical | block | inline ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "none",
-	applies_to = "all elements",
+	applies_to = "elements that are scroll containers and optionally replaced elements such as images, videos, and iframes",
 	inherited = "no",
 	percentages = "n/a",
 	canonical_order = "per grammar",
 	animation_type = "discrete"
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.appearance"))]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.resize"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum AppearanceStyleValue {}
+pub enum ResizeStyleValue {}
+
+/// Represents the style value for `user-select` as defined in [css-ui-4](https://drafts.csswg.org/css-ui-4/#user-select).
+///
+/// The user-select CSS property controls which elements can be selected by the user.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// auto | text | none | contain | all
+/// ```
+///
+// https://drafts.csswg.org/css-ui-4/#user-select
+#[syntax(" auto | text | none | contain | all ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "auto",
+	applies_to = "all elements, and optionally to the ::before and ::after pseudo-elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.user-select"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum UserSelectStyleValue {}

--- a/crates/css_ast/src/values/view_transitions/mod.rs
+++ b/crates/css_ast/src/values/view_transitions/mod.rs
@@ -7,32 +7,6 @@ mod impls;
 use super::prelude::*;
 use impls::*;
 
-/// Represents the style value for `view-transition-name` as defined in [css-view-transitions-2](https://drafts.csswg.org/css-view-transitions-2/#view-transition-name).
-///
-/// View transitions allow you to create animated visual transitions between different states of a document.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// none | <custom-ident>
-/// ```
-///
-// https://drafts.csswg.org/css-view-transitions-2/#view-transition-name
-#[syntax(" none | <custom-ident> ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "none",
-	applies_to = "all elements",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "discrete"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.view-transition-name"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub struct ViewTransitionNameStyleValue;
-
 /// Represents the style value for `view-transition-class` as defined in [css-view-transitions-2](https://drafts.csswg.org/css-view-transitions-2/#view-transition-class).
 ///
 /// The view-transition-class CSS property sets a name that can be used to apply styles to multiple named view transition pseudo-elements.
@@ -82,3 +56,29 @@ pub struct ViewTransitionClassStyleValue<'a>;
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.view-transition-group"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum ViewTransitionGroupStyleValue {}
+
+/// Represents the style value for `view-transition-name` as defined in [css-view-transitions-2](https://drafts.csswg.org/css-view-transitions-2/#view-transition-name).
+///
+/// View transitions allow you to create animated visual transitions between different states of a document.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// none | <custom-ident>
+/// ```
+///
+// https://drafts.csswg.org/css-view-transitions-2/#view-transition-name
+#[syntax(" none | <custom-ident> ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "none",
+	applies_to = "all elements",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "discrete"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.view-transition-name"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub struct ViewTransitionNameStyleValue;

--- a/crates/css_ast/src/values/writing_modes/mod.rs
+++ b/crates/css_ast/src/values/writing_modes/mod.rs
@@ -33,84 +33,6 @@ use impls::*;
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum DirectionStyleValue {}
 
-/// Represents the style value for `unicode-bidi` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#unicode-bidi).
-///
-/// The unicode-bidi and direction CSS properties override the Unicode layout algorithm. They are intended for Document Type Definition (DTD) designers. For HTML documents, you should use the dir global HTML attribute and <bdo> HTML element instead.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// normal | embed | isolate | bidi-override | isolate-override | plaintext
-/// ```
-///
-// https://drafts.csswg.org/css-writing-modes-4/#unicode-bidi
-#[syntax(" normal | embed | isolate | bidi-override | isolate-override | plaintext ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "normal",
-	applies_to = "all elements, but see prose",
-	inherited = "no",
-	percentages = "n/a",
-	canonical_order = "per grammar",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.unicode-bidi"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum UnicodeBidiStyleValue {}
-
-/// Represents the style value for `writing-mode` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#writing-mode).
-///
-/// The writing-mode CSS property sets whether text is laid out horizontally or vertically, and left to right, or right to left.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr
-/// ```
-///
-// https://drafts.csswg.org/css-writing-modes-4/#writing-mode
-#[syntax(" horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "horizontal-tb",
-	applies_to = "All elements except table row groups, table column groups, table rows, table columns, ruby base containers, ruby annotation containers",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "n/a",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.writing-mode"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum WritingModeStyleValue {}
-
-/// Represents the style value for `text-orientation` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#text-orientation).
-///
-/// The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.
-///
-/// The grammar is defined as:
-///
-/// ```text,ignore
-/// mixed | upright | sideways
-/// ```
-///
-// https://drafts.csswg.org/css-writing-modes-4/#text-orientation
-#[syntax(" mixed | upright | sideways ")]
-#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[style_value(
-	initial = "mixed",
-	applies_to = "all elements except table row groups, rows, column groups, and columns; and text",
-	inherited = "yes",
-	percentages = "n/a",
-	canonical_order = "n/a",
-	animation_type = "not animatable"
-)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-orientation"))]
-#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
-pub enum TextOrientationStyleValue {}
-
 /// Represents the style value for `glyph-orientation-vertical` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#glyph-orientation-vertical).
 ///
 /// The glyph-orientation-vertical CSS property sets the orientation of glyphs in text rendered in a vertical writing mode.
@@ -166,3 +88,81 @@ pub enum GlyphOrientationVerticalStyleValue {}
 #[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-combine-upright"))]
 #[cfg_attr(feature = "visitable", derive(Visitable), visit)]
 pub enum TextCombineUprightStyleValue {}
+
+/// Represents the style value for `text-orientation` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#text-orientation).
+///
+/// The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// mixed | upright | sideways
+/// ```
+///
+// https://drafts.csswg.org/css-writing-modes-4/#text-orientation
+#[syntax(" mixed | upright | sideways ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "mixed",
+	applies_to = "all elements except table row groups, rows, column groups, and columns; and text",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "n/a",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.text-orientation"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum TextOrientationStyleValue {}
+
+/// Represents the style value for `unicode-bidi` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#unicode-bidi).
+///
+/// The unicode-bidi and direction CSS properties override the Unicode layout algorithm. They are intended for Document Type Definition (DTD) designers. For HTML documents, you should use the dir global HTML attribute and <bdo> HTML element instead.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// normal | embed | isolate | bidi-override | isolate-override | plaintext
+/// ```
+///
+// https://drafts.csswg.org/css-writing-modes-4/#unicode-bidi
+#[syntax(" normal | embed | isolate | bidi-override | isolate-override | plaintext ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "normal",
+	applies_to = "all elements, but see prose",
+	inherited = "no",
+	percentages = "n/a",
+	canonical_order = "per grammar",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.unicode-bidi"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum UnicodeBidiStyleValue {}
+
+/// Represents the style value for `writing-mode` as defined in [css-writing-modes-4](https://drafts.csswg.org/css-writing-modes-4/#writing-mode).
+///
+/// The writing-mode CSS property sets whether text is laid out horizontally or vertically, and left to right, or right to left.
+///
+/// The grammar is defined as:
+///
+/// ```text,ignore
+/// horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr
+/// ```
+///
+// https://drafts.csswg.org/css-writing-modes-4/#writing-mode
+#[syntax(" horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr ")]
+#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[style_value(
+	initial = "horizontal-tb",
+	applies_to = "All elements except table row groups, table column groups, table rows, table columns, ruby base containers, ruby annotation containers",
+	inherited = "yes",
+	percentages = "n/a",
+	canonical_order = "n/a",
+	animation_type = "not animatable"
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature("css.properties.writing-mode"))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+pub enum WritingModeStyleValue {}

--- a/crates/css_feature_data/src/data.rs
+++ b/crates/css_feature_data/src/data.rs
@@ -1,5 +1,4 @@
 //! Auto-generated CSS features data
-//! Generated on: 2025-10-20T00:03:14.621Z
 
 use crate::*;
 use chrono::NaiveDate;
@@ -137,7 +136,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.8451,
+		popularity: 2.0124,
 	},
 	"css.properties.accent-color.auto" => CSSFeature {
 		id: "css.properties.accent-color.auto",
@@ -156,7 +155,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.8451,
+		popularity: 2.0124,
 	},
 	"css.selectors.active-view-transition" => CSSFeature {
 		id: "css.selectors.active-view-transition",
@@ -164,7 +163,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "The :active-view-transition CSS pseudo-class matches the root element when a view transition is active. The :active-view-transition-type() CSS pseudo-class matches only when the active view transition was started with the specified type.",
 		spec: "https://drafts.csswg.org/css-view-transitions-2/#the-active-view-transition-pseudo",
 		groups: &["view-transitions", "selectors"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(125,0),
 						chrome_android: BrowserVersion(125,0),
@@ -232,7 +231,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4412,
+		popularity: 0.5833,
 	},
 	"css.properties.alignment-baseline.alphabetic" => CSSFeature {
 		id: "css.properties.alignment-baseline.alphabetic",
@@ -251,7 +250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4412,
+		popularity: 0.5833,
 	},
 	"css.properties.alignment-baseline.baseline" => CSSFeature {
 		id: "css.properties.alignment-baseline.baseline",
@@ -270,7 +269,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4412,
+		popularity: 0.5833,
 	},
 	"css.properties.alignment-baseline.central" => CSSFeature {
 		id: "css.properties.alignment-baseline.central",
@@ -289,7 +288,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4412,
+		popularity: 0.5833,
 	},
 	"css.properties.alignment-baseline.ideographic" => CSSFeature {
 		id: "css.properties.alignment-baseline.ideographic",
@@ -308,7 +307,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4412,
+		popularity: 0.5833,
 	},
 	"css.properties.alignment-baseline.mathematical" => CSSFeature {
 		id: "css.properties.alignment-baseline.mathematical",
@@ -327,7 +326,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4412,
+		popularity: 0.5833,
 	},
 	"css.properties.alignment-baseline.middle" => CSSFeature {
 		id: "css.properties.alignment-baseline.middle",
@@ -346,7 +345,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4412,
+		popularity: 0.5833,
 	},
 	"css.properties.alignment-baseline.text-after-edge" => CSSFeature {
 		id: "css.properties.alignment-baseline.text-after-edge",
@@ -365,7 +364,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4412,
+		popularity: 0.5833,
 	},
 	"css.properties.alignment-baseline.text-before-edge" => CSSFeature {
 		id: "css.properties.alignment-baseline.text-before-edge",
@@ -384,7 +383,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 0.4412,
+		popularity: 0.5833,
 	},
 	"css.properties.all" => CSSFeature {
 		id: "css.properties.all",
@@ -403,7 +402,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-all"],
-		popularity: 11.4668,
+		popularity: 12.9544,
 	},
 	"css.properties.content.alt_text" => CSSFeature {
 		id: "css.properties.content.alt_text",
@@ -2892,7 +2891,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &[],
-		popularity: 0.2861,
+		popularity: 0.3790,
 	},
 	"css.at-rules.keyframes" => CSSFeature {
 		id: "css.at-rules.keyframes",
@@ -3424,7 +3423,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.auto" => CSSFeature {
 		id: "css.properties.appearance.auto",
@@ -3443,7 +3442,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.button" => CSSFeature {
 		id: "css.properties.appearance.button",
@@ -3462,7 +3461,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.checkbox" => CSSFeature {
 		id: "css.properties.appearance.checkbox",
@@ -3481,7 +3480,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.listbox" => CSSFeature {
 		id: "css.properties.appearance.listbox",
@@ -3500,7 +3499,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.menulist" => CSSFeature {
 		id: "css.properties.appearance.menulist",
@@ -3519,7 +3518,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.menulist-button" => CSSFeature {
 		id: "css.properties.appearance.menulist-button",
@@ -3538,7 +3537,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.meter" => CSSFeature {
 		id: "css.properties.appearance.meter",
@@ -3557,7 +3556,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.none" => CSSFeature {
 		id: "css.properties.appearance.none",
@@ -3576,7 +3575,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.progress-bar" => CSSFeature {
 		id: "css.properties.appearance.progress-bar",
@@ -3595,7 +3594,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.radio" => CSSFeature {
 		id: "css.properties.appearance.radio",
@@ -3614,7 +3613,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.searchfield" => CSSFeature {
 		id: "css.properties.appearance.searchfield",
@@ -3633,7 +3632,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.textarea" => CSSFeature {
 		id: "css.properties.appearance.textarea",
@@ -3652,7 +3651,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.appearance.textfield" => CSSFeature {
 		id: "css.properties.appearance.textfield",
@@ -3671,7 +3670,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 44.0857,
+		popularity: 45.8998,
 	},
 	"css.properties.aspect-ratio" => CSSFeature {
 		id: "css.properties.aspect-ratio",
@@ -3690,7 +3689,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,0),
 				},
 		caniuse: &[],
-		popularity: 32.4605,
+		popularity: 30.2041,
 	},
 	"css.properties.aspect-ratio.auto" => CSSFeature {
 		id: "css.properties.aspect-ratio.auto",
@@ -3709,7 +3708,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,0),
 				},
 		caniuse: &[],
-		popularity: 32.4605,
+		popularity: 30.2041,
 	},
 	"css.types.attr.fallback" => CSSFeature {
 		id: "css.types.attr.fallback",
@@ -4051,7 +4050,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,0),
 				},
 		caniuse: &["https://caniuse.com/css-backdrop-filter"],
-		popularity: 29.7701,
+		popularity: 28.1973,
 	},
 	"css.properties.background" => CSSFeature {
 		id: "css.properties.background",
@@ -4070,7 +4069,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/multibackgrounds"],
-		popularity: 86.9962,
+		popularity: 87.2349,
 	},
 	"css.properties.background.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background.multiple_backgrounds",
@@ -4089,7 +4088,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/multibackgrounds"],
-		popularity: 86.9962,
+		popularity: 87.2349,
 	},
 	"css.properties.background-attachment" => CSSFeature {
 		id: "css.properties.background-attachment",
@@ -4108,7 +4107,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.2788,
+		popularity: 8.3945,
 	},
 	"css.properties.background-attachment.fixed" => CSSFeature {
 		id: "css.properties.background-attachment.fixed",
@@ -4127,7 +4126,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.2788,
+		popularity: 8.3945,
 	},
 	"css.properties.background-attachment.local" => CSSFeature {
 		id: "css.properties.background-attachment.local",
@@ -4146,7 +4145,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.2788,
+		popularity: 8.3945,
 	},
 	"css.properties.background-attachment.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background-attachment.multiple_backgrounds",
@@ -4165,7 +4164,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.2788,
+		popularity: 8.3945,
 	},
 	"css.properties.background-attachment.scroll" => CSSFeature {
 		id: "css.properties.background-attachment.scroll",
@@ -4184,7 +4183,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/background-attachment"],
-		popularity: 8.2788,
+		popularity: 8.3945,
 	},
 	"css.properties.background-blend-mode" => CSSFeature {
 		id: "css.properties.background-blend-mode",
@@ -4203,7 +4202,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-backgroundblendmode"],
-		popularity: 3.7362,
+		popularity: 4.1735,
 	},
 	"css.types.blend-mode" => CSSFeature {
 		id: "css.types.blend-mode",
@@ -4222,7 +4221,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-backgroundblendmode"],
-		popularity: 3.7362,
+		popularity: 4.1735,
 	},
 	"css.properties.background-clip" => CSSFeature {
 		id: "css.properties.background-clip",
@@ -4241,7 +4240,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.7793,
+		popularity: 43.3438,
 	},
 	"css.properties.background-clip.border-box" => CSSFeature {
 		id: "css.properties.background-clip.border-box",
@@ -4260,7 +4259,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.7793,
+		popularity: 43.3438,
 	},
 	"css.properties.background-clip.content-box" => CSSFeature {
 		id: "css.properties.background-clip.content-box",
@@ -4279,7 +4278,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.7793,
+		popularity: 43.3438,
 	},
 	"css.properties.background-clip.padding-box" => CSSFeature {
 		id: "css.properties.background-clip.padding-box",
@@ -4298,7 +4297,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.7793,
+		popularity: 43.3438,
 	},
 	"css.properties.background.background-clip" => CSSFeature {
 		id: "css.properties.background.background-clip",
@@ -4317,7 +4316,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &[],
-		popularity: 40.7793,
+		popularity: 43.3438,
 	},
 	"css.properties.background-clip.border-area" => CSSFeature {
 		id: "css.properties.background-clip.border-area",
@@ -4374,7 +4373,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.3859,
+		popularity: 89.7507,
 	},
 	"css.properties.background-image" => CSSFeature {
 		id: "css.properties.background-image",
@@ -4393,7 +4392,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 77.4377,
+		popularity: 77.7969,
 	},
 	"css.properties.background-image.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background-image.multiple_backgrounds",
@@ -4412,7 +4411,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 77.4377,
+		popularity: 77.7969,
 	},
 	"css.properties.background-image.none" => CSSFeature {
 		id: "css.properties.background-image.none",
@@ -4431,7 +4430,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 77.4377,
+		popularity: 77.7969,
 	},
 	"css.properties.background-origin" => CSSFeature {
 		id: "css.properties.background-origin",
@@ -4450,7 +4449,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.4820,
+		popularity: 7.2517,
 	},
 	"css.properties.background-origin.border-box" => CSSFeature {
 		id: "css.properties.background-origin.border-box",
@@ -4469,7 +4468,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.4820,
+		popularity: 7.2517,
 	},
 	"css.properties.background-origin.content-box" => CSSFeature {
 		id: "css.properties.background-origin.content-box",
@@ -4488,7 +4487,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.4820,
+		popularity: 7.2517,
 	},
 	"css.properties.background-origin.padding-box" => CSSFeature {
 		id: "css.properties.background-origin.padding-box",
@@ -4507,7 +4506,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.4820,
+		popularity: 7.2517,
 	},
 	"css.properties.background.background-origin" => CSSFeature {
 		id: "css.properties.background.background-origin",
@@ -4526,7 +4525,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,0),
 				},
 		caniuse: &[],
-		popularity: 7.4820,
+		popularity: 7.2517,
 	},
 	"css.properties.background-position" => CSSFeature {
 		id: "css.properties.background-position",
@@ -4545,7 +4544,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position-x" => CSSFeature {
 		id: "css.properties.background-position-x",
@@ -4564,7 +4563,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position-x.side-relative_values" => CSSFeature {
 		id: "css.properties.background-position-x.side-relative_values",
@@ -4583,7 +4582,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position-y" => CSSFeature {
 		id: "css.properties.background-position-y",
@@ -4602,7 +4601,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position-y.side-relative_values" => CSSFeature {
 		id: "css.properties.background-position-y.side-relative_values",
@@ -4621,7 +4620,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position.bottom" => CSSFeature {
 		id: "css.properties.background-position.bottom",
@@ -4640,7 +4639,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position.center" => CSSFeature {
 		id: "css.properties.background-position.center",
@@ -4659,7 +4658,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position.left" => CSSFeature {
 		id: "css.properties.background-position.left",
@@ -4678,7 +4677,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background-position.multiple_backgrounds",
@@ -4697,7 +4696,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position.right" => CSSFeature {
 		id: "css.properties.background-position.right",
@@ -4716,7 +4715,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position.side-relative_values" => CSSFeature {
 		id: "css.properties.background-position.side-relative_values",
@@ -4735,7 +4734,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-position.top" => CSSFeature {
 		id: "css.properties.background-position.top",
@@ -4754,7 +4753,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/css-background-offsets", "https://caniuse.com/background-position-x-y"],
-		popularity: 75.1153,
+		popularity: 75.0076,
 	},
 	"css.properties.background-repeat" => CSSFeature {
 		id: "css.properties.background-repeat",
@@ -4773,7 +4772,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.2894,
+		popularity: 71.8905,
 	},
 	"css.properties.background-repeat.2-value" => CSSFeature {
 		id: "css.properties.background-repeat.2-value",
@@ -4792,7 +4791,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.2894,
+		popularity: 71.8905,
 	},
 	"css.properties.background-repeat.multiple_backgrounds" => CSSFeature {
 		id: "css.properties.background-repeat.multiple_backgrounds",
@@ -4811,7 +4810,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.2894,
+		popularity: 71.8905,
 	},
 	"css.properties.background-repeat.no-repeat" => CSSFeature {
 		id: "css.properties.background-repeat.no-repeat",
@@ -4830,7 +4829,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.2894,
+		popularity: 71.8905,
 	},
 	"css.properties.background-repeat.repeat" => CSSFeature {
 		id: "css.properties.background-repeat.repeat",
@@ -4849,7 +4848,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.2894,
+		popularity: 71.8905,
 	},
 	"css.properties.background-repeat.repeat-x" => CSSFeature {
 		id: "css.properties.background-repeat.repeat-x",
@@ -4868,7 +4867,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.2894,
+		popularity: 71.8905,
 	},
 	"css.properties.background-repeat.repeat-y" => CSSFeature {
 		id: "css.properties.background-repeat.repeat-y",
@@ -4887,7 +4886,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.2894,
+		popularity: 71.8905,
 	},
 	"css.properties.background-repeat.round" => CSSFeature {
 		id: "css.properties.background-repeat.round",
@@ -4906,7 +4905,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.2894,
+		popularity: 71.8905,
 	},
 	"css.properties.background-repeat.space" => CSSFeature {
 		id: "css.properties.background-repeat.space",
@@ -4925,7 +4924,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/background-repeat-round-space"],
-		popularity: 72.2894,
+		popularity: 71.8905,
 	},
 	"css.properties.background-size" => CSSFeature {
 		id: "css.properties.background-size",
@@ -4944,7 +4943,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.1641,
+		popularity: 72.2386,
 	},
 	"css.properties.background-size.auto" => CSSFeature {
 		id: "css.properties.background-size.auto",
@@ -4963,7 +4962,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.1641,
+		popularity: 72.2386,
 	},
 	"css.properties.background-size.contain" => CSSFeature {
 		id: "css.properties.background-size.contain",
@@ -4982,7 +4981,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.1641,
+		popularity: 72.2386,
 	},
 	"css.properties.background-size.cover" => CSSFeature {
 		id: "css.properties.background-size.cover",
@@ -5001,7 +5000,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.1641,
+		popularity: 72.2386,
 	},
 	"css.properties.background.background-size" => CSSFeature {
 		id: "css.properties.background.background-size",
@@ -5020,7 +5019,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &[],
-		popularity: 73.1641,
+		popularity: 72.2386,
 	},
 	"css.properties.baseline-shift" => CSSFeature {
 		id: "css.properties.baseline-shift",
@@ -5039,7 +5038,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.3885,
+		popularity: 0.4674,
 	},
 	"css.properties.baseline-shift.baseline" => CSSFeature {
 		id: "css.properties.baseline-shift.baseline",
@@ -5058,7 +5057,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.3885,
+		popularity: 0.4674,
 	},
 	"css.properties.baseline-shift.sub" => CSSFeature {
 		id: "css.properties.baseline-shift.sub",
@@ -5077,7 +5076,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.3885,
+		popularity: 0.4674,
 	},
 	"css.properties.baseline-shift.super" => CSSFeature {
 		id: "css.properties.baseline-shift.super",
@@ -5096,7 +5095,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.3885,
+		popularity: 0.4674,
 	},
 	"css.properties.baseline-source" => CSSFeature {
 		id: "css.properties.baseline-source",
@@ -5115,7 +5114,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0243,
+		popularity: 0.0264,
 	},
 	"css.properties.baseline-source.auto" => CSSFeature {
 		id: "css.properties.baseline-source.auto",
@@ -5134,7 +5133,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0243,
+		popularity: 0.0264,
 	},
 	"css.properties.baseline-source.first" => CSSFeature {
 		id: "css.properties.baseline-source.first",
@@ -5153,7 +5152,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0243,
+		popularity: 0.0264,
 	},
 	"css.properties.baseline-source.last" => CSSFeature {
 		id: "css.properties.baseline-source.last",
@@ -5172,7 +5171,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0243,
+		popularity: 0.0264,
 	},
 	"css.selectors.after" => CSSFeature {
 		id: "css.selectors.after",
@@ -5267,7 +5266,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-outset" => CSSFeature {
 		id: "css.properties.border-image-outset",
@@ -5286,7 +5285,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-repeat" => CSSFeature {
 		id: "css.properties.border-image-repeat",
@@ -5305,7 +5304,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-repeat.repeat" => CSSFeature {
 		id: "css.properties.border-image-repeat.repeat",
@@ -5324,7 +5323,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-repeat.round" => CSSFeature {
 		id: "css.properties.border-image-repeat.round",
@@ -5343,7 +5342,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-repeat.space" => CSSFeature {
 		id: "css.properties.border-image-repeat.space",
@@ -5362,7 +5361,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-repeat.stretch" => CSSFeature {
 		id: "css.properties.border-image-repeat.stretch",
@@ -5381,7 +5380,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-slice" => CSSFeature {
 		id: "css.properties.border-image-slice",
@@ -5400,7 +5399,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-source" => CSSFeature {
 		id: "css.properties.border-image-source",
@@ -5419,7 +5418,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-width" => CSSFeature {
 		id: "css.properties.border-image-width",
@@ -5438,7 +5437,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image-width.auto" => CSSFeature {
 		id: "css.properties.border-image-width.auto",
@@ -5457,7 +5456,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image.fill" => CSSFeature {
 		id: "css.properties.border-image.fill",
@@ -5476,7 +5475,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image.gradient" => CSSFeature {
 		id: "css.properties.border-image.gradient",
@@ -5495,7 +5494,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-image.optional_border_image_slice" => CSSFeature {
 		id: "css.properties.border-image.optional_border_image_slice",
@@ -5514,7 +5513,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/border-image"],
-		popularity: 5.3882,
+		popularity: 5.4173,
 	},
 	"css.properties.border-bottom-left-radius" => CSSFeature {
 		id: "css.properties.border-bottom-left-radius",
@@ -5533,7 +5532,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-bottom-left-radius.elliptical_corners" => CSSFeature {
 		id: "css.properties.border-bottom-left-radius.elliptical_corners",
@@ -5552,7 +5551,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-bottom-left-radius.percentages" => CSSFeature {
 		id: "css.properties.border-bottom-left-radius.percentages",
@@ -5571,7 +5570,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-bottom-right-radius" => CSSFeature {
 		id: "css.properties.border-bottom-right-radius",
@@ -5590,7 +5589,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-bottom-right-radius.elliptical_corners" => CSSFeature {
 		id: "css.properties.border-bottom-right-radius.elliptical_corners",
@@ -5609,7 +5608,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-bottom-right-radius.percentages" => CSSFeature {
 		id: "css.properties.border-bottom-right-radius.percentages",
@@ -5628,7 +5627,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-radius" => CSSFeature {
 		id: "css.properties.border-radius",
@@ -5647,7 +5646,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-radius.4_values_for_4_corners" => CSSFeature {
 		id: "css.properties.border-radius.4_values_for_4_corners",
@@ -5666,7 +5665,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-radius.elliptical_borders" => CSSFeature {
 		id: "css.properties.border-radius.elliptical_borders",
@@ -5685,7 +5684,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-radius.percentages" => CSSFeature {
 		id: "css.properties.border-radius.percentages",
@@ -5704,7 +5703,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-top-left-radius" => CSSFeature {
 		id: "css.properties.border-top-left-radius",
@@ -5723,7 +5722,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-top-left-radius.elliptical_corners" => CSSFeature {
 		id: "css.properties.border-top-left-radius.elliptical_corners",
@@ -5742,7 +5741,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-top-left-radius.percentages" => CSSFeature {
 		id: "css.properties.border-top-left-radius.percentages",
@@ -5761,7 +5760,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-top-right-radius" => CSSFeature {
 		id: "css.properties.border-top-right-radius",
@@ -5780,7 +5779,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-top-right-radius.elliptical_corners" => CSSFeature {
 		id: "css.properties.border-top-right-radius.elliptical_corners",
@@ -5799,7 +5798,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border-top-right-radius.percentages" => CSSFeature {
 		id: "css.properties.border-top-right-radius.percentages",
@@ -5818,7 +5817,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(4,2),
 				},
 		caniuse: &["https://caniuse.com/border-radius"],
-		popularity: 85.9938,
+		popularity: 85.8865,
 	},
 	"css.properties.border" => CSSFeature {
 		id: "css.properties.border",
@@ -6426,7 +6425,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-boxdecorationbreak"],
-		popularity: 2.0897,
+		popularity: 2.5842,
 	},
 	"css.properties.box-decoration-break.clone" => CSSFeature {
 		id: "css.properties.box-decoration-break.clone",
@@ -6445,7 +6444,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-boxdecorationbreak"],
-		popularity: 2.0897,
+		popularity: 2.5842,
 	},
 	"css.properties.box-decoration-break.slice" => CSSFeature {
 		id: "css.properties.box-decoration-break.slice",
@@ -6464,7 +6463,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-boxdecorationbreak"],
-		popularity: 2.0897,
+		popularity: 2.5842,
 	},
 	"css.properties.box-shadow" => CSSFeature {
 		id: "css.properties.box-shadow",
@@ -6483,7 +6482,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &["https://caniuse.com/css-boxshadow"],
-		popularity: 81.3924,
+		popularity: 81.5068,
 	},
 	"css.properties.box-shadow.inset" => CSSFeature {
 		id: "css.properties.box-shadow.inset",
@@ -6502,7 +6501,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &["https://caniuse.com/css-boxshadow"],
-		popularity: 81.3924,
+		popularity: 81.5068,
 	},
 	"css.properties.box-shadow.multiple_shadows" => CSSFeature {
 		id: "css.properties.box-shadow.multiple_shadows",
@@ -6521,7 +6520,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &["https://caniuse.com/css-boxshadow"],
-		popularity: 81.3924,
+		popularity: 81.5068,
 	},
 	"css.properties.box-shadow.spread_radius" => CSSFeature {
 		id: "css.properties.box-shadow.spread_radius",
@@ -6540,7 +6539,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(5,0),
 				},
 		caniuse: &["https://caniuse.com/css-boxshadow"],
-		popularity: 81.3924,
+		popularity: 81.5068,
 	},
 	"css.properties.box-sizing" => CSSFeature {
 		id: "css.properties.box-sizing",
@@ -6559,7 +6558,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(6,0),
 				},
 		caniuse: &["https://caniuse.com/css3-boxsizing"],
-		popularity: 85.2495,
+		popularity: 85.4739,
 	},
 	"css.properties.box-sizing.border-box" => CSSFeature {
 		id: "css.properties.box-sizing.border-box",
@@ -6578,7 +6577,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(6,0),
 				},
 		caniuse: &["https://caniuse.com/css3-boxsizing"],
-		popularity: 85.2495,
+		popularity: 85.4739,
 	},
 	"css.properties.box-sizing.content-box" => CSSFeature {
 		id: "css.properties.box-sizing.content-box",
@@ -6597,7 +6596,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(6,0),
 				},
 		caniuse: &["https://caniuse.com/css3-boxsizing"],
-		popularity: 85.2495,
+		popularity: 85.4739,
 	},
 	"css.types.calc" => CSSFeature {
 		id: "css.types.calc",
@@ -6825,7 +6824,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &["https://caniuse.com/css-caret-color"],
-		popularity: 13.2078,
+		popularity: 14.8500,
 	},
 	"css.properties.caret-shape" => CSSFeature {
 		id: "css.properties.caret-shape",
@@ -7072,7 +7071,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 49.6618,
+		popularity: 51.7410,
 	},
 	"css.properties.clip.auto" => CSSFeature {
 		id: "css.properties.clip.auto",
@@ -7091,7 +7090,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 49.6618,
+		popularity: 51.7410,
 	},
 	"css.types.shape" => CSSFeature {
 		id: "css.types.shape",
@@ -7110,7 +7109,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 49.6618,
+		popularity: 51.7410,
 	},
 	"css.types.shape.rect" => CSSFeature {
 		id: "css.types.shape.rect",
@@ -7129,7 +7128,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 49.6618,
+		popularity: 51.7410,
 	},
 	"css.properties.clip-path" => CSSFeature {
 		id: "css.properties.clip-path",
@@ -7148,7 +7147,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.3345,
+		popularity: 40.4376,
 	},
 	"css.properties.clip-path.basic_shape" => CSSFeature {
 		id: "css.properties.clip-path.basic_shape",
@@ -7167,7 +7166,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.3345,
+		popularity: 40.4376,
 	},
 	"css.properties.clip-path.html_elements" => CSSFeature {
 		id: "css.properties.clip-path.html_elements",
@@ -7186,7 +7185,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.3345,
+		popularity: 40.4376,
 	},
 	"css.properties.clip-path.path" => CSSFeature {
 		id: "css.properties.clip-path.path",
@@ -7205,7 +7204,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.3345,
+		popularity: 40.4376,
 	},
 	"css.properties.clip-path.svg_elements" => CSSFeature {
 		id: "css.properties.clip-path.svg_elements",
@@ -7224,7 +7223,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 39.3345,
+		popularity: 40.4376,
 	},
 	"css.properties.clip-path.is_animatable" => CSSFeature {
 		id: "css.properties.clip-path.is_animatable",
@@ -7319,7 +7318,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.5811,
+		popularity: 89.9217,
 	},
 	"css.types.color" => CSSFeature {
 		id: "css.types.color",
@@ -7338,7 +7337,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.5811,
+		popularity: 89.9217,
 	},
 	"css.properties.color-adjust" => CSSFeature {
 		id: "css.properties.color-adjust",
@@ -7452,7 +7451,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.2504,
+		popularity: 17.9243,
 	},
 	"css.properties.color-scheme.dark" => CSSFeature {
 		id: "css.properties.color-scheme.dark",
@@ -7471,7 +7470,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.2504,
+		popularity: 17.9243,
 	},
 	"css.properties.color-scheme.light" => CSSFeature {
 		id: "css.properties.color-scheme.light",
@@ -7490,7 +7489,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.2504,
+		popularity: 17.9243,
 	},
 	"css.properties.color-scheme.normal" => CSSFeature {
 		id: "css.properties.color-scheme.normal",
@@ -7509,7 +7508,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.2504,
+		popularity: 17.9243,
 	},
 	"css.properties.color-scheme.only" => CSSFeature {
 		id: "css.properties.color-scheme.only",
@@ -7528,7 +7527,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 17.2504,
+		popularity: 17.9243,
 	},
 	"css.at-rules.font-face.OpenType_COLRv0" => CSSFeature {
 		id: "css.at-rules.font-face.OpenType_COLRv0",
@@ -7870,7 +7869,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.8715,
+		popularity: 1.7343,
 	},
 	"css.properties.column-fill.auto" => CSSFeature {
 		id: "css.properties.column-fill.auto",
@@ -7889,7 +7888,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.8715,
+		popularity: 1.7343,
 	},
 	"css.properties.column-fill.balance" => CSSFeature {
 		id: "css.properties.column-fill.balance",
@@ -7908,7 +7907,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.8715,
+		popularity: 1.7343,
 	},
 	"css.selectors.column" => CSSFeature {
 		id: "css.selectors.column",
@@ -7965,7 +7964,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 0.8852,
+		popularity: 0.8247,
 	},
 	"css.properties.column-span.all" => CSSFeature {
 		id: "css.properties.column-span.all",
@@ -7984,7 +7983,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 0.8852,
+		popularity: 0.8247,
 	},
 	"css.properties.column-span.none" => CSSFeature {
 		id: "css.properties.column-span.none",
@@ -8003,7 +8002,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 0.8852,
+		popularity: 0.8247,
 	},
 	"css.types.gradient.conic-gradient" => CSSFeature {
 		id: "css.types.gradient.conic-gradient",
@@ -8098,7 +8097,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-containment"],
-		popularity: 19.0893,
+		popularity: 20.5373,
 	},
 	"css.properties.contain.content" => CSSFeature {
 		id: "css.properties.contain.content",
@@ -8117,7 +8116,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-containment"],
-		popularity: 19.0893,
+		popularity: 20.5373,
 	},
 	"css.properties.contain.none" => CSSFeature {
 		id: "css.properties.contain.none",
@@ -8136,7 +8135,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-containment"],
-		popularity: 19.0893,
+		popularity: 20.5373,
 	},
 	"css.properties.contain.strict" => CSSFeature {
 		id: "css.properties.contain.strict",
@@ -8155,7 +8154,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-containment"],
-		popularity: 19.0893,
+		popularity: 20.5373,
 	},
 	"css.properties.contain.inline-size" => CSSFeature {
 		id: "css.properties.contain.inline-size",
@@ -8193,7 +8192,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-block-size.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-block-size.none",
@@ -8212,7 +8211,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-height" => CSSFeature {
 		id: "css.properties.contain-intrinsic-height",
@@ -8231,7 +8230,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-height.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-height.none",
@@ -8250,7 +8249,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-inline-size" => CSSFeature {
 		id: "css.properties.contain-intrinsic-inline-size",
@@ -8269,7 +8268,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-inline-size.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-inline-size.none",
@@ -8288,7 +8287,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-size" => CSSFeature {
 		id: "css.properties.contain-intrinsic-size",
@@ -8307,7 +8306,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-size.auto_none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-size.auto_none",
@@ -8326,7 +8325,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-size.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-size.none",
@@ -8345,7 +8344,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-width" => CSSFeature {
 		id: "css.properties.contain-intrinsic-width",
@@ -8364,7 +8363,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain-intrinsic-width.none" => CSSFeature {
 		id: "css.properties.contain-intrinsic-width.none",
@@ -8383,7 +8382,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 7.2439,
+		popularity: 6.5173,
 	},
 	"css.properties.contain.layout" => CSSFeature {
 		id: "css.properties.contain.layout",
@@ -8763,7 +8762,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2817,
+		popularity: 81.5847,
 	},
 	"css.properties.content.element_replacement" => CSSFeature {
 		id: "css.properties.content.element_replacement",
@@ -8782,7 +8781,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2817,
+		popularity: 81.5847,
 	},
 	"css.properties.content.gradient" => CSSFeature {
 		id: "css.properties.content.gradient",
@@ -8801,7 +8800,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2817,
+		popularity: 81.5847,
 	},
 	"css.properties.content.none" => CSSFeature {
 		id: "css.properties.content.none",
@@ -8820,7 +8819,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2817,
+		popularity: 81.5847,
 	},
 	"css.properties.content.none_applies_to_elements" => CSSFeature {
 		id: "css.properties.content.none_applies_to_elements",
@@ -8839,7 +8838,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2817,
+		popularity: 81.5847,
 	},
 	"css.properties.content.normal" => CSSFeature {
 		id: "css.properties.content.normal",
@@ -8858,7 +8857,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2817,
+		popularity: 81.5847,
 	},
 	"css.properties.content.url" => CSSFeature {
 		id: "css.properties.content.url",
@@ -8877,7 +8876,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2817,
+		popularity: 81.5847,
 	},
 	"css.types.string" => CSSFeature {
 		id: "css.types.string",
@@ -8896,7 +8895,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2817,
+		popularity: 81.5847,
 	},
 	"css.types.string.unicode_escaped_characters" => CSSFeature {
 		id: "css.types.string.unicode_escaped_characters",
@@ -8915,7 +8914,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.2817,
+		popularity: 81.5847,
 	},
 	"css.properties.content-visibility" => CSSFeature {
 		id: "css.properties.content-visibility",
@@ -8934,7 +8933,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &["https://caniuse.com/css-content-visibility"],
-		popularity: 5.9751,
+		popularity: 5.6245,
 	},
 	"css.properties.content-visibility.auto" => CSSFeature {
 		id: "css.properties.content-visibility.auto",
@@ -8953,7 +8952,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &["https://caniuse.com/css-content-visibility"],
-		popularity: 5.9751,
+		popularity: 5.6245,
 	},
 	"css.properties.content-visibility.hidden" => CSSFeature {
 		id: "css.properties.content-visibility.hidden",
@@ -8972,7 +8971,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &["https://caniuse.com/css-content-visibility"],
-		popularity: 5.9751,
+		popularity: 5.6245,
 	},
 	"css.properties.content-visibility.visible" => CSSFeature {
 		id: "css.properties.content-visibility.visible",
@@ -8991,7 +8990,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &["https://caniuse.com/css-content-visibility"],
-		popularity: 5.9751,
+		popularity: 5.6245,
 	},
 	"css.types.color.contrast-color" => CSSFeature {
 		id: "css.types.color.contrast-color",
@@ -9029,7 +9028,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-block-start-shape" => CSSFeature {
 		id: "css.properties.corner-block-start-shape",
@@ -9048,7 +9047,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-bottom-left-shape" => CSSFeature {
 		id: "css.properties.corner-bottom-left-shape",
@@ -9067,7 +9066,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-bottom-right-shape" => CSSFeature {
 		id: "css.properties.corner-bottom-right-shape",
@@ -9086,7 +9085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-bottom-shape" => CSSFeature {
 		id: "css.properties.corner-bottom-shape",
@@ -9105,7 +9104,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-end-end-shape" => CSSFeature {
 		id: "css.properties.corner-end-end-shape",
@@ -9124,7 +9123,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-end-start-shape" => CSSFeature {
 		id: "css.properties.corner-end-start-shape",
@@ -9143,7 +9142,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-inline-end-shape" => CSSFeature {
 		id: "css.properties.corner-inline-end-shape",
@@ -9162,7 +9161,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-inline-start-shape" => CSSFeature {
 		id: "css.properties.corner-inline-start-shape",
@@ -9181,7 +9180,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-left-shape" => CSSFeature {
 		id: "css.properties.corner-left-shape",
@@ -9200,7 +9199,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-right-shape" => CSSFeature {
 		id: "css.properties.corner-right-shape",
@@ -9219,7 +9218,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-shape" => CSSFeature {
 		id: "css.properties.corner-shape",
@@ -9238,7 +9237,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-start-end-shape" => CSSFeature {
 		id: "css.properties.corner-start-end-shape",
@@ -9257,7 +9256,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-start-start-shape" => CSSFeature {
 		id: "css.properties.corner-start-start-shape",
@@ -9276,7 +9275,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-top-left-shape" => CSSFeature {
 		id: "css.properties.corner-top-left-shape",
@@ -9295,7 +9294,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-top-right-shape" => CSSFeature {
 		id: "css.properties.corner-top-right-shape",
@@ -9314,7 +9313,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.corner-top-shape" => CSSFeature {
 		id: "css.properties.corner-top-shape",
@@ -9333,7 +9332,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.types.corner-shape-value" => CSSFeature {
 		id: "css.types.corner-shape-value",
@@ -9352,7 +9351,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.types.corner-shape-value.bevel" => CSSFeature {
 		id: "css.types.corner-shape-value.bevel",
@@ -9371,7 +9370,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.types.corner-shape-value.notch" => CSSFeature {
 		id: "css.types.corner-shape-value.notch",
@@ -9390,7 +9389,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.types.corner-shape-value.round" => CSSFeature {
 		id: "css.types.corner-shape-value.round",
@@ -9409,7 +9408,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.types.corner-shape-value.scoop" => CSSFeature {
 		id: "css.types.corner-shape-value.scoop",
@@ -9428,7 +9427,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.types.corner-shape-value.square" => CSSFeature {
 		id: "css.types.corner-shape-value.square",
@@ -9447,7 +9446,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.types.corner-shape-value.squircle" => CSSFeature {
 		id: "css.types.corner-shape-value.squircle",
@@ -9466,7 +9465,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.types.corner-shape-value.superellipse" => CSSFeature {
 		id: "css.types.corner-shape-value.superellipse",
@@ -9485,7 +9484,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.types.superellipse" => CSSFeature {
 		id: "css.types.superellipse",
@@ -9504,7 +9503,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2352,
+		popularity: 0.2069,
 	},
 	"css.properties.counter-reset.reversed" => CSSFeature {
 		id: "css.properties.counter-reset.reversed",
@@ -9542,7 +9541,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,2),
 				},
 		caniuse: &[],
-		popularity: 0.3944,
+		popularity: 0.6309,
 	},
 	"css.properties.counter-set.list-item" => CSSFeature {
 		id: "css.properties.counter-set.list-item",
@@ -9561,7 +9560,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,2),
 				},
 		caniuse: &[],
-		popularity: 0.3944,
+		popularity: 0.6309,
 	},
 	"css.properties.counter-set.none" => CSSFeature {
 		id: "css.properties.counter-set.none",
@@ -9580,7 +9579,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,2),
 				},
 		caniuse: &[],
-		popularity: 0.3944,
+		popularity: 0.6309,
 	},
 	"css.at-rules.counter-style" => CSSFeature {
 		id: "css.at-rules.counter-style",
@@ -10093,7 +10092,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.alias" => CSSFeature {
 		id: "css.properties.cursor.alias",
@@ -10112,7 +10111,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.all-scroll" => CSSFeature {
 		id: "css.properties.cursor.all-scroll",
@@ -10131,7 +10130,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.auto" => CSSFeature {
 		id: "css.properties.cursor.auto",
@@ -10150,7 +10149,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.cell" => CSSFeature {
 		id: "css.properties.cursor.cell",
@@ -10169,7 +10168,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.col-resize" => CSSFeature {
 		id: "css.properties.cursor.col-resize",
@@ -10188,7 +10187,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.context-menu" => CSSFeature {
 		id: "css.properties.cursor.context-menu",
@@ -10207,7 +10206,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.copy" => CSSFeature {
 		id: "css.properties.cursor.copy",
@@ -10226,7 +10225,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.crosshair" => CSSFeature {
 		id: "css.properties.cursor.crosshair",
@@ -10245,7 +10244,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.default" => CSSFeature {
 		id: "css.properties.cursor.default",
@@ -10264,7 +10263,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.e-resize" => CSSFeature {
 		id: "css.properties.cursor.e-resize",
@@ -10283,7 +10282,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.ew-resize" => CSSFeature {
 		id: "css.properties.cursor.ew-resize",
@@ -10302,7 +10301,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.grab" => CSSFeature {
 		id: "css.properties.cursor.grab",
@@ -10321,7 +10320,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.grabbing" => CSSFeature {
 		id: "css.properties.cursor.grabbing",
@@ -10340,7 +10339,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.help" => CSSFeature {
 		id: "css.properties.cursor.help",
@@ -10359,7 +10358,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.move" => CSSFeature {
 		id: "css.properties.cursor.move",
@@ -10378,7 +10377,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.n-resize" => CSSFeature {
 		id: "css.properties.cursor.n-resize",
@@ -10397,7 +10396,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.ne-resize" => CSSFeature {
 		id: "css.properties.cursor.ne-resize",
@@ -10416,7 +10415,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.nesw-resize" => CSSFeature {
 		id: "css.properties.cursor.nesw-resize",
@@ -10435,7 +10434,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.no-drop" => CSSFeature {
 		id: "css.properties.cursor.no-drop",
@@ -10454,7 +10453,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.none" => CSSFeature {
 		id: "css.properties.cursor.none",
@@ -10473,7 +10472,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.not-allowed" => CSSFeature {
 		id: "css.properties.cursor.not-allowed",
@@ -10492,7 +10491,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.ns-resize" => CSSFeature {
 		id: "css.properties.cursor.ns-resize",
@@ -10511,7 +10510,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.nw-resize" => CSSFeature {
 		id: "css.properties.cursor.nw-resize",
@@ -10530,7 +10529,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.nwse-resize" => CSSFeature {
 		id: "css.properties.cursor.nwse-resize",
@@ -10549,7 +10548,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.pointer" => CSSFeature {
 		id: "css.properties.cursor.pointer",
@@ -10568,7 +10567,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.progress" => CSSFeature {
 		id: "css.properties.cursor.progress",
@@ -10587,7 +10586,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.row-resize" => CSSFeature {
 		id: "css.properties.cursor.row-resize",
@@ -10606,7 +10605,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.s-resize" => CSSFeature {
 		id: "css.properties.cursor.s-resize",
@@ -10625,7 +10624,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.se-resize" => CSSFeature {
 		id: "css.properties.cursor.se-resize",
@@ -10644,7 +10643,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.sw-resize" => CSSFeature {
 		id: "css.properties.cursor.sw-resize",
@@ -10663,7 +10662,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.text" => CSSFeature {
 		id: "css.properties.cursor.text",
@@ -10682,7 +10681,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.url" => CSSFeature {
 		id: "css.properties.cursor.url",
@@ -10701,7 +10700,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.url_positioning_syntax" => CSSFeature {
 		id: "css.properties.cursor.url_positioning_syntax",
@@ -10720,7 +10719,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.vertical-text" => CSSFeature {
 		id: "css.properties.cursor.vertical-text",
@@ -10739,7 +10738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.w-resize" => CSSFeature {
 		id: "css.properties.cursor.w-resize",
@@ -10758,7 +10757,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.wait" => CSSFeature {
 		id: "css.properties.cursor.wait",
@@ -10777,7 +10776,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.zoom-in" => CSSFeature {
 		id: "css.properties.cursor.zoom-in",
@@ -10796,7 +10795,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.cursor.zoom-out" => CSSFeature {
 		id: "css.properties.cursor.zoom-out",
@@ -10815,7 +10814,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-		popularity: 83.9438,
+		popularity: 84.3805,
 	},
 	"css.properties.text-overflow.string" => CSSFeature {
 		id: "css.properties.text-overflow.string",
@@ -11100,7 +11099,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 91.9782,
+		popularity: 92.3380,
 	},
 	"css.properties.display.block" => CSSFeature {
 		id: "css.properties.display.block",
@@ -11119,7 +11118,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 91.9782,
+		popularity: 92.3380,
 	},
 	"css.properties.display.inline" => CSSFeature {
 		id: "css.properties.display.inline",
@@ -11138,7 +11137,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 91.9782,
+		popularity: 92.3380,
 	},
 	"css.properties.display.inline-block" => CSSFeature {
 		id: "css.properties.display.inline-block",
@@ -11157,7 +11156,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 91.9782,
+		popularity: 92.3380,
 	},
 	"css.properties.display.none" => CSSFeature {
 		id: "css.properties.display.none",
@@ -11176,7 +11175,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 91.9782,
+		popularity: 92.3380,
 	},
 	"css.properties.display.none.option_is_hidden" => CSSFeature {
 		id: "css.properties.display.none.option_is_hidden",
@@ -11195,7 +11194,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/inline-block"],
-		popularity: 91.9782,
+		popularity: 92.3380,
 	},
 	"css.properties.content-visibility.is_transitionable" => CSSFeature {
 		id: "css.properties.content-visibility.is_transitionable",
@@ -11784,7 +11783,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6937,
+		popularity: 0.8490,
 	},
 	"css.properties.dominant-baseline.alphabetic" => CSSFeature {
 		id: "css.properties.dominant-baseline.alphabetic",
@@ -11803,7 +11802,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6937,
+		popularity: 0.8490,
 	},
 	"css.properties.dominant-baseline.auto" => CSSFeature {
 		id: "css.properties.dominant-baseline.auto",
@@ -11822,7 +11821,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6937,
+		popularity: 0.8490,
 	},
 	"css.properties.dominant-baseline.central" => CSSFeature {
 		id: "css.properties.dominant-baseline.central",
@@ -11841,7 +11840,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6937,
+		popularity: 0.8490,
 	},
 	"css.properties.dominant-baseline.hanging" => CSSFeature {
 		id: "css.properties.dominant-baseline.hanging",
@@ -11860,7 +11859,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6937,
+		popularity: 0.8490,
 	},
 	"css.properties.dominant-baseline.ideographic" => CSSFeature {
 		id: "css.properties.dominant-baseline.ideographic",
@@ -11879,7 +11878,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6937,
+		popularity: 0.8490,
 	},
 	"css.properties.dominant-baseline.mathematical" => CSSFeature {
 		id: "css.properties.dominant-baseline.mathematical",
@@ -11898,7 +11897,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6937,
+		popularity: 0.8490,
 	},
 	"css.properties.dominant-baseline.middle" => CSSFeature {
 		id: "css.properties.dominant-baseline.middle",
@@ -11917,7 +11916,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &[],
-		popularity: 0.6937,
+		popularity: 0.8490,
 	},
 	"css.at-rules.media.dynamic-range" => CSSFeature {
 		id: "css.at-rules.media.dynamic-range",
@@ -12164,7 +12163,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.9115,
+		popularity: 1.1247,
 	},
 	"css.properties.field-sizing.content" => CSSFeature {
 		id: "css.properties.field-sizing.content",
@@ -12183,7 +12182,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.9115,
+		popularity: 1.1247,
 	},
 	"css.properties.field-sizing.fixed" => CSSFeature {
 		id: "css.properties.field-sizing.fixed",
@@ -12202,7 +12201,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.9115,
+		popularity: 1.1247,
 	},
 	"css.selectors.file-selector-button" => CSSFeature {
 		id: "css.selectors.file-selector-button",
@@ -12240,7 +12239,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.blur" => CSSFeature {
 		id: "css.properties.filter.blur",
@@ -12259,7 +12258,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.brightness" => CSSFeature {
 		id: "css.properties.filter.brightness",
@@ -12278,7 +12277,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.contrast" => CSSFeature {
 		id: "css.properties.filter.contrast",
@@ -12297,7 +12296,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.drop-shadow" => CSSFeature {
 		id: "css.properties.filter.drop-shadow",
@@ -12316,7 +12315,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.grayscale" => CSSFeature {
 		id: "css.properties.filter.grayscale",
@@ -12335,7 +12334,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.hue-rotate" => CSSFeature {
 		id: "css.properties.filter.hue-rotate",
@@ -12354,7 +12353,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.invert" => CSSFeature {
 		id: "css.properties.filter.invert",
@@ -12373,7 +12372,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.opacity" => CSSFeature {
 		id: "css.properties.filter.opacity",
@@ -12392,7 +12391,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.saturate" => CSSFeature {
 		id: "css.properties.filter.saturate",
@@ -12411,7 +12410,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.properties.filter.sepia" => CSSFeature {
 		id: "css.properties.filter.sepia",
@@ -12430,7 +12429,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function" => CSSFeature {
 		id: "css.types.filter-function",
@@ -12449,7 +12448,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.blur" => CSSFeature {
 		id: "css.types.filter-function.blur",
@@ -12468,7 +12467,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.brightness" => CSSFeature {
 		id: "css.types.filter-function.brightness",
@@ -12487,7 +12486,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.contrast" => CSSFeature {
 		id: "css.types.filter-function.contrast",
@@ -12506,7 +12505,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.drop-shadow" => CSSFeature {
 		id: "css.types.filter-function.drop-shadow",
@@ -12525,7 +12524,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.grayscale" => CSSFeature {
 		id: "css.types.filter-function.grayscale",
@@ -12544,7 +12543,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.hue-rotate" => CSSFeature {
 		id: "css.types.filter-function.hue-rotate",
@@ -12563,7 +12562,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.invert" => CSSFeature {
 		id: "css.types.filter-function.invert",
@@ -12582,7 +12581,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.opacity" => CSSFeature {
 		id: "css.types.filter-function.opacity",
@@ -12601,7 +12600,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.saturate" => CSSFeature {
 		id: "css.types.filter-function.saturate",
@@ -12620,7 +12619,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.types.filter-function.sepia" => CSSFeature {
 		id: "css.types.filter-function.sepia",
@@ -12639,7 +12638,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-filters"],
-		popularity: 48.7909,
+		popularity: 48.7905,
 	},
 	"css.selectors.first-letter" => CSSFeature {
 		id: "css.selectors.first-letter",
@@ -14767,7 +14766,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &["https://caniuse.com/css-font-rendering-controls"],
-		popularity: 51.9080,
+		popularity: 49.8808,
 	},
 	"css.at-rules.font-face" => CSSFeature {
 		id: "css.at-rules.font-face",
@@ -15033,7 +15032,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.8486,
+		popularity: 88.0038,
 	},
 	"css.properties.font-family.math" => CSSFeature {
 		id: "css.properties.font-family.math",
@@ -15166,7 +15165,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-feature"],
-		popularity: 20.6067,
+		popularity: 21.3760,
 	},
 	"css.properties.font-feature-settings" => CSSFeature {
 		id: "css.properties.font-feature-settings",
@@ -15185,7 +15184,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-feature"],
-		popularity: 20.6067,
+		popularity: 21.3760,
 	},
 	"css.properties.font-feature-settings.normal" => CSSFeature {
 		id: "css.properties.font-feature-settings.normal",
@@ -15204,7 +15203,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-feature"],
-		popularity: 20.6067,
+		popularity: 21.3760,
 	},
 	"css.properties.font-kerning" => CSSFeature {
 		id: "css.properties.font-kerning",
@@ -15223,7 +15222,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/font-kerning"],
-		popularity: 1.5747,
+		popularity: 1.7092,
 	},
 	"css.properties.font-kerning.auto" => CSSFeature {
 		id: "css.properties.font-kerning.auto",
@@ -15242,7 +15241,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/font-kerning"],
-		popularity: 1.5747,
+		popularity: 1.7092,
 	},
 	"css.properties.font-kerning.none" => CSSFeature {
 		id: "css.properties.font-kerning.none",
@@ -15261,7 +15260,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/font-kerning"],
-		popularity: 1.5747,
+		popularity: 1.7092,
 	},
 	"css.properties.font-kerning.normal" => CSSFeature {
 		id: "css.properties.font-kerning.normal",
@@ -15280,7 +15279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/font-kerning"],
-		popularity: 1.5747,
+		popularity: 1.7092,
 	},
 	"css.properties.font-language-override" => CSSFeature {
 		id: "css.properties.font-language-override",
@@ -15299,7 +15298,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1899,
+		popularity: 0.2582,
 	},
 	"css.at-rules.font-face.ascent-override" => CSSFeature {
 		id: "css.at-rules.font-face.ascent-override",
@@ -15375,7 +15374,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 1.8358,
+		popularity: 1.9537,
 	},
 	"css.properties.font-optical-sizing.auto" => CSSFeature {
 		id: "css.properties.font-optical-sizing.auto",
@@ -15394,7 +15393,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 1.8358,
+		popularity: 1.9537,
 	},
 	"css.properties.font-optical-sizing.none" => CSSFeature {
 		id: "css.properties.font-optical-sizing.none",
@@ -15413,7 +15412,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 1.8358,
+		popularity: 1.9537,
 	},
 	"css.at-rules.font-palette-values" => CSSFeature {
 		id: "css.at-rules.font-palette-values",
@@ -15432,7 +15431,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0342,
+		popularity: 0.0428,
 	},
 	"css.at-rules.font-palette-values.base-palette" => CSSFeature {
 		id: "css.at-rules.font-palette-values.base-palette",
@@ -15451,7 +15450,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0342,
+		popularity: 0.0428,
 	},
 	"css.at-rules.font-palette-values.font-family" => CSSFeature {
 		id: "css.at-rules.font-palette-values.font-family",
@@ -15470,7 +15469,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0342,
+		popularity: 0.0428,
 	},
 	"css.at-rules.font-palette-values.override-colors" => CSSFeature {
 		id: "css.at-rules.font-palette-values.override-colors",
@@ -15489,7 +15488,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0342,
+		popularity: 0.0428,
 	},
 	"css.properties.font-palette" => CSSFeature {
 		id: "css.properties.font-palette",
@@ -15508,7 +15507,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0342,
+		popularity: 0.0428,
 	},
 	"css.properties.font-palette.dark" => CSSFeature {
 		id: "css.properties.font-palette.dark",
@@ -15527,7 +15526,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0342,
+		popularity: 0.0428,
 	},
 	"css.properties.font-palette.light" => CSSFeature {
 		id: "css.properties.font-palette.light",
@@ -15546,7 +15545,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0342,
+		popularity: 0.0428,
 	},
 	"css.properties.font-palette.normal" => CSSFeature {
 		id: "css.properties.font-palette.normal",
@@ -15565,7 +15564,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-font-palette"],
-		popularity: 0.0342,
+		popularity: 0.0428,
 	},
 	"css.properties.font-palette.animation_computed" => CSSFeature {
 		id: "css.properties.font-palette.animation_computed",
@@ -15755,7 +15754,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.3614,
+		popularity: 89.5584,
 	},
 	"css.properties.font-size.rem_values" => CSSFeature {
 		id: "css.properties.font-size.rem_values",
@@ -15774,7 +15773,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.3614,
+		popularity: 89.5584,
 	},
 	"css.properties.font-size.xxx-large" => CSSFeature {
 		id: "css.properties.font-size.xxx-large",
@@ -15793,7 +15792,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 89.3614,
+		popularity: 89.5584,
 	},
 	"css.at-rules.font-face.size-adjust" => CSSFeature {
 		id: "css.at-rules.font-face.size-adjust",
@@ -15812,7 +15811,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7119,
+		popularity: 1.7537,
 	},
 	"css.properties.font-size-adjust" => CSSFeature {
 		id: "css.properties.font-size-adjust",
@@ -15831,7 +15830,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7119,
+		popularity: 1.7537,
 	},
 	"css.properties.font-size-adjust.from-font" => CSSFeature {
 		id: "css.properties.font-size-adjust.from-font",
@@ -15850,7 +15849,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7119,
+		popularity: 1.7537,
 	},
 	"css.properties.font-size-adjust.none" => CSSFeature {
 		id: "css.properties.font-size-adjust.none",
@@ -15869,7 +15868,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7119,
+		popularity: 1.7537,
 	},
 	"css.properties.font-size-adjust.two-values" => CSSFeature {
 		id: "css.properties.font-size-adjust.two-values",
@@ -15888,7 +15887,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/font-size-adjust"],
-		popularity: 1.7119,
+		popularity: 1.7537,
 	},
 	"css.at-rules.font-face.font-stretch" => CSSFeature {
 		id: "css.at-rules.font-face.font-stretch",
@@ -15907,7 +15906,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/css-font-stretch"],
-		popularity: 23.8904,
+		popularity: 23.8199,
 	},
 	"css.properties.font-stretch" => CSSFeature {
 		id: "css.properties.font-stretch",
@@ -15926,7 +15925,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/css-font-stretch"],
-		popularity: 23.8904,
+		popularity: 23.8199,
 	},
 	"css.properties.font-stretch.percentage" => CSSFeature {
 		id: "css.properties.font-stretch.percentage",
@@ -15945,7 +15944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/css-font-stretch"],
-		popularity: 23.8904,
+		popularity: 23.8199,
 	},
 	"css.properties.font.font-width_keyword_values" => CSSFeature {
 		id: "css.properties.font.font-width_keyword_values",
@@ -15964,7 +15963,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/css-font-stretch"],
-		popularity: 23.8904,
+		popularity: 23.8199,
 	},
 	"css.at-rules.font-face.font-style" => CSSFeature {
 		id: "css.at-rules.font-face.font-style",
@@ -15983,7 +15982,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 78.6069,
+		popularity: 79.0850,
 	},
 	"css.properties.font-style" => CSSFeature {
 		id: "css.properties.font-style",
@@ -16002,7 +16001,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 78.6069,
+		popularity: 79.0850,
 	},
 	"css.properties.font-style.italic" => CSSFeature {
 		id: "css.properties.font-style.italic",
@@ -16021,7 +16020,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 78.6069,
+		popularity: 79.0850,
 	},
 	"css.properties.font-style.normal" => CSSFeature {
 		id: "css.properties.font-style.normal",
@@ -16040,7 +16039,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 78.6069,
+		popularity: 79.0850,
 	},
 	"css.properties.font-style.oblique-angle" => CSSFeature {
 		id: "css.properties.font-style.oblique-angle",
@@ -16059,7 +16058,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 78.6069,
+		popularity: 79.0850,
 	},
 	"css.properties.font-synthesis" => CSSFeature {
 		id: "css.properties.font-synthesis",
@@ -16078,7 +16077,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4310,
+		popularity: 1.5569,
 	},
 	"css.properties.font-synthesis.position" => CSSFeature {
 		id: "css.properties.font-synthesis.position",
@@ -16097,7 +16096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4310,
+		popularity: 1.5569,
 	},
 	"css.properties.font-synthesis.small-caps" => CSSFeature {
 		id: "css.properties.font-synthesis.small-caps",
@@ -16116,7 +16115,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4310,
+		popularity: 1.5569,
 	},
 	"css.properties.font-synthesis.style" => CSSFeature {
 		id: "css.properties.font-synthesis.style",
@@ -16135,7 +16134,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4310,
+		popularity: 1.5569,
 	},
 	"css.properties.font-synthesis.weight" => CSSFeature {
 		id: "css.properties.font-synthesis.weight",
@@ -16154,7 +16153,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &[],
-		popularity: 1.4310,
+		popularity: 1.5569,
 	},
 	"css.properties.font-synthesis-position" => CSSFeature {
 		id: "css.properties.font-synthesis-position",
@@ -16230,7 +16229,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0144,
+		popularity: 0.0173,
 	},
 	"css.properties.font-synthesis-small-caps.auto" => CSSFeature {
 		id: "css.properties.font-synthesis-small-caps.auto",
@@ -16249,7 +16248,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0144,
+		popularity: 0.0173,
 	},
 	"css.properties.font-synthesis-small-caps.none" => CSSFeature {
 		id: "css.properties.font-synthesis-small-caps.none",
@@ -16268,7 +16267,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0144,
+		popularity: 0.0173,
 	},
 	"css.properties.font-synthesis-style" => CSSFeature {
 		id: "css.properties.font-synthesis-style",
@@ -16287,7 +16286,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0360,
+		popularity: 0.0376,
 	},
 	"css.properties.font-synthesis-style.auto" => CSSFeature {
 		id: "css.properties.font-synthesis-style.auto",
@@ -16306,7 +16305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0360,
+		popularity: 0.0376,
 	},
 	"css.properties.font-synthesis-style.none" => CSSFeature {
 		id: "css.properties.font-synthesis-style.none",
@@ -16325,7 +16324,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0360,
+		popularity: 0.0376,
 	},
 	"css.properties.font-synthesis-weight" => CSSFeature {
 		id: "css.properties.font-synthesis-weight",
@@ -16344,7 +16343,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0809,
+		popularity: 0.0982,
 	},
 	"css.properties.font-synthesis-weight.auto" => CSSFeature {
 		id: "css.properties.font-synthesis-weight.auto",
@@ -16363,7 +16362,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0809,
+		popularity: 0.0982,
 	},
 	"css.properties.font-synthesis-weight.none" => CSSFeature {
 		id: "css.properties.font-synthesis-weight.none",
@@ -16382,7 +16381,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 0.0809,
+		popularity: 0.0982,
 	},
 	"css.at-rules.font-face.font-variant" => CSSFeature {
 		id: "css.at-rules.font-face.font-variant",
@@ -16401,7 +16400,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant" => CSSFeature {
 		id: "css.properties.font-variant",
@@ -16420,7 +16419,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant.css_fonts_shorthand" => CSSFeature {
 		id: "css.properties.font-variant.css_fonts_shorthand",
@@ -16439,7 +16438,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant.greek_accented_characters" => CSSFeature {
 		id: "css.properties.font-variant.greek_accented_characters",
@@ -16458,7 +16457,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant.historical-forms" => CSSFeature {
 		id: "css.properties.font-variant.historical-forms",
@@ -16477,7 +16476,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant.none" => CSSFeature {
 		id: "css.properties.font-variant.none",
@@ -16496,7 +16495,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant.normal" => CSSFeature {
 		id: "css.properties.font-variant.normal",
@@ -16515,7 +16514,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant.sub" => CSSFeature {
 		id: "css.properties.font-variant.sub",
@@ -16534,7 +16533,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant.super" => CSSFeature {
 		id: "css.properties.font-variant.super",
@@ -16553,7 +16552,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant.turkic_is" => CSSFeature {
 		id: "css.properties.font-variant.turkic_is",
@@ -16572,7 +16571,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.properties.font-variant.uppercase_eszett" => CSSFeature {
 		id: "css.properties.font-variant.uppercase_eszett",
@@ -16591,7 +16590,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 27.9218,
+		popularity: 28.0023,
 	},
 	"css.at-rules.font-feature-values" => CSSFeature {
 		id: "css.at-rules.font-feature-values",
@@ -16610,7 +16609,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.at-rules.font-feature-values.annotation" => CSSFeature {
 		id: "css.at-rules.font-feature-values.annotation",
@@ -16629,7 +16628,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.at-rules.font-feature-values.character-variant" => CSSFeature {
 		id: "css.at-rules.font-feature-values.character-variant",
@@ -16648,7 +16647,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.at-rules.font-feature-values.historical-forms" => CSSFeature {
 		id: "css.at-rules.font-feature-values.historical-forms",
@@ -16667,7 +16666,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.at-rules.font-feature-values.ornaments" => CSSFeature {
 		id: "css.at-rules.font-feature-values.ornaments",
@@ -16686,7 +16685,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.at-rules.font-feature-values.styleset" => CSSFeature {
 		id: "css.at-rules.font-feature-values.styleset",
@@ -16705,7 +16704,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.at-rules.font-feature-values.stylistic" => CSSFeature {
 		id: "css.at-rules.font-feature-values.stylistic",
@@ -16724,7 +16723,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.at-rules.font-feature-values.swash" => CSSFeature {
 		id: "css.at-rules.font-feature-values.swash",
@@ -16743,7 +16742,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-alternates" => CSSFeature {
 		id: "css.properties.font-variant-alternates",
@@ -16762,7 +16761,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-alternates.annotation" => CSSFeature {
 		id: "css.properties.font-variant-alternates.annotation",
@@ -16781,7 +16780,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-alternates.character_variant" => CSSFeature {
 		id: "css.properties.font-variant-alternates.character_variant",
@@ -16800,7 +16799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-alternates.historical-forms" => CSSFeature {
 		id: "css.properties.font-variant-alternates.historical-forms",
@@ -16819,7 +16818,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-alternates.normal" => CSSFeature {
 		id: "css.properties.font-variant-alternates.normal",
@@ -16838,7 +16837,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-alternates.ornaments" => CSSFeature {
 		id: "css.properties.font-variant-alternates.ornaments",
@@ -16857,7 +16856,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-alternates.styleset" => CSSFeature {
 		id: "css.properties.font-variant-alternates.styleset",
@@ -16876,7 +16875,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-alternates.stylistic" => CSSFeature {
 		id: "css.properties.font-variant-alternates.stylistic",
@@ -16895,7 +16894,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-alternates.swash" => CSSFeature {
 		id: "css.properties.font-variant-alternates.swash",
@@ -16914,7 +16913,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-alternates"],
-		popularity: 0.2799,
+		popularity: 0.3476,
 	},
 	"css.properties.font-variant-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps",
@@ -16933,7 +16932,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.6949,
+		popularity: 0.8554,
 	},
 	"css.properties.font-variant-caps.all-petite-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.all-petite-caps",
@@ -16952,7 +16951,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.6949,
+		popularity: 0.8554,
 	},
 	"css.properties.font-variant-caps.all-small-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.all-small-caps",
@@ -16971,7 +16970,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.6949,
+		popularity: 0.8554,
 	},
 	"css.properties.font-variant-caps.normal" => CSSFeature {
 		id: "css.properties.font-variant-caps.normal",
@@ -16990,7 +16989,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.6949,
+		popularity: 0.8554,
 	},
 	"css.properties.font-variant-caps.petite-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.petite-caps",
@@ -17009,7 +17008,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.6949,
+		popularity: 0.8554,
 	},
 	"css.properties.font-variant-caps.small-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.small-caps",
@@ -17028,7 +17027,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.6949,
+		popularity: 0.8554,
 	},
 	"css.properties.font-variant-caps.titling-caps" => CSSFeature {
 		id: "css.properties.font-variant-caps.titling-caps",
@@ -17047,7 +17046,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.6949,
+		popularity: 0.8554,
 	},
 	"css.properties.font-variant-caps.unicase" => CSSFeature {
 		id: "css.properties.font-variant-caps.unicase",
@@ -17066,7 +17065,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.6949,
+		popularity: 0.8554,
 	},
 	"css.properties.font-variant-east-asian" => CSSFeature {
 		id: "css.properties.font-variant-east-asian",
@@ -17085,7 +17084,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.full-width" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.full-width",
@@ -17104,7 +17103,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.jis04" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.jis04",
@@ -17123,7 +17122,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.jis78" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.jis78",
@@ -17142,7 +17141,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.jis83" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.jis83",
@@ -17161,7 +17160,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.jis90" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.jis90",
@@ -17180,7 +17179,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.normal" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.normal",
@@ -17199,7 +17198,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.proportional-width" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.proportional-width",
@@ -17218,7 +17217,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.ruby" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.ruby",
@@ -17237,7 +17236,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.simplified" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.simplified",
@@ -17256,7 +17255,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-east-asian.traditional" => CSSFeature {
 		id: "css.properties.font-variant-east-asian.traditional",
@@ -17275,7 +17274,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.5098,
+		popularity: 0.5692,
 	},
 	"css.properties.font-variant-emoji" => CSSFeature {
 		id: "css.properties.font-variant-emoji",
@@ -17294,7 +17293,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0477,
+		popularity: 0.0612,
 	},
 	"css.properties.font-variant-emoji.emoji" => CSSFeature {
 		id: "css.properties.font-variant-emoji.emoji",
@@ -17313,7 +17312,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0477,
+		popularity: 0.0612,
 	},
 	"css.properties.font-variant-emoji.normal" => CSSFeature {
 		id: "css.properties.font-variant-emoji.normal",
@@ -17332,7 +17331,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0477,
+		popularity: 0.0612,
 	},
 	"css.properties.font-variant-emoji.text" => CSSFeature {
 		id: "css.properties.font-variant-emoji.text",
@@ -17351,7 +17350,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0477,
+		popularity: 0.0612,
 	},
 	"css.properties.font-variant-emoji.unicode" => CSSFeature {
 		id: "css.properties.font-variant-emoji.unicode",
@@ -17370,7 +17369,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0477,
+		popularity: 0.0612,
 	},
 	"css.properties.font-variant-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures",
@@ -17389,7 +17388,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.common-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.common-ligatures",
@@ -17408,7 +17407,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.contextual" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.contextual",
@@ -17427,7 +17426,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.discretionary-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.discretionary-ligatures",
@@ -17446,7 +17445,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.historical-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.historical-ligatures",
@@ -17465,7 +17464,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.no-common-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.no-common-ligatures",
@@ -17484,7 +17483,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.no-contextual" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.no-contextual",
@@ -17503,7 +17502,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.no-discretionary-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.no-discretionary-ligatures",
@@ -17522,7 +17521,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.no-historical-ligatures" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.no-historical-ligatures",
@@ -17541,7 +17540,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.none" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.none",
@@ -17560,7 +17559,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-ligatures.normal" => CSSFeature {
 		id: "css.properties.font-variant-ligatures.normal",
@@ -17579,7 +17578,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 5.6938,
+		popularity: 7.1392,
 	},
 	"css.properties.font-variant-numeric" => CSSFeature {
 		id: "css.properties.font-variant-numeric",
@@ -17598,7 +17597,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-numeric.diagonal-fractions" => CSSFeature {
 		id: "css.properties.font-variant-numeric.diagonal-fractions",
@@ -17617,7 +17616,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-numeric.lining-nums" => CSSFeature {
 		id: "css.properties.font-variant-numeric.lining-nums",
@@ -17636,7 +17635,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-numeric.normal" => CSSFeature {
 		id: "css.properties.font-variant-numeric.normal",
@@ -17655,7 +17654,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-numeric.oldstyle-nums" => CSSFeature {
 		id: "css.properties.font-variant-numeric.oldstyle-nums",
@@ -17674,7 +17673,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-numeric.ordinal" => CSSFeature {
 		id: "css.properties.font-variant-numeric.ordinal",
@@ -17693,7 +17692,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-numeric.proportional-nums" => CSSFeature {
 		id: "css.properties.font-variant-numeric.proportional-nums",
@@ -17712,7 +17711,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-numeric.slashed-zero" => CSSFeature {
 		id: "css.properties.font-variant-numeric.slashed-zero",
@@ -17731,7 +17730,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-numeric.stacked-fractions" => CSSFeature {
 		id: "css.properties.font-variant-numeric.stacked-fractions",
@@ -17750,7 +17749,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-numeric.tabular-nums" => CSSFeature {
 		id: "css.properties.font-variant-numeric.tabular-nums",
@@ -17769,7 +17768,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/font-variant-numeric"],
-		popularity: 4.6095,
+		popularity: 5.0792,
 	},
 	"css.properties.font-variant-position" => CSSFeature {
 		id: "css.properties.font-variant-position",
@@ -17788,7 +17787,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.2672,
+		popularity: 0.3036,
 	},
 	"css.properties.font-variant-position.normal" => CSSFeature {
 		id: "css.properties.font-variant-position.normal",
@@ -17807,7 +17806,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.2672,
+		popularity: 0.3036,
 	},
 	"css.properties.font-variant-position.sub" => CSSFeature {
 		id: "css.properties.font-variant-position.sub",
@@ -17826,7 +17825,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.2672,
+		popularity: 0.3036,
 	},
 	"css.properties.font-variant-position.super" => CSSFeature {
 		id: "css.properties.font-variant-position.super",
@@ -17845,7 +17844,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &[],
-		popularity: 0.2672,
+		popularity: 0.3036,
 	},
 	"css.at-rules.font-face.font-variation-settings" => CSSFeature {
 		id: "css.at-rules.font-face.font-variation-settings",
@@ -17864,7 +17863,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/variable-fonts"],
-		popularity: 16.9931,
+		popularity: 18.7501,
 	},
 	"css.properties.font-variation-settings" => CSSFeature {
 		id: "css.properties.font-variation-settings",
@@ -17883,7 +17882,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,0),
 				},
 		caniuse: &["https://caniuse.com/variable-fonts"],
-		popularity: 16.9931,
+		popularity: 18.7501,
 	},
 	"css.at-rules.font-face.font-weight" => CSSFeature {
 		id: "css.at-rules.font-face.font-weight",
@@ -17902,7 +17901,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.4273,
+		popularity: 87.7921,
 	},
 	"css.properties.font-weight" => CSSFeature {
 		id: "css.properties.font-weight",
@@ -17921,7 +17920,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.4273,
+		popularity: 87.7921,
 	},
 	"css.properties.font-weight.bold" => CSSFeature {
 		id: "css.properties.font-weight.bold",
@@ -17940,7 +17939,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.4273,
+		popularity: 87.7921,
 	},
 	"css.properties.font-weight.bolder" => CSSFeature {
 		id: "css.properties.font-weight.bolder",
@@ -17959,7 +17958,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.4273,
+		popularity: 87.7921,
 	},
 	"css.properties.font-weight.lighter" => CSSFeature {
 		id: "css.properties.font-weight.lighter",
@@ -17978,7 +17977,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.4273,
+		popularity: 87.7921,
 	},
 	"css.properties.font-weight.normal" => CSSFeature {
 		id: "css.properties.font-weight.normal",
@@ -17997,7 +17996,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.4273,
+		popularity: 87.7921,
 	},
 	"css.properties.font-weight.number" => CSSFeature {
 		id: "css.properties.font-weight.number",
@@ -18016,7 +18015,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.4273,
+		popularity: 87.7921,
 	},
 	"css.properties.font-width" => CSSFeature {
 		id: "css.properties.font-width",
@@ -19365,7 +19364,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.align-items.grid_context" => CSSFeature {
 		id: "css.properties.align-items.grid_context",
@@ -19384,7 +19383,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.align-items.grid_context.start_end" => CSSFeature {
 		id: "css.properties.align-items.grid_context.start_end",
@@ -19403,7 +19402,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.align-self.grid_context" => CSSFeature {
 		id: "css.properties.align-self.grid_context",
@@ -19422,7 +19421,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.column-gap.grid_context" => CSSFeature {
 		id: "css.properties.column-gap.grid_context",
@@ -19441,7 +19440,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.display.grid" => CSSFeature {
 		id: "css.properties.display.grid",
@@ -19460,7 +19459,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.display.inline-grid" => CSSFeature {
 		id: "css.properties.display.inline-grid",
@@ -19479,7 +19478,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.gap" => CSSFeature {
 		id: "css.properties.gap",
@@ -19498,7 +19497,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.gap.grid_context" => CSSFeature {
 		id: "css.properties.gap.grid_context",
@@ -19517,7 +19516,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.gap.grid_context.calc_values" => CSSFeature {
 		id: "css.properties.gap.grid_context.calc_values",
@@ -19536,7 +19535,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.gap.grid_context.percentage_values" => CSSFeature {
 		id: "css.properties.gap.grid_context.percentage_values",
@@ -19555,7 +19554,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.gap.normal" => CSSFeature {
 		id: "css.properties.gap.normal",
@@ -19574,7 +19573,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid" => CSSFeature {
 		id: "css.properties.grid",
@@ -19593,7 +19592,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-area" => CSSFeature {
 		id: "css.properties.grid-area",
@@ -19612,7 +19611,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-auto-columns" => CSSFeature {
 		id: "css.properties.grid-auto-columns",
@@ -19631,7 +19630,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-auto-flow" => CSSFeature {
 		id: "css.properties.grid-auto-flow",
@@ -19650,7 +19649,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-auto-flow.column" => CSSFeature {
 		id: "css.properties.grid-auto-flow.column",
@@ -19669,7 +19668,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-auto-flow.dense" => CSSFeature {
 		id: "css.properties.grid-auto-flow.dense",
@@ -19688,7 +19687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-auto-flow.row" => CSSFeature {
 		id: "css.properties.grid-auto-flow.row",
@@ -19707,7 +19706,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-auto-rows" => CSSFeature {
 		id: "css.properties.grid-auto-rows",
@@ -19726,7 +19725,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-column" => CSSFeature {
 		id: "css.properties.grid-column",
@@ -19745,7 +19744,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-column-end" => CSSFeature {
 		id: "css.properties.grid-column-end",
@@ -19764,7 +19763,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-column-start" => CSSFeature {
 		id: "css.properties.grid-column-start",
@@ -19783,7 +19782,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-row" => CSSFeature {
 		id: "css.properties.grid-row",
@@ -19802,7 +19801,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-row-end" => CSSFeature {
 		id: "css.properties.grid-row-end",
@@ -19821,7 +19820,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-row-start" => CSSFeature {
 		id: "css.properties.grid-row-start",
@@ -19840,7 +19839,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template" => CSSFeature {
 		id: "css.properties.grid-template",
@@ -19859,7 +19858,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-areas" => CSSFeature {
 		id: "css.properties.grid-template-areas",
@@ -19878,7 +19877,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-areas.none" => CSSFeature {
 		id: "css.properties.grid-template-areas.none",
@@ -19897,7 +19896,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-columns" => CSSFeature {
 		id: "css.properties.grid-template-columns",
@@ -19916,7 +19915,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-columns.auto" => CSSFeature {
 		id: "css.properties.grid-template-columns.auto",
@@ -19935,7 +19934,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-columns.fit-content" => CSSFeature {
 		id: "css.properties.grid-template-columns.fit-content",
@@ -19954,7 +19953,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-columns.max-content" => CSSFeature {
 		id: "css.properties.grid-template-columns.max-content",
@@ -19973,7 +19972,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-columns.min-content" => CSSFeature {
 		id: "css.properties.grid-template-columns.min-content",
@@ -19992,7 +19991,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-columns.minmax" => CSSFeature {
 		id: "css.properties.grid-template-columns.minmax",
@@ -20011,7 +20010,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-columns.none" => CSSFeature {
 		id: "css.properties.grid-template-columns.none",
@@ -20030,7 +20029,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-columns.repeat" => CSSFeature {
 		id: "css.properties.grid-template-columns.repeat",
@@ -20049,7 +20048,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-rows" => CSSFeature {
 		id: "css.properties.grid-template-rows",
@@ -20068,7 +20067,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-rows.auto" => CSSFeature {
 		id: "css.properties.grid-template-rows.auto",
@@ -20087,7 +20086,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-rows.fit-content" => CSSFeature {
 		id: "css.properties.grid-template-rows.fit-content",
@@ -20106,7 +20105,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-rows.max-content" => CSSFeature {
 		id: "css.properties.grid-template-rows.max-content",
@@ -20125,7 +20124,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-rows.min-content" => CSSFeature {
 		id: "css.properties.grid-template-rows.min-content",
@@ -20144,7 +20143,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-rows.minmax" => CSSFeature {
 		id: "css.properties.grid-template-rows.minmax",
@@ -20163,7 +20162,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-rows.none" => CSSFeature {
 		id: "css.properties.grid-template-rows.none",
@@ -20182,7 +20181,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-rows.repeat" => CSSFeature {
 		id: "css.properties.grid-template-rows.repeat",
@@ -20201,7 +20200,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template.none" => CSSFeature {
 		id: "css.properties.grid-template.none",
@@ -20220,7 +20219,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.justify-content.grid_context" => CSSFeature {
 		id: "css.properties.justify-content.grid_context",
@@ -20239,7 +20238,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.justify-items.grid_context" => CSSFeature {
 		id: "css.properties.justify-items.grid_context",
@@ -20258,7 +20257,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.justify-self" => CSSFeature {
 		id: "css.properties.justify-self",
@@ -20277,7 +20276,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.justify-self.auto" => CSSFeature {
 		id: "css.properties.justify-self.auto",
@@ -20296,7 +20295,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.justify-self.grid_context" => CSSFeature {
 		id: "css.properties.justify-self.grid_context",
@@ -20315,7 +20314,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.justify-self.left" => CSSFeature {
 		id: "css.properties.justify-self.left",
@@ -20334,7 +20333,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.justify-self.normal" => CSSFeature {
 		id: "css.properties.justify-self.normal",
@@ -20353,7 +20352,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.justify-self.right" => CSSFeature {
 		id: "css.properties.justify-self.right",
@@ -20372,7 +20371,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.justify-self.stretch" => CSSFeature {
 		id: "css.properties.justify-self.stretch",
@@ -20391,7 +20390,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.place-content.grid_context" => CSSFeature {
 		id: "css.properties.place-content.grid_context",
@@ -20410,7 +20409,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.place-items.grid_context" => CSSFeature {
 		id: "css.properties.place-items.grid_context",
@@ -20429,7 +20428,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.place-self.grid_context" => CSSFeature {
 		id: "css.properties.place-self.grid_context",
@@ -20448,7 +20447,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.row-gap" => CSSFeature {
 		id: "css.properties.row-gap",
@@ -20467,7 +20466,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.row-gap.grid_context" => CSSFeature {
 		id: "css.properties.row-gap.grid_context",
@@ -20486,7 +20485,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.row-gap.normal" => CSSFeature {
 		id: "css.properties.row-gap.normal",
@@ -20505,7 +20504,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.types.flex" => CSSFeature {
 		id: "css.types.flex",
@@ -20524,7 +20523,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-grid"],
-		popularity: 0.7000,
+		popularity: 0.6808,
 	},
 	"css.properties.grid-template-columns.animation" => CSSFeature {
 		id: "css.properties.grid-template-columns.animation",
@@ -20942,7 +20941,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 0.2027,
+		popularity: 0.3031,
 	},
 	"css.properties.hyphenate-character.auto" => CSSFeature {
 		id: "css.properties.hyphenate-character.auto",
@@ -20961,7 +20960,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 0.2027,
+		popularity: 0.3031,
 	},
 	"css.properties.hyphenate-limit-chars" => CSSFeature {
 		id: "css.properties.hyphenate-limit-chars",
@@ -20980,7 +20979,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0978,
+		popularity: 0.1068,
 	},
 	"css.properties.hyphenate-limit-chars.auto" => CSSFeature {
 		id: "css.properties.hyphenate-limit-chars.auto",
@@ -20999,7 +20998,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0978,
+		popularity: 0.1068,
 	},
 	"css.properties.hyphens" => CSSFeature {
 		id: "css.properties.hyphens",
@@ -21018,7 +21017,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.auto" => CSSFeature {
 		id: "css.properties.hyphens.auto",
@@ -21037,7 +21036,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_afrikaans" => CSSFeature {
 		id: "css.properties.hyphens.language_afrikaans",
@@ -21056,7 +21055,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_albanian" => CSSFeature {
 		id: "css.properties.hyphens.language_albanian",
@@ -21075,7 +21074,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_amharic" => CSSFeature {
 		id: "css.properties.hyphens.language_amharic",
@@ -21094,7 +21093,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_armenian" => CSSFeature {
 		id: "css.properties.hyphens.language_armenian",
@@ -21113,7 +21112,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_assamese" => CSSFeature {
 		id: "css.properties.hyphens.language_assamese",
@@ -21132,7 +21131,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_basque" => CSSFeature {
 		id: "css.properties.hyphens.language_basque",
@@ -21151,7 +21150,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_belarusian" => CSSFeature {
 		id: "css.properties.hyphens.language_belarusian",
@@ -21170,7 +21169,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_bengali" => CSSFeature {
 		id: "css.properties.hyphens.language_bengali",
@@ -21189,7 +21188,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_bosnian" => CSSFeature {
 		id: "css.properties.hyphens.language_bosnian",
@@ -21208,7 +21207,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_bulgarian" => CSSFeature {
 		id: "css.properties.hyphens.language_bulgarian",
@@ -21227,7 +21226,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_catalan" => CSSFeature {
 		id: "css.properties.hyphens.language_catalan",
@@ -21246,7 +21245,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_croatian" => CSSFeature {
 		id: "css.properties.hyphens.language_croatian",
@@ -21265,7 +21264,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_cyrillic_mongolian" => CSSFeature {
 		id: "css.properties.hyphens.language_cyrillic_mongolian",
@@ -21284,7 +21283,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_czech" => CSSFeature {
 		id: "css.properties.hyphens.language_czech",
@@ -21303,7 +21302,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_danish" => CSSFeature {
 		id: "css.properties.hyphens.language_danish",
@@ -21322,7 +21321,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_dutch" => CSSFeature {
 		id: "css.properties.hyphens.language_dutch",
@@ -21341,7 +21340,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_english" => CSSFeature {
 		id: "css.properties.hyphens.language_english",
@@ -21360,7 +21359,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_esperanto" => CSSFeature {
 		id: "css.properties.hyphens.language_esperanto",
@@ -21379,7 +21378,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_estonian" => CSSFeature {
 		id: "css.properties.hyphens.language_estonian",
@@ -21398,7 +21397,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_ethiopic_script_mul" => CSSFeature {
 		id: "css.properties.hyphens.language_ethiopic_script_mul",
@@ -21417,7 +21416,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_ethiopic_script_und" => CSSFeature {
 		id: "css.properties.hyphens.language_ethiopic_script_und",
@@ -21436,7 +21435,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_finnish" => CSSFeature {
 		id: "css.properties.hyphens.language_finnish",
@@ -21455,7 +21454,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_french" => CSSFeature {
 		id: "css.properties.hyphens.language_french",
@@ -21474,7 +21473,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_galician" => CSSFeature {
 		id: "css.properties.hyphens.language_galician",
@@ -21493,7 +21492,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_georgian" => CSSFeature {
 		id: "css.properties.hyphens.language_georgian",
@@ -21512,7 +21511,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_german_reformed_orthography" => CSSFeature {
 		id: "css.properties.hyphens.language_german_reformed_orthography",
@@ -21531,7 +21530,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_german_swiss_orthography" => CSSFeature {
 		id: "css.properties.hyphens.language_german_swiss_orthography",
@@ -21550,7 +21549,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_german_traditional_orthography" => CSSFeature {
 		id: "css.properties.hyphens.language_german_traditional_orthography",
@@ -21569,7 +21568,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_gujarati" => CSSFeature {
 		id: "css.properties.hyphens.language_gujarati",
@@ -21588,7 +21587,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_hindi" => CSSFeature {
 		id: "css.properties.hyphens.language_hindi",
@@ -21607,7 +21606,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_hungarian" => CSSFeature {
 		id: "css.properties.hyphens.language_hungarian",
@@ -21626,7 +21625,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_icelandic" => CSSFeature {
 		id: "css.properties.hyphens.language_icelandic",
@@ -21645,7 +21644,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_interlingua" => CSSFeature {
 		id: "css.properties.hyphens.language_interlingua",
@@ -21664,7 +21663,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_irish" => CSSFeature {
 		id: "css.properties.hyphens.language_irish",
@@ -21683,7 +21682,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_italian" => CSSFeature {
 		id: "css.properties.hyphens.language_italian",
@@ -21702,7 +21701,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_kannada" => CSSFeature {
 		id: "css.properties.hyphens.language_kannada",
@@ -21721,7 +21720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_kurmanji" => CSSFeature {
 		id: "css.properties.hyphens.language_kurmanji",
@@ -21740,7 +21739,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_latin" => CSSFeature {
 		id: "css.properties.hyphens.language_latin",
@@ -21759,7 +21758,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_latvian" => CSSFeature {
 		id: "css.properties.hyphens.language_latvian",
@@ -21778,7 +21777,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_lithuanian" => CSSFeature {
 		id: "css.properties.hyphens.language_lithuanian",
@@ -21797,7 +21796,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_malayalam" => CSSFeature {
 		id: "css.properties.hyphens.language_malayalam",
@@ -21816,7 +21815,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_marathi" => CSSFeature {
 		id: "css.properties.hyphens.language_marathi",
@@ -21835,7 +21834,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_modern_greek" => CSSFeature {
 		id: "css.properties.hyphens.language_modern_greek",
@@ -21854,7 +21853,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_mongolian" => CSSFeature {
 		id: "css.properties.hyphens.language_mongolian",
@@ -21873,7 +21872,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_norwegian_nn" => CSSFeature {
 		id: "css.properties.hyphens.language_norwegian_nn",
@@ -21892,7 +21891,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_norwegian_no" => CSSFeature {
 		id: "css.properties.hyphens.language_norwegian_no",
@@ -21911,7 +21910,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_old_slavonic" => CSSFeature {
 		id: "css.properties.hyphens.language_old_slavonic",
@@ -21930,7 +21929,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_oriya" => CSSFeature {
 		id: "css.properties.hyphens.language_oriya",
@@ -21949,7 +21948,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_polish" => CSSFeature {
 		id: "css.properties.hyphens.language_polish",
@@ -21968,7 +21967,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_portuguese" => CSSFeature {
 		id: "css.properties.hyphens.language_portuguese",
@@ -21987,7 +21986,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_punjabi" => CSSFeature {
 		id: "css.properties.hyphens.language_punjabi",
@@ -22006,7 +22005,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_russian" => CSSFeature {
 		id: "css.properties.hyphens.language_russian",
@@ -22025,7 +22024,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_slovak" => CSSFeature {
 		id: "css.properties.hyphens.language_slovak",
@@ -22044,7 +22043,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_slovenian" => CSSFeature {
 		id: "css.properties.hyphens.language_slovenian",
@@ -22063,7 +22062,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_spanish" => CSSFeature {
 		id: "css.properties.hyphens.language_spanish",
@@ -22082,7 +22081,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_swedish" => CSSFeature {
 		id: "css.properties.hyphens.language_swedish",
@@ -22101,7 +22100,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_tamil" => CSSFeature {
 		id: "css.properties.hyphens.language_tamil",
@@ -22120,7 +22119,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_telugu" => CSSFeature {
 		id: "css.properties.hyphens.language_telugu",
@@ -22139,7 +22138,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_turkish" => CSSFeature {
 		id: "css.properties.hyphens.language_turkish",
@@ -22158,7 +22157,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_turkmen" => CSSFeature {
 		id: "css.properties.hyphens.language_turkmen",
@@ -22177,7 +22176,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_ukrainian" => CSSFeature {
 		id: "css.properties.hyphens.language_ukrainian",
@@ -22196,7 +22195,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_upper_sorbian" => CSSFeature {
 		id: "css.properties.hyphens.language_upper_sorbian",
@@ -22215,7 +22214,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.properties.hyphens.language_welsh" => CSSFeature {
 		id: "css.properties.hyphens.language_welsh",
@@ -22234,7 +22233,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &["https://caniuse.com/css-hyphens"],
-		popularity: 10.6420,
+		popularity: 11.2768,
 	},
 	"css.types.length.ic" => CSSFeature {
 		id: "css.types.length.ic",
@@ -22291,7 +22290,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css-image-orientation"],
-		popularity: 0.1956,
+		popularity: 0.3262,
 	},
 	"css.properties.image-orientation.from-image" => CSSFeature {
 		id: "css.properties.image-orientation.from-image",
@@ -22310,7 +22309,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css-image-orientation"],
-		popularity: 0.1956,
+		popularity: 0.3262,
 	},
 	"css.properties.image-orientation.none" => CSSFeature {
 		id: "css.properties.image-orientation.none",
@@ -22329,7 +22328,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css-image-orientation"],
-		popularity: 0.1956,
+		popularity: 0.3262,
 	},
 	"css.properties.image-rendering" => CSSFeature {
 		id: "css.properties.image-rendering",
@@ -22348,7 +22347,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/css-crisp-edges"],
-		popularity: 7.2553,
+		popularity: 6.9465,
 	},
 	"css.properties.image-rendering.auto" => CSSFeature {
 		id: "css.properties.image-rendering.auto",
@@ -22367,7 +22366,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/css-crisp-edges"],
-		popularity: 7.2553,
+		popularity: 6.9465,
 	},
 	"css.properties.image-rendering.pixelated" => CSSFeature {
 		id: "css.properties.image-rendering.pixelated",
@@ -22386,7 +22385,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/css-crisp-edges"],
-		popularity: 7.2553,
+		popularity: 6.9465,
 	},
 	"css.properties.background-image.image-set" => CSSFeature {
 		id: "css.properties.background-image.image-set",
@@ -22747,7 +22746,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0720,
+		popularity: 0.0706,
 	},
 	"css.properties.initial-letter.normal" => CSSFeature {
 		id: "css.properties.initial-letter.normal",
@@ -22766,7 +22765,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0720,
+		popularity: 0.0706,
 	},
 	"css.types.global_keywords.initial" => CSSFeature {
 		id: "css.types.global_keywords.initial",
@@ -22785,7 +22784,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-initial-value"],
-		popularity: 4.4046,
+		popularity: 5.4372,
 	},
 	"css.selectors.checked" => CSSFeature {
 		id: "css.selectors.checked",
@@ -22937,7 +22936,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0176,
+		popularity: 0.0183,
 	},
 	"css.properties.interactivity.auto" => CSSFeature {
 		id: "css.properties.interactivity.auto",
@@ -22956,7 +22955,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0176,
+		popularity: 0.0183,
 	},
 	"css.properties.interactivity.inert" => CSSFeature {
 		id: "css.properties.interactivity.inert",
@@ -22975,7 +22974,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0176,
+		popularity: 0.0183,
 	},
 	"css.properties.interpolate-size" => CSSFeature {
 		id: "css.properties.interpolate-size",
@@ -22994,7 +22993,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.3420,
+		popularity: 2.5390,
 	},
 	"css.properties.interpolate-size.allow-keywords" => CSSFeature {
 		id: "css.properties.interpolate-size.allow-keywords",
@@ -23013,7 +23012,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.3420,
+		popularity: 2.5390,
 	},
 	"css.properties.interpolate-size.numeric-only" => CSSFeature {
 		id: "css.properties.interpolate-size.numeric-only",
@@ -23032,7 +23031,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 1.3420,
+		popularity: 2.5390,
 	},
 	"css.at-rules.media.inverted-colors" => CSSFeature {
 		id: "css.at-rules.media.inverted-colors",
@@ -23108,7 +23107,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &[],
-		popularity: 12.5776,
+		popularity: 13.5103,
 	},
 	"css.types.color.lab" => CSSFeature {
 		id: "css.types.color.lab",
@@ -23450,7 +23449,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-letter-spacing"],
-		popularity: 66.2765,
+		popularity: 65.8828,
 	},
 	"css.properties.letter-spacing.normal" => CSSFeature {
 		id: "css.properties.letter-spacing.normal",
@@ -23469,7 +23468,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-letter-spacing"],
-		popularity: 66.2765,
+		popularity: 65.8828,
 	},
 	"css.types.length.lh" => CSSFeature {
 		id: "css.types.length.lh",
@@ -23526,7 +23525,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.1530,
+		popularity: 5.3009,
 	},
 	"css.properties.line-break.anywhere" => CSSFeature {
 		id: "css.properties.line-break.anywhere",
@@ -23545,7 +23544,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.1530,
+		popularity: 5.3009,
 	},
 	"css.properties.line-break.auto" => CSSFeature {
 		id: "css.properties.line-break.auto",
@@ -23564,7 +23563,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.1530,
+		popularity: 5.3009,
 	},
 	"css.properties.line-break.loose" => CSSFeature {
 		id: "css.properties.line-break.loose",
@@ -23583,7 +23582,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.1530,
+		popularity: 5.3009,
 	},
 	"css.properties.line-break.normal" => CSSFeature {
 		id: "css.properties.line-break.normal",
@@ -23602,7 +23601,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.1530,
+		popularity: 5.3009,
 	},
 	"css.properties.line-break.strict" => CSSFeature {
 		id: "css.properties.line-break.strict",
@@ -23621,7 +23620,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,0),
 				},
 		caniuse: &[],
-		popularity: 5.1530,
+		popularity: 5.3009,
 	},
 	"css.properties.line-clamp" => CSSFeature {
 		id: "css.properties.line-clamp",
@@ -23640,7 +23639,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-line-clamp"],
-		popularity: 0.0027,
+		popularity: 0.0032,
 	},
 	"css.properties.line-clamp.none" => CSSFeature {
 		id: "css.properties.line-clamp.none",
@@ -23659,7 +23658,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-line-clamp"],
-		popularity: 0.0027,
+		popularity: 0.0032,
 	},
 	"css.properties.line-height" => CSSFeature {
 		id: "css.properties.line-height",
@@ -23678,7 +23677,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.7451,
+		popularity: 85.8297,
 	},
 	"css.properties.line-height.normal" => CSSFeature {
 		id: "css.properties.line-height.normal",
@@ -23697,7 +23696,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.7451,
+		popularity: 85.8297,
 	},
 	"css.types.easing-function.linear-function" => CSSFeature {
 		id: "css.types.easing-function.linear-function",
@@ -23868,7 +23867,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-image" => CSSFeature {
 		id: "css.properties.list-style-image",
@@ -23887,7 +23886,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-image.none" => CSSFeature {
 		id: "css.properties.list-style-image.none",
@@ -23906,7 +23905,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-position" => CSSFeature {
 		id: "css.properties.list-style-position",
@@ -23925,7 +23924,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-position.inside" => CSSFeature {
 		id: "css.properties.list-style-position.inside",
@@ -23944,7 +23943,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-position.outside" => CSSFeature {
 		id: "css.properties.list-style-position.outside",
@@ -23963,7 +23962,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type" => CSSFeature {
 		id: "css.properties.list-style-type",
@@ -23982,7 +23981,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.arabic-indic" => CSSFeature {
 		id: "css.properties.list-style-type.arabic-indic",
@@ -24001,7 +24000,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.armenian" => CSSFeature {
 		id: "css.properties.list-style-type.armenian",
@@ -24020,7 +24019,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.bengali" => CSSFeature {
 		id: "css.properties.list-style-type.bengali",
@@ -24039,7 +24038,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.cambodian" => CSSFeature {
 		id: "css.properties.list-style-type.cambodian",
@@ -24058,7 +24057,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.circle" => CSSFeature {
 		id: "css.properties.list-style-type.circle",
@@ -24077,7 +24076,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.cjk-decimal" => CSSFeature {
 		id: "css.properties.list-style-type.cjk-decimal",
@@ -24096,7 +24095,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.cjk-earthly-branch" => CSSFeature {
 		id: "css.properties.list-style-type.cjk-earthly-branch",
@@ -24115,7 +24114,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.cjk-heavenly-stem" => CSSFeature {
 		id: "css.properties.list-style-type.cjk-heavenly-stem",
@@ -24134,7 +24133,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.cjk-ideographic" => CSSFeature {
 		id: "css.properties.list-style-type.cjk-ideographic",
@@ -24153,7 +24152,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.decimal" => CSSFeature {
 		id: "css.properties.list-style-type.decimal",
@@ -24172,7 +24171,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.decimal-leading-zero" => CSSFeature {
 		id: "css.properties.list-style-type.decimal-leading-zero",
@@ -24191,7 +24190,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.devanagari" => CSSFeature {
 		id: "css.properties.list-style-type.devanagari",
@@ -24210,7 +24209,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.disc" => CSSFeature {
 		id: "css.properties.list-style-type.disc",
@@ -24229,7 +24228,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.disclosure-closed" => CSSFeature {
 		id: "css.properties.list-style-type.disclosure-closed",
@@ -24248,7 +24247,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.disclosure-open" => CSSFeature {
 		id: "css.properties.list-style-type.disclosure-open",
@@ -24267,7 +24266,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.ethiopic-numeric" => CSSFeature {
 		id: "css.properties.list-style-type.ethiopic-numeric",
@@ -24286,7 +24285,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.georgian" => CSSFeature {
 		id: "css.properties.list-style-type.georgian",
@@ -24305,7 +24304,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.gujarati" => CSSFeature {
 		id: "css.properties.list-style-type.gujarati",
@@ -24324,7 +24323,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.gurmukhi" => CSSFeature {
 		id: "css.properties.list-style-type.gurmukhi",
@@ -24343,7 +24342,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.hebrew" => CSSFeature {
 		id: "css.properties.list-style-type.hebrew",
@@ -24362,7 +24361,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.hiragana" => CSSFeature {
 		id: "css.properties.list-style-type.hiragana",
@@ -24381,7 +24380,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.hiragana-iroha" => CSSFeature {
 		id: "css.properties.list-style-type.hiragana-iroha",
@@ -24400,7 +24399,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.japanese-formal" => CSSFeature {
 		id: "css.properties.list-style-type.japanese-formal",
@@ -24419,7 +24418,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.japanese-informal" => CSSFeature {
 		id: "css.properties.list-style-type.japanese-informal",
@@ -24438,7 +24437,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.kannada" => CSSFeature {
 		id: "css.properties.list-style-type.kannada",
@@ -24457,7 +24456,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.katakana" => CSSFeature {
 		id: "css.properties.list-style-type.katakana",
@@ -24476,7 +24475,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.katakana-iroha" => CSSFeature {
 		id: "css.properties.list-style-type.katakana-iroha",
@@ -24495,7 +24494,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.khmer" => CSSFeature {
 		id: "css.properties.list-style-type.khmer",
@@ -24514,7 +24513,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.korean-hangul-formal" => CSSFeature {
 		id: "css.properties.list-style-type.korean-hangul-formal",
@@ -24533,7 +24532,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.korean-hanja-formal" => CSSFeature {
 		id: "css.properties.list-style-type.korean-hanja-formal",
@@ -24552,7 +24551,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.korean-hanja-informal" => CSSFeature {
 		id: "css.properties.list-style-type.korean-hanja-informal",
@@ -24571,7 +24570,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.lao" => CSSFeature {
 		id: "css.properties.list-style-type.lao",
@@ -24590,7 +24589,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.lower-alpha" => CSSFeature {
 		id: "css.properties.list-style-type.lower-alpha",
@@ -24609,7 +24608,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.lower-armenian" => CSSFeature {
 		id: "css.properties.list-style-type.lower-armenian",
@@ -24628,7 +24627,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.lower-greek" => CSSFeature {
 		id: "css.properties.list-style-type.lower-greek",
@@ -24647,7 +24646,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.lower-latin" => CSSFeature {
 		id: "css.properties.list-style-type.lower-latin",
@@ -24666,7 +24665,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.lower-roman" => CSSFeature {
 		id: "css.properties.list-style-type.lower-roman",
@@ -24685,7 +24684,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.malayalam" => CSSFeature {
 		id: "css.properties.list-style-type.malayalam",
@@ -24704,7 +24703,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.mongolian" => CSSFeature {
 		id: "css.properties.list-style-type.mongolian",
@@ -24723,7 +24722,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.myanmar" => CSSFeature {
 		id: "css.properties.list-style-type.myanmar",
@@ -24742,7 +24741,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.none" => CSSFeature {
 		id: "css.properties.list-style-type.none",
@@ -24761,7 +24760,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.oriya" => CSSFeature {
 		id: "css.properties.list-style-type.oriya",
@@ -24780,7 +24779,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.persian" => CSSFeature {
 		id: "css.properties.list-style-type.persian",
@@ -24799,7 +24798,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.simp-chinese-formal" => CSSFeature {
 		id: "css.properties.list-style-type.simp-chinese-formal",
@@ -24818,7 +24817,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.simp-chinese-informal" => CSSFeature {
 		id: "css.properties.list-style-type.simp-chinese-informal",
@@ -24837,7 +24836,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.square" => CSSFeature {
 		id: "css.properties.list-style-type.square",
@@ -24856,7 +24855,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.string" => CSSFeature {
 		id: "css.properties.list-style-type.string",
@@ -24875,7 +24874,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.symbols" => CSSFeature {
 		id: "css.properties.list-style-type.symbols",
@@ -24894,7 +24893,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.tamil" => CSSFeature {
 		id: "css.properties.list-style-type.tamil",
@@ -24913,7 +24912,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.telugu" => CSSFeature {
 		id: "css.properties.list-style-type.telugu",
@@ -24932,7 +24931,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.thai" => CSSFeature {
 		id: "css.properties.list-style-type.thai",
@@ -24951,7 +24950,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.tibetan" => CSSFeature {
 		id: "css.properties.list-style-type.tibetan",
@@ -24970,7 +24969,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.trad-chinese-formal" => CSSFeature {
 		id: "css.properties.list-style-type.trad-chinese-formal",
@@ -24989,7 +24988,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.trad-chinese-informal" => CSSFeature {
 		id: "css.properties.list-style-type.trad-chinese-informal",
@@ -25008,7 +25007,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.upper-alpha" => CSSFeature {
 		id: "css.properties.list-style-type.upper-alpha",
@@ -25027,7 +25026,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.upper-armenian" => CSSFeature {
 		id: "css.properties.list-style-type.upper-armenian",
@@ -25046,7 +25045,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.upper-latin" => CSSFeature {
 		id: "css.properties.list-style-type.upper-latin",
@@ -25065,7 +25064,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style-type.upper-roman" => CSSFeature {
 		id: "css.properties.list-style-type.upper-roman",
@@ -25084,7 +25083,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.list-style.symbols" => CSSFeature {
 		id: "css.properties.list-style.symbols",
@@ -25103,7 +25102,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 66.9511,
+		popularity: 67.0428,
 	},
 	"css.properties.block-size" => CSSFeature {
 		id: "css.properties.block-size",
@@ -26756,7 +26755,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin-bottom" => CSSFeature {
 		id: "css.properties.margin-bottom",
@@ -26775,7 +26774,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin-bottom.auto" => CSSFeature {
 		id: "css.properties.margin-bottom.auto",
@@ -26794,7 +26793,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin-left" => CSSFeature {
 		id: "css.properties.margin-left",
@@ -26813,7 +26812,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin-left.auto" => CSSFeature {
 		id: "css.properties.margin-left.auto",
@@ -26832,7 +26831,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin-right" => CSSFeature {
 		id: "css.properties.margin-right",
@@ -26851,7 +26850,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin-right.auto" => CSSFeature {
 		id: "css.properties.margin-right.auto",
@@ -26870,7 +26869,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin-top" => CSSFeature {
 		id: "css.properties.margin-top",
@@ -26889,7 +26888,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin-top.auto" => CSSFeature {
 		id: "css.properties.margin-top.auto",
@@ -26908,7 +26907,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin.auto" => CSSFeature {
 		id: "css.properties.margin.auto",
@@ -26927,7 +26926,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.3123,
+		popularity: 91.3888,
 	},
 	"css.properties.margin-trim" => CSSFeature {
 		id: "css.properties.margin-trim",
@@ -27098,7 +27097,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-marker-pseudo"],
-		popularity: 0.0460,
+		popularity: 0.0503,
 	},
 	"css.selectors.marker.animation_and_transition_support" => CSSFeature {
 		id: "css.selectors.marker.animation_and_transition_support",
@@ -27117,7 +27116,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-marker-pseudo"],
-		popularity: 0.0460,
+		popularity: 0.0503,
 	},
 	"css.properties.mask-border" => CSSFeature {
 		id: "css.properties.mask-border",
@@ -27250,7 +27249,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &[],
-		popularity: 1.9155,
+		popularity: 2.1177,
 	},
 	"css.properties.mask-type.alpha" => CSSFeature {
 		id: "css.properties.mask-type.alpha",
@@ -27269,7 +27268,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &[],
-		popularity: 1.9155,
+		popularity: 2.1177,
 	},
 	"css.properties.mask-type.luminance" => CSSFeature {
 		id: "css.properties.mask-type.luminance",
@@ -27288,7 +27287,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &[],
-		popularity: 1.9155,
+		popularity: 2.1177,
 	},
 	"css.properties.mask" => CSSFeature {
 		id: "css.properties.mask",
@@ -28884,7 +28883,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-mixblendmode"],
-		popularity: 9.1813,
+		popularity: 9.1993,
 	},
 	"css.properties.mix-blend-mode.plus-darker" => CSSFeature {
 		id: "css.properties.mix-blend-mode.plus-darker",
@@ -28903,7 +28902,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-mixblendmode"],
-		popularity: 9.1813,
+		popularity: 9.1993,
 	},
 	"css.properties.mix-blend-mode.plus-lighter" => CSSFeature {
 		id: "css.properties.mix-blend-mode.plus-lighter",
@@ -28922,7 +28921,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-mixblendmode"],
-		popularity: 9.1813,
+		popularity: 9.1993,
 	},
 	"css.properties.mix-blend-mode.svg_elements" => CSSFeature {
 		id: "css.properties.mix-blend-mode.svg_elements",
@@ -28941,7 +28940,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(8,0),
 				},
 		caniuse: &["https://caniuse.com/css-mixblendmode"],
-		popularity: 9.1813,
+		popularity: 9.1993,
 	},
 	"css.selectors.modal" => CSSFeature {
 		id: "css.selectors.modal",
@@ -30442,7 +30441,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 51.6980,
+		popularity: 49.1836,
 	},
 	"css.properties.object-fit.contain" => CSSFeature {
 		id: "css.properties.object-fit.contain",
@@ -30461,7 +30460,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 51.6980,
+		popularity: 49.1836,
 	},
 	"css.properties.object-fit.cover" => CSSFeature {
 		id: "css.properties.object-fit.cover",
@@ -30480,7 +30479,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 51.6980,
+		popularity: 49.1836,
 	},
 	"css.properties.object-fit.fill" => CSSFeature {
 		id: "css.properties.object-fit.fill",
@@ -30499,7 +30498,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 51.6980,
+		popularity: 49.1836,
 	},
 	"css.properties.object-fit.none" => CSSFeature {
 		id: "css.properties.object-fit.none",
@@ -30518,7 +30517,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 51.6980,
+		popularity: 49.1836,
 	},
 	"css.properties.object-fit.scale-down" => CSSFeature {
 		id: "css.properties.object-fit.scale-down",
@@ -30537,7 +30536,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &["https://caniuse.com/object-fit"],
-		popularity: 51.6980,
+		popularity: 49.1836,
 	},
 	"css.properties.object-position" => CSSFeature {
 		id: "css.properties.object-position",
@@ -30556,7 +30555,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,0),
 				},
 		caniuse: &[],
-		popularity: 18.1688,
+		popularity: 17.1685,
 	},
 	"css.properties.object-view-box" => CSSFeature {
 		id: "css.properties.object-view-box",
@@ -30575,7 +30574,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0292,
+		popularity: 0.0322,
 	},
 	"css.properties.object-view-box.none" => CSSFeature {
 		id: "css.properties.object-view-box.none",
@@ -30594,7 +30593,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0292,
+		popularity: 0.0322,
 	},
 	"css.types.color.oklab" => CSSFeature {
 		id: "css.types.color.oklab",
@@ -30689,7 +30688,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-opacity"],
-		popularity: 86.1179,
+		popularity: 86.5967,
 	},
 	"css.properties.opacity.percentages" => CSSFeature {
 		id: "css.properties.opacity.percentages",
@@ -30708,7 +30707,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-opacity"],
-		popularity: 86.1179,
+		popularity: 86.5967,
 	},
 	"css.types.number" => CSSFeature {
 		id: "css.types.number",
@@ -30727,7 +30726,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-opacity"],
-		popularity: 86.1179,
+		popularity: 86.5967,
 	},
 	"css.types.number.scientific_notation" => CSSFeature {
 		id: "css.types.number.scientific_notation",
@@ -30746,7 +30745,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-opacity"],
-		popularity: 86.1179,
+		popularity: 86.5967,
 	},
 	"css.properties.fill-opacity" => CSSFeature {
 		id: "css.properties.fill-opacity",
@@ -30822,7 +30821,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,4),
 				},
 		caniuse: &[],
-		popularity: 77.0019,
+		popularity: 77.6356,
 	},
 	"css.properties.outline-color" => CSSFeature {
 		id: "css.properties.outline-color",
@@ -31107,7 +31106,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 86.6999,
+		popularity: 87.1314,
 	},
 	"css.at-rules.media.overflow-inline" => CSSFeature {
 		id: "css.at-rules.media.overflow-inline",
@@ -31126,7 +31125,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,0),
 				},
 		caniuse: &[],
-		popularity: 86.6999,
+		popularity: 87.1314,
 	},
 	"css.properties.overflow-anchor" => CSSFeature {
 		id: "css.properties.overflow-anchor",
@@ -31145,7 +31144,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-overflow-anchor"],
-		popularity: 5.9236,
+		popularity: 6.2656,
 	},
 	"css.properties.overflow-anchor.auto" => CSSFeature {
 		id: "css.properties.overflow-anchor.auto",
@@ -31164,7 +31163,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-overflow-anchor"],
-		popularity: 5.9236,
+		popularity: 6.2656,
 	},
 	"css.properties.overflow-anchor.none" => CSSFeature {
 		id: "css.properties.overflow-anchor.none",
@@ -31183,7 +31182,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-overflow-anchor"],
-		popularity: 5.9236,
+		popularity: 6.2656,
 	},
 	"css.properties.overflow-x.clip" => CSSFeature {
 		id: "css.properties.overflow-x.clip",
@@ -31278,7 +31277,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7922,
+		popularity: 1.3857,
 	},
 	"css.properties.overflow-clip-margin.border-box" => CSSFeature {
 		id: "css.properties.overflow-clip-margin.border-box",
@@ -31297,7 +31296,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7922,
+		popularity: 1.3857,
 	},
 	"css.properties.overflow-clip-margin.content-box" => CSSFeature {
 		id: "css.properties.overflow-clip-margin.content-box",
@@ -31316,7 +31315,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7922,
+		popularity: 1.3857,
 	},
 	"css.properties.overflow-clip-margin.padding-box" => CSSFeature {
 		id: "css.properties.overflow-clip-margin.padding-box",
@@ -31335,7 +31334,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7922,
+		popularity: 1.3857,
 	},
 	"css.types.overflow.overlay" => CSSFeature {
 		id: "css.types.overflow.overlay",
@@ -31696,7 +31695,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/wordwrap"],
-		popularity: 38.5411,
+		popularity: 39.8625,
 	},
 	"css.properties.overflow-wrap.anywhere" => CSSFeature {
 		id: "css.properties.overflow-wrap.anywhere",
@@ -31715,7 +31714,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/wordwrap"],
-		popularity: 38.5411,
+		popularity: 39.8625,
 	},
 	"css.properties.overflow-wrap.break-word" => CSSFeature {
 		id: "css.properties.overflow-wrap.break-word",
@@ -31734,7 +31733,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/wordwrap"],
-		popularity: 38.5411,
+		popularity: 39.8625,
 	},
 	"css.properties.overflow-wrap.normal" => CSSFeature {
 		id: "css.properties.overflow-wrap.normal",
@@ -31753,7 +31752,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/wordwrap"],
-		popularity: 38.5411,
+		popularity: 39.8625,
 	},
 	"css.properties.overlay" => CSSFeature {
 		id: "css.properties.overlay",
@@ -31772,7 +31771,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0337,
+		popularity: 0.0438,
 	},
 	"css.properties.overlay.auto" => CSSFeature {
 		id: "css.properties.overlay.auto",
@@ -31791,7 +31790,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0337,
+		popularity: 0.0438,
 	},
 	"css.properties.overlay.none" => CSSFeature {
 		id: "css.properties.overlay.none",
@@ -31810,7 +31809,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0337,
+		popularity: 0.0438,
 	},
 	"css.properties.overscroll-behavior" => CSSFeature {
 		id: "css.properties.overscroll-behavior",
@@ -31829,7 +31828,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-block" => CSSFeature {
 		id: "css.properties.overscroll-behavior-block",
@@ -31848,7 +31847,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-block.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior-block.auto",
@@ -31867,7 +31866,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-block.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior-block.contain",
@@ -31886,7 +31885,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-block.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior-block.none",
@@ -31905,7 +31904,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-inline" => CSSFeature {
 		id: "css.properties.overscroll-behavior-inline",
@@ -31924,7 +31923,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-inline.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior-inline.auto",
@@ -31943,7 +31942,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-inline.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior-inline.contain",
@@ -31962,7 +31961,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-inline.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior-inline.none",
@@ -31981,7 +31980,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-x" => CSSFeature {
 		id: "css.properties.overscroll-behavior-x",
@@ -32000,7 +31999,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-x.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior-x.auto",
@@ -32019,7 +32018,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-x.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior-x.contain",
@@ -32038,7 +32037,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-x.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior-x.none",
@@ -32057,7 +32056,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-y" => CSSFeature {
 		id: "css.properties.overscroll-behavior-y",
@@ -32076,7 +32075,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-y.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior-y.auto",
@@ -32095,7 +32094,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-y.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior-y.contain",
@@ -32114,7 +32113,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior-y.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior-y.none",
@@ -32133,7 +32132,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior.auto" => CSSFeature {
 		id: "css.properties.overscroll-behavior.auto",
@@ -32152,7 +32151,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior.contain" => CSSFeature {
 		id: "css.properties.overscroll-behavior.contain",
@@ -32171,7 +32170,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.overscroll-behavior.none" => CSSFeature {
 		id: "css.properties.overscroll-behavior.none",
@@ -32190,7 +32189,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-overscroll-behavior"],
-		popularity: 16.1955,
+		popularity: 14.8690,
 	},
 	"css.properties.padding" => CSSFeature {
 		id: "css.properties.padding",
@@ -32209,7 +32208,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.1960,
+		popularity: 91.6333,
 	},
 	"css.properties.padding-bottom" => CSSFeature {
 		id: "css.properties.padding-bottom",
@@ -32228,7 +32227,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.1960,
+		popularity: 91.6333,
 	},
 	"css.properties.padding-left" => CSSFeature {
 		id: "css.properties.padding-left",
@@ -32247,7 +32246,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.1960,
+		popularity: 91.6333,
 	},
 	"css.properties.padding-right" => CSSFeature {
 		id: "css.properties.padding-right",
@@ -32266,7 +32265,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.1960,
+		popularity: 91.6333,
 	},
 	"css.properties.padding-top" => CSSFeature {
 		id: "css.properties.padding-top",
@@ -32285,7 +32284,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 91.1960,
+		popularity: 91.6333,
 	},
 	"css.properties.page-break-after" => CSSFeature {
 		id: "css.properties.page-break-after",
@@ -33216,7 +33215,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.2002,
+		popularity: 2.1220,
 	},
 	"css.properties.page" => CSSFeature {
 		id: "css.properties.page",
@@ -33729,7 +33728,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.7583,
+		popularity: 0.7139,
 	},
 	"css.types.basic-shape.path" => CSSFeature {
 		id: "css.types.basic-shape.path",
@@ -34071,7 +34070,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &["https://caniuse.com/pointer-events"],
-		popularity: 68.1338,
+		popularity: 68.3892,
 	},
 	"css.properties.pointer-events.html_elements" => CSSFeature {
 		id: "css.properties.pointer-events.html_elements",
@@ -34090,7 +34089,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,2),
 				},
 		caniuse: &["https://caniuse.com/pointer-events"],
-		popularity: 68.1338,
+		popularity: 68.3892,
 	},
 	"css.selectors.backdrop.popover" => CSSFeature {
 		id: "css.selectors.backdrop.popover",
@@ -34147,7 +34146,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 90.6603,
+		popularity: 91.3661,
 	},
 	"css.at-rules.media.prefers-color-scheme" => CSSFeature {
 		id: "css.at-rules.media.prefers-color-scheme",
@@ -34280,7 +34279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 2.3625,
+		popularity: 2.8190,
 	},
 	"css.properties.print-color-adjust.economy" => CSSFeature {
 		id: "css.properties.print-color-adjust.economy",
@@ -34299,7 +34298,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 2.3625,
+		popularity: 2.8190,
 	},
 	"css.properties.print-color-adjust.exact" => CSSFeature {
 		id: "css.properties.print-color-adjust.exact",
@@ -34318,7 +34317,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 2.3625,
+		popularity: 2.8190,
 	},
 	"css.types.length.Q" => CSSFeature {
 		id: "css.types.length.Q",
@@ -34356,7 +34355,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,5),
 				},
 		caniuse: &[],
-		popularity: 9.0075,
+		popularity: 8.6301,
 	},
 	"css.properties.quotes.auto" => CSSFeature {
 		id: "css.properties.quotes.auto",
@@ -34375,7 +34374,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,5),
 				},
 		caniuse: &[],
-		popularity: 9.0075,
+		popularity: 8.6301,
 	},
 	"css.properties.quotes.none" => CSSFeature {
 		id: "css.properties.quotes.none",
@@ -34394,7 +34393,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,5),
 				},
 		caniuse: &[],
-		popularity: 9.0075,
+		popularity: 8.6301,
 	},
 	"css.types.length.rcap" => CSSFeature {
 		id: "css.types.length.rcap",
@@ -34489,7 +34488,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0283,
+		popularity: 0.0331,
 	},
 	"css.properties.reading-flow.flex-flow" => CSSFeature {
 		id: "css.properties.reading-flow.flex-flow",
@@ -34508,7 +34507,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0283,
+		popularity: 0.0331,
 	},
 	"css.properties.reading-flow.flex-visual" => CSSFeature {
 		id: "css.properties.reading-flow.flex-visual",
@@ -34527,7 +34526,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0283,
+		popularity: 0.0331,
 	},
 	"css.properties.reading-flow.grid-columns" => CSSFeature {
 		id: "css.properties.reading-flow.grid-columns",
@@ -34546,7 +34545,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0283,
+		popularity: 0.0331,
 	},
 	"css.properties.reading-flow.grid-order" => CSSFeature {
 		id: "css.properties.reading-flow.grid-order",
@@ -34565,7 +34564,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0283,
+		popularity: 0.0331,
 	},
 	"css.properties.reading-flow.grid-rows" => CSSFeature {
 		id: "css.properties.reading-flow.grid-rows",
@@ -34584,7 +34583,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0283,
+		popularity: 0.0331,
 	},
 	"css.properties.reading-flow.normal" => CSSFeature {
 		id: "css.properties.reading-flow.normal",
@@ -34603,7 +34602,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0283,
+		popularity: 0.0331,
 	},
 	"css.properties.reading-flow.source-order" => CSSFeature {
 		id: "css.properties.reading-flow.source-order",
@@ -34622,7 +34621,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0283,
+		popularity: 0.0331,
 	},
 	"css.properties.reading-order" => CSSFeature {
 		id: "css.properties.reading-order",
@@ -34641,7 +34640,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0283,
+		popularity: 0.0331,
 	},
 	"css.at-rules.property" => CSSFeature {
 		id: "css.at-rules.property",
@@ -34945,7 +34944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-resize"],
-		popularity: 32.4042,
+		popularity: 34.4149,
 	},
 	"css.properties.resize.block" => CSSFeature {
 		id: "css.properties.resize.block",
@@ -34964,7 +34963,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-resize"],
-		popularity: 32.4042,
+		popularity: 34.4149,
 	},
 	"css.properties.resize.block_level_support" => CSSFeature {
 		id: "css.properties.resize.block_level_support",
@@ -34983,7 +34982,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-resize"],
-		popularity: 32.4042,
+		popularity: 34.4149,
 	},
 	"css.properties.resize.inline" => CSSFeature {
 		id: "css.properties.resize.inline",
@@ -35002,7 +35001,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/css-resize"],
-		popularity: 32.4042,
+		popularity: 34.4149,
 	},
 	"css.at-rules.media.resolution" => CSSFeature {
 		id: "css.at-rules.media.resolution",
@@ -35534,7 +35533,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.1870,
+		popularity: 0.1878,
 	},
 	"css.properties.ruby-align.center" => CSSFeature {
 		id: "css.properties.ruby-align.center",
@@ -35553,7 +35552,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.1870,
+		popularity: 0.1878,
 	},
 	"css.properties.ruby-align.space-around" => CSSFeature {
 		id: "css.properties.ruby-align.space-around",
@@ -35572,7 +35571,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.1870,
+		popularity: 0.1878,
 	},
 	"css.properties.ruby-align.space-between" => CSSFeature {
 		id: "css.properties.ruby-align.space-between",
@@ -35591,7 +35590,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.1870,
+		popularity: 0.1878,
 	},
 	"css.properties.ruby-align.start" => CSSFeature {
 		id: "css.properties.ruby-align.start",
@@ -35610,7 +35609,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.1870,
+		popularity: 0.1878,
 	},
 	"css.properties.ruby-overhang" => CSSFeature {
 		id: "css.properties.ruby-overhang",
@@ -35686,7 +35685,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2164,
+		popularity: 0.2321,
 	},
 	"css.properties.ruby-position.inter-character" => CSSFeature {
 		id: "css.properties.ruby-position.inter-character",
@@ -35705,7 +35704,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2164,
+		popularity: 0.2321,
 	},
 	"css.properties.ruby-position.over" => CSSFeature {
 		id: "css.properties.ruby-position.over",
@@ -35724,7 +35723,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2164,
+		popularity: 0.2321,
 	},
 	"css.properties.ruby-position.under" => CSSFeature {
 		id: "css.properties.ruby-position.under",
@@ -35743,7 +35742,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.2164,
+		popularity: 0.2321,
 	},
 	"css.types.env" => CSSFeature {
 		id: "css.types.env",
@@ -35933,7 +35932,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-scroll-behavior"],
-		popularity: 19.0603,
+		popularity: 18.5557,
 	},
 	"css.properties.scroll-behavior.auto" => CSSFeature {
 		id: "css.properties.scroll-behavior.auto",
@@ -35952,7 +35951,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-scroll-behavior"],
-		popularity: 19.0603,
+		popularity: 18.5557,
 	},
 	"css.properties.scroll-behavior.smooth" => CSSFeature {
 		id: "css.properties.scroll-behavior.smooth",
@@ -35971,7 +35970,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &["https://caniuse.com/css-scroll-behavior"],
-		popularity: 19.0603,
+		popularity: 18.5557,
 	},
 	"css.selectors.scroll-button" => CSSFeature {
 		id: "css.selectors.scroll-button",
@@ -36750,7 +36749,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0207,
+		popularity: 0.0233,
 	},
 	"css.properties.scroll-initial-target.nearest" => CSSFeature {
 		id: "css.properties.scroll-initial-target.nearest",
@@ -36769,7 +36768,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0207,
+		popularity: 0.0233,
 	},
 	"css.properties.scroll-initial-target.none" => CSSFeature {
 		id: "css.properties.scroll-initial-target.none",
@@ -36788,7 +36787,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.0207,
+		popularity: 0.0233,
 	},
 	"css.properties.scroll-marker-group" => CSSFeature {
 		id: "css.properties.scroll-marker-group",
@@ -37757,7 +37756,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 12.6248,
+		popularity: 15.1768,
 	},
 	"css.properties.scrollbar-color.auto" => CSSFeature {
 		id: "css.properties.scrollbar-color.auto",
@@ -37776,7 +37775,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 12.6248,
+		popularity: 15.1768,
 	},
 	"css.properties.scrollbar-gutter" => CSSFeature {
 		id: "css.properties.scrollbar-gutter",
@@ -37795,7 +37794,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 10.3113,
+		popularity: 11.2060,
 	},
 	"css.properties.scrollbar-gutter.auto" => CSSFeature {
 		id: "css.properties.scrollbar-gutter.auto",
@@ -37814,7 +37813,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 10.3113,
+		popularity: 11.2060,
 	},
 	"css.properties.scrollbar-gutter.stable" => CSSFeature {
 		id: "css.properties.scrollbar-gutter.stable",
@@ -37833,7 +37832,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 10.3113,
+		popularity: 11.2060,
 	},
 	"css.properties.scrollbar-width" => CSSFeature {
 		id: "css.properties.scrollbar-width",
@@ -37852,7 +37851,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 38.5361,
+		popularity: 37.3490,
 	},
 	"css.properties.scrollbar-width.auto" => CSSFeature {
 		id: "css.properties.scrollbar-width.auto",
@@ -37871,7 +37870,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 38.5361,
+		popularity: 37.3490,
 	},
 	"css.properties.scrollbar-width.none" => CSSFeature {
 		id: "css.properties.scrollbar-width.none",
@@ -37890,7 +37889,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 38.5361,
+		popularity: 37.3490,
 	},
 	"css.properties.scrollbar-width.thin" => CSSFeature {
 		id: "css.properties.scrollbar-width.thin",
@@ -37909,7 +37908,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 38.5361,
+		popularity: 37.3490,
 	},
 	"css.selectors.selection" => CSSFeature {
 		id: "css.selectors.selection",
@@ -38194,7 +38193,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-image-threshold.percentages" => CSSFeature {
 		id: "css.properties.shape-image-threshold.percentages",
@@ -38213,7 +38212,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-margin" => CSSFeature {
 		id: "css.properties.shape-margin",
@@ -38232,7 +38231,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-outside" => CSSFeature {
 		id: "css.properties.shape-outside",
@@ -38251,7 +38250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-outside.circle" => CSSFeature {
 		id: "css.properties.shape-outside.circle",
@@ -38270,7 +38269,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-outside.gradient" => CSSFeature {
 		id: "css.properties.shape-outside.gradient",
@@ -38289,7 +38288,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-outside.image" => CSSFeature {
 		id: "css.properties.shape-outside.image",
@@ -38308,7 +38307,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-outside.inset" => CSSFeature {
 		id: "css.properties.shape-outside.inset",
@@ -38327,7 +38326,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-outside.none" => CSSFeature {
 		id: "css.properties.shape-outside.none",
@@ -38346,7 +38345,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-outside.path" => CSSFeature {
 		id: "css.properties.shape-outside.path",
@@ -38365,7 +38364,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.properties.shape-outside.polygon" => CSSFeature {
 		id: "css.properties.shape-outside.polygon",
@@ -38384,7 +38383,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &[],
-		popularity: 0.4736,
+		popularity: 0.5534,
 	},
 	"css.types.basic-shape" => CSSFeature {
 		id: "css.types.basic-shape",
@@ -38650,7 +38649,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 10.7752,
+		popularity: 11.4510,
 	},
 	"css.properties.speak-as" => CSSFeature {
 		id: "css.properties.speak-as",
@@ -38669,7 +38668,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &[],
-		popularity: 0.0008,
+		popularity: 0.0006,
 	},
 	"css.properties.speak-as.digits" => CSSFeature {
 		id: "css.properties.speak-as.digits",
@@ -38688,7 +38687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &[],
-		popularity: 0.0008,
+		popularity: 0.0006,
 	},
 	"css.properties.speak-as.literal-punctuation" => CSSFeature {
 		id: "css.properties.speak-as.literal-punctuation",
@@ -38707,7 +38706,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &[],
-		popularity: 0.0008,
+		popularity: 0.0006,
 	},
 	"css.properties.speak-as.no-punctuation" => CSSFeature {
 		id: "css.properties.speak-as.no-punctuation",
@@ -38726,7 +38725,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &[],
-		popularity: 0.0008,
+		popularity: 0.0006,
 	},
 	"css.properties.speak-as.normal" => CSSFeature {
 		id: "css.properties.speak-as.normal",
@@ -38745,7 +38744,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &[],
-		popularity: 0.0008,
+		popularity: 0.0006,
 	},
 	"css.properties.speak-as.spell-out" => CSSFeature {
 		id: "css.properties.speak-as.spell-out",
@@ -38764,7 +38763,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(11,3),
 				},
 		caniuse: &[],
-		popularity: 0.0008,
+		popularity: 0.0006,
 	},
 	"css.selectors.grammar-error" => CSSFeature {
 		id: "css.selectors.grammar-error",
@@ -40417,7 +40416,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css3-tabsize"],
-		popularity: 10.6014,
+		popularity: 11.2957,
 	},
 	"css.properties.tab-size.length" => CSSFeature {
 		id: "css.properties.tab-size.length",
@@ -40436,7 +40435,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &["https://caniuse.com/css3-tabsize"],
-		popularity: 10.6014,
+		popularity: 11.2957,
 	},
 	"css.properties.border-collapse" => CSSFeature {
 		id: "css.properties.border-collapse",
@@ -40797,7 +40796,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7879,
+		popularity: 87.7217,
 	},
 	"css.properties.text-align.center" => CSSFeature {
 		id: "css.properties.text-align.center",
@@ -40816,7 +40815,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7879,
+		popularity: 87.7217,
 	},
 	"css.properties.text-align.end" => CSSFeature {
 		id: "css.properties.text-align.end",
@@ -40835,7 +40834,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7879,
+		popularity: 87.7217,
 	},
 	"css.properties.text-align.justify" => CSSFeature {
 		id: "css.properties.text-align.justify",
@@ -40854,7 +40853,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7879,
+		popularity: 87.7217,
 	},
 	"css.properties.text-align.left" => CSSFeature {
 		id: "css.properties.text-align.left",
@@ -40873,7 +40872,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7879,
+		popularity: 87.7217,
 	},
 	"css.properties.text-align.match-parent" => CSSFeature {
 		id: "css.properties.text-align.match-parent",
@@ -40892,7 +40891,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7879,
+		popularity: 87.7217,
 	},
 	"css.properties.text-align.right" => CSSFeature {
 		id: "css.properties.text-align.right",
@@ -40911,7 +40910,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7879,
+		popularity: 87.7217,
 	},
 	"css.properties.text-align.start" => CSSFeature {
 		id: "css.properties.text-align.start",
@@ -40930,7 +40929,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 87.7879,
+		popularity: 87.7217,
 	},
 	"css.properties.text-align-last" => CSSFeature {
 		id: "css.properties.text-align-last",
@@ -40949,7 +40948,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-align-last"],
-		popularity: 2.6455,
+		popularity: 2.5124,
 	},
 	"css.properties.text-align-last.auto" => CSSFeature {
 		id: "css.properties.text-align-last.auto",
@@ -40968,7 +40967,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(16,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-align-last"],
-		popularity: 2.6455,
+		popularity: 2.5124,
 	},
 	"css.properties.text-autospace" => CSSFeature {
 		id: "css.properties.text-autospace",
@@ -40987,7 +40986,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1860,
+		popularity: 2.0879,
 	},
 	"css.properties.text-autospace.auto" => CSSFeature {
 		id: "css.properties.text-autospace.auto",
@@ -41006,7 +41005,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1860,
+		popularity: 2.0879,
 	},
 	"css.properties.text-autospace.ideograph-alpha" => CSSFeature {
 		id: "css.properties.text-autospace.ideograph-alpha",
@@ -41025,7 +41024,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1860,
+		popularity: 2.0879,
 	},
 	"css.properties.text-autospace.ideograph-numeric" => CSSFeature {
 		id: "css.properties.text-autospace.ideograph-numeric",
@@ -41044,7 +41043,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1860,
+		popularity: 2.0879,
 	},
 	"css.properties.text-autospace.insert" => CSSFeature {
 		id: "css.properties.text-autospace.insert",
@@ -41063,7 +41062,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1860,
+		popularity: 2.0879,
 	},
 	"css.properties.text-autospace.no-autospace" => CSSFeature {
 		id: "css.properties.text-autospace.no-autospace",
@@ -41082,7 +41081,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1860,
+		popularity: 2.0879,
 	},
 	"css.properties.text-autospace.normal" => CSSFeature {
 		id: "css.properties.text-autospace.normal",
@@ -41101,7 +41100,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1860,
+		popularity: 2.0879,
 	},
 	"css.properties.text-autospace.punctuation" => CSSFeature {
 		id: "css.properties.text-autospace.punctuation",
@@ -41120,7 +41119,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1860,
+		popularity: 2.0879,
 	},
 	"css.properties.text-autospace.replace" => CSSFeature {
 		id: "css.properties.text-autospace.replace",
@@ -41139,7 +41138,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.1860,
+		popularity: 2.0879,
 	},
 	"css.properties.text-box" => CSSFeature {
 		id: "css.properties.text-box",
@@ -41158,7 +41157,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.properties.text-box-edge" => CSSFeature {
 		id: "css.properties.text-box-edge",
@@ -41177,7 +41176,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.properties.text-box-edge.auto" => CSSFeature {
 		id: "css.properties.text-box-edge.auto",
@@ -41196,7 +41195,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.properties.text-box-trim" => CSSFeature {
 		id: "css.properties.text-box-trim",
@@ -41215,7 +41214,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.properties.text-box-trim.none" => CSSFeature {
 		id: "css.properties.text-box-trim.none",
@@ -41234,7 +41233,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.properties.text-box-trim.trim-both" => CSSFeature {
 		id: "css.properties.text-box-trim.trim-both",
@@ -41253,7 +41252,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.properties.text-box-trim.trim-end" => CSSFeature {
 		id: "css.properties.text-box-trim.trim-end",
@@ -41272,7 +41271,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.properties.text-box-trim.trim-start" => CSSFeature {
 		id: "css.properties.text-box-trim.trim-start",
@@ -41291,7 +41290,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.properties.text-box.normal" => CSSFeature {
 		id: "css.properties.text-box.normal",
@@ -41310,7 +41309,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.types.text-edge" => CSSFeature {
 		id: "css.types.text-edge",
@@ -41329,7 +41328,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.types.text-edge.alphabetic" => CSSFeature {
 		id: "css.types.text-edge.alphabetic",
@@ -41348,7 +41347,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.types.text-edge.cap" => CSSFeature {
 		id: "css.types.text-edge.cap",
@@ -41367,7 +41366,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.types.text-edge.ex" => CSSFeature {
 		id: "css.types.text-edge.ex",
@@ -41386,7 +41385,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.types.text-edge.text" => CSSFeature {
 		id: "css.types.text-edge.text",
@@ -41405,7 +41404,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &["https://caniuse.com/css-text-box-trim"],
-		popularity: 0.1217,
+		popularity: 0.1243,
 	},
 	"css.properties.text-combine-upright" => CSSFeature {
 		id: "css.properties.text-combine-upright",
@@ -41424,7 +41423,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 0.2695,
+		popularity: 0.2879,
 	},
 	"css.properties.text-combine-upright.all" => CSSFeature {
 		id: "css.properties.text-combine-upright.all",
@@ -41443,7 +41442,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 0.2695,
+		popularity: 0.2879,
 	},
 	"css.properties.text-combine-upright.none" => CSSFeature {
 		id: "css.properties.text-combine-upright.none",
@@ -41462,7 +41461,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(15,4),
 				},
 		caniuse: &[],
-		popularity: 0.2695,
+		popularity: 0.2879,
 	},
 	"css.properties.text-decoration" => CSSFeature {
 		id: "css.properties.text-decoration",
@@ -41481,7 +41480,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-color" => CSSFeature {
 		id: "css.properties.text-decoration-color",
@@ -41500,7 +41499,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-line" => CSSFeature {
 		id: "css.properties.text-decoration-line",
@@ -41519,7 +41518,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-line.grammar-error" => CSSFeature {
 		id: "css.properties.text-decoration-line.grammar-error",
@@ -41538,7 +41537,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-line.line-through" => CSSFeature {
 		id: "css.properties.text-decoration-line.line-through",
@@ -41557,7 +41556,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-line.none" => CSSFeature {
 		id: "css.properties.text-decoration-line.none",
@@ -41576,7 +41575,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-line.overline" => CSSFeature {
 		id: "css.properties.text-decoration-line.overline",
@@ -41595,7 +41594,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-line.spelling-error" => CSSFeature {
 		id: "css.properties.text-decoration-line.spelling-error",
@@ -41614,7 +41613,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-line.underline" => CSSFeature {
 		id: "css.properties.text-decoration-line.underline",
@@ -41633,7 +41632,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-skip" => CSSFeature {
 		id: "css.properties.text-decoration-skip",
@@ -41652,7 +41651,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-skip-ink" => CSSFeature {
 		id: "css.properties.text-decoration-skip-ink",
@@ -41671,7 +41670,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-skip-ink.all" => CSSFeature {
 		id: "css.properties.text-decoration-skip-ink.all",
@@ -41690,7 +41689,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-skip-ink.auto" => CSSFeature {
 		id: "css.properties.text-decoration-skip-ink.auto",
@@ -41709,7 +41708,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-skip-ink.none" => CSSFeature {
 		id: "css.properties.text-decoration-skip-ink.none",
@@ -41728,7 +41727,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-skip.auto" => CSSFeature {
 		id: "css.properties.text-decoration-skip.auto",
@@ -41747,7 +41746,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-skip.none" => CSSFeature {
 		id: "css.properties.text-decoration-skip.none",
@@ -41766,7 +41765,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-style" => CSSFeature {
 		id: "css.properties.text-decoration-style",
@@ -41785,7 +41784,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-style.wavy" => CSSFeature {
 		id: "css.properties.text-decoration-style.wavy",
@@ -41804,7 +41803,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-thickness" => CSSFeature {
 		id: "css.properties.text-decoration-thickness",
@@ -41823,7 +41822,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-thickness.auto" => CSSFeature {
 		id: "css.properties.text-decoration-thickness.auto",
@@ -41842,7 +41841,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-thickness.from-font" => CSSFeature {
 		id: "css.properties.text-decoration-thickness.from-font",
@@ -41861,7 +41860,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-thickness.percentage" => CSSFeature {
 		id: "css.properties.text-decoration-thickness.percentage",
@@ -41880,7 +41879,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration.includes_color-and-style" => CSSFeature {
 		id: "css.properties.text-decoration.includes_color-and-style",
@@ -41899,7 +41898,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration.includes_thickness" => CSSFeature {
 		id: "css.properties.text-decoration.includes_thickness",
@@ -41918,7 +41917,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-decoration"],
-		popularity: 83.4600,
+		popularity: 83.4803,
 	},
 	"css.properties.text-decoration-line.blink" => CSSFeature {
 		id: "css.properties.text-decoration-line.blink",
@@ -41975,7 +41974,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-color" => CSSFeature {
 		id: "css.properties.text-emphasis-color",
@@ -41994,7 +41993,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-position" => CSSFeature {
 		id: "css.properties.text-emphasis-position",
@@ -42013,7 +42012,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-position.auto" => CSSFeature {
 		id: "css.properties.text-emphasis-position.auto",
@@ -42032,7 +42031,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-position.left" => CSSFeature {
 		id: "css.properties.text-emphasis-position.left",
@@ -42051,7 +42050,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-position.over" => CSSFeature {
 		id: "css.properties.text-emphasis-position.over",
@@ -42070,7 +42069,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-position.right" => CSSFeature {
 		id: "css.properties.text-emphasis-position.right",
@@ -42089,7 +42088,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-position.under" => CSSFeature {
 		id: "css.properties.text-emphasis-position.under",
@@ -42108,7 +42107,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-style" => CSSFeature {
 		id: "css.properties.text-emphasis-style",
@@ -42127,7 +42126,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-style.circle" => CSSFeature {
 		id: "css.properties.text-emphasis-style.circle",
@@ -42146,7 +42145,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-style.dot" => CSSFeature {
 		id: "css.properties.text-emphasis-style.dot",
@@ -42165,7 +42164,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-style.double-circle" => CSSFeature {
 		id: "css.properties.text-emphasis-style.double-circle",
@@ -42184,7 +42183,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-style.filled" => CSSFeature {
 		id: "css.properties.text-emphasis-style.filled",
@@ -42203,7 +42202,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-style.none" => CSSFeature {
 		id: "css.properties.text-emphasis-style.none",
@@ -42222,7 +42221,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-style.sesame" => CSSFeature {
 		id: "css.properties.text-emphasis-style.sesame",
@@ -42241,7 +42240,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-emphasis-style.triangle" => CSSFeature {
 		id: "css.properties.text-emphasis-style.triangle",
@@ -42260,7 +42259,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(7,0),
 				},
 		caniuse: &["https://caniuse.com/text-emphasis"],
-		popularity: 0.2180,
+		popularity: 0.3211,
 	},
 	"css.properties.text-indent" => CSSFeature {
 		id: "css.properties.text-indent",
@@ -42279,7 +42278,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-indent"],
-		popularity: 35.1002,
+		popularity: 36.2869,
 	},
 	"css.properties.text-indent.each-line" => CSSFeature {
 		id: "css.properties.text-indent.each-line",
@@ -42431,7 +42430,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-orientation"],
-		popularity: 0.6123,
+		popularity: 0.6141,
 	},
 	"css.properties.text-orientation.mixed" => CSSFeature {
 		id: "css.properties.text-orientation.mixed",
@@ -42450,7 +42449,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-orientation"],
-		popularity: 0.6123,
+		popularity: 0.6141,
 	},
 	"css.properties.text-orientation.sideways" => CSSFeature {
 		id: "css.properties.text-orientation.sideways",
@@ -42469,7 +42468,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-orientation"],
-		popularity: 0.6123,
+		popularity: 0.6141,
 	},
 	"css.properties.text-orientation.upright" => CSSFeature {
 		id: "css.properties.text-orientation.upright",
@@ -42488,7 +42487,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(14,0),
 				},
 		caniuse: &["https://caniuse.com/css-text-orientation"],
-		popularity: 0.6123,
+		popularity: 0.6141,
 	},
 	"css.properties.text-overflow" => CSSFeature {
 		id: "css.properties.text-overflow",
@@ -42507,7 +42506,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-overflow"],
-		popularity: 65.2767,
+		popularity: 65.1243,
 	},
 	"css.properties.text-overflow.clip" => CSSFeature {
 		id: "css.properties.text-overflow.clip",
@@ -42526,7 +42525,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-overflow"],
-		popularity: 65.2767,
+		popularity: 65.1243,
 	},
 	"css.properties.text-overflow.ellipsis" => CSSFeature {
 		id: "css.properties.text-overflow.ellipsis",
@@ -42545,7 +42544,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-overflow"],
-		popularity: 65.2767,
+		popularity: 65.1243,
 	},
 	"css.properties.text-overflow.two_value_syntax" => CSSFeature {
 		id: "css.properties.text-overflow.two_value_syntax",
@@ -42564,7 +42563,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/text-overflow"],
-		popularity: 65.2767,
+		popularity: 65.1243,
 	},
 	"css.properties.text-shadow" => CSSFeature {
 		id: "css.properties.text-shadow",
@@ -42583,7 +42582,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &["https://caniuse.com/css-textshadow"],
-		popularity: 44.8310,
+		popularity: 43.4020,
 	},
 	"css.properties.text-size-adjust" => CSSFeature {
 		id: "css.properties.text-size-adjust",
@@ -42602,7 +42601,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/text-size-adjust"],
-		popularity: 22.0524,
+		popularity: 21.6343,
 	},
 	"css.properties.text-size-adjust.auto" => CSSFeature {
 		id: "css.properties.text-size-adjust.auto",
@@ -42621,7 +42620,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/text-size-adjust"],
-		popularity: 22.0524,
+		popularity: 21.6343,
 	},
 	"css.properties.text-size-adjust.none" => CSSFeature {
 		id: "css.properties.text-size-adjust.none",
@@ -42640,7 +42639,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/text-size-adjust"],
-		popularity: 22.0524,
+		popularity: 21.6343,
 	},
 	"css.properties.text-size-adjust.percentages" => CSSFeature {
 		id: "css.properties.text-size-adjust.percentages",
@@ -42659,7 +42658,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/text-size-adjust"],
-		popularity: 22.0524,
+		popularity: 21.6343,
 	},
 	"css.properties.text-spacing-trim" => CSSFeature {
 		id: "css.properties.text-spacing-trim",
@@ -42678,7 +42677,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3949,
+		popularity: 0.7622,
 	},
 	"css.properties.text-spacing-trim.normal" => CSSFeature {
 		id: "css.properties.text-spacing-trim.normal",
@@ -42697,7 +42696,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3949,
+		popularity: 0.7622,
 	},
 	"css.properties.text-spacing-trim.space-all" => CSSFeature {
 		id: "css.properties.text-spacing-trim.space-all",
@@ -42716,7 +42715,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3949,
+		popularity: 0.7622,
 	},
 	"css.properties.text-spacing-trim.space-first" => CSSFeature {
 		id: "css.properties.text-spacing-trim.space-first",
@@ -42735,7 +42734,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3949,
+		popularity: 0.7622,
 	},
 	"css.properties.text-spacing-trim.trim-start" => CSSFeature {
 		id: "css.properties.text-spacing-trim.trim-start",
@@ -42754,7 +42753,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &[],
-		popularity: 0.3949,
+		popularity: 0.7622,
 	},
 	"css.properties.-webkit-text-fill-color" => CSSFeature {
 		id: "css.properties.-webkit-text-fill-color",
@@ -42849,7 +42848,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.capitalize" => CSSFeature {
 		id: "css.properties.text-transform.capitalize",
@@ -42868,7 +42867,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.dutch_ij_digraph" => CSSFeature {
 		id: "css.properties.text-transform.dutch_ij_digraph",
@@ -42887,7 +42886,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.full-size-kana" => CSSFeature {
 		id: "css.properties.text-transform.full-size-kana",
@@ -42906,7 +42905,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.full-width" => CSSFeature {
 		id: "css.properties.text-transform.full-width",
@@ -42925,7 +42924,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.greek_accented_characters" => CSSFeature {
 		id: "css.properties.text-transform.greek_accented_characters",
@@ -42944,7 +42943,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.lowercase" => CSSFeature {
 		id: "css.properties.text-transform.lowercase",
@@ -42963,7 +42962,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.lowercase_sigma" => CSSFeature {
 		id: "css.properties.text-transform.lowercase_sigma",
@@ -42982,7 +42981,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.none" => CSSFeature {
 		id: "css.properties.text-transform.none",
@@ -43001,7 +43000,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.turkic_is" => CSSFeature {
 		id: "css.properties.text-transform.turkic_is",
@@ -43020,7 +43019,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.uppercase" => CSSFeature {
 		id: "css.properties.text-transform.uppercase",
@@ -43039,7 +43038,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-transform.uppercase_eszett" => CSSFeature {
 		id: "css.properties.text-transform.uppercase_eszett",
@@ -43058,7 +43057,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 72.2825,
+		popularity: 71.8311,
 	},
 	"css.properties.text-underline-offset" => CSSFeature {
 		id: "css.properties.text-underline-offset",
@@ -43077,7 +43076,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 14.5654,
+		popularity: 14.4264,
 	},
 	"css.properties.text-underline-offset.auto" => CSSFeature {
 		id: "css.properties.text-underline-offset.auto",
@@ -43096,7 +43095,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 14.5654,
+		popularity: 14.4264,
 	},
 	"css.properties.text-underline-offset.percentage" => CSSFeature {
 		id: "css.properties.text-underline-offset.percentage",
@@ -43115,7 +43114,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 14.5654,
+		popularity: 14.4264,
 	},
 	"css.properties.text-underline-position" => CSSFeature {
 		id: "css.properties.text-underline-position",
@@ -43134,7 +43133,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 4.3607,
+		popularity: 4.6079,
 	},
 	"css.properties.text-underline-position.auto" => CSSFeature {
 		id: "css.properties.text-underline-position.auto",
@@ -43153,7 +43152,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 4.3607,
+		popularity: 4.6079,
 	},
 	"css.properties.text-underline-position.from-font" => CSSFeature {
 		id: "css.properties.text-underline-position.from-font",
@@ -43172,7 +43171,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 4.3607,
+		popularity: 4.6079,
 	},
 	"css.properties.text-underline-position.left" => CSSFeature {
 		id: "css.properties.text-underline-position.left",
@@ -43191,7 +43190,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 4.3607,
+		popularity: 4.6079,
 	},
 	"css.properties.text-underline-position.right" => CSSFeature {
 		id: "css.properties.text-underline-position.right",
@@ -43210,7 +43209,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 4.3607,
+		popularity: 4.6079,
 	},
 	"css.properties.text-underline-position.under" => CSSFeature {
 		id: "css.properties.text-underline-position.under",
@@ -43229,7 +43228,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(12,2),
 				},
 		caniuse: &[],
-		popularity: 4.3607,
+		popularity: 4.6079,
 	},
 	"css.properties.text-wrap" => CSSFeature {
 		id: "css.properties.text-wrap",
@@ -43248,7 +43247,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 18.8954,
+		popularity: 20.3717,
 	},
 	"css.properties.text-wrap.wrap" => CSSFeature {
 		id: "css.properties.text-wrap.wrap",
@@ -43267,7 +43266,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 18.8954,
+		popularity: 20.3717,
 	},
 	"css.properties.text-wrap.balance" => CSSFeature {
 		id: "css.properties.text-wrap.balance",
@@ -43305,7 +43304,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 3.5245,
+		popularity: 3.5587,
 	},
 	"css.properties.text-wrap-mode.nowrap" => CSSFeature {
 		id: "css.properties.text-wrap-mode.nowrap",
@@ -43324,7 +43323,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 3.5245,
+		popularity: 3.5587,
 	},
 	"css.properties.text-wrap-mode.wrap" => CSSFeature {
 		id: "css.properties.text-wrap-mode.wrap",
@@ -43343,7 +43342,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 3.5245,
+		popularity: 3.5587,
 	},
 	"css.properties.text-wrap.nowrap" => CSSFeature {
 		id: "css.properties.text-wrap.nowrap",
@@ -43419,7 +43418,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1070,
+		popularity: 0.0941,
 	},
 	"css.properties.text-wrap-style.auto" => CSSFeature {
 		id: "css.properties.text-wrap-style.auto",
@@ -43438,7 +43437,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1070,
+		popularity: 0.0941,
 	},
 	"css.properties.text-wrap-style.balance" => CSSFeature {
 		id: "css.properties.text-wrap-style.balance",
@@ -43457,7 +43456,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1070,
+		popularity: 0.0941,
 	},
 	"css.properties.text-wrap-style.pretty" => CSSFeature {
 		id: "css.properties.text-wrap-style.pretty",
@@ -43476,7 +43475,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1070,
+		popularity: 0.0941,
 	},
 	"css.properties.text-wrap-style.stable" => CSSFeature {
 		id: "css.properties.text-wrap-style.stable",
@@ -43495,7 +43494,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(26,0),
 				},
 		caniuse: &[],
-		popularity: 0.1070,
+		popularity: 0.0941,
 	},
 	"css.selectors.future" => CSSFeature {
 		id: "css.selectors.future",
@@ -43552,7 +43551,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.touch-action.manipulation" => CSSFeature {
 		id: "css.properties.touch-action.manipulation",
@@ -43571,7 +43570,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.touch-action.none" => CSSFeature {
 		id: "css.properties.touch-action.none",
@@ -43590,7 +43589,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.touch-action.pan-down" => CSSFeature {
 		id: "css.properties.touch-action.pan-down",
@@ -43609,7 +43608,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.touch-action.pan-left" => CSSFeature {
 		id: "css.properties.touch-action.pan-left",
@@ -43628,7 +43627,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.touch-action.pan-right" => CSSFeature {
 		id: "css.properties.touch-action.pan-right",
@@ -43647,7 +43646,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.touch-action.pan-up" => CSSFeature {
 		id: "css.properties.touch-action.pan-up",
@@ -43666,7 +43665,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.touch-action.pan-x" => CSSFeature {
 		id: "css.properties.touch-action.pan-x",
@@ -43685,7 +43684,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.touch-action.pan-y" => CSSFeature {
 		id: "css.properties.touch-action.pan-y",
@@ -43704,7 +43703,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.touch-action.pinch-zoom" => CSSFeature {
 		id: "css.properties.touch-action.pinch-zoom",
@@ -43723,7 +43722,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/css-touch-action"],
-		popularity: 41.8519,
+		popularity: 41.1350,
 	},
 	"css.properties.transform-box" => CSSFeature {
 		id: "css.properties.transform-box",
@@ -43742,7 +43741,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 3.0674,
+		popularity: 3.3687,
 	},
 	"css.properties.transform-box.border-box" => CSSFeature {
 		id: "css.properties.transform-box.border-box",
@@ -43761,7 +43760,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 3.0674,
+		popularity: 3.3687,
 	},
 	"css.properties.transform-box.content-box" => CSSFeature {
 		id: "css.properties.transform-box.content-box",
@@ -43780,7 +43779,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 3.0674,
+		popularity: 3.3687,
 	},
 	"css.properties.transform-box.fill-box" => CSSFeature {
 		id: "css.properties.transform-box.fill-box",
@@ -43799,7 +43798,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 3.0674,
+		popularity: 3.3687,
 	},
 	"css.properties.transform-box.stroke-box" => CSSFeature {
 		id: "css.properties.transform-box.stroke-box",
@@ -43818,7 +43817,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 3.0674,
+		popularity: 3.3687,
 	},
 	"css.properties.transform-box.view-box" => CSSFeature {
 		id: "css.properties.transform-box.view-box",
@@ -43837,7 +43836,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(13,4),
 				},
 		caniuse: &[],
-		popularity: 3.0674,
+		popularity: 3.3687,
 	},
 	"css.properties.transform" => CSSFeature {
 		id: "css.properties.transform",
@@ -44825,7 +44824,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 0.5060,
+		popularity: 0.6311,
 	},
 	"css.properties.transition.transition-behavior" => CSSFeature {
 		id: "css.properties.transition.transition-behavior",
@@ -44844,7 +44843,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 0.5060,
+		popularity: 0.6311,
 	},
 	"css.properties.transition" => CSSFeature {
 		id: "css.properties.transition",
@@ -45395,7 +45394,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 65.7354,
+		popularity: 66.2312,
 	},
 	"css.properties.user-select.all" => CSSFeature {
 		id: "css.properties.user-select.all",
@@ -45414,7 +45413,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 65.7354,
+		popularity: 66.2312,
 	},
 	"css.properties.user-select.auto" => CSSFeature {
 		id: "css.properties.user-select.auto",
@@ -45433,7 +45432,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 65.7354,
+		popularity: 66.2312,
 	},
 	"css.properties.user-select.none" => CSSFeature {
 		id: "css.properties.user-select.none",
@@ -45452,7 +45451,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 65.7354,
+		popularity: 66.2312,
 	},
 	"css.properties.user-select.text" => CSSFeature {
 		id: "css.properties.user-select.text",
@@ -45471,7 +45470,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(0, 0),
 				},
 		caniuse: &["https://caniuse.com/user-select-none"],
-		popularity: 65.7354,
+		popularity: 66.2312,
 	},
 	"css.properties.vertical-align" => CSSFeature {
 		id: "css.properties.vertical-align",
@@ -45490,7 +45489,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.1570,
+		popularity: 81.7056,
 	},
 	"css.properties.vertical-align.baseline" => CSSFeature {
 		id: "css.properties.vertical-align.baseline",
@@ -45509,7 +45508,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.1570,
+		popularity: 81.7056,
 	},
 	"css.properties.vertical-align.bottom" => CSSFeature {
 		id: "css.properties.vertical-align.bottom",
@@ -45528,7 +45527,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.1570,
+		popularity: 81.7056,
 	},
 	"css.properties.vertical-align.middle" => CSSFeature {
 		id: "css.properties.vertical-align.middle",
@@ -45547,7 +45546,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.1570,
+		popularity: 81.7056,
 	},
 	"css.properties.vertical-align.sub" => CSSFeature {
 		id: "css.properties.vertical-align.sub",
@@ -45566,7 +45565,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.1570,
+		popularity: 81.7056,
 	},
 	"css.properties.vertical-align.super" => CSSFeature {
 		id: "css.properties.vertical-align.super",
@@ -45585,7 +45584,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.1570,
+		popularity: 81.7056,
 	},
 	"css.properties.vertical-align.text-bottom" => CSSFeature {
 		id: "css.properties.vertical-align.text-bottom",
@@ -45604,7 +45603,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.1570,
+		popularity: 81.7056,
 	},
 	"css.properties.vertical-align.text-top" => CSSFeature {
 		id: "css.properties.vertical-align.text-top",
@@ -45623,7 +45622,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.1570,
+		popularity: 81.7056,
 	},
 	"css.properties.vertical-align.top" => CSSFeature {
 		id: "css.properties.vertical-align.top",
@@ -45642,7 +45641,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 81.1570,
+		popularity: 81.7056,
 	},
 	"css.properties.direction.vertical_slider_direction" => CSSFeature {
 		id: "css.properties.direction.vertical_slider_direction",
@@ -45707,18 +45706,18 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "The view-transition-class CSS property sets a name that can be used to apply styles to multiple named view transition pseudo-elements.",
 		spec: "https://drafts.csswg.org/css-view-transitions-2/#propdef-view-transition-class",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(125,0),
 						chrome_android: BrowserVersion(125,0),
 						edge: BrowserVersion(125,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,2),
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.0563,
+		popularity: 0.0621,
 	},
 	"css.properties.view-transition-class.none" => CSSFeature {
 		id: "css.properties.view-transition-class.none",
@@ -45726,18 +45725,18 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "The view-transition-class CSS property sets a name that can be used to apply styles to multiple named view transition pseudo-elements.",
 		spec: "https://drafts.csswg.org/css-view-transitions-2/#propdef-view-transition-class",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(125,0),
 						chrome_android: BrowserVersion(125,0),
 						edge: BrowserVersion(125,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,2),
 						safari_ios: BrowserVersion(18,2),
 				},
 		caniuse: &[],
-		popularity: 0.0563,
+		popularity: 0.0621,
 	},
 	"css.properties.view-transition-name" => CSSFeature {
 		id: "css.properties.view-transition-name",
@@ -45745,13 +45744,13 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "View transitions allow you to create animated visual transitions between different states of a document.",
 		spec: "https://drafts.csswg.org/css-view-transitions-1/",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(111,0),
 						chrome_android: BrowserVersion(111,0),
 						edge: BrowserVersion(111,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,0),
 						safari_ios: BrowserVersion(18,0),
 				},
@@ -45764,13 +45763,13 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "View transitions allow you to create animated visual transitions between different states of a document.",
 		spec: "https://drafts.csswg.org/css-view-transitions-1/",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(111,0),
 						chrome_android: BrowserVersion(111,0),
 						edge: BrowserVersion(111,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,0),
 						safari_ios: BrowserVersion(18,0),
 				},
@@ -45783,13 +45782,13 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "View transitions allow you to create animated visual transitions between different states of a document.",
 		spec: "https://drafts.csswg.org/css-view-transitions-1/",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(111,0),
 						chrome_android: BrowserVersion(111,0),
 						edge: BrowserVersion(111,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,0),
 						safari_ios: BrowserVersion(18,0),
 				},
@@ -45802,13 +45801,13 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "View transitions allow you to create animated visual transitions between different states of a document.",
 		spec: "https://drafts.csswg.org/css-view-transitions-1/",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(111,0),
 						chrome_android: BrowserVersion(111,0),
 						edge: BrowserVersion(111,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,0),
 						safari_ios: BrowserVersion(18,0),
 				},
@@ -45821,13 +45820,13 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "View transitions allow you to create animated visual transitions between different states of a document.",
 		spec: "https://drafts.csswg.org/css-view-transitions-1/",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(111,0),
 						chrome_android: BrowserVersion(111,0),
 						edge: BrowserVersion(111,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,0),
 						safari_ios: BrowserVersion(18,0),
 				},
@@ -45840,13 +45839,13 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "View transitions allow you to create animated visual transitions between different states of a document.",
 		spec: "https://drafts.csswg.org/css-view-transitions-1/",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(111,0),
 						chrome_android: BrowserVersion(111,0),
 						edge: BrowserVersion(111,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,0),
 						safari_ios: BrowserVersion(18,0),
 				},
@@ -45859,13 +45858,13 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "View transitions allow you to create animated visual transitions between different states of a document.",
 		spec: "https://drafts.csswg.org/css-view-transitions-1/",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(111,0),
 						chrome_android: BrowserVersion(111,0),
 						edge: BrowserVersion(111,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,0),
 						safari_ios: BrowserVersion(18,0),
 				},
@@ -45878,13 +45877,13 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 		description: "View transitions allow you to create animated visual transitions between different states of a document.",
 		spec: "https://drafts.csswg.org/css-view-transitions-1/",
 		groups: &["view-transitions"],
-		baseline_status: BaselineStatus::False,
+		baseline_status: BaselineStatus::Low(NaiveDate::from_ymd_opt(2025,10,14).unwrap()),
 		browser_support: BrowserSupport {
 						chrome: BrowserVersion(111,0),
 						chrome_android: BrowserVersion(111,0),
 						edge: BrowserVersion(111,0),
-						firefox: BrowserVersion(0, 0),
-						firefox_android: BrowserVersion(0, 0),
+						firefox: BrowserVersion(144,0),
+						firefox_android: BrowserVersion(144,0),
 						safari: BrowserVersion(18,0),
 						safari_ios: BrowserVersion(18,0),
 				},
@@ -46231,7 +46230,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 75.2855,
+		popularity: 76.0240,
 	},
 	"css.properties.visibility.collapse" => CSSFeature {
 		id: "css.properties.visibility.collapse",
@@ -46250,7 +46249,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 75.2855,
+		popularity: 76.0240,
 	},
 	"css.properties.visibility.hidden" => CSSFeature {
 		id: "css.properties.visibility.hidden",
@@ -46269,7 +46268,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 75.2855,
+		popularity: 76.0240,
 	},
 	"css.properties.visibility.visible" => CSSFeature {
 		id: "css.properties.visibility.visible",
@@ -46288,7 +46287,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 75.2855,
+		popularity: 76.0240,
 	},
 	"css.selectors.cue" => CSSFeature {
 		id: "css.selectors.cue",
@@ -46402,7 +46401,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space.break-spaces" => CSSFeature {
 		id: "css.properties.white-space.break-spaces",
@@ -46421,7 +46420,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space.normal" => CSSFeature {
 		id: "css.properties.white-space.normal",
@@ -46440,7 +46439,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space.nowrap" => CSSFeature {
 		id: "css.properties.white-space.nowrap",
@@ -46459,7 +46458,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space.pre" => CSSFeature {
 		id: "css.properties.white-space.pre",
@@ -46478,7 +46477,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space.pre-line" => CSSFeature {
 		id: "css.properties.white-space.pre-line",
@@ -46497,7 +46496,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space.pre-wrap" => CSSFeature {
 		id: "css.properties.white-space.pre-wrap",
@@ -46516,7 +46515,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space.shorthand_values" => CSSFeature {
 		id: "css.properties.white-space.shorthand_values",
@@ -46535,7 +46534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space.svg_elements" => CSSFeature {
 		id: "css.properties.white-space.svg_elements",
@@ -46554,7 +46553,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space.textarea_support" => CSSFeature {
 		id: "css.properties.white-space.textarea_support",
@@ -46573,7 +46572,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 80.8282,
+		popularity: 81.1460,
 	},
 	"css.properties.white-space-collapse" => CSSFeature {
 		id: "css.properties.white-space-collapse",
@@ -46592,7 +46591,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1867,
+		popularity: 1.4880,
 	},
 	"css.properties.white-space-collapse.break-spaces" => CSSFeature {
 		id: "css.properties.white-space-collapse.break-spaces",
@@ -46611,7 +46610,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1867,
+		popularity: 1.4880,
 	},
 	"css.properties.white-space-collapse.collapse" => CSSFeature {
 		id: "css.properties.white-space-collapse.collapse",
@@ -46630,7 +46629,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1867,
+		popularity: 1.4880,
 	},
 	"css.properties.white-space-collapse.preserve" => CSSFeature {
 		id: "css.properties.white-space-collapse.preserve",
@@ -46649,7 +46648,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1867,
+		popularity: 1.4880,
 	},
 	"css.properties.white-space-collapse.preserve-breaks" => CSSFeature {
 		id: "css.properties.white-space-collapse.preserve-breaks",
@@ -46668,7 +46667,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1867,
+		popularity: 1.4880,
 	},
 	"css.properties.white-space-collapse.preserve-spaces" => CSSFeature {
 		id: "css.properties.white-space-collapse.preserve-spaces",
@@ -46687,7 +46686,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(17,4),
 				},
 		caniuse: &[],
-		popularity: 1.1867,
+		popularity: 1.4880,
 	},
 	"css.properties.orphans" => CSSFeature {
 		id: "css.properties.orphans",
@@ -46915,7 +46914,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/will-change"],
-		popularity: 36.9794,
+		popularity: 37.1657,
 	},
 	"css.properties.will-change.auto" => CSSFeature {
 		id: "css.properties.will-change.auto",
@@ -46934,7 +46933,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/will-change"],
-		popularity: 36.9794,
+		popularity: 37.1657,
 	},
 	"css.properties.will-change.contents" => CSSFeature {
 		id: "css.properties.will-change.contents",
@@ -46953,7 +46952,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/will-change"],
-		popularity: 36.9794,
+		popularity: 37.1657,
 	},
 	"css.properties.will-change.scroll-position" => CSSFeature {
 		id: "css.properties.will-change.scroll-position",
@@ -46972,7 +46971,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,3),
 				},
 		caniuse: &["https://caniuse.com/will-change"],
-		popularity: 36.9794,
+		popularity: 37.1657,
 	},
 	"css.types.env.titlebar-area-height" => CSSFeature {
 		id: "css.types.env.titlebar-area-height",
@@ -47067,7 +47066,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/word-break"],
-		popularity: 55.8729,
+		popularity: 56.1102,
 	},
 	"css.properties.word-break.break-all" => CSSFeature {
 		id: "css.properties.word-break.break-all",
@@ -47086,7 +47085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/word-break"],
-		popularity: 55.8729,
+		popularity: 56.1102,
 	},
 	"css.properties.word-break.keep-all" => CSSFeature {
 		id: "css.properties.word-break.keep-all",
@@ -47105,7 +47104,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/word-break"],
-		popularity: 55.8729,
+		popularity: 56.1102,
 	},
 	"css.properties.word-break.normal" => CSSFeature {
 		id: "css.properties.word-break.normal",
@@ -47124,7 +47123,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(9,0),
 				},
 		caniuse: &["https://caniuse.com/word-break"],
-		popularity: 55.8729,
+		popularity: 56.1102,
 	},
 	"css.properties.word-break.auto-phrase" => CSSFeature {
 		id: "css.properties.word-break.auto-phrase",
@@ -47181,7 +47180,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 12.1518,
+		popularity: 12.1928,
 	},
 	"css.properties.word-spacing.normal" => CSSFeature {
 		id: "css.properties.word-spacing.normal",
@@ -47200,7 +47199,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 12.1518,
+		popularity: 12.1928,
 	},
 	"css.properties.writing-mode" => CSSFeature {
 		id: "css.properties.writing-mode",
@@ -47219,7 +47218,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.1562,
+		popularity: 6.8756,
 	},
 	"css.properties.writing-mode.horizontal-tb" => CSSFeature {
 		id: "css.properties.writing-mode.horizontal-tb",
@@ -47238,7 +47237,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.1562,
+		popularity: 6.8756,
 	},
 	"css.properties.writing-mode.sideways-lr" => CSSFeature {
 		id: "css.properties.writing-mode.sideways-lr",
@@ -47257,7 +47256,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.1562,
+		popularity: 6.8756,
 	},
 	"css.properties.writing-mode.sideways-rl" => CSSFeature {
 		id: "css.properties.writing-mode.sideways-rl",
@@ -47276,7 +47275,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.1562,
+		popularity: 6.8756,
 	},
 	"css.properties.writing-mode.vertical-lr" => CSSFeature {
 		id: "css.properties.writing-mode.vertical-lr",
@@ -47295,7 +47294,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.1562,
+		popularity: 6.8756,
 	},
 	"css.properties.writing-mode.vertical-rl" => CSSFeature {
 		id: "css.properties.writing-mode.vertical-rl",
@@ -47314,7 +47313,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(10,3),
 				},
 		caniuse: &["https://caniuse.com/css-writing-mode"],
-		popularity: 7.1562,
+		popularity: 6.8756,
 	},
 	"css.properties.writing-mode.lr" => CSSFeature {
 		id: "css.properties.writing-mode.lr",
@@ -47447,7 +47446,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.0832,
+		popularity: 85.1927,
 	},
 	"css.properties.z-index.auto" => CSSFeature {
 		id: "css.properties.z-index.auto",
@@ -47466,7 +47465,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.0832,
+		popularity: 85.1927,
 	},
 	"css.properties.z-index.negative_values" => CSSFeature {
 		id: "css.properties.z-index.negative_values",
@@ -47485,7 +47484,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.0832,
+		popularity: 85.1927,
 	},
 	"css.types.integer" => CSSFeature {
 		id: "css.types.integer",
@@ -47504,7 +47503,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(1,0),
 				},
 		caniuse: &[],
-		popularity: 85.0832,
+		popularity: 85.1927,
 	},
 	"css.properties.zoom" => CSSFeature {
 		id: "css.properties.zoom",
@@ -47523,7 +47522,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 						safari_ios: BrowserVersion(3,0),
 				},
 		caniuse: &["https://caniuse.com/css-zoom"],
-		popularity: 30.6300,
+		popularity: 31.3475,
 	},
 };
 


### PR DESCRIPTION
This sorts all types lexicographically within a spec to keep things stable.