### PR TITLE
Update apt before installing gcc-aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
       - name: Install arm64 toolchain
         if: matrix.code-target == 'linux-arm64'
-        run: sudo apt-get install -y gcc-aarch64-linux-gnu
+        run: sudo apt update && sudo apt install -y gcc-aarch64-linux-gnu
       - name: Build Binary
         run: cargo build --release --target ${{ matrix.target }} -p csskit
         env:


### PR DESCRIPTION
This is an attempt at fixing the failing release build
