### PR TITLE
css_parse: elide more whitespace in CursorCompactWriteSink

### DIFF
--- a/coverage/basic/vars.min.css
+++ b/coverage/basic/vars.min.css
@@ -1,1 +1,1 @@
-hr{background:linear-gradient(to right, transparent, var(--border-color) 20%, var(--border-color) 80%, transparent)}
+hr{background:linear-gradient(to right,transparent,var(--border-color)20%,var(--border-color)80%,transparent)}


### PR DESCRIPTION
There are a few patterns where whitespace can be removed, where they aren't currently. Typically these are where there
are incompatible characters for an identifier start.

So this change implements two KindSets; `NO_WHITESPACE_BEFORE_KINDSET` and `NO_WHITESPACE_AFTER_KINDSET`. Both of these
use the Kind to check for types which are incompatible with identifier starts, and elide whitespace where they can.
