### PR TITLE
csskit_proc_macro: drop hardcoded types, rely on ast imports more

### DIFF
--- a/crates/css_ast/src/types/image_1d.rs
+++ b/crates/css_ast/src/types/image_1d.rs
@@ -9,7 +9,7 @@ use crate::StripesFunction;
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
-pub struct Image1D<'a>(StripesFunction<'a>);
+pub struct Image1d<'a>(StripesFunction<'a>);
 
 #[cfg(test)]
 mod tests {
@@ -19,11 +19,11 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<Image1D>(), 56);
+		assert_eq!(std::mem::size_of::<Image1d>(), 56);
 	}
 
 	#[test]
 	fn test_writes() {
-		assert_parse!(CssAtomSet::ATOMS, Image1D, "stripes(red 1fr,green 2fr,blue 100px)");
+		assert_parse!(CssAtomSet::ATOMS, Image1d, "stripes(red 1fr,green 2fr,blue 100px)");
 	}
 }

--- a/crates/css_ast/src/types/mod.rs
+++ b/crates/css_ast/src/types/mod.rs
@@ -165,3 +165,10 @@ mod prelude {
 	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, ToCursors, ToSpan};
 	pub(crate) use csskit_proc_macro::syntax;
 }
+
+// Type aliases for primitive CSS types referenced in syntax definitions
+pub type Integer = crate::CSSInt;
+pub type String = css_parse::T![String];
+pub type Number = css_parse::T![Number];
+pub type Uri = crate::Url;
+pub type BgImage<'a> = crate::NoneOr<crate::Image<'a>>;

--- a/crates/css_ast/src/values/speech/impls.rs
+++ b/crates/css_ast/src/values/speech/impls.rs
@@ -16,9 +16,9 @@ mod tests {
 		assert_eq!(std::mem::size_of::<RestBeforeStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<RestAfterStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<RestStyleValue>(), 32);
-		assert_eq!(std::mem::size_of::<CueBeforeStyleValue>(), 28);
-		assert_eq!(std::mem::size_of::<CueAfterStyleValue>(), 28);
-		assert_eq!(std::mem::size_of::<CueStyleValue>(), 56);
+		assert_eq!(std::mem::size_of::<CueBeforeStyleValue>(), 56);
+		assert_eq!(std::mem::size_of::<CueAfterStyleValue>(), 56);
+		assert_eq!(std::mem::size_of::<CueStyleValue>(), 112);
 		// assert_eq!(std::mem::size_of::<VoiceFamilyStyleValue>(), 16);
 		// assert_eq!(std::mem::size_of::<VoiceRateStyleValue>(), 16);
 		// assert_eq!(std::mem::size_of::<VoicePitchStyleValue>(), 16);

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -61,6 +61,14 @@ where
 	}
 }
 
+impl Visitable for token_macros::Number {
+	fn accept<V: Visit>(&self, _: &mut V) {}
+}
+
+impl VisitableMut for token_macros::Number {
+	fn accept_mut<V: VisitMut>(&mut self, _: &mut V) {}
+}
+
 impl Visitable for token_macros::String {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		v.visit_string(self);

--- a/crates/css_ast/tests/snapshots/popular_snapshots__960.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__960.snap
@@ -10787,11 +10787,11 @@ StyleSheet(
               offset: SourceOffset(9701),
               len: 1,
             )),
