### PR TITLE
css_parse: Ensure trailing/leading descendant combinators aren't parsed

### DIFF
--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -252,6 +252,8 @@ mod tests {
 		assert_visits!(".foo#bar", CompoundSelector, Class, Id);
 		assert_visits!(".foo", CompoundSelector, Class);
 		assert_visits!("*.foo#bar", CompoundSelector, Wildcard, Class, Id);
+		assert_visits!(".foo .bar", CompoundSelector, Class, Combinator, Class);
+		assert_visits!(".foo ", CompoundSelector, Class);
 	}
 
 	#[test]

--- a/crates/css_parse/src/traits/selectors.rs
+++ b/crates/css_parse/src/traits/selectors.rs
@@ -17,8 +17,11 @@ pub trait CompoundSelector<'a>: Sized + Parse<'a> {
 		// Trim leading whitespace
 		p.consume_trivia();
 		loop {
-			// If a stop token has been reached, break the loop
-			if p.at_end() || p.peek_n(1) == KindSet::LEFT_CURLY_RIGHT_PAREN_COMMA_OR_SEMICOLON {
+			// If a stop token has been reached (skipping whitespace), break the loop
+			let skip = p.set_skip(KindSet::TRIVIA);
+			let next = p.peek_n(1);
+			p.set_skip(skip);
+			if next == Kind::Eof || next == KindSet::LEFT_CURLY_RIGHT_PAREN_COMMA_OR_SEMICOLON {
 				break;
 			}
 			components.push(p.parse::<Self::SelectorComponent>()?);


### PR DESCRIPTION
Currently in certain cases the descendant (whitespace) combinator will be parsed if it's at the start of end of a
selector, which is incorrect. This is because the parser checks based on the current skip state which could include
whitespace.

This change specifically sets the state while peeking at the next token, to ensure that if it peeked a stop token it can
break rather than consume & parse the whitespace.
