### PR TITLE
csskit_spec_generator: reinstate opt-outs for Parse impls

### DIFF
--- a/crates/csskit_spec_generator/src/main.rs
+++ b/crates/csskit_spec_generator/src/main.rs
@@ -3,6 +3,7 @@ mod codegen;
 mod excluded_specs;
 mod fetch_cached;
 mod ignore_properties;
+mod manual_parse_properties;
 mod spec_parser;
 mod todo_properties;
 mod value_extensions;

--- a/crates/csskit_spec_generator/src/manual_parse_properties.rs
+++ b/crates/csskit_spec_generator/src/manual_parse_properties.rs
@@ -1,0 +1,18 @@
+use std::collections::{HashMap, HashSet};
+
+/// Properties that require manual Parse implementations instead of generated ones.
+///
+/// Some properties have complex parsing rules that make them difficult or impractical
+/// to express using the derive(Parse) macro. For these properties, we exclude Parse
+/// from the generated derive list, allowing developers to provide custom implementations.
+///
+/// Examples include:
+/// - `glyph-orientation-vertical`: Requires special handling for literal integers and dimensions
+pub fn get_manual_parse_properties() -> HashMap<&'static str, HashSet<&'static str>> {
+	let mut map = HashMap::new();
+
+	// Properties with hand-written Parse implementations
+	map.insert("writing-modes", HashSet::from(["glyph-orientation-vertical"]));
+
+	map
+}

--- a/crates/csskit_spec_generator/src/todo_properties.rs
+++ b/crates/csskit_spec_generator/src/todo_properties.rs
@@ -213,8 +213,6 @@ pub fn get_todo_properties() -> HashMap<&'static str, HashSet<&'static str>> {
 
 	map.insert("variables", HashSet::from(["--*"]));
 
-	map.insert("writing-modes", HashSet::from(["glyph-orientation-vertical"]));
-
 	map.insert("counter-styles", HashSet::from(["range", "additive-symbols"]));
 
 	// Font properties with complex grammars that cause panics or use unsupported operators like /


### PR DESCRIPTION
glyph-orientation-vertical requires a manual parse impl. We should be able to opt out properties in codegen.rs, just
like generate-values/mod.ts did.