-            value: Number(Number(Cursor(
+            value: LengthPercentage(Length(Zero(Number(Cursor(
               kind: "Number",
               offset: SourceOffset(9703),
               len: 1,
-            ))),
+            ))))),
             important: None,
             semicolon: Some(Semicolon(Cursor(
               kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__blueprint.1.0.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__blueprint.1.0.1.snap
@@ -3532,11 +3532,11 @@ StyleSheet(
               offset: SourceOffset(3285),
               len: 1,
             )),
-            value: Number(Number(Cursor(
+            value: LengthPercentage(Length(Zero(Number(Cursor(
               kind: "Number",
               offset: SourceOffset(3287),
               len: 1,
-            ))),
+            ))))),
             important: None,
             semicolon: Some(Semicolon(Cursor(
               kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
@@ -3389,11 +3389,11 @@ StyleSheet(
               offset: SourceOffset(2743),
               len: 1,
             )),
-            value: Number(Number(Cursor(
+            value: LengthPercentage(Length(Zero(Number(Cursor(
               kind: "Number",
               offset: SourceOffset(2745),
               len: 1,
-            ))),
+            ))))),
             important: None,
             semicolon: Some(Semicolon(Cursor(
               kind: "Semicolon",
@@ -157754,11 +157754,11 @@ StyleSheet(
               offset: SourceOffset(112040),
               len: 1,
             )),
-            value: Number(Number(Cursor(
+            value: LengthPercentage(Length(Zero(Number(Cursor(
               kind: "Number",
               offset: SourceOffset(112042),
               len: 1,
-            ))),
+            ))))),
             important: None,
             semicolon: Some(Semicolon(Cursor(
               kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.min.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.min.snap
@@ -9539,11 +9539,11 @@ StyleSheet(
               offset: SourceOffset(7249),
               len: 1,
             )),
-            value: Number(Number(Cursor(
+            value: LengthPercentage(Length(Zero(Number(Cursor(
               kind: "Number",
               offset: SourceOffset(7250),
               len: 1,
-            ))),
+            ))))),
             important: None,
             semicolon: Some(Semicolon(Cursor(
               kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
@@ -11026,11 +11026,11 @@ StyleSheet(
               offset: SourceOffset(8462),
               len: 1,
             )),
-            value: Number(Number(Cursor(
+            value: LengthPercentage(Length(Zero(Number(Cursor(
               kind: "Number",
               offset: SourceOffset(8464),
               len: 1,
-            ))),
+            ))))),
             important: None,
             semicolon: Some(Semicolon(Cursor(
               kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__inuitcss.6.0.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__inuitcss.6.0.0.snap
@@ -1621,11 +1621,11 @@ StyleSheet(
               offset: SourceOffset(13796),
               len: 1,
             )),
-            value: Number(Number(Cursor(
+            value: LengthPercentage(Length(Zero(Number(Cursor(
               kind: "Number",
               offset: SourceOffset(13798),
               len: 1,
-            ))),
+            ))))),
             important: None,
             semicolon: Some(Semicolon(Cursor(
               kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
@@ -5661,11 +5661,11 @@ StyleSheet(
               offset: SourceOffset(4049),
               len: 1,
             )),
-            value: Number(Number(Cursor(
+            value: LengthPercentage(Length(Zero(Number(Cursor(
               kind: "Number",
               offset: SourceOffset(4051),
               len: 1,
-            ))),
+            ))))),
             important: None,
             semicolon: Some(Semicolon(Cursor(
               kind: "Semicolon",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__pure.2.0.3.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__pure.2.0.3.snap
@@ -1001,11 +1001,11 @@ StyleSheet(
               offset: SourceOffset(2684),
               len: 1,
             )),
-            value: Number(Number(Cursor(
+            value: LengthPercentage(Length(Zero(Number(Cursor(
               kind: "Number",
               offset: SourceOffset(2686),
               len: 1,
-            ))),
+            ))))),
             important: None,
             semicolon: Some(Semicolon(Cursor(
               kind: "Semicolon",

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bg_image.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bg_image.snap
@@ -2,4 +2,4 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-struct Foo<'a>(pub crate::NoneOr<crate::Image<'a>>);
+struct Foo<'a>(pub crate::BgImage<'a>);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_type_with_lifetime.snap
@@ -4,5 +4,5 @@ expression: pretty
 ---
 enum Foo<'a> {
     Color(crate::Color),
-    Image(crate::Image1D<'a>),
+    Image1d(crate::Image1d<'a>),
 }

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type.snap
@@ -2,4 +2,4 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
-struct Foo(pub crate::CSSInt);
+struct Foo(pub crate::Integer);

--- a/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
+++ b/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
@@ -524,7 +524,7 @@ expression: "matches.iter().map(|ty|\nty.to_token_stream().to_string()).sorted()
   "pub struct HyphenateCharacterStyleValue { }",
   "pub struct HyphenateLimitZoneStyleValue { }",
   "pub struct Id { }",
-  "pub struct Image1D < \'a > { }",
+  "pub struct Image1d < \'a > { }",
   "pub struct ImageSetFunction < \'a > { }",
   "pub struct InlineSizeStyleValue { }",
   "pub struct InsetBlockEndStyleValue { }",


### PR DESCRIPTION
The csskit_proc_macro Def & Generate code had long match statements matching a bunch of hard coded types, mostly just to
provide range checks, lifetime matching, and aliasing, but this is a little redundant.

This change drops all of those, and instead expects the types from the crate (i.e. css_ast) to match the names in the
grammar.
