### PR TITLE
css_ast: Make container/supports nodes queryable

### DIFF
--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -56,7 +56,7 @@ discrete_feature!(
 
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum StyleQuery<'a> {
 	Is(Declaration<'a, StyleValue<'a>, CssMetadata>),
 	Not(T![Ident], Declaration<'a, StyleValue<'a>, CssMetadata>),
@@ -109,7 +109,7 @@ impl<'a> Parse<'a> for StyleQuery<'a> {
 
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum ScrollStateQuery<'a> {
 	Is(ScrollStateFeature),
 	Not(T![Ident], ScrollStateFeature),

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -80,7 +80,7 @@ impl<'a> Parse<'a> for ContainerCondition<'a> {
 
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum ContainerQuery<'a> {
 	Is(ContainerFeature<'a>),
 	Not(T![Ident], ContainerFeature<'a>),

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -59,7 +59,7 @@ pub struct SupportsRuleBlock<'a>(pub RuleList<'a, Rule<'a>, CssMetadata>);
 
 #[derive(ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum SupportsCondition<'a> {
 	Is(SupportsFeature<'a>),
 	Not(T![Ident], SupportsFeature<'a>),
@@ -116,7 +116,7 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
 #[allow(clippy::large_enum_variant)] // TODO: Box?
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum SupportsFeature<'a> {
 	FontTech(
 		#[cfg_attr(feature = "visitable", visit(skip))] Option<T!['(']>,


### PR DESCRIPTION
Add `visit` attribute to make these nodes queryable.
