### PR TITLE
csskit_spec_generator: Fork generate-values/mod.ts into Rust package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "serde",
  "version_check",
@@ -47,6 +47,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
  "equator",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -121,10 +136,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-compression"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -163,6 +203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +228,27 @@ checksum = "e6cbbb8f56245b5a479b30a62cdc86d26e2f35c2b9f594bc4671654b03851380"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -237,6 +304,18 @@ name = "bytemuck"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cast"
@@ -354,6 +433,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +486,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +506,15 @@ name = "cpp_demangle"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -518,7 +634,7 @@ version = "0.0.5"
 dependencies = [
  "browserslist-rs",
  "chrono",
- "phf",
+ "phf 0.13.1",
 ]
 
 [[package]]
@@ -687,6 +803,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csskit_spec_generator"
+version = "0.0.5"
+dependencies = [
+ "anyhow",
+ "clap",
+ "css_value_definition_parser",
+ "futures",
+ "heck",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "reqwest",
+ "scraper",
+ "serde",
+ "serde_json",
+ "syn",
+ "tokio",
+]
+
+[[package]]
 name = "csskit_transform"
 version = "0.0.5"
 dependencies = [
@@ -715,6 +852,29 @@ dependencies = [
  "serde-wasm-bindgen",
  "wasm-bindgen",
  "wasm-bindgen-test",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -752,6 +912,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dhat"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +946,38 @@ dependencies = [
  "serde_json",
  "thousands",
 ]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -830,7 +1042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -858,12 +1070,180 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fluent-uri"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -875,7 +1255,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.4+wasi-0.2.4",
 ]
 
 [[package]]
@@ -928,6 +1308,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,10 +1361,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "html5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+dependencies = [
+ "log",
+ "markup5ever",
+ "match_token",
+]
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -989,6 +1513,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1030,6 +1661,22 @@ dependencies = [
  "ron",
  "serde",
  "similar",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1117,6 +1764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1796,34 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+]
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1192,6 +1873,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minicov"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1221,6 +1909,40 @@ name = "mintex"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -1299,6 +2021,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.110"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,14 +2094,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand",
 ]
 
 [[package]]
@@ -1345,7 +2147,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1354,11 +2169,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1375,6 +2199,18 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1405,6 +2241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "pprof"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +2271,12 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -1471,6 +2322,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1513,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1529,6 +2395,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "reqwest"
+version = "0.12.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+dependencies = [
+ "async-compression",
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,12 +2448,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ron"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "serde",
 ]
@@ -1580,7 +2504,40 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1605,10 +2562,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scraper"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f3a24d916e78954af99281a455168d4a9515d65eca99a18da1b813689c4ad9"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
+dependencies = [
+ "bitflags 2.9.4",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.11.3",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
+]
 
 [[package]]
 name = "serde"
@@ -1676,6 +2699,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "204ea332803bd95a0b60388590d59cf6468ec9becf626e2451f1d26a1d972de4"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +2735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,12 +2753,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1739,6 +2805,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,6 +2855,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -1821,16 +2918,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -1909,6 +3058,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +3076,110 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1976,6 +3239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +3269,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +3321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +3341,21 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2143,6 +3463,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +3483,18 @@ checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -2229,6 +3574,17 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -2420,6 +3776,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +3819,66 @@ name = "zerocopy-derive"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ csskit_transform = { version = "0.0.6", path = "crates/csskit_transform" }      
 csskit_highlight = { version = "0.0.6", path = "crates/csskit_highlight" }                       #@release
 csskit_lsp = { version = "0.0.6", path = "crates/csskit_lsp" }                                   #@release
 chromashift = { version = "0.0.6", path = "crates/chromashift" }                                 #@release
+csskit_spec_generator = { version = "0.0.0", path = "crates/csskit_spec_generator" }
 
 # Memory
 allocator-api2 = { version = "0.2.21" } # Held back for bumpalo (https://github.com/fitzgen/bumpalo/pull/288)
@@ -64,6 +65,7 @@ console = { version = "0.16.1" }
 # Error handling
 miette = { version = "7.6.0", default-features = false }
 thiserror = { version = "2.0.17" }
+anyhow = { version = "1.0.100" }
 
 # Procc Macro Tools
 syn = { version = "2.0.106" }
@@ -88,6 +90,10 @@ dhat = { version = "0.3.3" }
 grep-regex = { version = "0.1.13" }
 grep-matcher = { version = "0.1.7" }
 grep-searcher = { version = "0.1.14" }
+regex = { version = "1.12.2" }
+reqwest = { version = "0.12.24" }
+scraper = { version = "0.24.0" }
+tokio = { version = "1.48.0" }
 
 # Wasm
 wasm-bindgen = { version = "0.2.104" }

--- a/crates/csskit_spec_generator/Cargo.toml
+++ b/crates/csskit_spec_generator/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "csskit_spec_generator"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+css_value_definition_parser = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+reqwest = { workspace = true, features = [
+	"json",
+	"gzip",
+	"brotli",
+	"deflate",
+	"stream",
+] }
+anyhow = { workspace = true }
+heck = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+futures = "0.3"
+prettyplease = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+regex = { workspace = true }
+scraper = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+syn = { workspace = true, features = ["full", "extra-traits"] }

