### PR TITLE
css_ast/csskit_proc_macro: Support `,` literals better.

### DIFF
--- a/crates/css_ast/src/values/ui/mod.rs
+++ b/crates/css_ast/src/values/ui/mod.rs
@@ -163,11 +163,11 @@ pub enum CaretShapeStyleValue {}
 /// The grammar is defined as:
 ///
 /// ```text,ignore
-/// <cursor-image>#? <cursor-predefined>
+/// [<cursor-image>,]* <cursor-predefined>
 /// ```
 ///
 /// https://drafts.csswg.org/css-ui-4/#cursor
-#[syntax(" <cursor-image>#? <cursor-predefined> ")]
+#[syntax(" [<cursor-image>,]* <cursor-predefined> ")]
 #[derive(Parse, Peek, ToSpan, ToCursors, StyleValue, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[style_value(
 	initial = "auto",

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -61,6 +61,14 @@ where
 	}
 }
 
+impl Visitable for token_macros::Comma {
+	fn accept<V: Visit>(&self, _: &mut V) {}
+}
+
+impl VisitableMut for token_macros::Comma {
+	fn accept_mut<V: VisitMut>(&mut self, _: &mut V) {}
+}
+
 impl Visitable for token_macros::Number {
 	fn accept<V: Visit>(&self, _: &mut V) {}
 }

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -1,7 +1,7 @@
 use css_value_definition_parser::*;
 use heck::{ToPascalCase, ToSnakeCase};
 use itertools::Itertools;
-use proc_macro2::TokenStream;
+use proc_macro2::{Punct, Spacing, TokenStream};
 use quote::{format_ident, quote};
 use std::ops::{Deref, Range};
 use syn::{Error, Generics, Ident, Visibility, parse_quote};
@@ -182,7 +182,10 @@ impl ToType for Def {
 			}
 			Self::IntLiteral(_) => vec![quote! { crate::CSSInt }],
 			Self::DimensionLiteral(_, _) => vec![quote! { ::css_parse::T![Dimension] }],
-			Self::Punct(char) => vec![quote! { ::css_parse::T![#char] }],
+			Self::Punct(char) => {
+				let punct = Punct::new(*char, Spacing::Alone);
+				vec![quote! { ::css_parse::T![#punct] }]
+			}
 			Self::Group(inner, _) => inner.deref().to_types(),
 		}
 	}


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/pull/13018 changed the syntax of Cursor from using `#?` to `,]*`. This subtle change
means trailing commas are always required. We didn't support this for a couple of reasons:

- Punct wasn't being rendered correctly due to quoting of the char, so `T![,]` was rendering as `T![',']` which isn't a
	known macro. css_parse could have included quoted variants of all characters, or we could have updated
	csskit_proc_macro to unquote the chars, which is what this change does.

- `T![,]` wasn't Visitable, meaning the `Vec<'a, (X, T![,])>` wasn't Visitable either. Both `Vec` & `(A, B)` _are_
	visitable, so it's only `T![,]` that needs to be to make the whole thing work. This change makes `T![,]` Visitable.
