### PR TITLE
csskit_proc_macro: Split def.rs into it's own library.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "css_value_definition_parser"
+version = "0.0.4"
+dependencies = [
+ "css_lexer",
+ "heck",
+ "insta",
+ "itertools 0.14.0",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "csskit"
 version = "0.0.1"
 dependencies = [
@@ -646,6 +660,7 @@ name = "csskit_proc_macro"
 version = "0.0.4"
 dependencies = [
  "css_lexer",
+ "css_value_definition_parser",
  "heck",
  "insta",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ version = "0.0.4"
 csskit = { version = "0.0.1", path = "crates/csskit" }
 csskit_derives = { version = "0.0.4", path = "crates/csskit_derives" }
 csskit_proc_macro = { version = "0.0.4", path = "crates/csskit_proc_macro" }
+css_value_definition_parser = { version = "0.0.4", path = "crates/css_value_definition_parser" }
 css_parse = { version = "0.0.4", path = "crates/css_parse" }
 css_lexer = { version = "0.0.4", path = "crates/css_lexer" }
 css_ast = { version = "0.0.0", path = "crates/css_ast" }

--- a/crates/css_value_definition_parser/Cargo.toml
+++ b/crates/css_value_definition_parser/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "csskit_proc_macro"
+name = "css_value_definition_parser"
 version.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -11,11 +11,9 @@ repository.workspace = true
 
 [lib]
 bench = false
-proc-macro = true
 
 [dependencies]
 css_lexer.workspace = true
-css_value_definition_parser.workspace = true
 
 syn = { workspace = true, features = ["extra-traits"] }
 quote = { workspace = true }

--- a/crates/css_value_definition_parser/src/lib.rs
+++ b/crates/css_value_definition_parser/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 use heck::ToPascalCase;
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident};
@@ -13,7 +14,10 @@ use syn::{
 	parse2, token,
 };
 
-pub(crate) struct StrWrapped<T: Parse>(pub T);
+#[cfg(test)]
+mod test;
+
+pub struct StrWrapped<T: Parse>(pub T);
 impl<T: Parse> Parse for StrWrapped<T> {
 	fn parse(input_raw: ParseStream) -> Result<Self> {
 		Ok(Self(parse2::<T>(
@@ -23,7 +27,7 @@ impl<T: Parse> Parse for StrWrapped<T> {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub(crate) enum Def {
+pub enum Def {
 	Ident(DefIdent),
 	Function(DefIdent, Box<Def>),
 	AutoOr(Box<Def>),
@@ -42,13 +46,13 @@ pub(crate) enum Def {
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub(crate) enum DefGroupStyle {
+pub enum DefGroupStyle {
 	None,         // [ ] - regular group notation
 	OneMustOccur, // [ ]! - at least one in the group must occur
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
-pub(crate) enum DefCombinatorStyle {
+pub enum DefCombinatorStyle {
 	Ordered,      // <space>
 	AllMustOccur, // && - all must occur
 	Options,      // || - one or more must occur
@@ -56,13 +60,13 @@ pub(crate) enum DefCombinatorStyle {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
-pub(crate) enum DefMultiplierSeparator {
+pub enum DefMultiplierSeparator {
 	None,   // *, +, or {,}
 	Commas, // #, #? or #{,}
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub(crate) enum DefRange {
+pub enum DefRange {
 	None,
 	Range(Range<f32>), // {A,B}
 	RangeFrom(f32),    // {A,}
@@ -71,10 +75,10 @@ pub(crate) enum DefRange {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub(crate) struct DefIdent(pub String);
+pub struct DefIdent(pub String);
 
 #[derive(Debug, PartialEq, Clone)]
-pub(crate) struct DefType {
+pub struct DefType {
 	pub ident: DefIdent,
 	pub range: DefRange,
 }

--- a/crates/css_value_definition_parser/src/test.rs
+++ b/crates/css_value_definition_parser/src/test.rs
@@ -1,4 +1,4 @@
-use crate::def::*;
+use crate::*;
 use quote::quote;
 
 macro_rules! to_valuedef {

--- a/crates/csskit_proc_macro/src/lib.rs
+++ b/crates/csskit_proc_macro/src/lib.rs
@@ -2,14 +2,13 @@
 use proc_macro::TokenStream;
 use syn::{DeriveInput, parse_macro_input};
 
-mod def;
 mod generate;
 mod syntax;
 
 #[cfg(test)]
 mod test;
 
-use def::{Def, StrWrapped};
+use css_value_definition_parser::{Def, StrWrapped};
 
 #[proc_macro_attribute]
 pub fn syntax(args: TokenStream, input: TokenStream) -> TokenStream {

--- a/crates/csskit_proc_macro/src/syntax.rs
+++ b/crates/csskit_proc_macro/src/syntax.rs
@@ -3,8 +3,8 @@ use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Error, Meta, Token};
 
-use crate::def::*;
 use crate::generate::*;
+use css_value_definition_parser::*;
 
 fn has_derive_of(attrs: &[Attribute], name: &'static str) -> bool {
 	for attr in attrs {

--- a/crates/csskit_proc_macro/src/test/mod.rs
+++ b/crates/csskit_proc_macro/src/test/mod.rs
@@ -1,2 +1,1 @@
-mod test_def;
 mod test_generate;

--- a/crates/csskit_proc_macro/src/test/test_generate.rs
+++ b/crates/csskit_proc_macro/src/test/test_generate.rs
@@ -1,4 +1,5 @@
-use crate::{def::*, syntax::generate};
+use crate::syntax::generate;
+use css_value_definition_parser::*;
 
 macro_rules! to_valuedef {
 	( $lit:literal ) => {


### PR DESCRIPTION
Def.rs is a somewhat standalone package, and so we can move it into one.

The new `css_value_definition_parser` crate is a new low level crate that encapsulates the Def type, which parses CSS
Value Definition syntax.

This change also updates csskit_proc_macro to use this new crate.