--- a/crates/csskit_spec_generator/src/codegen.rs
+++ b/crates/csskit_spec_generator/src/codegen.rs
@@ -1,0 +1,533 @@
+use crate::ignore_properties::get_ignore_properties;
+use crate::spec_parser::PropertyDefinition;
+use crate::todo_properties::get_todo_properties;
+use crate::value_extensions::get_value_extensions;
+use crate::web_features_data::{BaselineStatus, FeatureData, StringOrArray, WebFeaturesData};
+use css_value_definition_parser::Def;
+use heck::ToPascalCase;
+use proc_macro2::TokenStream;
+use quote::quote;
+use std::collections::{HashMap, HashSet};
+use syn::{File, parse2};
+
+/// Generate Rust code for a CSS spec module
+pub fn generate_spec_module(
+	spec_name: &str,
+	version: usize,
+	properties: &[PropertyDefinition],
+	spec_title: Option<&str>,
+	property_descriptions: &HashMap<String, String>,
+) -> String {
+	let url = format!("https://drafts.csswg.org/css-{}-{}/", spec_name, version);
+
+	let module_doc =
+		if let Some(title) = spec_title { format!("//! {}\n//! {}\n", title, url) } else { format!("//! {}\n", url) };
+
+	let ignore_properties = get_ignore_properties();
+	let should_ignore: HashSet<&str> = ignore_properties.get(spec_name).cloned().unwrap_or_default();
+
+	let mut filtered_properties: Vec<_> =
+		properties.iter().filter(|prop| !should_ignore.contains(prop.name.as_str())).collect();
+	filtered_properties.sort_by_key(|prop| &prop.name);
+
+	let todo_properties = get_todo_properties();
+	let should_comment_out: HashSet<&str> = todo_properties.get(spec_name).cloned().unwrap_or_default();
+
+	let value_extensions = get_value_extensions();
+	let spec_extensions = value_extensions.get(spec_name);
+
+	let property_types = filtered_properties.iter().map(|prop| {
+		let description = property_descriptions.get(&prop.name);
+		let extension = spec_extensions.and_then(|ext| ext.get(prop.name.as_str()).copied());
+		generate_property_type(spec_name, version, prop, description, extension)
+	});
+
+	let tokens = quote! {
+		mod impls;
+
+		use super::prelude::*;
+		use impls::*;
+
+		#(#property_types)*
+	};
+
+	let file: File = syn::parse2(tokens).expect("generated code should parse");
+	let mut code = prettyplease::unparse(&file);
+
+	code = format!("#![allow(warnings)]\n{}\n{}", module_doc, code);
+
+	code = fix_formatting(&code, spec_name, version, &filtered_properties);
+
+	code = add_blank_lines_between_properties(&code);
+
+	comment_out_properties(&code, &filtered_properties, &should_comment_out)
+}
+
+fn fix_formatting(code: &str, spec_name: &str, version: usize, properties: &[&PropertyDefinition]) -> String {
+	let mut result = String::new();
+
+	for line in code.lines() {
+		let mut fixed_line = line.to_string();
+
+		if fixed_line.starts_with("///") && !fixed_line.starts_with("/// ") {
+			fixed_line = fixed_line.replacen("///", "/// ", 1);
+		}
+
+		if fixed_line.contains(&format!("css-{}-{}", spec_name, version)) {
+			for prop in properties {
+				let property_id = if prop.name == "--*" { "defining-variables" } else { &prop.name };
+				let wrong_url = format!("css-{}-{}#{}", spec_name, version, property_id);
+				let correct_url = format!("css-{}-{}/#{}", spec_name, version, property_id);
+				fixed_line = fixed_line.replace(&wrong_url, &correct_url);
+			}
+		}
+
+		result.push_str(&fixed_line);
+		result.push('\n');
+	}
+
+	result
+}
+
+fn add_blank_lines_between_properties(code: &str) -> String {
+	let lines: Vec<&str> = code.lines().collect();
+	let mut result = Vec::new();
+	let mut prev_was_property_end = false;
+
+	for (i, line) in lines.iter().enumerate() {
+		let is_property_start = line.starts_with("/// Represents the style value for");
+
+		if is_property_start && prev_was_property_end && i > 0 {
+			result.push(String::new());
+		}
+
+		result.push(line.to_string());
+
+		let is_enum_end = line.starts_with("pub enum ") && line.contains("StyleValue") && line.ends_with(" {}");
+		let is_struct_end = line.starts_with("pub struct ") && line.contains("StyleValue") && line.ends_with(";");
+		let is_property_end = is_enum_end || is_struct_end;
+
+		prev_was_property_end = is_property_end;
+	}
+
+	result.join("\n")
+}
+
+fn comment_out_properties(
+	code: &str,
+	properties: &[&PropertyDefinition],
+	should_comment_out: &HashSet<&str>,
+) -> String {
+	let lines: Vec<&str> = code.lines().collect();
+	let mut result = Vec::new();
+	let mut in_commented_property = false;
+
+	for line in lines.iter() {
+		if line.starts_with("/// Represents the style value for") {
+			in_commented_property = properties.iter().any(|prop| {
+				should_comment_out.contains(prop.name.as_str()) && line.contains(&format!("`{}`", prop.name))
+			});
+		}
+
+		if in_commented_property {
+			if line.trim().is_empty() {
+				result.push(String::new());
+			} else {
+				result.push(format!("// {}", line));
+			}
+
+			if line.starts_with("pub enum ") || line.starts_with("pub struct ") {
+				in_commented_property = false;
+			}
+		} else {
+			result.push(line.to_string());
+		}
+	}
+
+	result.join("\n")
+}
+
+fn generate_property_type(
+	spec_name: &str,
+	version: usize,
+	prop: &PropertyDefinition,
+	description: Option<&String>,
+	value_extension: Option<&str>,
+) -> TokenStream {
+	let type_name_base = if prop.name == "--*" { "Custom".to_string() } else { prop.name.to_pascal_case() };
+
+	let property_id = if prop.name == "--*" { "defining-variables" } else { &prop.name };
+
+	let type_name = syn::Ident::new(&format!("{}StyleValue", type_name_base), proc_macro2::Span::call_site());
+
+	let extended_value =
+		if let Some(extension) = value_extension { format!("{}{}", prop.value, extension) } else { prop.value.clone() };
+
+	let grammar_cleaned = extended_value.replace("'", "\"").replace("∞", "");
+	let (is_enum, needs_lifetime) = match grammar_cleaned.parse::<TokenStream>() {
+		Ok(tokens) => match parse2::<Def>(tokens) {
+			Ok(def) => {
+				let optimized_def = def.optimize();
+				let data_type = optimized_def.suggested_data_type();
+				let is_enum = data_type.is_enum();
+				let needs_lifetime = optimized_def.maybe_unsized();
+				(is_enum, needs_lifetime)
+			}
+			Err(e) => {
+				eprintln!("Warning: Failed to parse Def for {}: {} - Error: {}", prop.name, prop.value, e);
+				(false, false)
+			}
+		},
+		Err(e) => {
+			eprintln!("Warning: Failed to tokenize syntax for {}: {} - Error: {}", prop.name, prop.value, e);
+			(false, false)
+		}
+	};
+
+	let doc_link_url = format!("https://drafts.csswg.org/css-{}-{}/#{}", spec_name, version, property_id);
+	let doc_intro = format!(
+		" Represents the style value for `{}` as defined in [css-{}-{}]({}).",
+		prop.name, spec_name, version, doc_link_url
+	);
+
+	let doc_grammar_header = " The grammar is defined as:";
+	let grammar = &extended_value;
+
+	let doc_link = format!("https://drafts.csswg.org/css-{}-{}/#{}", spec_name, version, property_id);
+
+	let syntax_value = format!(" {} ", extended_value.replace('\n', " "));
+
+	// Build style_value attributes
+	let initial = &prop.initial;
+	let applies_to = &prop.applies_to;
+	let inherited = prop.inherited.to_lowercase();
+	let percentages = prop.percentages.to_lowercase();
+	let canonical_order = prop.canonical_order.as_deref().unwrap_or("per grammar").to_lowercase();
+	let animation_type = prop.animation_type.as_deref().unwrap_or("not animatable").to_lowercase();
+
+	let css_feature = format!("css.properties.{}", prop.name);
+
+	let (keyword, suffix) = if is_enum { (quote! { enum }, quote! { {} }) } else { (quote! { struct }, quote! { ; }) };
+
+	let lifetime = if needs_lifetime {
+		quote! { <'a> }
+	} else {
+		quote! {}
+	};
+
+	let doc_tokens = if let Some(desc) = description {
+		let doc_desc = format!(" {}", desc);
+		quote! {
+			#[doc = #doc_intro]
+			#[doc = ""]
+			#[doc = #doc_desc]
+			#[doc = ""]
+			#[doc = #doc_grammar_header]
+			#[doc = ""]
+			#[doc = "```text,ignore"]
+			#[doc = #grammar]
+			#[doc = "```"]
+			#[doc = ""]
+			#[doc = #doc_link]
+		}
+	} else {
+		quote! {
+			#[doc = #doc_intro]
+			#[doc = ""]
+			#[doc = #doc_grammar_header]
+			#[doc = ""]
+			#[doc = "```text,ignore"]
+			#[doc = #grammar]
+			#[doc = "```"]
+			#[doc = ""]
+			#[doc = #doc_link]
+		}
+	};
+
+	quote! {
+		#doc_tokens
+		#[syntax(#syntax_value)]
+		#[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[style_value(
+			initial = #initial,
+			applies_to = #applies_to,
+			inherited = #inherited,
+			percentages = #percentages,
+			canonical_order = #canonical_order,
+			animation_type = #animation_type,
+		)]
+		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+		#[cfg_attr(feature = "css_feature_data", derive(ToCSSFeature), css_feature(#css_feature))]
+		#[cfg_attr(feature = "visitable", derive(Visitable), visit)]
+		pub #keyword #type_name #lifetime #suffix
+	}
+}
+
+/// Generate CSS feature data as a Rust source file
+pub fn generate_feature_data(web_features: &WebFeaturesData, popularity_map: &HashMap<String, f64>) -> String {
+	let mut all_groups: HashMap<String, HashSet<String>> = HashMap::new();
+	let mut all_specs: HashMap<String, HashSet<String>> = HashMap::new();
+	let mut feature_entries: Vec<(String, TokenStream)> = Vec::new();
+
+	// Collect all features
+	for (feature_id, feature) in &web_features.features {
+		if let Some(status) = &feature.status
+			&& let Some(by_compat_key) = &status.by_compat_key
+		{
+			for (id, compat_status) in by_compat_key {
+				if id.starts_with("css.") {
+					let entry = generate_feature_entry_tokens(
+						id,
+						feature_id,
+						feature,
+						compat_status,
+						popularity_map,
+						&mut all_groups,
+						&mut all_specs,
+					);
+					feature_entries.push((id.to_string(), entry));
+				}
+			}
+		}
+	}
+
+	feature_entries.sort_by(|a, b| a.0.cmp(&b.0));
+	let feature_entries: Vec<TokenStream> = feature_entries.into_iter().map(|(_, tokens)| tokens).collect();
+
+	let mut sorted_groups: Vec<_> = all_groups.into_iter().collect();
+	sorted_groups.sort_by(|a, b| a.0.cmp(&b.0));
+	let group_entries: Vec<TokenStream> = sorted_groups
+		.into_iter()
+		.filter(|(group, _)| !group.is_empty())
+		.map(|(group, members)| {
+			let mut sorted_members: Vec<_> = members.into_iter().collect();
+			sorted_members.sort();
+			let member_strs = sorted_members.iter().map(|m| m.as_str());
+			quote! {
+				#group => &[#(#member_strs),*]
+			}
+		})
+		.collect();
+
+	let mut sorted_specs: Vec<_> = all_specs.into_iter().collect();
+	sorted_specs.sort_by(|a, b| a.0.cmp(&b.0));
+	let spec_entries: Vec<TokenStream> = sorted_specs
+		.into_iter()
+		.filter(|(spec, _)| !spec.is_empty())
+		.map(|(spec, members)| {
+			let mut sorted_members: Vec<_> = members.into_iter().collect();
+			sorted_members.sort();
+			let member_strs = sorted_members.iter().map(|m| m.as_str());
+			quote! {
+				#spec => &[#(#member_strs),*]
+			}
+		})
+		.collect();
+
+	let tokens = quote! {
+		use crate::*;
+		use phf::{phf_map, Map};
+		use chrono::NaiveDate;
+
+		pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
+			#(#feature_entries)*
+		};
+
+		pub static GROUPS: Map<&'static str, &'static [&'static str]> = phf_map! {
+			#(#group_entries),*
+		};
+
+		pub static SPECS: Map<&'static str, &'static [&'static str]> = phf_map! {
+			#(#spec_entries),*
+		};
+	};
+
+	let file: File = parse2(tokens).expect("generated code should parse");
+	let code = prettyplease::unparse(&file);
+
+	format!("//! Auto-generated CSS features data\n\n{}", code)
+}
+
+fn generate_feature_entry_tokens(
+	id: &str,
+	feature_id: &str,
+	feature: &FeatureData,
+	compat_status: &crate::web_features_data::CompatKeyStatus,
+	popularity_map: &HashMap<String, f64>,
+	all_groups: &mut HashMap<String, HashSet<String>>,
+	all_specs: &mut HashMap<String, HashSet<String>>,
+) -> TokenStream {
+	let name = feature.name.as_deref().unwrap_or("");
+	let description = feature.description.as_deref().unwrap_or("");
+
+	let spec = if let Some(spec_val) = &feature.spec {
+		match spec_val {
+			StringOrArray::Single(s) => s.as_str(),
+			StringOrArray::Multiple(v) => v.first().map(|s| s.as_str()).unwrap_or(""),
+		}
+	} else {
+		""
+	};
+
+	if !spec.is_empty()
+		&& let Some(spec_val) = &feature.spec
+	{
+		match spec_val {
+			StringOrArray::Single(s) => {
+				all_specs.entry(s.clone()).or_default().insert(id.to_string());
+			}
+			StringOrArray::Multiple(v) => {
+				for s in v {
+					all_specs.entry(s.clone()).or_default().insert(id.to_string());
+				}
+			}
+		}
+	}
+
+	let groups: Vec<&str> = if let Some(group_val) = &feature.group {
+		match group_val {
+			StringOrArray::Single(s) => {
+				if !s.is_empty() && s != "css" {
+					all_groups.entry(s.clone()).or_default().insert(id.to_string());
+					vec![s.as_str()]
+				} else {
+					vec![]
+				}
+			}
+			StringOrArray::Multiple(v) => v
+				.iter()
+				.filter(|g| !g.is_empty() && g.as_str() != "css")
+				.map(|g| {
+					all_groups.entry(g.clone()).or_default().insert(id.to_string());
+					g.as_str()
+				})
+				.collect(),
+		}
+	} else {
+		vec![]
+	};
+
+	let baseline_status = generate_baseline_status_tokens(
+		&compat_status.baseline,
+		compat_status.baseline_high_date.as_deref(),
+		compat_status.baseline_low_date.as_deref(),
+	);
+
+	let browser_support = generate_browser_support_tokens(&compat_status.support);
+
+	let caniuse: Vec<String> = if let Some(caniuse_val) = &feature.caniuse {
+		match caniuse_val {
+			StringOrArray::Single(s) => {
+				if !s.is_empty() {
+					vec![format!("https://caniuse.com/{}", s)]
+				} else {
+					vec![]
+				}
+			}
+			StringOrArray::Multiple(v) => {
+				v.iter().filter(|s| !s.is_empty()).map(|s| format!("https://caniuse.com/{}", s)).collect()
+			}
+		}
+	} else {
+		vec![]
+	};
+
+	let caniuse_strs: Vec<&str> = caniuse.iter().map(|s| s.as_str()).collect();
+
+	let popularity = popularity_map.get(feature_id).copied().unwrap_or(0.0) as f32;
+
+	quote! {
+		#id => CSSFeature {
+			id: #id,
+			name: #name,
+			description: #description,
+			spec: #spec,
+			groups: &[#(#groups),*],
+			baseline_status: #baseline_status,
+			browser_support: #browser_support,
+			caniuse: &[#(#caniuse_strs),*],
+			popularity: #popularity,
+		},
+	}
+}
+
+fn generate_baseline_status_tokens(
+	baseline: &BaselineStatus,
+	high_date: Option<&str>,
+	low_date: Option<&str>,
+) -> TokenStream {
+	match baseline {
+		BaselineStatus::String(s) if s == "high" => {
+			let since = date_str_to_naive_date_tokens(high_date.unwrap_or(""));
+			let low_since = date_str_to_naive_date_tokens(low_date.unwrap_or(""));
+			quote! {
+				BaselineStatus::High { since: #since, low_since: #low_since }
+			}
+		}
+		BaselineStatus::String(s) if s == "low" => {
+			let low_since = date_str_to_naive_date_tokens(low_date.unwrap_or(""));
+			quote! {
+				BaselineStatus::Low(#low_since)
+			}
+		}
+		BaselineStatus::Bool(false) => quote! { BaselineStatus::False },
+		_ => quote! { BaselineStatus::Unknown },
+	}
+}
+
+fn date_str_to_naive_date_tokens(date: &str) -> TokenStream {
+	let parts: Vec<&str> = date.split('-').collect();
+	if parts.len() != 3 {
+		return quote! { NaiveDate::from_ymd_opt(1970, 1, 1).unwrap() };
+	}
+
+	let mut year = parts[0];
+	if year.len() > 4 {
+		year = &year[year.len() - 4..];
+	}
+
+	let year_num: i32 = year.parse().unwrap_or(1970);
+	let month_num: u32 = parts[1].parse().unwrap_or(1);
+	let day_num: u32 = parts[2].parse().unwrap_or(1);
+
+	quote! { NaiveDate::from_ymd_opt(#year_num, #month_num, #day_num).unwrap() }
+}
+
+fn generate_browser_support_tokens(support: &crate::web_features_data::SupportData) -> TokenStream {
+	let chrome = browser_version_tokens(support.chrome.as_deref());
+	let chrome_android = browser_version_tokens(support.chrome_android.as_deref());
+	let edge = browser_version_tokens(support.edge.as_deref());
+	let firefox = browser_version_tokens(support.firefox.as_deref());
+	let firefox_android = browser_version_tokens(support.firefox_android.as_deref());
+	let safari = browser_version_tokens(support.safari.as_deref());
+	let safari_ios = browser_version_tokens(support.safari_ios.as_deref());
+
+	quote! {
+		BrowserSupport {
+			chrome: #chrome,
+			chrome_android: #chrome_android,
+			edge: #edge,
+			firefox: #firefox,
+			firefox_android: #firefox_android,
+			safari: #safari,
+			safari_ios: #safari_ios,
+		}
+	}
+}
+
+fn browser_version_tokens(version: Option<&str>) -> TokenStream {
+	if let Some(ver) = version {
+		if ver.is_empty() {
+			return quote! { BrowserVersion(0, 0) };
+		}
+
+		if ver.chars().all(|c| c.is_ascii_digit() || c == '.') {
+			let parts: Vec<&str> = ver.split('.').collect();
+			let major: u16 = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
+			let minor: u16 = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+			return quote! { BrowserVersion(#major, #minor) };
+		}
+	}
+
+	quote! { BrowserVersion(0, 0) }
+}

--- a/crates/csskit_spec_generator/src/excluded_specs.rs
+++ b/crates/csskit_spec_generator/src/excluded_specs.rs
@@ -1,0 +1,14 @@
+/// Specs that should NOT be generated automatically.
+///
+/// These specs either:
+/// - Are not real specs (e.g., easter eggs like css-egg)
+/// - Have been superseded by other specs
+pub fn is_excluded_spec(spec_name: &str) -> bool {
+	EXCLUDED_SPECS.contains(&spec_name)
+}
+
+/// List of specs to exclude from automatic generation.
+const EXCLUDED_SPECS: &[&str] = &[
+	"egg",      // Easter egg spec - not a real spec (https://drafts.csswg.org/css-egg-1/)
+	"template", // Template Layout spec - superseded by CSS Grid
+];

--- a/crates/csskit_spec_generator/src/fetch_cached.rs
+++ b/crates/csskit_spec_generator/src/fetch_cached.rs
@@ -1,0 +1,179 @@
+use anyhow::{Result, anyhow};
+use reqwest::{
+	Client,
+	header::{HeaderMap, HeaderValue, USER_AGENT},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::{
+	env::current_dir,
+	fs::{create_dir_all, metadata, read_to_string, write},
+	path::PathBuf,
+	time::{Duration, SystemTime},
+};
+
+use crate::web_features_data::WebFeaturesData;
+
+const CACHE_DURATION_SECS: u64 = 24 * 60 * 60;
+
+const USER_AGENT_STRING: &str = "csskit_spec_generator/0.1";
+
+const CACHE_DIR_NAME: &str = "cache";
+
+const GITHUB_CSSWG_TREE_URL: &str = "https://api.github.com/repos/w3c/csswg-drafts/git/trees/main";
+
+const WEB_FEATURES_DATA_URL: &str =
+	"https://github.com/web-platform-dx/web-features/releases/latest/download/data.extended.json";
+
+const CSS_SPEC_PREFIX: &str = "css-";
+
+const CSSWG_DRAFTS_BASE_URL: &str = "https://drafts.csswg.org";
+
+/// Creates an HTTP client configured with appropriate headers and compression
+pub fn default_http_client() -> Result<Client> {
+	let mut headers = HeaderMap::new();
+	headers.insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_STRING));
+	let client = Client::builder().default_headers(headers).gzip(true).brotli(true).build()?;
+	Ok(client)
+}
+
+/// Finds the workspace root and returns the cache directory path
+///
+/// Searches upward from the current directory until it finds a Cargo.toml file,
+/// then returns the target/cache directory within that workspace.
+fn workspace_target_cache() -> Result<PathBuf> {
+	let workspace_root = find_workspace_root()?;
+	let cache_dir = workspace_root.join("target").join(CACHE_DIR_NAME);
+	create_dir_all(&cache_dir)?;
+	Ok(cache_dir)
+}
+
+/// Finds the workspace root by searching for Cargo.toml upward from the current directory
+fn find_workspace_root() -> Result<PathBuf> {
+	let mut dir = current_dir()?;
+	while !dir.join("Cargo.toml").exists() {
+		dir = dir.parent().ok_or_else(|| anyhow!("Could not find workspace"))?.to_path_buf();
+	}
+	Ok(dir)
+}
+
+/// Fetches content from a URL, using cached content if it's fresh enough
+///
+/// If the cache file exists and is less than 24 hours old, returns the cached content.
+/// Otherwise, fetches fresh content from the URL and updates the cache.
+async fn fetch_cached(client: &Client, url: &str, cache_name: &str) -> Result<String> {
+	let cache_path = workspace_target_cache()?.join(cache_name);
+
+	if let Some(cached_content) = try_read_cache(&cache_path)? {
+		return Ok(cached_content);
+	}
+
+	fetch_and_cache(client, url, &cache_path).await
+}
+
+/// Attempts to read cached content if it's still fresh
+fn try_read_cache(cache_path: &PathBuf) -> Result<Option<String>> {
+	let modified = metadata(cache_path).and_then(|m| m.modified()).unwrap_or(SystemTime::UNIX_EPOCH);
+	let age = SystemTime::now().duration_since(modified)?;
+
+	if age < Duration::from_secs(CACHE_DURATION_SECS) { Ok(Some(read_to_string(cache_path)?)) } else { Ok(None) }
+}
+
+/// Fetches content from a URL and writes it to the cache
+async fn fetch_and_cache(client: &Client, url: &str, cache_path: &PathBuf) -> Result<String> {
+	let res = client.get(url).send().await?;
+	if !res.status().is_success() {
+		anyhow::bail!("HTTP {} for {}", res.status(), url);
+	}
+	let contents = res.text().await?;
+	write(cache_path, &contents)?;
+	Ok(contents)
+}
+
+/// Fetches web features data from the web-features repository
+pub async fn get_web_features_data(client: &Client) -> Result<WebFeaturesData> {
+	let text = fetch_cached(client, WEB_FEATURES_DATA_URL, "web-features-data.extended.json").await?;
+	Ok(serde_json::from_str(&text)?)
+}
+
+/// Gets a map of spec name to list of available versions
+///
+/// For example: "align" -> [3, 4]
+///
+/// Parses spec directory names in the format "css-{name}-{version}"
+pub async fn get_spec_versions(client: &Client) -> Result<HashMap<String, Vec<usize>>> {
+	let text = fetch_cached(client, GITHUB_CSSWG_TREE_URL, "index.json").await?;
+	let v: Value = serde_json::from_str(&text)?;
+	let paths = extract_tree_directories(&v)?;
+
+	let mut map: HashMap<String, Vec<usize>> = HashMap::new();
+	for path in paths {
+		if let Some((name, version)) = parse_spec_path(&path) {
+			map.entry(name).or_default().push(version);
+		}
+	}
+
+	for versions in map.values_mut() {
+		versions.sort();
+	}
+
+	Ok(map)
+}
+
+/// Extracts directory paths from the GitHub API tree response
+fn extract_tree_directories(tree_value: &Value) -> Result<Vec<String>> {
+	Ok(serde_json::from_value::<Vec<Value>>(tree_value["tree"].clone())?
+		.into_iter()
+		.filter_map(|item| {
+			if item["type"] == "tree" { serde_json::from_value::<String>(item["path"].clone()).ok() } else { None }
+		})
+		.filter(|s| s.starts_with(CSS_SPEC_PREFIX))
+		.collect())
+}
+
+/// Parses a spec path in the format "css-{name}-{version}" into (name, version)
+///
+/// Returns None if the path doesn't match the expected format
+fn parse_spec_path(path: &str) -> Option<(String, usize)> {
+	let parts: Vec<&str> = path.split('-').collect();
+	if parts.len() >= 3
+		&& parts[0] == "css"
+		&& let Ok(version) = parts[parts.len() - 1].parse::<usize>()
+	{
+		let name = parts[1..parts.len() - 1].join("-");
+		return Some((name, version));
+	}
+	None
+}
+
+/// Fetches the HTML content for a specific CSS spec version
+pub async fn get_spec(client: &Client, name: &str, ver: usize) -> Result<String> {
+	let url = format!("{}/css-{}-{}/", CSSWG_DRAFTS_BASE_URL, name, ver);
+	let cache_name = format!("{}-{}.txt", name, ver);
+	fetch_cached(client, &url, &cache_name).await
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PopularityEntry {
+	pub property_name: String,
+	pub day_percentage: f64,
+}
+
+/// Fetches CSS popularity data from chromestatus.com
+///
+/// Returns a map of property names to their usage percentage (0-100)
+pub async fn get_css_popularity(client: &Client) -> Result<HashMap<String, f64>> {
+	let cache_key = "popularity.json";
+	let url = "https://chromestatus.com/data/csspopularity";
+
+	let text = fetch_cached(client, url, cache_key).await?;
+	let data: Vec<PopularityEntry> = serde_json::from_str(&text)?;
+
+	let mut popularity_map = HashMap::new();
+	for entry in data {
+		popularity_map.insert(entry.property_name, entry.day_percentage * 100.0);
+	}
+
+	Ok(popularity_map)
+}

--- a/crates/csskit_spec_generator/src/ignore_properties.rs
+++ b/crates/csskit_spec_generator/src/ignore_properties.rs
@@ -1,0 +1,142 @@
+use std::collections::{HashMap, HashSet};
+
+/// Properties to ignore from certain specs because they've moved around or are defined
+/// in multiple specifications. These properties should not be generated from these specs.
+pub fn get_ignore_properties() -> HashMap<&'static str, HashSet<&'static str>> {
+	let mut map = HashMap::new();
+
+	// https://drafts.csswg.org/css-ui-4/#changes-22-12-2017
+	// Moved the box-sizing and text-overflow properties to [CSS-SIZING-3] and [CSS-OVERFLOW-4] respectively.
+	map.insert("ui", HashSet::from(["box-sizing", "text-overflow"]));
+
+	// CSS Shapes [CSS-SHAPES-2] define the shape-inside property that aligns contents along the edge of a possibly non-rectangular wrapping area.
+	// (Round-Display just extends to add the `display` keyword which is specified in shapes-2 anyway)
+	map.insert("round-display", HashSet::from(["shape-inside"]));
+
+	map.insert(
+		"backgrounds",
+		HashSet::from([
+			// https://drafts.csswg.org/css-backgrounds-4/#background-layers
+			// The name of this property is discussed in issue https://github.com/w3c/csswg-drafts/issues/9083.
+			"background-tbd",
+			// https://drafts.csswg.org/css-borders-4/#intro
+			//  This module is currently maintained as a diff against the parts related to borders and box
+			//  decorations of CSS Backgrounds and Borders Module Level 3 [CSS3BG]. We will fold in the text
+			//  once it's all formatted up and in CR again, as this will reduce the effort of keeping them in
+			//  sync (source diffs will be accurate in reflecting the differences).
+			// (IOW these are all defined in CSS Borders 4)
+			"border-color",
+			"border-top-color",
+			"border-right-color",
+			"border-bottom-color",
+			"border-left-color",
+			"border-style",
+			"border-top-style",
+			"border-right-style",
+			"border-bottom-style",
+			"border-left-style",
+			"border-width",
+			"border-top-width",
+			"border-right-width",
+			"border-bottom-width",
+			"border-left-width",
+			"border",
+			"border-top",
+			"border-right",
+			"border-bottom",
+			"border-left",
+			"border-radius",
+			"border-top-left-radius",
+			"border-top-right-radius",
+			"border-bottom-left-radius",
+			"border-bottom-right-radius",
+			"border-image",
+			"border-image-slice",
+			"border-image-source",
+			"border-image-outset",
+			"border-image-repeat",
+			"border-image-width",
+			"box-shadow",
+		]),
+	);
+
+	// While GCPM is effectively "deprecated" (see https://github.com/w3c/csswg-drafts/issues/6435) the "string-set"
+	// property definition inside of css-content is incomplete, as it is missing <content-list> (see
+	// https://github.com/w3c/csswg-drafts/issues/1829). This is properly defined in GCPM. So we should exclude the
+	// definition from css-content and use the more complete one from gcpm until both issues are properly addressed.
+	map.insert("content", HashSet::from(["string-set"]));
+
+	map.insert(
+		"logical",
+		HashSet::from([
+			// https://drafts.csswg.org/css-logical-1/
+			// These are extended definitions which are already defined in their respective specifications
+			//
+			// https://drafts.csswg.org/css-borders-4/
+			"border-block",
+			"border-block-color",
+			"border-block-end",
+			"border-block-end-color",
+			"border-block-end-style",
+			"border-block-end-width",
+			"border-block-start",
+			"border-block-start-color",
+			"border-block-start-style",
+			"border-block-start-width",
+			"border-block-style",
+			"border-block-width",
+			"border-end-end-radius",
+			"border-end-start-radius",
+			"border-inline",
+			"border-inline-color",
+			"border-inline-end",
+			"border-inline-end-color",
+			"border-inline-end-style",
+			"border-inline-end-width",
+			"border-inline-start",
+			"border-inline-start-color",
+			"border-inline-start-style",
+			"border-inline-start-width",
+			"border-inline-style",
+			"border-inline-width",
+			"border-start-end-radius",
+			"border-start-start-radius",
+			// https://drafts.csswg.org/css-position-4/
+			"inset",
+			"inset-block",
+			"inset-block-start",
+			"inset-block-end",
+			"inset-inline",
+			"inset-inline-end",
+			"inset-inline-start",
+		]),
+	);
+
+	// https://drafts.csswg.org/css-multicol/
+	// Moved the column-rule-* properties to [CSS-GAP-1].
+	map.insert(
+		"multicol",
+		HashSet::from(["column-rule", "column-rule-width", "column-rule-color", "column-rule-style"]),
+	);
+
+	// https://drafts.csswg.org/css-flexbox-1/
+	// Moved some align properties to [CSS-ALIGN-3].
+	map.insert("flexbox", HashSet::from(["align-content", "align-items", "align-self", "justify-content"]));
+
+	// The --* (custom properties) are handled specially in properties/mod.rs with a hardcoded Custom variant
+	map.insert("variables", HashSet::from(["--*"]));
+
+	// aspect-ratio, width, height, inline-size, block-size are defined in both conditional and sizing specs. Sizing is the canonical location.
+	map.insert("conditional", HashSet::from(["aspect-ratio", "inline-size", "block-size", "width", "height"]));
+
+	// fallback is defined in both anchor-position and counter-styles specs. Counter-styles is the canonical location.
+	map.insert("anchor-position", HashSet::from(["fallback"]));
+
+	// src is defined in both color and fonts specs. Fonts is the canonical location (@font-face).
+	map.insert("color", HashSet::from(["src"]));
+
+	// speak-as is defined in both counter-styles and speech specs. Speech is the canonical location.
+	map.insert("counter-styles", HashSet::from(["speak-as"]));
+
+	map
+}

--- a/crates/csskit_spec_generator/src/main.rs
+++ b/crates/csskit_spec_generator/src/main.rs
@@ -1,0 +1,328 @@
+#![deny(warnings)]
+mod codegen;
+mod excluded_specs;
+mod fetch_cached;
+mod ignore_properties;
+mod spec_parser;
+mod todo_properties;
+mod value_extensions;
+mod web_features_data;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use heck::ToSnakeCase;
+use std::collections::HashMap;
+use std::fs::{create_dir_all, write};
+use std::path::PathBuf;
+
+use crate::codegen::{generate_feature_data, generate_spec_module};
+use crate::fetch_cached::{
+	default_http_client, get_css_popularity, get_spec, get_spec_versions, get_web_features_data,
+};
+use crate::spec_parser::{PropertyDefinition, parse_spec_properties};
+
+/// Preview line count when verbose mode is enabled
+const PREVIEW_LINE_COUNT: usize = 30;
+
+/// Type alias for property descriptions map
+type PropertyDescriptions = HashMap<String, String>;
+
+#[derive(Parser, Debug)]
+#[command(name = "csskit_spec_generator")]
+#[command(about = "Generate CSS spec definitions and feature data", long_about = None)]
+struct Cli {
+	#[command(subcommand)]
+	command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+	/// List all available CSS specs
+	List,
+	/// Generate CSS feature data from web-features
+	GenerateFeatureData,
+	/// Generate Rust code for a specific CSS spec
+	GenerateSpec {
+		/// Name of the spec (e.g., "align", "backgrounds", "borders")
+		name: String,
+		/// Show verbose output including generated code preview
+		#[arg(short, long)]
+		verbose: bool,
+	},
+	/// Generate all CSS specs
+	GenerateAll,
+}
+
+/// Generates code for a single spec by processing all its versions
+///
+/// Accumulates properties from all spec versions, with later versions overwriting
+/// earlier ones for properties with the same name, then generates a single Rust
+/// module containing all the property definitions.
+async fn generate_single_spec(
+	client: &reqwest::Client,
+	name: &str,
+	versions: &[usize],
+	verbose: bool,
+	property_descriptions: &PropertyDescriptions,
+) -> Result<()> {
+	let (properties, latest_version) = collect_properties_from_versions(client, name, versions).await?;
+
+	if properties.is_empty() {
+		println!("  No properties found across all versions");
+		return Ok(());
+	}
+
+	println!("  Total unique properties across all versions: {}", properties.len());
+
+	let code = generate_spec_module(name, latest_version, &properties, None, property_descriptions);
+	let line_count = code.lines().count();
+
+	if verbose {
+		show_verbose_output(&properties, &code, line_count);
+	}
+
+	write_spec_module(name, &code)?;
+
+	Ok(())
+}
+
+/// Collects and merges properties from all versions of a spec
+///
+/// Returns the unique properties and the latest version number
+async fn collect_properties_from_versions(
+	client: &reqwest::Client,
+	name: &str,
+	versions: &[usize],
+) -> Result<(Vec<PropertyDefinition>, usize)> {
+	let mut all_properties: HashMap<String, PropertyDefinition> = HashMap::new();
+	let mut latest_version = 0;
+
+	for &version in versions {
+		println!("    Processing css-{}-{}...", name, version);
+		latest_version = version;
+
+		match process_single_version(client, name, version, &mut all_properties).await {
+			Ok(count) => {
+				if count == 0 {
+					println!("    No properties found");
+				} else {
+					println!("    Found {} properties", count);
+				}
+			}
+			Err(e) => {
+				eprintln!("    Error processing version: {}", e);
+			}
+		}
+	}
+
+	let properties: Vec<PropertyDefinition> = all_properties.into_values().collect();
+	Ok((properties, latest_version))
+}
+
+/// Processes a single spec version and adds its properties to the accumulator
+///
+/// Returns the number of properties found
+async fn process_single_version(
+	client: &reqwest::Client,
+	name: &str,
+	version: usize,
+	accumulator: &mut HashMap<String, PropertyDefinition>,
+) -> Result<usize> {
+	let html = get_spec(client, name, version).await?;
+	let properties = parse_spec_properties(&html)?;
+
+	let count = properties.len();
+	for prop in properties {
+		accumulator.insert(prop.name.clone(), prop);
+	}
+
+	Ok(count)
+}
+
+/// Displays verbose output including property names and code preview
+fn show_verbose_output(properties: &[PropertyDefinition], code: &str, line_count: usize) {
+	println!("  Properties:");
+	for prop in properties {
+		println!("    • {}", prop.name);
+	}
+
+	println!("  Code preview (first {} lines):", PREVIEW_LINE_COUNT);
+	for (i, line) in code.lines().take(PREVIEW_LINE_COUNT).enumerate() {
+		println!("    {:3} | {}", i + 1, line);
+	}
+	if line_count > PREVIEW_LINE_COUNT {
+		println!("    ... ({} more lines)", line_count - PREVIEW_LINE_COUNT);
+	}
+}
+
+/// Writes the generated spec module to the appropriate file
+fn write_spec_module(name: &str, code: &str) -> Result<()> {
+	let workspace_root = find_workspace_root()?;
+	let spec_snake = name.to_snake_case();
+	let output_dir = workspace_root.join("crates").join("css_ast").join("src").join("values").join(&spec_snake);
+
+	create_dir_all(&output_dir)?;
+
+	let file_path = output_dir.join("mod.rs");
+	write(&file_path, code)?;
+	println!("  Wrote to {}", file_path.display());
+
+	Ok(())
+}
+
+/// Finds the workspace root by searching for Cargo.toml upward from the current directory
+fn find_workspace_root() -> Result<PathBuf> {
+	let mut workspace_root = std::env::current_dir()?;
+	while !workspace_root.join("Cargo.toml").exists() {
+		workspace_root =
+			workspace_root.parent().ok_or_else(|| anyhow::anyhow!("Could not find workspace root"))?.to_path_buf();
+	}
+	Ok(workspace_root)
+}
+
+/// Extracts property descriptions from web features data
+///
+/// Maps CSS property names (e.g., "align-content") to their descriptions by
+/// searching for compat keys that match "css.properties.{name}" pattern.
+fn extract_property_descriptions(web_features: &crate::web_features_data::WebFeaturesData) -> PropertyDescriptions {
+	let mut descriptions = HashMap::new();
+
+	for feature in web_features.features.values() {
+		if let Some(description) = extract_description_from_feature(feature) {
+			descriptions.extend(description);
+		}
+	}
+
+	descriptions
+}
+
+/// Extracts descriptions from a single feature's compat keys
+fn extract_description_from_feature(feature: &crate::web_features_data::FeatureData) -> Option<PropertyDescriptions> {
+	const CSS_PROPERTIES_PREFIX: &str = "css.properties.";
+
+	let status = feature.status.as_ref()?;
+	let by_compat_key = status.by_compat_key.as_ref()?;
+	let description = feature.description.as_ref()?;
+
+	let mut descriptions = HashMap::new();
+	for id in by_compat_key.keys() {
+		if let Some(prop_name) = id.strip_prefix(CSS_PROPERTIES_PREFIX) {
+			descriptions.insert(prop_name.to_string(), description.clone());
+		}
+	}
+
+	Some(descriptions)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+	let client = default_http_client()?;
+	let cli = Cli::parse();
+
+	// Fetch web features data for property descriptions
+	let web_features = get_web_features_data(&client).await?;
+	let property_descriptions = extract_property_descriptions(&web_features);
+
+	match cli.command {
+		Commands::List => {
+			println!("Available CSS spec modules:");
+			let specs = get_spec_versions(&client).await?;
+			let mut spec_names: Vec<_> = specs.keys().collect();
+			spec_names.sort();
+			for name in spec_names {
+				let versions = &specs[name];
+				println!(
+					"  {} (versions: {})",
+					name,
+					versions.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", ")
+				);
+			}
+			println!("Total: {} spec modules", specs.len());
+		}
+		Commands::GenerateFeatureData => {
+			println!("Generating CSS feature data...");
+
+			println!("  Fetching web features data...");
+			let features = get_web_features_data(&client).await?;
+			println!("  Fetched {} features", features.features.len());
+
+			println!("  Fetching CSS popularity data...");
+			let popularity = get_css_popularity(&client).await?;
+			println!("  Fetched popularity data for {} properties", popularity.len());
+
+			println!("  Generating Rust code...");
+			let code = generate_feature_data(&features, &popularity);
+
+			println!("  Writing to file...");
+			let workspace_root = find_workspace_root()?;
+			let output_path = workspace_root.join("crates").join("css_feature_data").join("src").join("data.rs");
+			write(&output_path, code)?;
+
+			println!("Generated feature data at {}", output_path.display());
+		}
+		Commands::GenerateSpec { name, verbose } => {
+			println!("Generating spec: {}", name);
+			let specs = get_spec_versions(&client).await?;
+			match specs.get(&name) {
+				Some(versions) => {
+					println!("Found {} version(s) for spec '{}'", versions.len(), name);
+					generate_single_spec(&client, &name, versions, verbose, &property_descriptions).await?;
+					println!("  Spec generation complete");
+				}
+				None => {
+					eprintln!("  Error: Spec '{}' not found", name);
+					eprintln!("  Run 'list' command to see available specs");
+					std::process::exit(1);
+				}
+			}
+		}
+		Commands::GenerateAll => {
+			println!("Generating all CSS specs...");
+			let specs = get_spec_versions(&client).await?;
+			println!("Found {} spec modules to generate", specs.len());
+
+			let mut spec_names: Vec<_> = specs.keys().cloned().collect();
+			spec_names.sort();
+
+			let mut successful = 0;
+			let mut failed = 0;
+			let mut skipped = 0;
+
+			for name in &spec_names {
+				// Skip excluded specs (easter eggs, superseded specs, etc.)
+				if excluded_specs::is_excluded_spec(name) {
+					skipped += 1;
+					println!("  Skipping excluded spec: {}", name);
+					continue;
+				}
+
+				if let Some(versions) = specs.get(name) {
+					println!("  Generating spec: {}", name);
+					match generate_single_spec(&client, name, versions, false, &property_descriptions).await {
+						Ok(_) => {
+							successful += 1;
+							println!("  Completed: {}", name);
+						}
+						Err(e) => {
+							failed += 1;
+							eprintln!("  Failed: {} - {}", name, e);
+						}
+					}
+				}
+			}
+
+			println!("═══════════════════════════════════");
+			println!("✓ Generation complete!");
+			println!("  Successful: {}", successful);
+			if skipped > 0 {
+				println!("  Skipped: {}", skipped);
+			}
+			if failed > 0 {
+				println!("  Failed: {}", failed);
+			}
+			println!("═══════════════════════════════════");
+		}
+	}
+
+	Ok(())
+}

--- a/crates/csskit_spec_generator/src/spec_parser.rs
+++ b/crates/csskit_spec_generator/src/spec_parser.rs
@@ -1,0 +1,113 @@
+use anyhow::Result;
+use scraper::{Html, Selector};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct PropertyDefinition {
+	pub name: String,
+	pub value: String,
+	pub initial: String,
+	pub applies_to: String,
+	pub inherited: String,
+	pub percentages: String,
+	pub canonical_order: Option<String>,
+	pub animation_type: Option<String>,
+}
+
+/// Parse property definitions from a CSS spec HTML
+pub fn parse_spec_properties(html: &str) -> Result<Vec<PropertyDefinition>> {
+	let document = Html::parse_document(html);
+	let table_selector = Selector::parse("table.propdef, table.descdef").unwrap();
+	let tr_selector = Selector::parse("tr").unwrap();
+	let th_selector = Selector::parse("th").unwrap();
+	let td_selector = Selector::parse("td").unwrap();
+
+	let mut properties = Vec::new();
+
+	for table in document.select(&table_selector) {
+		let mut prop_data: HashMap<String, String> = HashMap::new();
+		for row in table.select(&tr_selector) {
+			let headers: Vec<_> = row.select(&th_selector).collect();
+			let data: Vec<_> = row.select(&td_selector).collect();
+
+			if headers.len() == 1 && data.len() == 1 {
+				let key = headers[0].text().collect::<String>().trim().to_lowercase();
+				let key = key.trim_end_matches(':').to_string();
+				let value = data[0].text().collect::<String>().trim().to_string();
+				prop_data.insert(key, value);
+			}
+		}
+
+		if let Some(names) = prop_data.get("name") {
+			for name in names.split(',') {
+				let name = name.trim().to_string();
+
+				// Skip if:
+				//  - this has "new values" - it means it's extending an existing property
+				//  - this has "for" - it means it's for an @-rule and not a general style value
+				//  TODO: We should be smarter about these, but for now we can simply skip
+				if prop_data.contains_key("new values") || prop_data.contains_key("for") {
+					continue;
+				}
+
+				if let Some(value) = prop_data.get("value") {
+					properties.push(PropertyDefinition {
+						name: name.clone(),
+						value: value.clone(),
+						initial: prop_data.get("initial").cloned().unwrap_or_default(),
+						applies_to: prop_data.get("applies to").cloned().unwrap_or_default(),
+						inherited: prop_data.get("inherited").cloned().unwrap_or_default(),
+						percentages: prop_data.get("percentages").cloned().unwrap_or_default(),
+						canonical_order: prop_data.get("canonical order").cloned(),
+						animation_type: prop_data
+							.get("animation type")
+							.or_else(|| prop_data.get("animatable"))
+							.cloned(),
+					});
+				}
+			}
+		}
+	}
+
+	Ok(properties)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_parse_simple_property() {
+		let html = r#"
+		<table class="propdef">
+			<tr><th>Name:</th><td>align-content</td></tr>
+			<tr><th>Value:</th><td>normal | <baseline-position> | <content-distribution></td></tr>
+			<tr><th>Initial:</th><td>normal</td></tr>
+			<tr><th>Applies to:</th><td>block containers</td></tr>
+			<tr><th>Inherited:</th><td>no</td></tr>
+			<tr><th>Percentages:</th><td>n/a</td></tr>
+			<tr><th>Animation type:</th><td>discrete</td></tr>
+		</table>
+		"#;
+
+		let props = parse_spec_properties(html).unwrap();
+		assert_eq!(props.len(), 1);
+		assert_eq!(props[0].name, "align-content");
+		assert_eq!(props[0].initial, "normal");
+	}
+
+	#[test]
+	fn test_skip_property_with_for_field() {
+		let html = r#"
+		<table class="propdef">
+			<tr><th>Name:</th><td>font-display</td></tr>
+			<tr><th>For:</th><td>@font-face</td></tr>
+			<tr><th>Value:</th><td>auto | block | swap | fallback | optional</td></tr>
+			<tr><th>Initial:</th><td>auto</td></tr>
+		</table>
+		"#;
+
+		let props = parse_spec_properties(html).unwrap();
+		assert_eq!(props.len(), 0);
+	}
+}

--- a/crates/csskit_spec_generator/src/todo_properties.rs
+++ b/crates/csskit_spec_generator/src/todo_properties.rs
@@ -1,0 +1,253 @@
+use std::collections::{HashMap, HashSet};
+
+/// Properties that should be commented out because their parsing rules are tricky.
+/// Once we figure out how to parse them in csskit_proc_macro/src/def.rs, we can
+/// remove them from this map and the generator will uncomment them.
+pub fn get_todo_properties() -> HashMap<&'static str, HashSet<&'static str>> {
+	let mut map = HashMap::new();
+
+	map.insert(
+		"align",
+		HashSet::from([
+			"justify-content",
+			"justify-self",
+			"place-self",
+			"justify-items",
+			"align-items",
+			"place-content",
+			"place-items",
+		]),
+	);
+
+	map.insert("anchor-position", HashSet::from(["position-visibility", "position-try-fallbacks", "position-try"]));
+
+	map.insert(
+		"animations",
+		HashSet::from([
+			"animation",
+			"animation-trigger-exit-range",
+			"animation-trigger-exit-range-end",
+			"animation-trigger-exit-range-start",
+			"animation-trigger-range",
+			"animation-trigger-range-end",
+			"animation-trigger-range-start",
+			"timeline-trigger",
+			"timeline-trigger-range",
+			"timeline-trigger-range-end",
+			"timeline-trigger-range-start",
+			"timeline-trigger-exit-range",
+			"timeline-trigger-exit-range-end",
+			"timeline-trigger-exit-range-start",
+		]),
+	);
+
+	map.insert(
+		"backgrounds",
+		HashSet::from([
+			"background",
+			"background-position",
+			"background-position-block",
+			"background-position-inline",
+			"background-position-x",
+			"background-position-y",
+		]),
+	);
+
+	map.insert(
+		"borders",
+		HashSet::from([
+			"border-block-end-radius",
+			"border-block-start-radius",
+			"border-bottom-radius",
+			"border-color",
+			"border-inline-end-radius",
+			"border-inline-start-radius",
+			"border-left-radius",
+			"border-limit",
+			"border-radius",
+			"border-right-radius",
+			"border-shape",
+			"border-top-radius",
+			"box-shadow-offset",
+			"corner-top-left",
+			"corner-top-right",
+			"corner-bottom-left",
+			"corner-bottom-right",
+			"corner-start-start",
+			"corner-start-end",
+			"corner-end-start",
+			"corner-end-end",
+			"corner-top",
+			"corner-left",
+			"corner-right",
+			"corner-bottom",
+			"corner-block-start",
+			"corner-block-end",
+			"corner-inline-start",
+			"corner-inline-end",
+			"corner",
+			"border-image",
+			"border-image-slice",
+			"border-image-width",
+		]),
+	);
+
+	map.insert("box", HashSet::from(["margin-trim"]));
+
+	map.insert("color-adjust", HashSet::from(["color-scheme"]));
+
+	map.insert("conditional", HashSet::from(["container", "container-type"]));
+
+	map.insert("contain", HashSet::from(["contain"]));
+
+	map.insert("content", HashSet::from(["content", "quotes"]));
+
+	map.insert("display", HashSet::from(["display"]));
+
+	map.insert("flexbox", HashSet::from(["flex"]));
+
+	map.insert(
+		"fonts",
+		HashSet::from([
+			"font",
+			"font-feature-settings",
+			"font-palette",
+			"font-size-adjust",
+			"font-synthesis",
+			"font-variant",
+			"font-variant-alternates",
+			"font-variant-east-asian",
+			"font-variant-ligatures",
+			"font-variant-numeric",
+			"font-variation-settings",
+		]),
+	);
+
+	map.insert("gcpm", HashSet::from(["string-set", "copy-into"]));
+
+	map.insert(
+		"grid",
+		HashSet::from([
+			"grid",
+			"grid-area",
+			"grid-auto-flow",
+			"grid-column",
+			"grid-row",
+			"grid-template",
+			"grid-template-columns",
+			"grid-template-rows",
+			"item-cross",
+			"item-flow",
+			"item-pack",
+			"item-wrap",
+		]),
+	);
+
+	map.insert("images", HashSet::from(["image-orientation", "image-resolution", "object-fit"]));
+
+	map.insert("inline", HashSet::from(["initial-letter", "initial-letter-align", "text-box", "vertical-align"]));
+
+	map.insert("multicol", HashSet::from(["columns"]));
+
+	map.insert("lists", HashSet::from(["counter-increment", "counter-reset", "counter-set", "list-style"]));
+
+	map.insert("overflow", HashSet::from(["line-clamp", "scrollbar-gutter", "text-overflow"]));
+
+	map.insert("regions", HashSet::from(["flow-into"]));
+
+	map.insert("ruby", HashSet::from(["ruby-position"]));
+
+	map.insert("scroll-snap", HashSet::from(["scroll-snap-type"]));
+
+	map.insert("shapes", HashSet::from(["shape-inside", "shape-outside"]));
+
+	map.insert(
+		"sizing",
+		HashSet::from([
+			"contain-intrinsic-block-size",
+			"contain-intrinsic-height",
+			"contain-intrinsic-inline-size",
+			"contain-intrinsic-size",
+			"contain-intrinsic-width",
+			"min-intrinsic-sizing",
+		]),
+	);
+
+	map.insert(
+		"speech",
+		HashSet::from(["speak-as", "voice-family", "voice-pitch", "voice-range", "voice-rate", "voice-volume"]),
+	);
+
+	map.insert(
+		"text",
+		HashSet::from([
+			"hanging-punctuation",
+			"hyphenate-limit-chars",
+			"text-indent",
+			"text-justify",
+			"text-spacing",
+			"text-transform",
+			"white-space",
+			"white-space-trim",
+			"word-space-transform",
+		]),
+	);
+
+	map.insert(
+		"text-decor",
+		HashSet::from([
+			"text-decoration",
+			"text-decoration-line",
+			"text-decoration-skip-self",
+			"text-decoration-skip-spaces",
+			"text-emphasis",
+			"text-emphasis-position",
+			"text-emphasis-style",
+			"text-underline-position",
+		]),
+	);
+
+	map.insert("transforms", HashSet::from(["rotate", "transform-origin", "translate"]));
+
+	map.insert("ui", HashSet::from(["nav-down", "nav-left", "nav-right", "nav-up"]));
+
+	map.insert("variables", HashSet::from(["--*"]));
+
+	map.insert("writing-modes", HashSet::from(["glyph-orientation-vertical"]));
+
+	map.insert("counter-styles", HashSet::from(["range", "additive-symbols"]));
+
+	// Font properties with complex grammars that cause panics or use unsupported operators like /
+	map.insert(
+		"fonts",
+		HashSet::from([
+			"superscript-size-override",
+			"superscript-position-override",
+			"ascent-override",
+			"line-gap-override",
+			"subscript-size-override",
+			"descent-override",
+			"subscript-position-override",
+			"font-variant",
+			"font-variant-east-asian",
+			"font-size-adjust",
+			"font-variant-numeric",
+			"font-variant-ligatures",
+			"font-variant-alternates",
+			"font",                    // Uses / operator for font-size / line-height
+			"unicode-range",           // Requires UnicodeRangeToken type
+			"src",                     // Requires FontSrcList type
+			"font-palette",            // Requires PaletteMixFunction function
+			"font-feature-settings",   // Requires FeatureTagValue type
+			"font-variation-settings", // Requires OpentypeTag type
+		]),
+	);
+
+	// Page properties with complex grammars
+	map.insert("page", HashSet::from(["size", "marks"]));
+
+	// Mixins properties - declaration-value is a trait not a type
+	map.insert("mixins", HashSet::from(["result"]));
+
+	map
+}

--- a/crates/csskit_spec_generator/src/value_extensions.rs
+++ b/crates/csskit_spec_generator/src/value_extensions.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+
+/// Returns a map of spec names to property value extensions
+///
+/// Each entry maps a property name to a string that will be appended to its grammar.
+/// For example, the sizing spec adds " | stretch | fit-content | contain" to width.
+pub fn get_value_extensions() -> HashMap<&'static str, HashMap<&'static str, &'static str>> {
+	let mut extensions = HashMap::new();
+
+	// https://drafts.csswg.org/css-sizing-4/#sizing-values
+	let mut sizing_extensions = HashMap::new();
+	sizing_extensions.insert("width", " | stretch | fit-content | contain");
+	sizing_extensions.insert("max-width", " | stretch | fit-content | contain");
+	sizing_extensions.insert("min-width", " | stretch | fit-content | contain");
+	sizing_extensions.insert("height", " | stretch | fit-content | contain");
+	sizing_extensions.insert("max-height", " | stretch | fit-content | contain");
+	sizing_extensions.insert("min-height", " | stretch | fit-content | contain");
+	extensions.insert("sizing", sizing_extensions);
+
+	extensions
+}

--- a/crates/csskit_spec_generator/src/web_features_data.rs
+++ b/crates/csskit_spec_generator/src/web_features_data.rs
@@ -1,0 +1,131 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebFeaturesData {
+	pub browsers: Browsers,
+	pub features: HashMap<String, FeatureData>,
+	pub groups: HashMap<String, GroupData>,
+	pub snapshots: HashMap<String, SnapshotData>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Browsers {
+	pub chrome: BrowserData,
+	pub chrome_android: BrowserData,
+	pub edge: BrowserData,
+	pub firefox: BrowserData,
+	pub firefox_android: BrowserData,
+	pub safari: BrowserData,
+	pub safari_ios: BrowserData,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrowserData {
+	pub name: String,
+	pub releases: Vec<Release>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Release {
+	pub version: String,
+	pub date: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeatureData {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub description: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub description_html: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub spec: Option<StringOrArray>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub status: Option<Status>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub caniuse: Option<StringOrArray>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub compat_features: Option<Vec<String>>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub group: Option<StringOrArray>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub snapshot: Option<StringOrArray>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub discouraged: Option<Discouraged>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum StringOrArray {
+	Single(String),
+	Multiple(Vec<String>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Discouraged {
+	pub according_to: Vec<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub alternatives: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Status {
+	pub baseline: BaselineStatus,
+	pub support: SupportData,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub baseline_low_date: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub baseline_high_date: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub by_compat_key: Option<HashMap<String, CompatKeyStatus>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BaselineStatus {
+	String(String), // matches "high", "low", or any other string value
+	Bool(bool),     // matches false (or true if it exists)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompatKeyStatus {
+	pub baseline: BaselineStatus,
+	pub support: SupportData,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub baseline_low_date: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub baseline_high_date: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SupportData {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub chrome: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub chrome_android: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub edge: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub firefox: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub firefox_android: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub safari: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub safari_ios: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupData {
+	pub name: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub parent: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotData {
+	pub name: String,
+	pub spec: String,
+}


### PR DESCRIPTION
generate-values is getting a little messy, and is probably not the right architecture:

 - Requiring Deno for the generator means having to context switch between Ts & Rust
 - It's the only part of the project that uses Deno, so another set of deps to manage
 - If it were in rust we could leverage Def generation to reason about allocator/structs properly
 - Right now it's one giant Ts file, we can do better.

This change introduces csskit_spec_generator, a port of generate-values/mod.ts into Rust. This
achieves most of the goals above.
