### PR TITLE
csskit: add `csskit find`, csskit_ast 

### DIFF
--- a/.mise-tasks/csskit-acceptance
+++ b/.mise-tasks/csskit-acceptance
@@ -23,6 +23,7 @@ for arg in "$@"; do
 	esac
 done
 
+# Files to skip for specific variants (known issues)
 skip_min="coverage/popular/bootstrap.5.3.0.css coverage/popular/foundation.6.7.5.css"
 
 should_skip() {
@@ -71,6 +72,34 @@ check_variant() {
 	fi
 }
 
+check_find() {
+	css_file="$1"
+	find_file="$2"
+
+	# Parse front-matter: first line is query, second is ---, rest is expected output
+	query=$(head -n1 "$find_file")
+	expected=$(tail -n +3 "$find_file")
+
+	if actual=$($CSSKIT --color never find "$query" "$css_file" 2>/dev/null); then
+		if [ "$actual" = "$expected" ]; then
+			echo " $PASS find '$query' $css_file"
+			passed=$((passed + 1))
+		else
+			echo " $FAIL find '$query' $css_file"
+			if ! $QUIET; then
+				echo "Expected:"
+				echo "$expected"
+				echo "Actual:"
+				echo "$actual"
+			fi
+			failed=$((failed + 1))
+		fi
+	else
+		echo " $FAIL find '$query' $css_file (command failed)"
+		failed=$((failed + 1))
+	fi
+}
+
 for css in coverage/basic/*.css coverage/popular/*.css; do
 	[ -f "$css" ] || continue
 	case "$css" in *.min.css | *.fmt.css) continue ;; esac
@@ -79,6 +108,12 @@ for css in coverage/basic/*.css coverage/popular/*.css; do
 	check_parse "$css"
 	check_variant "fmt" "$css" "$base"
 	check_variant "min" "$css" "$base"
+
+	# Check find tests (*.find.N.txt files)
+	for find_file in "$base".find.*.txt; do
+		[ -f "$find_file" ] || continue
+		check_find "$css" "$find_file"
+	done
 done
 
 total=$((passed + failed))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,14 +711,27 @@ dependencies = [
  "css_ast",
  "css_lexer",
  "css_parse",
+ "csskit_ast",
  "csskit_highlight",
  "csskit_lsp",
  "itertools 0.14.0",
  "miette",
  "serde",
  "serde_json",
+ "strsim",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "csskit_ast"
+version = "0.0.7"
+dependencies = [
+ "bumpalo",
+ "css_ast",
+ "css_lexer",
+ "css_parse",
+ "derive_atom_set",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ csskit_source_finder = { version = "0.0.7", path = "crates/csskit_source_finder"
 csskit_transform = { version = "0.0.7", path = "crates/csskit_transform" }                       #@release
 csskit_highlight = { version = "0.0.7", path = "crates/csskit_highlight" }                       #@release
 csskit_lsp = { version = "0.0.7", path = "crates/csskit_lsp" }                                   #@release
+csskit_ast = { version = "0.0.7", path = "crates/csskit_ast" }                                   #@release
 chromashift = { version = "0.0.7", path = "crates/chromashift" }                                 #@release
 csskit_spec_generator = { version = "0.0.0", path = "crates/csskit_spec_generator" }
 
@@ -48,6 +49,7 @@ clap = { version = "4.5.48" }
 glob = { version = "0.3.3" }
 project-root = { version = "0.2.2" }
 anstyle = { version = "1.0.13" }
+strsim = { version = "0.11.1" }
 
 # LSP packages
 lsp-types = { version = "0.97.0" }

--- a/coverage/basic/media.find.1.txt
+++ b/coverage/basic/media.find.1.txt
@@ -1,0 +1,3 @@
+style-rule
+---
+coverage/basic/media.css:2:2:	body {

--- a/coverage/basic/media.find.2.txt
+++ b/coverage/basic/media.find.2.txt
@@ -1,0 +1,3 @@
+media-rule
+---
+coverage/basic/media.css:1:1:@media screen {

--- a/coverage/basic/media.find.3.txt
+++ b/coverage/basic/media.find.3.txt
@@ -1,0 +1,3 @@
+media-rule > style-rule
+---
+coverage/basic/media.css:2:2:	body {

--- a/coverage/basic/media.find.4.txt
+++ b/coverage/basic/media.find.4.txt
@@ -1,0 +1,3 @@
+color
+---
+coverage/basic/media.css:3:10:		color: black;

--- a/coverage/basic/media.find.5.txt
+++ b/coverage/basic/media.find.5.txt
@@ -1,0 +1,3 @@
+html-tag
+---
+coverage/basic/media.css:2:2:	body {

--- a/coverage/basic/nth.find.1.txt
+++ b/coverage/basic/nth.find.1.txt
@@ -1,0 +1,3 @@
+style-rule
+---
+coverage/basic/nth.css:1:1::nth-child(n+1) {

--- a/coverage/basic/rule.find.1.txt
+++ b/coverage/basic/rule.find.1.txt
@@ -1,0 +1,3 @@
+style-rule
+---
+coverage/basic/rule.css:1:1:body {

--- a/coverage/basic/rule.find.2.txt
+++ b/coverage/basic/rule.find.2.txt
@@ -1,0 +1,3 @@
+selector-list
+---
+coverage/basic/rule.css:1:1:body {

--- a/coverage/basic/rule.find.3.txt
+++ b/coverage/basic/rule.find.3.txt
@@ -1,0 +1,2 @@
+media-rule
+---

--- a/coverage/basic/vars.find.1.txt
+++ b/coverage/basic/vars.find.1.txt
@@ -1,0 +1,3 @@
+style-rule
+---
+coverage/basic/vars.css:1:1:hr {

--- a/coverage/popular/animate.4.1.1.find.1.txt
+++ b/coverage/popular/animate.4.1.1.find.1.txt
@@ -1,0 +1,3 @@
+charset-rule
+---
+coverage/popular/animate.4.1.1.css:1:1:@charset "UTF-8";

--- a/coverage/popular/animate.4.1.1.find.2.txt
+++ b/coverage/popular/animate.4.1.1.find.2.txt
@@ -1,0 +1,30 @@
+*:prefixed
+---
+coverage/popular/animate.4.1.1.css:15:3:  -webkit-animation-duration: 1s;
+coverage/popular/animate.4.1.1.css:17:3:  -webkit-animation-duration: var(--animate-duration);
+coverage/popular/animate.4.1.1.css:19:3:  -webkit-animation-fill-mode: both;
+coverage/popular/animate.4.1.1.css:23:3:  -webkit-animation-iteration-count: infinite;
+coverage/popular/animate.4.1.1.css:27:3:  -webkit-animation-iteration-count: 1;
+coverage/popular/animate.4.1.1.css:29:3:  -webkit-animation-iteration-count: var(--animate-repeat);
+coverage/popular/animate.4.1.1.css:33:3:  -webkit-animation-iteration-count: calc(1 * 2);
+coverage/popular/animate.4.1.1.css:35:3:  -webkit-animation-iteration-count: calc(var(--animate-repeat) * 2);
+coverage/popular/animate.4.1.1.css:39:3:  -webkit-animation-iteration-count: calc(1 * 3);
+coverage/popular/animate.4.1.1.css:41:3:  -webkit-animation-iteration-count: calc(var(--animate-repeat) * 3);
+coverage/popular/animate.4.1.1.css:45:3:  -webkit-animation-delay: 1s;
+coverage/popular/animate.4.1.1.css:47:3:  -webkit-animation-delay: var(--animate-delay);
+coverage/popular/animate.4.1.1.css:51:3:  -webkit-animation-delay: calc(1s * 2);
+coverage/popular/animate.4.1.1.css:53:3:  -webkit-animation-delay: calc(var(--animate-delay) * 2);
+coverage/popular/animate.4.1.1.css:57:3:  -webkit-animation-delay: calc(1s * 3);
+coverage/popular/animate.4.1.1.css:59:3:  -webkit-animation-delay: calc(var(--animate-delay) * 3);
+coverage/popular/animate.4.1.1.css:63:3:  -webkit-animation-delay: calc(1s * 4);
+coverage/popular/animate.4.1.1.css:65:3:  -webkit-animation-delay: calc(var(--animate-delay) * 4);
+coverage/popular/animate.4.1.1.css:69:3:  -webkit-animation-delay: calc(1s * 5);
+coverage/popular/animate.4.1.1.css:71:3:  -webkit-animation-delay: calc(var(--animate-delay) * 5);
+coverage/popular/animate.4.1.1.css:75:3:  -webkit-animation-duration: calc(1s / 2);
+coverage/popular/animate.4.1.1.css:77:3:  -webkit-animation-duration: calc(var(--animate-duration) / 2);
+coverage/popular/animate.4.1.1.css:81:3:  -webkit-animation-duration: calc(1s * 0.8);
+coverage/popular/animate.4.1.1.css:83:3:  -webkit-animation-duration: calc(var(--animate-duration) * 0.8);
+coverage/popular/animate.4.1.1.css:87:3:  -webkit-animation-duration: calc(1s * 2);
+coverage/popular/animate.4.1.1.css:89:3:  -webkit-animation-duration: calc(var(--animate-duration) * 2);
+coverage/popular/animate.4.1.1.css:93:3:  -webkit-animation-duration: calc(1s * 3);
+coverage/popular/animate.4.1.1.css:95:3:  -webkit-animation-duration: calc(var(--animate-duration) * 3);

--- a/coverage/popular/reset.2.0.find.1.txt
+++ b/coverage/popular/reset.2.0.find.1.txt
@@ -1,0 +1,9 @@
+style-rule
+---
+coverage/popular/reset.2.0.css:6:1:html, body, div, span, applet, object, iframe,
+coverage/popular/reset.2.0.css:27:1:article, aside, details, figcaption, figure, 
+coverage/popular/reset.2.0.css:31:1:body {
+coverage/popular/reset.2.0.css:34:1:ol, ul {
+coverage/popular/reset.2.0.css:37:1:blockquote, q {
+coverage/popular/reset.2.0.css:40:1:blockquote:before, blockquote:after,
+coverage/popular/reset.2.0.css:45:1:table {

--- a/coverage/popular/reset.2.0.find.2.txt
+++ b/coverage/popular/reset.2.0.find.2.txt
@@ -1,0 +1,6 @@
+legacy-pseudo-element
+---
+coverage/popular/reset.2.0.css:40:11:blockquote:before, blockquote:after,
+coverage/popular/reset.2.0.css:40:30:blockquote:before, blockquote:after,
+coverage/popular/reset.2.0.css:41:2:q:before, q:after {
+coverage/popular/reset.2.0.css:41:12:q:before, q:after {

--- a/coverage/popular/reset.2.0.find.3.txt
+++ b/coverage/popular/reset.2.0.find.3.txt
@@ -1,0 +1,3 @@
+style-rule:nth-child(2)
+---
+coverage/popular/reset.2.0.css:27:1:article, aside, details, figcaption, figure, 

--- a/coverage/popular/sakura.1.5.1.find.1.txt
+++ b/coverage/popular/sakura.1.5.1.find.1.txt
@@ -1,0 +1,4 @@
+media-rule
+---
+coverage/popular/sakura.1.5.1.css:22:1:@media (max-width: 684px) {
+coverage/popular/sakura.1.5.1.css:27:1:@media (max-width: 382px) {

--- a/coverage/popular/sakura.1.5.1.find.2.txt
+++ b/coverage/popular/sakura.1.5.1.find.2.txt
@@ -1,0 +1,4 @@
+media-rule > style-rule
+---
+coverage/popular/sakura.1.5.1.css:23:3:  body {
+coverage/popular/sakura.1.5.1.css:28:3:  body {

--- a/coverage/popular/sakura.1.5.1.find.3.txt
+++ b/coverage/popular/sakura.1.5.1.find.3.txt
@@ -1,0 +1,3 @@
+style-rule:first-child
+---
+coverage/popular/sakura.1.5.1.css:7:1:html {

--- a/coverage/popular/sakura.1.5.1.find.4.txt
+++ b/coverage/popular/sakura.1.5.1.find.4.txt
@@ -1,0 +1,9 @@
+[name=color]
+---
+coverage/popular/sakura.1.5.1.css:17:3:  color: #4a4a4a;
+coverage/popular/sakura.1.5.1.css:83:3:  color: #1d7484;
+coverage/popular/sakura.1.5.1.css:86:3:  color: #144f5a;
+coverage/popular/sakura.1.5.1.css:89:3:  color: #982c61;
+coverage/popular/sakura.1.5.1.css:187:3:  color: #f9f9f9;
+coverage/popular/sakura.1.5.1.css:199:3:  color: #f9f9f9;
+coverage/popular/sakura.1.5.1.css:221:3:  color: #4a4a4a;

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -142,6 +142,34 @@ impl ToCursors for Nth {
 	}
 }
 
+impl Nth {
+	/// Check if the given 1-based index matches this Nth pattern.
+	///
+	/// For example:
+	/// - `odd` matches indices 1, 3, 5, ...
+	/// - `even` matches indices 2, 4, 6, ...
+	/// - `3` matches only index 3
+	/// - `2n+1` matches indices 1, 3, 5, ... (same as odd)
+	/// - `3n` matches indices 3, 6, 9, ...
+	pub fn matches(&self, index: i32) -> bool {
+		match self {
+			Self::Odd(_) => index % 2 == 1,
+			Self::Even(_) => index % 2 == 0,
+			Self::Integer(n) => index == i32::from(*n),
+			Self::Anb(a, b, _) => {
+				if *a == 0 {
+					// 0n+b just matches index b
+					index == *b
+				} else {
+					// Check if (index - b) / a is a non-negative integer
+					let diff = index - b;
+					diff % a == 0 && diff / a >= 0
+				}
+			}
+		}
+	}
+}
+
 impl SemanticEq for Nth {
 	fn semantic_eq(&self, other: &Self) -> bool {
 		match (self, other) {

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 css_lexer = { workspace = true } # @release
 css_ast = { workspace = true, features = ["chromashift", "visitable"] } # @release
 css_parse = { workspace = true } # @release
+csskit_ast = { workspace = true } # @release
 csskit_lsp = { workspace = true } # @release
 csskit_highlight = { workspace = true, features = ["ansi"] } # @release
 chromashift = { workspace = true, features = ["anstyle"] } # @release
@@ -22,6 +23,7 @@ itertools = { workspace = true }
 clap = { workspace = true, features = ["derive", "cargo"] }
 miette = { workspace = true }
 anstyle = { workspace = true }
+strsim = { workspace = true }
 
 bumpalo = { workspace = true, features = ["collections", "boxed"] }
 

--- a/crates/csskit/src/commands/find.rs
+++ b/crates/csskit/src/commands/find.rs
@@ -1,0 +1,289 @@
+use std::io::Read;
+
+use anstyle::{AnsiColor, Style};
+use bumpalo::Bump;
+use clap::{Args, ValueEnum};
+use css_ast::visit::NodeId;
+use css_ast::{CssAtomSet, StyleSheet};
+use css_lexer::Lexer;
+use css_parse::Parser;
+use csskit_ast::{QuerySelectorList, SelectorMatcher};
+
+use crate::{CliError, CliResult, GlobalConfig, InputArgs};
+
+const PATH_STYLE: Style = Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Magenta)));
+const LINE_STYLE: Style = Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Green)));
+const MATCH_STYLE: Style = Style::new().bold().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Red)));
+const NO_STYLE: Style = Style::new();
+
+/// Output format for find results.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+	/// Ripgrep-style text output
+	#[default]
+	Text,
+	/// JSON output
+	Json,
+}
+
+/// Find CSS nodes using selector syntax
+///
+/// Query the parsed CSS AST using CSS-like selectors. Supports node types,
+/// pseudo-classes, attribute selectors, and combinators.
+///
+/// Examples:
+///   csskit find style-rule *.css
+///   csskit find '*:important' src/**/*.css
+///   csskit find 'media-rule > style-rule' theme.css
+#[derive(Debug, Args)]
+pub struct Find {
+	/// Selector pattern (e.g., "style-rule", "*:important")
+	selector: Option<String>,
+
+	#[command(flatten)]
+	input: InputArgs,
+
+	/// Show match count per file instead of matches
+	#[arg(long)]
+	count: bool,
+
+	/// Output format
+	#[arg(short, long, value_enum, default_value_t = OutputFormat::Text)]
+	format: OutputFormat,
+
+	/// List available node types
+	#[arg(long)]
+	list_types: bool,
+}
+
+/// Returns (line_start, line_end) byte offsets for the line containing `offset`.
+fn line_bounds(source: &str, offset: usize) -> (usize, usize) {
+	let start = source[..offset].rfind('\n').map_or(0, |i| i + 1);
+	let end = source[offset..].find('\n').map_or(source.len(), |i| offset + i);
+	(start, end)
+}
+
+impl Find {
+	pub fn run(&self, config: GlobalConfig) -> CliResult {
+		if self.list_types {
+			return self.list_types();
+		}
+
+		let Some(selector_str) = &self.selector else {
+			eprintln!("error: selector required (use --list-types to see available types)");
+			return Err(CliError::ParseFailed);
+		};
+
+		let selectors = match QuerySelectorList::parse(selector_str) {
+			Ok(s) => s,
+			Err(e) => {
+				eprintln!("error: {e}");
+				self.suggest_types(selector_str);
+				return Err(CliError::ParseFailed);
+			}
+		};
+
+		match self.format {
+			OutputFormat::Text => self.output_text(&selectors, config.colors()),
+			OutputFormat::Json => self.output_json(&selectors),
+		}
+	}
+
+	fn output_text(&self, selectors: &QuerySelectorList, color: bool) -> CliResult {
+		let bump = Bump::default();
+		let mut total = 0;
+		let mut files = 0;
+		let (path_style, line_style, match_style) =
+			if color { (PATH_STYLE, LINE_STYLE, MATCH_STYLE) } else { (NO_STYLE, NO_STYLE, NO_STYLE) };
+
+		for (filename, mut source) in self.input.sources()? {
+			let mut src = String::new();
+			source.read_to_string(&mut src)?;
+
+			let lexer = Lexer::new(&CssAtomSet::ATOMS, &src);
+			let mut parser = Parser::new(&bump, &src, lexer);
+			let result = parser.parse_entirely::<StyleSheet>();
+
+			let Some(stylesheet) = result.output.as_ref() else {
+				for err in result.errors {
+					eprintln!("{}", crate::commands::format_diagnostic_error(&err, &src, filename));
+				}
+				continue;
+			};
+
+			let matches = SelectorMatcher::new(selectors, &src).run(stylesheet);
+			if matches.is_empty() {
+				continue;
+			}
+
+			if files > 0 && !self.count {
+				println!();
+			}
+			files += 1;
+			total += matches.len();
+
+			if self.count {
+				println!("{filename}:{}", matches.len());
+				continue;
+			}
+
+			for m in &matches {
+				let (line, col) = m.span.line_and_column(&src);
+				let (ls, le) = line_bounds(&src, m.span.start().into());
+				let line_text = &src[ls..le];
+				let ms = m.span.start().0 as usize - ls;
+				let me = (m.span.end().0 as usize).min(le) - ls;
+
+				println!(
+					"{path_style}{filename}{path_style:#}:{line_style}{}{line_style:#}:{line_style}{}{line_style:#}:{}{match_style}{}{match_style:#}{}",
+					line + 1,
+					col + 1,
+					&line_text[..ms],
+					&line_text[ms..me],
+					&line_text[me..]
+				);
+			}
+		}
+
+		if self.count && files > 1 {
+			println!("\nTotal: {total}");
+		}
+
+		Ok(())
+	}
+
+	fn output_json(&self, selectors: &QuerySelectorList) -> CliResult {
+		let bump = Bump::default();
+		let mut count = 0;
+		let mut first = true;
+
+		if !self.count {
+			print!("[");
+		}
+
+		for (filename, mut source) in self.input.sources()? {
+			let mut src = String::new();
+			source.read_to_string(&mut src)?;
+
+			let lexer = Lexer::new(&CssAtomSet::ATOMS, &src);
+			let mut parser = Parser::new(&bump, &src, lexer);
+			let result = parser.parse_entirely::<StyleSheet>();
+
+			let Some(stylesheet) = result.output.as_ref() else {
+				continue;
+			};
+
+			let matches = SelectorMatcher::new(selectors, &src).run(stylesheet);
+			if matches.is_empty() {
+				continue;
+			}
+
+			count += matches.len();
+			if self.count {
+				continue;
+			}
+
+			let filename_json = json_str(filename);
+			for m in matches {
+				let (line, col) = m.span.line_and_column(&src);
+				let (ls, le) = line_bounds(&src, m.span.start().into());
+
+				if first {
+					first = false;
+					print!("\n  ");
+				} else {
+					print!(",\n  ");
+				}
+				print!(
+					"{{\"file\":{},\"type\":{},\"line\":{},\"column\":{},\"start\":{},\"end\":{},\"text\":{},\"context\":{}}}",
+					filename_json,
+					json_str(m.node_id.tag_name()),
+					line + 1,
+					col + 1,
+					usize::from(m.span.start()),
+					usize::from(m.span.end()),
+					json_str(&src[m.span.start().into()..m.span.end().into()]),
+					json_str(&src[ls..le]),
+				);
+			}
+		}
+
+		if self.count {
+			println!("{{\"count\":{count}}}");
+		} else if first {
+			println!("]");
+		} else {
+			println!("\n]");
+		}
+
+		Ok(())
+	}
+
+	fn list_types(&self) -> CliResult {
+		let mut types: Vec<_> = NodeId::all_variants().map(|id| id.tag_name()).collect();
+		types.sort_unstable();
+
+		println!("Node types:");
+		let mut prev_prefix = "";
+		for name in &types {
+			let prefix = name.split('-').next().unwrap_or(name);
+			if prefix != prev_prefix && !prev_prefix.is_empty() {
+				println!();
+			}
+			prev_prefix = prefix;
+			println!("  {name}");
+		}
+
+		println!("\nExamples:");
+		println!("  csskit find style-rule *.css");
+		println!("  csskit find '*:important' src/**/*.css");
+		println!("  csskit find 'media-rule > style-rule' theme.css");
+
+		Ok(())
+	}
+
+	fn suggest_types(&self, input: &str) {
+		let type_name = input.split(|c: char| c == ':' || c.is_whitespace()).next().unwrap_or(input);
+		if type_name == "*" || type_name.is_empty() {
+			return;
+		}
+
+		let suggestions: Vec<_> = NodeId::all_variants()
+			.map(|id| id.tag_name())
+			.filter(|name| {
+				name.contains(type_name) || type_name.contains(name) || strsim::levenshtein(name, type_name) <= 2
+			})
+			.take(5)
+			.collect();
+
+		if !suggestions.is_empty() {
+			eprintln!("\nDid you mean:");
+			for s in suggestions {
+				eprintln!("  {s}");
+			}
+		}
+		eprintln!("\nRun 'csskit find --list-types' for all types.");
+	}
+}
+
+/// Escape and quote a string for JSON output.
+fn json_str(s: &str) -> String {
+	use std::fmt::Write;
+	let mut out = String::with_capacity(s.len() + 2);
+	out.push('"');
+	for c in s.chars() {
+		match c {
+			'"' => out.push_str("\\\""),
+			'\\' => out.push_str("\\\\"),
+			'\n' => out.push_str("\\n"),
+			'\r' => out.push_str("\\r"),
+			'\t' => out.push_str("\\t"),
+			c if c.is_control() => {
+				let _ = write!(out, "\\u{:04x}", c as u32);
+			}
+			c => out.push(c),
+		}
+	}
+	out.push('"');
+	out
+}

--- a/crates/csskit/src/commands/mod.rs
+++ b/crates/csskit/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod check;
 mod colors;
 mod dbg_lex;
 mod dbg_parse;
+mod find;
 mod fmt;
 mod lsp;
 mod min;
@@ -15,6 +16,9 @@ mod min;
 pub enum Commands {
 	/// Report potential issues around some CSS files
 	Check(check::Check),
+
+	/// Find AST nodes matching a selector pattern
+	Find(find::Find),
 
 	/// Format CSS files to make them more readable.
 	Fmt(fmt::Fmt),
@@ -48,6 +52,7 @@ impl Commands {
 	pub fn run(&self, config: GlobalConfig) -> CliResult {
 		match self {
 			Commands::Check(cmd) => cmd.run(config),
+			Commands::Find(cmd) => cmd.run(config),
 			Commands::Fmt(cmd) => cmd.run(config),
 			Commands::Min(cmd) => cmd.run(config),
 			Commands::Colors(cmd) => cmd.run(config),

--- a/crates/csskit_ast/Cargo.toml
+++ b/crates/csskit_ast/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "csskit_ast"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+bench = false
+
+[dependencies]
+css_lexer = { workspace = true } # @release
+css_parse = { workspace = true } # @release
+css_ast = { workspace = true, features = ["visitable"] } # @release
+derive_atom_set = { workspace = true } # @release
+
+[dev-dependencies]
+bumpalo = { workspace = true, features = ["collections", "boxed"] }
+
+[features]
+default = []

--- a/crates/csskit_ast/src/lib.rs
+++ b/crates/csskit_ast/src/lib.rs
@@ -1,0 +1,160 @@
+#![deny(warnings)]
+
+//! CSS AST query utilities using selector-like syntax.
+
+pub mod selector;
+#[cfg(test)]
+mod test_helpers;
+
+use css_parse::AtomSet;
+use derive_atom_set::AtomSet;
+
+pub use selector::{
+	MatchOutput, NthValue, QueryAttribute, QueryCombinator, QueryPseudo, QuerySelector, QuerySelectorList,
+	QuerySelectorPart, QuerySimpleSelector, SelectorMatcher, SelectorParseError,
+};
+
+#[derive(AtomSet, Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub enum CsskitAtomSet {
+	#[default]
+	_None,
+
+	// Vendor prefixes
+	Webkit,
+	Moz,
+	Ms,
+	O,
+
+	// Pseudo-classes
+	Important,
+	Custom,
+	Prefixed,
+	Unknown,
+	Computed,
+	Shorthand,
+	Longhand,
+	#[atom("property-type")]
+	PropertyType,
+	Empty,
+	Nested,
+	Root,
+	#[atom("first-child")]
+	FirstChild,
+	#[atom("last-child")]
+	LastChild,
+	#[atom("only-child")]
+	OnlyChild,
+	#[atom("nth-child")]
+	NthChild,
+	#[atom("nth-last-child")]
+	NthLastChild,
+	#[atom("first-of-type")]
+	FirstOfType,
+	#[atom("last-of-type")]
+	LastOfType,
+	#[atom("only-of-type")]
+	OnlyOfType,
+	#[atom("nth-of-type")]
+	NthOfType,
+	#[atom("nth-last-of-type")]
+	NthLastOfType,
+	Not,
+	#[atom("at-rule")]
+	AtRule,
+	Rule,
+	Function,
+	Block,
+
+	// Property groups
+	Align,
+	Anchor,
+	#[atom("anchor-position")]
+	AnchorPosition,
+	Animation,
+	Animations,
+	Background,
+	Backgrounds,
+	Border,
+	Borders,
+	Box,
+	Break,
+	Cascade,
+	Color,
+	#[atom("color-adjust")]
+	ColorAdjust,
+	#[atom("color-hdr")]
+	ColorHdr,
+	Conditional,
+	Contain,
+	Content,
+	Display,
+	Exclusions,
+	Flex,
+	Flexbox,
+	Font,
+	Fonts,
+	Forms,
+	Gap,
+	Gaps,
+	Gcpm,
+	Grid,
+	Image,
+	Images,
+	Inline,
+	#[atom("line-grid")]
+	LineGrid,
+	#[atom("link-params")]
+	LinkParams,
+	List,
+	Lists,
+	Logical,
+	Mask,
+	Masking,
+	Multicol,
+	Nav,
+	Overflow,
+	Overscroll,
+	Page,
+	#[atom("page-floats")]
+	PageFloats,
+	Position,
+	Regions,
+	Rhythm,
+	#[atom("round-display")]
+	RoundDisplay,
+	Ruby,
+	#[atom("scroll-anchoring")]
+	ScrollAnchoring,
+	#[atom("scroll-snap")]
+	ScrollSnap,
+	Scrollbar,
+	Scrollbars,
+	Shaders,
+	Shape,
+	Shapes,
+	#[atom("size-adjust")]
+	SizeAdjust,
+	Sizing,
+	Speech,
+	Table,
+	Tables,
+	Text,
+	#[atom("text-decor")]
+	TextDecor,
+	#[atom("text-decoration")]
+	TextDecoration,
+	Transform,
+	Transforms,
+	Transition,
+	Transitions,
+	Ui,
+	Values,
+	Variables,
+	#[atom("view-transitions")]
+	ViewTransitions,
+	Viewport,
+	#[atom("will-change")]
+	WillChange,
+	#[atom("writing-modes")]
+	WritingModes,
+}

--- a/crates/csskit_ast/src/selector/matcher.rs
+++ b/crates/csskit_ast/src/selector/matcher.rs
@@ -1,0 +1,1362 @@
+use css_ast::visit::{NodeId, QueryableNode, Visit, Visitable};
+use css_ast::*;
+use css_lexer::{AtomSet, Span};
+use css_parse::{Cursor, Declaration, DeclarationValue, NodeWithMetadata, ToSpan};
+
+use super::output::MatchOutput;
+use super::query::{
+	NthValue, QueryAttribute, QueryCombinator, QueryPseudo, QuerySelector, QuerySelectorList, QuerySelectorPart,
+	QuerySimpleSelector,
+};
+
+use crate::CsskitAtomSet;
+
+fn parse_vendor_prefix(name: &str) -> Option<CsskitAtomSet> {
+	let name = name.strip_prefix('-').unwrap_or(name);
+	if name.starts_with("webkit") {
+		Some(CsskitAtomSet::Webkit)
+	} else if name.starts_with("moz") {
+		Some(CsskitAtomSet::Moz)
+	} else if name.starts_with("ms") {
+		Some(CsskitAtomSet::Ms)
+	} else if name.starts_with("o-") || name == "o" {
+		Some(CsskitAtomSet::O)
+	} else {
+		None
+	}
+}
+
+#[derive(Default, Clone)]
+struct MatchContext<'a> {
+	is_important: bool,
+	is_custom_property: bool,
+	is_computed: bool,
+	is_shorthand: bool,
+	is_longhand: bool,
+	is_unknown: bool,
+	property_group: Option<css_ast::PropertyGroup>,
+	property_name: Option<Cursor>,
+	source: &'a str,
+	sibling_index: i32,
+	vendor_prefix: Option<CsskitAtomSet>,
+}
+
+#[derive(Clone)]
+struct SiblingInfo {
+	node_id: Option<NodeId>,
+	span: Span,
+}
+
+#[derive(Clone)]
+struct ParentEntry<'a> {
+	node_id: Option<NodeId>,
+	span: Span,
+	context: MatchContext<'a>,
+	visited_children: Vec<SiblingInfo>,
+}
+
+#[derive(Default)]
+struct DeferredNeeds {
+	only_child: bool,
+	last_child: bool,
+	nth_last_child: Option<NthValue>,
+	first_of_type: bool,
+	last_of_type: bool,
+	only_of_type: bool,
+	nth_of_type: Option<NthValue>,
+	nth_last_of_type: Option<NthValue>,
+	empty: bool,
+}
+
+impl DeferredNeeds {
+	fn any(&self) -> bool {
+		self.only_child
+			|| self.last_child
+			|| self.nth_last_child.is_some()
+			|| self.first_of_type
+			|| self.last_of_type
+			|| self.only_of_type
+			|| self.nth_of_type.is_some()
+			|| self.nth_last_of_type.is_some()
+			|| self.empty
+	}
+
+	fn needs_type_tracking(&self) -> bool {
+		self.first_of_type
+			|| self.last_of_type
+			|| self.only_of_type
+			|| self.nth_of_type.is_some()
+			|| self.nth_last_of_type.is_some()
+	}
+}
+
+pub struct SelectorMatcher<'a> {
+	selectors: &'a QuerySelectorList,
+	source: &'a str,
+	matches: Vec<MatchOutput>,
+	parent_stack: Vec<ParentEntry<'a>>,
+}
+
+impl<'a> SelectorMatcher<'a> {
+	pub fn new(selectors: &'a QuerySelectorList, source: &'a str) -> Self {
+		Self { selectors, source, matches: Vec::new(), parent_stack: Vec::new() }
+	}
+
+	pub fn run<T: Visitable>(mut self, root: &T) -> Vec<MatchOutput> {
+		root.accept(&mut self);
+		self.matches
+	}
+
+	fn check_match<T: QueryableNode + ToSpan>(&mut self, node: &T) {
+		let node_id = T::NODE_ID;
+		let span = node.to_span();
+		let sibling_index = self.parent_stack.last().map(|p| p.visited_children.len() as i32 + 1).unwrap_or(1);
+		let context = MatchContext { source: self.source, sibling_index, ..Default::default() };
+		self.check_match_with_context(node_id, span, &context);
+		if let Some(parent) = self.parent_stack.last_mut() {
+			parent.visited_children.push(SiblingInfo { node_id: Some(node_id), span });
+		}
+		self.parent_stack.push(ParentEntry { node_id: Some(node_id), span, context, visited_children: Vec::new() });
+	}
+
+	fn exit_node<T: QueryableNode>(&mut self, _node: &T) {
+		if let Some(exiting) = self.parent_stack.last() {
+			let children = exiting.visited_children.clone();
+			self.check_deferred_matches(&children);
+		}
+		self.parent_stack.pop();
+	}
+
+	fn check_deferred_matches(&mut self, children: &[SiblingInfo]) {
+		let total = children.len();
+		for selector in &self.selectors.selectors {
+			let needs = self.get_deferred_pseudo_needs(selector);
+			if !needs.any() {
+				continue;
+			}
+			if needs.empty && total == 0 {
+				continue;
+			}
+
+			let type_info = if needs.needs_type_tracking() { self.compute_type_indices(children) } else { Vec::new() };
+
+			for (index, child) in children.iter().enumerate() {
+				let Some(node_id) = child.node_id else {
+					continue;
+				};
+
+				let child_index = (index + 1) as i32;
+				let index_from_end = (total - index) as i32;
+				let (type_index, type_index_from_end, type_count) =
+					if !type_info.is_empty() { type_info[index] } else { (1, 1, 1) };
+				if self.child_matches_deferred(
+					&needs,
+					node_id,
+					child_index,
+					index_from_end,
+					total,
+					type_index,
+					type_index_from_end,
+					type_count,
+				) && self.matches_deferred_selector(selector, node_id, &needs)
+				{
+					self.matches.push(MatchOutput { node_id, span: child.span });
+				}
+			}
+		}
+
+		if total == 0 {
+			self.check_empty_match();
+		}
+	}
+
+	fn compute_type_indices(&self, children: &[SiblingInfo]) -> Vec<(i32, i32, usize)> {
+		use std::collections::HashMap;
+
+		let mut type_counts: HashMap<NodeId, usize> = HashMap::new();
+		let mut type_indices: Vec<i32> = Vec::with_capacity(children.len());
+
+		for child in children {
+			if let Some(node_id) = child.node_id {
+				let count = type_counts.entry(node_id).or_insert(0);
+				*count += 1;
+				type_indices.push(*count as i32);
+			} else {
+				type_indices.push(0);
+			}
+		}
+
+		let mut type_counts_reverse: HashMap<NodeId, usize> = HashMap::new();
+		let mut result: Vec<(i32, i32, usize)> = vec![(0, 0, 0); children.len()];
+
+		for (i, child) in children.iter().enumerate().rev() {
+			if let Some(node_id) = child.node_id {
+				let count = type_counts_reverse.entry(node_id).or_insert(0);
+				*count += 1;
+				let total = type_counts.get(&node_id).copied().unwrap_or(1);
+				result[i] = (type_indices[i], *count as i32, total);
+			}
+		}
+
+		result
+	}
+
+	fn check_empty_match(&mut self) {
+		let Some(exiting) = self.parent_stack.last() else {
+			return;
+		};
+		let Some(node_id) = exiting.node_id else {
+			return;
+		};
+
+		for selector in &self.selectors.selectors {
+			let needs = self.get_deferred_pseudo_needs(selector);
+			if !needs.empty {
+				continue;
+			}
+			if self.matches_deferred_selector(selector, node_id, &needs) {
+				self.matches.push(MatchOutput { node_id, span: exiting.span });
+			}
+		}
+	}
+
+	fn get_deferred_pseudo_needs(&self, selector: &QuerySelector) -> DeferredNeeds {
+		let mut needs = DeferredNeeds::default();
+		for part in &selector.parts {
+			if let QuerySelectorPart::Simple(simple) = part {
+				for pseudo in &simple.pseudo_classes {
+					match pseudo {
+						QueryPseudo::OnlyChild => needs.only_child = true,
+						QueryPseudo::LastChild => needs.last_child = true,
+						QueryPseudo::NthLastChild(p) => needs.nth_last_child = Some(p.clone()),
+						QueryPseudo::FirstOfType => needs.first_of_type = true,
+						QueryPseudo::LastOfType => needs.last_of_type = true,
+						QueryPseudo::OnlyOfType => needs.only_of_type = true,
+						QueryPseudo::NthOfType(p) => needs.nth_of_type = Some(p.clone()),
+						QueryPseudo::NthLastOfType(p) => needs.nth_last_of_type = Some(p.clone()),
+						QueryPseudo::Empty => needs.empty = true,
+						_ => {}
+					}
+				}
+			}
+		}
+		needs
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	fn child_matches_deferred(
+		&self,
+		needs: &DeferredNeeds,
+		_node_id: NodeId,
+		_child_index: i32,
+		index_from_end: i32,
+		total: usize,
+		type_index: i32,
+		type_index_from_end: i32,
+		type_count: usize,
+	) -> bool {
+		!((needs.only_child && total != 1)
+			|| (needs.last_child && index_from_end != 1)
+			|| (needs.first_of_type && type_index != 1)
+			|| (needs.last_of_type && type_index_from_end != 1)
+			|| (needs.only_of_type && type_count != 1))
+			&& needs.nth_last_child.as_ref().is_none_or(|p| p.matches(index_from_end))
+			&& needs.nth_of_type.as_ref().is_none_or(|p| p.matches(type_index))
+			&& needs.nth_last_of_type.as_ref().is_none_or(|p| p.matches(type_index_from_end))
+	}
+
+	fn matches_deferred_selector(&self, selector: &QuerySelector, node_id: NodeId, needs: &DeferredNeeds) -> bool {
+		let parts = &selector.parts;
+		if parts.is_empty() {
+			return false;
+		}
+		let Some(QuerySelectorPart::Simple(rightmost)) = parts.last() else {
+			return false;
+		};
+		if let Some(expected) = rightmost.node_type
+			&& expected != node_id
+		{
+			return false;
+		}
+
+		let context = MatchContext { source: self.source, sibling_index: 1, ..Default::default() };
+		for pseudo in &rightmost.pseudo_classes {
+			let skip = match pseudo {
+				QueryPseudo::OnlyChild => needs.only_child,
+				QueryPseudo::LastChild => needs.last_child,
+				QueryPseudo::NthLastChild(_) => needs.nth_last_child.is_some(),
+				QueryPseudo::FirstOfType => needs.first_of_type,
+				QueryPseudo::LastOfType => needs.last_of_type,
+				QueryPseudo::OnlyOfType => needs.only_of_type,
+				QueryPseudo::NthOfType(_) => needs.nth_of_type.is_some(),
+				QueryPseudo::NthLastOfType(_) => needs.nth_last_of_type.is_some(),
+				QueryPseudo::Empty => needs.empty,
+				_ => false,
+			};
+			if skip {
+				continue;
+			}
+			if !self.matches_pseudo_with_context(pseudo, node_id, &context) {
+				return false;
+			}
+		}
+		parts.len() == 1
+	}
+
+	fn check_match_with_context(&mut self, node_id: NodeId, span: Span, context: &MatchContext) {
+		for selector in &self.selectors.selectors {
+			if self.matches_selector_with_context(selector, node_id, context) {
+				self.matches.push(MatchOutput { node_id, span });
+			}
+		}
+	}
+
+	fn check_declaration_match(&mut self, span: Span, context: &MatchContext) {
+		for selector in &self.selectors.selectors {
+			if self.matches_declaration_selector(selector, context) {
+				self.matches.push(MatchOutput { node_id: NodeId::StyleRule, span });
+			}
+		}
+	}
+
+	fn matches_declaration_selector(&self, selector: &QuerySelector, context: &MatchContext) -> bool {
+		if selector.parts.len() != 1 {
+			return false;
+		}
+		let Some(QuerySelectorPart::Simple(simple)) = selector.parts.first() else {
+			return false;
+		};
+		self.matches_declaration_simple(simple, context)
+	}
+
+	fn matches_attribute(&self, attr: &QueryAttribute, context: &MatchContext) -> bool {
+		match attr {
+			QueryAttribute::Name(expected_name) => {
+				let Some(cursor) = context.property_name else {
+					return false;
+				};
+				let expected_atom = CssAtomSet::from_str(expected_name);
+				if expected_atom != CssAtomSet::_None {
+					return CssAtomSet::from_bits(cursor.atom_bits()) == expected_atom;
+				}
+				cursor.str_slice(context.source).eq_ignore_ascii_case(expected_name)
+			}
+		}
+	}
+
+	fn matches_selector_with_context(&self, selector: &QuerySelector, node_id: NodeId, context: &MatchContext) -> bool {
+		let parts = &selector.parts;
+		if parts.is_empty() {
+			return false;
+		}
+		let Some(QuerySelectorPart::Simple(rightmost)) = parts.last() else {
+			return false;
+		};
+		if !self.matches_simple_with_context(rightmost, node_id, context) {
+			return false;
+		}
+		if parts.len() == 1 {
+			return true;
+		}
+		self.matches_ancestors(&parts[..parts.len() - 1])
+	}
+
+	fn matches_ancestors(&self, parts: &[QuerySelectorPart]) -> bool {
+		if parts.is_empty() {
+			return true;
+		}
+
+		let mut part_idx = parts.len();
+		let mut parent_idx = self.parent_stack.len();
+
+		while part_idx > 0 {
+			part_idx -= 1;
+			let part = &parts[part_idx];
+
+			match part {
+				QuerySelectorPart::Simple(simple) => {
+					let mut found = false;
+					while parent_idx > 0 {
+						parent_idx -= 1;
+						if self.matches_parent_entry(simple, &self.parent_stack[parent_idx]) {
+							found = true;
+							break;
+						}
+					}
+					if !found {
+						return false;
+					}
+				}
+				QuerySelectorPart::Combinator(combinator) => match combinator {
+					QueryCombinator::Descendant => {}
+					QueryCombinator::Child => {
+						if part_idx == 0 || parent_idx == 0 {
+							return false;
+						}
+						part_idx -= 1;
+						parent_idx -= 1;
+						let Some(QuerySelectorPart::Simple(parent_simple)) = parts.get(part_idx) else {
+							return false;
+						};
+						if !self.matches_parent_entry(parent_simple, &self.parent_stack[parent_idx]) {
+							return false;
+						}
+					}
+					QueryCombinator::NextSibling => {
+						if part_idx == 0 || parent_idx == 0 {
+							return false;
+						}
+						part_idx -= 1;
+						let Some(QuerySelectorPart::Simple(sibling_simple)) = parts.get(part_idx) else {
+							return false;
+						};
+						let siblings = &self.parent_stack[parent_idx - 1].visited_children;
+						if siblings.is_empty() {
+							return false;
+						}
+						if !self.matches_sibling_info(sibling_simple, siblings.last().unwrap()) {
+							return false;
+						}
+					}
+					QueryCombinator::SubsequentSibling => {
+						if part_idx == 0 || parent_idx == 0 {
+							return false;
+						}
+						part_idx -= 1;
+						let Some(QuerySelectorPart::Simple(sibling_simple)) = parts.get(part_idx) else {
+							return false;
+						};
+						let siblings = &self.parent_stack[parent_idx - 1].visited_children;
+						if !siblings.iter().any(|s| self.matches_sibling_info(sibling_simple, s)) {
+							return false;
+						}
+					}
+				},
+			}
+		}
+		true
+	}
+
+	fn matches_sibling_info(&self, simple: &QuerySimpleSelector, sibling: &SiblingInfo) -> bool {
+		match sibling.node_id {
+			Some(node_id) => simple.node_type.is_none_or(|expected| expected == node_id),
+			None => simple.node_type.is_none(),
+		}
+	}
+
+	fn matches_parent_entry(&self, simple: &QuerySimpleSelector, parent: &ParentEntry) -> bool {
+		match parent.node_id {
+			Some(node_id) => self.matches_simple_with_context(simple, node_id, &parent.context),
+			None => self.matches_declaration_simple(simple, &parent.context),
+		}
+	}
+
+	fn matches_declaration_simple(&self, simple: &QuerySimpleSelector, context: &MatchContext) -> bool {
+		if simple.node_type.is_some() {
+			return false;
+		}
+
+		for attr in &simple.attributes {
+			if !self.matches_attribute(attr, context) {
+				return false;
+			}
+		}
+
+		for pseudo in &simple.pseudo_classes {
+			let matches = match pseudo {
+				QueryPseudo::Important => context.is_important,
+				QueryPseudo::Custom => context.is_custom_property,
+				QueryPseudo::Prefixed(filter) => match filter {
+					Some(f) => context.vendor_prefix.is_some_and(|p| p == CsskitAtomSet::from_str(f)),
+					None => context.vendor_prefix.is_some(),
+				},
+				QueryPseudo::Computed => context.is_computed,
+				QueryPseudo::Shorthand => context.is_shorthand,
+				QueryPseudo::Longhand => context.is_longhand,
+				QueryPseudo::Unknown => context.is_unknown,
+				QueryPseudo::PropertyType(group) => self.matches_property_type(context, *group),
+				_ => true,
+			};
+			if !matches {
+				return false;
+			}
+		}
+
+		!simple.attributes.is_empty()
+			|| simple.pseudo_classes.iter().any(|p| {
+				matches!(
+					p,
+					QueryPseudo::Important
+						| QueryPseudo::Custom
+						| QueryPseudo::Prefixed(_)
+						| QueryPseudo::Computed
+						| QueryPseudo::Shorthand
+						| QueryPseudo::Longhand
+						| QueryPseudo::Unknown
+						| QueryPseudo::PropertyType(_)
+				)
+			})
+	}
+
+	fn matches_simple_with_context(
+		&self,
+		simple: &QuerySimpleSelector,
+		node_id: NodeId,
+		context: &MatchContext,
+	) -> bool {
+		if let Some(expected) = simple.node_type
+			&& expected != node_id
+		{
+			return false;
+		}
+		if simple.node_type.is_none() && simple.attributes.iter().any(|a| matches!(a, QueryAttribute::Name(_))) {
+			return false;
+		}
+		simple.pseudo_classes.iter().all(|p| self.matches_pseudo_with_context(p, node_id, context))
+	}
+
+	fn matches_pseudo_with_context(&self, pseudo: &QueryPseudo, node_id: NodeId, context: &MatchContext) -> bool {
+		match pseudo {
+			QueryPseudo::Not(inner) => {
+				if let Some(QuerySelectorPart::Simple(s)) = inner.parts.first()
+					&& let Some(expected) = s.node_type
+				{
+					return expected != node_id;
+				}
+				true
+			}
+			QueryPseudo::FirstChild => context.sibling_index == 1,
+			QueryPseudo::NthChild(pattern) => pattern.matches(context.sibling_index),
+			QueryPseudo::OnlyChild
+			| QueryPseudo::LastChild
+			| QueryPseudo::NthLastChild(_)
+			| QueryPseudo::FirstOfType
+			| QueryPseudo::LastOfType
+			| QueryPseudo::OnlyOfType
+			| QueryPseudo::NthOfType(_)
+			| QueryPseudo::NthLastOfType(_)
+			| QueryPseudo::Empty => false,
+			QueryPseudo::Root => self.parent_stack.is_empty(),
+			QueryPseudo::AtRule => self.is_at_rule(node_id),
+			QueryPseudo::Rule => self.is_rule(node_id),
+			QueryPseudo::Function => self.is_function(node_id),
+			QueryPseudo::Block => self.is_block(node_id),
+			QueryPseudo::Important => context.is_important,
+			QueryPseudo::Custom => context.is_custom_property,
+			QueryPseudo::Computed => context.is_computed,
+			QueryPseudo::Shorthand => context.is_shorthand,
+			QueryPseudo::Longhand => context.is_longhand,
+			QueryPseudo::PropertyType(group) => self.matches_property_type(context, *group),
+			QueryPseudo::Prefixed(filter) => self.is_prefixed(node_id, context, filter.as_deref()),
+			QueryPseudo::Unknown => context.is_unknown || node_id.tag_name().contains("unknown"),
+			QueryPseudo::Nested => self.parent_stack.iter().any(|p| p.node_id == Some(NodeId::StyleRule)),
+		}
+	}
+
+	fn is_at_rule(&self, node_id: NodeId) -> bool {
+		let name = node_id.tag_name();
+		name.ends_with("-rule") && name != "style-rule"
+	}
+
+	fn is_rule(&self, node_id: NodeId) -> bool {
+		node_id.tag_name().ends_with("-rule")
+	}
+
+	fn is_function(&self, node_id: NodeId) -> bool {
+		let name = node_id.tag_name();
+		name.ends_with("-function") || name.ends_with("-pseudo-function")
+	}
+
+	fn is_block(&self, node_id: NodeId) -> bool {
+		node_id.tag_name().ends_with("-block")
+	}
+
+	fn is_prefixed(&self, node_id: NodeId, context: &MatchContext, filter: Option<&str>) -> bool {
+		if let Some(prefix) = parse_vendor_prefix(node_id.tag_name()) {
+			return filter.is_none_or(|f| prefix == CsskitAtomSet::from_str(f));
+		}
+		if let Some(prefix) = context.vendor_prefix {
+			return filter.is_none_or(|f| prefix == CsskitAtomSet::from_str(f));
+		}
+		false
+	}
+
+	fn matches_property_type(&self, context: &MatchContext, group: crate::CsskitAtomSet) -> bool {
+		use crate::CsskitAtomSet::*;
+		let Some(property_group) = context.property_group else {
+			return false;
+		};
+		match group {
+			Align => property_group.contains(PropertyGroup::Align),
+			Anchor | AnchorPosition => property_group.contains(PropertyGroup::AnchorPosition),
+			Animation | Animations => property_group.contains(PropertyGroup::Animations),
+			Background | Backgrounds => property_group.contains(PropertyGroup::Backgrounds),
+			Border | Borders => property_group.contains(PropertyGroup::Borders),
+			Box => property_group.contains(PropertyGroup::Box),
+			Break => property_group.contains(PropertyGroup::Break),
+			Cascade => property_group.contains(PropertyGroup::Cascade),
+			Color => property_group.contains(PropertyGroup::Color),
+			ColorAdjust => property_group.contains(PropertyGroup::ColorAdjust),
+			ColorHdr => property_group.contains(PropertyGroup::ColorHdr),
+			Conditional => property_group.contains(PropertyGroup::Conditional),
+			Contain => property_group.contains(PropertyGroup::Contain),
+			Content => property_group.contains(PropertyGroup::Content),
+			Display => property_group.contains(PropertyGroup::Display),
+			Exclusions => property_group.contains(PropertyGroup::Exclusions),
+			Flex | Flexbox => property_group.contains(PropertyGroup::Flexbox),
+			Font | Fonts => property_group.contains(PropertyGroup::Fonts),
+			Forms => property_group.contains(PropertyGroup::Forms),
+			Gap | Gaps => property_group.contains(PropertyGroup::Gaps),
+			Gcpm => property_group.contains(PropertyGroup::Gcpm),
+			Grid => property_group.contains(PropertyGroup::Grid),
+			Image | Images => property_group.contains(PropertyGroup::Images),
+			Inline => property_group.contains(PropertyGroup::Inline),
+			LineGrid => property_group.contains(PropertyGroup::LineGrid),
+			LinkParams => property_group.contains(PropertyGroup::LinkParams),
+			List | Lists => property_group.contains(PropertyGroup::Lists),
+			Logical => property_group.contains(PropertyGroup::Logical),
+			Mask | Masking => property_group.contains(PropertyGroup::Masking),
+			Multicol => property_group.contains(PropertyGroup::Multicol),
+			Nav => property_group.contains(PropertyGroup::Nav),
+			Overflow => property_group.contains(PropertyGroup::Overflow),
+			Overscroll => property_group.contains(PropertyGroup::Overscroll),
+			Page => property_group.contains(PropertyGroup::Page),
+			PageFloats => property_group.contains(PropertyGroup::PageFloats),
+			Position => property_group.contains(PropertyGroup::Position),
+			Regions => property_group.contains(PropertyGroup::Regions),
+			Rhythm => property_group.contains(PropertyGroup::Rhythm),
+			RoundDisplay => property_group.contains(PropertyGroup::RoundDisplay),
+			Ruby => property_group.contains(PropertyGroup::Ruby),
+			ScrollAnchoring => property_group.contains(PropertyGroup::ScrollAnchoring),
+			ScrollSnap => property_group.contains(PropertyGroup::ScrollSnap),
+			Scrollbar | Scrollbars => property_group.contains(PropertyGroup::Scrollbars),
+			Shaders => property_group.contains(PropertyGroup::Shaders),
+			Shape | Shapes => property_group.contains(PropertyGroup::Shapes),
+			SizeAdjust => property_group.contains(PropertyGroup::SizeAdjust),
+			Sizing => property_group.contains(PropertyGroup::Sizing),
+			Speech => property_group.contains(PropertyGroup::Speech),
+			Table | Tables => property_group.contains(PropertyGroup::Tables),
+			Text => property_group.contains(PropertyGroup::Text),
+			TextDecor | TextDecoration => property_group.contains(PropertyGroup::TextDecor),
+			Transform | Transforms => property_group.contains(PropertyGroup::Transforms),
+			Transition | Transitions => property_group.contains(PropertyGroup::Transitions),
+			Ui => property_group.contains(PropertyGroup::Ui),
+			Values => property_group.contains(PropertyGroup::Values),
+			Variables => property_group.contains(PropertyGroup::Variables),
+			ViewTransitions => property_group.contains(PropertyGroup::ViewTransitions),
+			Viewport => property_group.contains(PropertyGroup::Viewport),
+			WillChange => property_group.contains(PropertyGroup::WillChange),
+			WritingModes => property_group.contains(PropertyGroup::WritingModes),
+			_ => false,
+		}
+	}
+}
+
+// Generate visit methods
+macro_rules! gen_visit_methods {
+	( $(
+		$name:ident$(<$($gen:tt),+>)?($obj:ty),
+	)+ ) => {
+		$(
+			fn $name$(<$($gen),+>)?(&mut self, node: &$obj) {
+				self.check_match(node);
+			}
+		)+
+	}
+}
+
+// Generate exit methods
+macro_rules! gen_exit_methods {
+	( $(
+		$name:ident$(<$($gen:tt),+>)?($obj:ty),
+	)+ ) => {
+		$(
+			fn $name$(<$($gen),+>)?(&mut self, node: &$obj) {
+				self.exit_node(node);
+			}
+		)+
+	}
+}
+
+impl Visit for SelectorMatcher<'_> {
+	css_ast::visit::apply_queryable_visit_methods!(gen_visit_methods);
+	css_ast::visit::apply_queryable_exit_methods!(gen_exit_methods);
+
+	// Special handling for Declaration to support :important, :custom, and [name=value]
+	fn visit_declaration<'b, T: DeclarationValue<'b, CssMetadata>>(&mut self, node: &Declaration<'b, T, CssMetadata>) {
+		let span = node.to_span();
+
+		// Calculate sibling index for declarations
+		let sibling_index = self.parent_stack.last().map(|p| p.visited_children.len() as i32 + 1).unwrap_or(1);
+
+		// Determine vendor prefix from property name
+		let property_cursor: Cursor = node.name.into();
+		let property_name_str = property_cursor.str_slice(self.source);
+		let vendor_prefix = parse_vendor_prefix(property_name_str);
+
+		// Get metadata for computed/property-type checks
+		let metadata = node.metadata();
+		let declaration_kinds = metadata.declaration_kinds;
+
+		// Check shorthand/longhand using the property name directly
+		let property_atom = CssAtomSet::from_bits(property_cursor.atom_bits());
+		let is_shorthand = StyleValue::is_shorthand_by_name(property_atom);
+		// A property is longhand if it's a known property that's not a shorthand
+		let is_longhand = property_atom != CssAtomSet::_None && !is_shorthand;
+
+		// Build context for pseudo-class matching
+		let context = MatchContext {
+			is_important: node.important.is_some(),
+			is_custom_property: node.name.is_dashed_ident(),
+			is_computed: declaration_kinds.contains(DeclarationKind::Computed),
+			is_shorthand,
+			is_longhand,
+			is_unknown: declaration_kinds.contains(DeclarationKind::Unknown),
+			property_group: if metadata.property_groups.is_none() { None } else { Some(metadata.property_groups) },
+			property_name: Some(node.name.into()),
+			source: self.source,
+			sibling_index,
+			vendor_prefix,
+		};
+
+		// Check if any selector targets "declaration" type with context-dependent pseudo-classes
+		self.check_declaration_match(span, &context);
+
+		// Record this declaration as a visited child in the parent's entry (for sibling combinators)
+		if let Some(parent) = self.parent_stack.last_mut() {
+			parent.visited_children.push(SiblingInfo { node_id: None, span });
+		}
+
+		// Push declaration onto parent stack so child nodes can see it as ancestor
+		self.parent_stack.push(ParentEntry {
+			node_id: None, // Declaration has no NodeId
+			span,
+			context,
+			visited_children: Vec::new(),
+		});
+	}
+
+	// Pop declaration from parent stack
+	fn exit_declaration<'b, T: DeclarationValue<'b, CssMetadata>>(&mut self, _node: &Declaration<'b, T, CssMetadata>) {
+		self.parent_stack.pop();
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::assert_query;
+
+	#[test]
+	fn match_style_rule() {
+		let matches = assert_query!("a { color: red; }", "style-rule", 1);
+		assert_eq!(matches[0].node_id, NodeId::StyleRule);
+		assert!(!matches[0].span.is_empty());
+	}
+
+	#[test]
+	fn match_selector_list() {
+		assert_query!("a, b { color: red; }", "selector-list", 1);
+	}
+
+	#[test]
+	fn match_multiple_selectors() {
+		assert_query!("a { color: red; } @media screen {}", "style-rule, media-rule", 2);
+	}
+
+	#[test]
+	fn descendant_combinator() {
+		let matches = assert_query!("a { color: red; }", "style-rule selector-list", 1);
+		assert_eq!(matches[0].node_id, NodeId::SelectorList);
+	}
+
+	#[test]
+	fn descendant_combinator_no_match() {
+		assert_query!("@media screen {}", "style-rule selector-list", 0);
+	}
+
+	#[test]
+	fn nested_descendant() {
+		let matches = assert_query!("@media screen { a { color: red; } }", "media-rule style-rule selector-list", 1);
+		assert_eq!(matches[0].node_id, NodeId::SelectorList);
+	}
+
+	#[test]
+	fn child_combinator() {
+		let matches = assert_query!("a { color: red; }", "style-rule > selector-list", 1);
+		assert_eq!(matches[0].node_id, NodeId::SelectorList);
+	}
+
+	#[test]
+	fn child_combinator_no_match() {
+		assert_query!("a { color: red; }", "style-sheet > selector-list", 0);
+	}
+
+	#[test]
+	fn next_sibling_combinator() {
+		assert_query!("a {} b {}", "style-rule + style-rule", 1);
+	}
+
+	#[test]
+	fn next_sibling_combinator_no_match() {
+		assert_query!("a {}", "style-rule + style-rule", 0);
+	}
+
+	#[test]
+	fn next_sibling_combinator_different_types() {
+		let matches = assert_query!("@media screen {} a {}", "media-rule + style-rule", 1);
+		assert_eq!(matches[0].node_id, NodeId::StyleRule);
+	}
+
+	#[test]
+	fn next_sibling_combinator_wrong_order() {
+		assert_query!("a {} @media screen {}", "media-rule + style-rule", 0);
+	}
+
+	#[test]
+	fn subsequent_sibling_combinator() {
+		assert_query!("a {} b {} c {}", "style-rule ~ style-rule", 2);
+	}
+
+	#[test]
+	fn subsequent_sibling_combinator_with_gap() {
+		let matches = assert_query!("@media screen {} @keyframes foo {} a {}", "media-rule ~ style-rule", 1);
+		assert_eq!(matches[0].node_id, NodeId::StyleRule);
+	}
+
+	#[test]
+	fn subsequent_sibling_combinator_no_match() {
+		assert_query!("a {} @media screen {}", "media-rule ~ style-rule", 0);
+	}
+
+	#[test]
+	fn match_custom_properties() {
+		assert_query!("a { --my-color: red; color: blue; --spacing: 10px; }", "*:custom", 2);
+	}
+
+	#[test]
+	fn no_match_custom_on_regular_properties() {
+		assert_query!("a { color: red; background: blue; }", "*:custom", 0);
+	}
+
+	#[test]
+	fn attribute_name_selector() {
+		assert_query!("a { color: red; background: blue; margin: 10px; }", "[name=color]", 1);
+	}
+
+	#[test]
+	fn attribute_name_selector_multiple() {
+		assert_query!("a { color: red; } b { color: blue; background: green; }", "[name=color]", 2);
+	}
+
+	#[test]
+	fn attribute_name_selector_quoted() {
+		assert_query!("a { background-color: red; }", "[name='background-color']", 1);
+	}
+
+	#[test]
+	fn attribute_name_selector_no_match() {
+		assert_query!("a { color: red; background: blue; }", "[name=margin]", 0);
+	}
+
+	#[test]
+	fn attribute_name_case_insensitive() {
+		assert_query!("a { COLOR: red; }", "[name=color]", 1);
+	}
+
+	#[test]
+	fn first_child() {
+		assert_query!("a {} b {} c {}", "style-rule:first-child", 1);
+	}
+
+	#[test]
+	fn first_child_no_match() {
+		assert_query!("@media screen {} a {}", "style-rule:first-child", 0);
+	}
+
+	#[test]
+	fn nth_child_index() {
+		assert_query!("a {} b {} c {} d {}", "style-rule:nth-child(2)", 1);
+	}
+
+	#[test]
+	fn nth_child_odd() {
+		assert_query!("a {} b {} c {} d {}", "style-rule:nth-child(odd)", 2);
+	}
+
+	#[test]
+	fn nth_child_even() {
+		assert_query!("a {} b {} c {} d {}", "style-rule:nth-child(even)", 2);
+	}
+
+	#[test]
+	fn nth_child_formula() {
+		assert_query!("a {} b {} c {} d {} e {} f {}", "style-rule:nth-child(3n)", 2);
+	}
+
+	#[test]
+	fn nth_child_formula_with_offset() {
+		assert_query!("a {} b {} c {} d {} e {} f {}", "style-rule:nth-child(2n+1)", 3);
+	}
+
+	#[test]
+	fn only_child() {
+		assert_query!("a {}", "style-rule:only-child", 1);
+	}
+
+	#[test]
+	fn only_child_no_match() {
+		assert_query!("a {} b {}", "style-rule:only-child", 0);
+	}
+
+	#[test]
+	fn style_rules_in_media() {
+		assert_query!("@media screen { a {} b {} }", "media-rule style-rule", 2);
+	}
+
+	#[test]
+	fn last_child() {
+		assert_query!("a {} b {} c {}", "style-rule:last-child", 1);
+	}
+
+	#[test]
+	fn last_child_no_match() {
+		// style-rule is not last (media-rule is)
+		assert_query!("a {} @media screen {}", "style-rule:last-child", 0);
+	}
+
+	#[test]
+	fn last_child_single() {
+		// Single child is both first and last
+		assert_query!("a {}", "style-rule:last-child", 1);
+	}
+
+	#[test]
+	fn nth_last_child_index() {
+		assert_query!("a {} b {} c {}", "style-rule:nth-last-child(1)", 1);
+	}
+
+	#[test]
+	fn nth_last_child_second() {
+		assert_query!("a {} b {} c {}", "style-rule:nth-last-child(2)", 1);
+	}
+
+	#[test]
+	fn nth_last_child_odd() {
+		assert_query!("a {} b {} c {} d {}", "style-rule:nth-last-child(odd)", 2);
+	}
+
+	#[test]
+	fn nth_last_child_even() {
+		assert_query!("a {} b {} c {} d {}", "style-rule:nth-last-child(even)", 2);
+	}
+
+	#[test]
+	fn nth_last_child_formula() {
+		assert_query!("a {} b {} c {} d {} e {} f {}", "style-rule:nth-last-child(2n)", 3);
+	}
+
+	#[test]
+	fn first_of_type() {
+		assert_query!("@media screen {} a {} b {}", "style-rule:first-of-type", 1);
+	}
+
+	#[test]
+	fn first_of_type_is_first() {
+		assert_query!("a {} b {} @media screen {}", "style-rule:first-of-type", 1);
+	}
+
+	#[test]
+	fn last_of_type() {
+		assert_query!("a {} b {} @media screen {}", "style-rule:last-of-type", 1);
+	}
+
+	#[test]
+	fn last_of_type_at_end() {
+		assert_query!("@media screen {} a {} b {}", "style-rule:last-of-type", 1);
+	}
+
+	#[test]
+	fn only_of_type() {
+		assert_query!("@media screen {} a {} @keyframes foo {}", "style-rule:only-of-type", 1);
+	}
+
+	#[test]
+	fn only_of_type_no_match() {
+		assert_query!("a {} b {}", "style-rule:only-of-type", 0);
+	}
+
+	#[test]
+	fn nth_of_type() {
+		assert_query!("@media screen {} a {} b {} c {}", "style-rule:nth-of-type(2)", 1);
+	}
+
+	#[test]
+	fn nth_of_type_odd() {
+		assert_query!("a {} b {} c {} d {}", "style-rule:nth-of-type(odd)", 2);
+	}
+
+	#[test]
+	fn nth_last_of_type() {
+		assert_query!("a {} b {} c {} @media screen {}", "style-rule:nth-last-of-type(2)", 1);
+	}
+
+	#[test]
+	fn nth_last_of_type_even() {
+		assert_query!("a {} b {} c {} d {}", "style-rule:nth-last-of-type(even)", 2);
+	}
+
+	#[test]
+	fn root() {
+		assert_query!("a {}", "style-sheet:root", 1);
+	}
+
+	#[test]
+	fn root_no_match() {
+		assert_query!("a {}", "style-rule:root", 0);
+	}
+
+	#[test]
+	fn at_rule() {
+		assert_query!("@media screen {} a {} @keyframes foo {}", "*:at-rule", 2);
+	}
+
+	#[test]
+	fn rule() {
+		assert_query!("@media screen {} a {}", "*:rule", 2);
+	}
+
+	#[test]
+	fn function() {
+		assert_query!("a { color: rgb(255, 0, 0); }", "*:function", 1);
+	}
+
+	#[test]
+	fn function_multiple() {
+		// linear-gradient and rotate are both functions
+		assert_query!("a { background: linear-gradient(red, blue); transform: rotate(45deg); }", "*:function", 2);
+	}
+
+	#[test]
+	fn at_rule_not_style_rule() {
+		assert_query!("a {}", "*:at-rule", 0);
+	}
+
+	#[test]
+	fn prefixed_declaration() {
+		assert_query!("a { -webkit-transform: rotate(45deg); }", "*:prefixed", 1);
+	}
+
+	#[test]
+	fn prefixed_declaration_multiple() {
+		assert_query!("a { -webkit-transform: rotate(45deg); -moz-appearance: none; }", "*:prefixed", 2);
+	}
+
+	#[test]
+	fn prefixed_declaration_filter_webkit() {
+		assert_query!("a { -webkit-transform: rotate(45deg); -moz-appearance: none; }", "*:prefixed(webkit)", 1);
+	}
+
+	#[test]
+	fn prefixed_declaration_filter_moz() {
+		assert_query!("a { -webkit-transform: rotate(45deg); -moz-appearance: none; }", "*:prefixed(moz)", 1);
+	}
+
+	#[test]
+	fn prefixed_no_match_regular() {
+		// Regular properties should not match :prefixed
+		assert_query!("a { color: red; margin: 10px; }", "*:prefixed", 0);
+	}
+
+	#[test]
+	fn prefixed_node_webkit_keyframes() {
+		// @-webkit-keyframes is a prefixed node type
+		assert_query!("@-webkit-keyframes spin { to { opacity: 1; } }", "webkit-keyframes-rule:prefixed", 1);
+	}
+
+	#[test]
+	fn prefixed_node_filter() {
+		// webkit-keyframes-rule should match :prefixed(webkit)
+		assert_query!("@-webkit-keyframes spin { to { opacity: 1; } }", "*:prefixed(webkit)", 1);
+	}
+
+	// :shorthand and :longhand tests
+	#[test]
+	fn shorthand() {
+		assert_query!("a { margin: 10px; }", "*:shorthand", 1);
+	}
+
+	#[test]
+	fn shorthand_multiple() {
+		assert_query!("a { margin: 10px; padding: 5px; border: 1px solid; }", "*:shorthand", 3);
+	}
+
+	#[test]
+	fn longhand() {
+		assert_query!("a { color: red; padding-top: 5px; }", "*:longhand", 2);
+	}
+
+	#[test]
+	fn longhand_not_shorthand() {
+		assert_query!("a { margin: 10px; }", "*:longhand", 0);
+	}
+
+	#[test]
+	fn property_type_color() {
+		assert_query!("a { color: red; margin: 10px; }", "*:property-type(color)", 1);
+	}
+
+	#[test]
+	fn property_type_sizing() {
+		assert_query!("a { width: 100px; height: 50px; color: red; }", "*:property-type(sizing)", 2);
+	}
+
+	#[test]
+	fn property_type_animation() {
+		assert_query!(
+			"a { animation-name: spin; animation-duration: 1s; color: red; }",
+			"*:property-type(animation)",
+			2
+		);
+	}
+
+	#[test]
+	fn nested_style_rule() {
+		assert_query!("a { & b { color: red; } }", "style-rule:nested", 1);
+	}
+
+	#[test]
+	fn nested_not_top_level() {
+		assert_query!("a { color: red; }", "style-rule:nested", 0);
+	}
+
+	#[test]
+	fn supports_rule() {
+		assert_query!("@supports (color: red) { a { color: red; } }", "supports-rule", 1);
+	}
+
+	#[test]
+	fn supports_condition() {
+		assert_query!("@supports (color: red) { a {} }", "supports-condition", 1);
+	}
+
+	#[test]
+	fn supports_condition_not() {
+		assert_query!("@supports not (color: red) { a {} }", "supports-condition", 1);
+	}
+
+	#[test]
+	fn supports_feature() {
+		assert_query!("@supports (color: red) { a {} }", "supports-feature", 1);
+	}
+
+	#[test]
+	fn supports_descendant() {
+		assert_query!("@supports (color: red) { a {} }", "supports-rule style-rule", 1);
+	}
+
+	#[test]
+	fn supports_nested_media() {
+		assert_query!("@supports (color: red) { @media screen { a {} } }", "supports-rule media-rule style-rule", 1);
+	}
+
+	#[test]
+	fn container_rule() {
+		assert_query!("@container (width > 400px) { a { color: red; } }", "container-rule", 1);
+	}
+
+	#[test]
+	fn container_query() {
+		assert_query!("@container (width > 400px) { a {} }", "container-query", 1);
+	}
+
+	#[test]
+	fn container_query_named() {
+		assert_query!("@container sidebar (width > 400px) { a {} }", "container-query", 1);
+	}
+
+	#[test]
+	fn container_descendant() {
+		assert_query!("@container (width > 400px) { a {} }", "container-rule style-rule", 1);
+	}
+
+	#[test]
+	fn container_nested_supports() {
+		assert_query!(
+			"@container (width > 400px) { @supports (color: red) { a {} } }",
+			"container-rule supports-rule",
+			1
+		);
+	}
+
+	#[test]
+	fn not_type_selector() {
+		// :not(media-rule) matches all nodes except MediaRule
+		assert_query!("a {} @media screen {} b {}", "*", 13);
+		assert_query!("a {} @media screen {} b {}", "media-rule", 1);
+		assert_query!("a {} @media screen {} b {}", ":not(media-rule)", 12);
+	}
+
+	#[test]
+	fn not_excludes_type() {
+		// :not(style-rule) matches all nodes except StyleRule
+		assert_query!("a {} @media screen {} b {}", "*", 13);
+		assert_query!("a {} @media screen {} b {}", "style-rule", 2);
+		assert_query!("a {} @media screen {} b {}", ":not(style-rule)", 11);
+	}
+
+	#[test]
+	fn universal_matches_all() {
+		assert_query!("a { color: red; }", "*", 9);
+	}
+
+	#[test]
+	fn universal_with_pseudo() {
+		assert_query!("a {} b {}", "*:first-child", 10);
+	}
+
+	#[test]
+	fn universal_descendant() {
+		assert_query!("a { color: red; }", "style-rule *", 7);
+	}
+
+	#[test]
+	fn important() {
+		assert_query!("a { color: red !important; }", "*:important", 1);
+	}
+
+	#[test]
+	fn important_multiple() {
+		assert_query!("a { color: red !important; margin: 10px; padding: 5px !important; }", "*:important", 2);
+	}
+
+	#[test]
+	fn important_no_match() {
+		assert_query!("a { color: red; margin: 10px; }", "*:important", 0);
+	}
+
+	#[test]
+	fn important_combined_with_name() {
+		assert_query!("a { color: red !important; margin: 10px !important; }", "[name=color]:important", 1);
+	}
+
+	#[test]
+	fn triple_descendant() {
+		assert_query!("@media screen { @supports (color: red) { a {} } }", "media-rule supports-rule style-rule", 1);
+	}
+
+	#[test]
+	fn mixed_combinators() {
+		assert_query!("@media screen { a {} b {} }", "media-rule > style-rule selector-list", 2);
+	}
+
+	#[test]
+	fn sibling_after_descendant() {
+		assert_query!("@media screen { a {} b {} }", "media-rule style-rule + style-rule", 1);
+	}
+
+	#[test]
+	fn child_chain() {
+		assert_query!("a { color: red; }", "style-sheet > style-rule > selector-list", 1);
+	}
+
+	#[test]
+	fn empty_stylesheet() {
+		assert_query!("", "style-rule", 0);
+	}
+
+	#[test]
+	fn comments_only() {
+		assert_query!("/* comment */", "style-rule", 0);
+	}
+
+	#[test]
+	fn whitespace_only() {
+		assert_query!("   \n\t   ", "style-rule", 0);
+	}
+
+	#[test]
+	fn deeply_nested_media() {
+		assert_query!("@media screen { @media print { a {} } }", "media-rule media-rule style-rule", 1);
+	}
+
+	#[test]
+	fn multiple_selector_list() {
+		assert_query!("a {} @media screen {} b {}", "style-rule, media-rule", 3);
+	}
+
+	#[test]
+	fn attribute_with_pseudo() {
+		assert_query!("a { color: red !important; margin: 10px !important; }", "[name=margin]:important", 1);
+	}
+
+	#[test]
+	fn property_type_backgrounds() {
+		assert_query!("a { background-color: red; }", "*:property-type(backgrounds)", 1);
+	}
+
+	#[test]
+	fn declaration_in_keyframes() {
+		assert_query!("@keyframes spin { from { opacity: 0; } to { opacity: 1; } }", "[name=opacity]", 2);
+	}
+
+	#[test]
+	fn declaration_in_font_face() {
+		assert_query!("@font-face { font-family: 'Custom'; src: url('font.woff'); }", "[name=font-family]", 1);
+	}
+
+	#[test]
+	fn custom_property_in_root() {
+		assert_query!(":root { --primary: blue; }", "*:custom", 1);
+	}
+
+	#[test]
+	fn color_function_rgb() {
+		assert_query!("a { color: rgb(255, 0, 0); }", "color-function", 1);
+	}
+
+	#[test]
+	fn color_function_hsl() {
+		assert_query!("a { color: hsl(120, 100%, 50%); }", "color-function", 1);
+	}
+
+	#[test]
+	fn color_function_multiple() {
+		assert_query!("a { color: rgb(255, 0, 0); background-color: hsl(120, 100%, 50%); }", "color-function", 2);
+	}
+
+	#[test]
+	fn linear_gradient() {
+		assert_query!("a { background-image: linear-gradient(red, blue); }", "linear-gradient-function", 1);
+	}
+
+	#[test]
+	fn url_in_background_image() {
+		assert_query!("a { background-image: url('image.png'); }", "url", 1);
+	}
+
+	#[test]
+	fn computed_with_calc() {
+		assert_query!("a { width: calc(100% - 20px); }", "*:computed", 1);
+	}
+
+	#[test]
+	fn computed_with_var() {
+		assert_query!("a { color: var(--primary); }", "*:computed", 1);
+	}
+
+	#[test]
+	fn computed_no_match() {
+		assert_query!("a { color: red; width: 100px; }", "*:computed", 0);
+	}
+
+	#[test]
+	fn unknown_property() {
+		assert_query!("a { not-a-real-property: value; }", "*:unknown", 1);
+	}
+
+	#[test]
+	fn unknown_no_match() {
+		assert_query!("a { color: red; margin: 10px; }", "*:unknown", 0);
+	}
+}

--- a/crates/csskit_ast/src/selector/mod.rs
+++ b/crates/csskit_ast/src/selector/mod.rs
@@ -1,0 +1,12 @@
+//! CSS AST selector query engine.
+
+mod matcher;
+mod output;
+mod query;
+
+pub use matcher::SelectorMatcher;
+pub use output::MatchOutput;
+pub use query::{
+	NthValue, QueryAttribute, QueryCombinator, QueryPseudo, QuerySelector, QuerySelectorList, QuerySelectorPart,
+	QuerySimpleSelector, SelectorParseError,
+};

--- a/crates/csskit_ast/src/selector/output.rs
+++ b/crates/csskit_ast/src/selector/output.rs
@@ -1,0 +1,8 @@
+use css_ast::visit::NodeId;
+use css_lexer::Span;
+
+#[derive(Debug, Clone)]
+pub struct MatchOutput {
+	pub node_id: NodeId,
+	pub span: Span,
+}

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -1,0 +1,590 @@
+use css_ast::visit::NodeId;
+use css_parse::AtomSet;
+
+use crate::CsskitAtomSet;
+
+#[derive(Debug, Clone)]
+pub struct QuerySelectorList {
+	pub selectors: Vec<QuerySelector>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuerySelector {
+	pub parts: Vec<QuerySelectorPart>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuerySelectorPart {
+	Simple(QuerySimpleSelector),
+	Combinator(QueryCombinator),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuerySimpleSelector {
+	pub node_type: Option<NodeId>,
+	pub attributes: Vec<QueryAttribute>,
+	pub pseudo_classes: Vec<QueryPseudo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryAttribute {
+	Name(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryCombinator {
+	Descendant,
+	Child,
+	NextSibling,
+	SubsequentSibling,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryPseudo {
+	Important,
+	Custom,
+	Prefixed(Option<String>),
+	Unknown,
+	Computed,
+	Shorthand,
+	Longhand,
+	PropertyType(CsskitAtomSet),
+	Empty,
+	Nested,
+	Root,
+	FirstChild,
+	LastChild,
+	OnlyChild,
+	NthChild(NthValue),
+	NthLastChild(NthValue),
+	FirstOfType,
+	LastOfType,
+	OnlyOfType,
+	NthOfType(NthValue),
+	NthLastOfType(NthValue),
+	Not(Box<QuerySelector>),
+	AtRule,
+	Rule,
+	Function,
+	Block,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NthValue {
+	Odd,
+	Even,
+	Index(i32),
+	AnPlusB(i32, i32),
+}
+
+impl NthValue {
+	pub fn matches(&self, index: i32) -> bool {
+		match self {
+			Self::Odd => index % 2 == 1,
+			Self::Even => index % 2 == 0,
+			Self::Index(n) => index == *n,
+			Self::AnPlusB(a, b) => {
+				if *a == 0 {
+					index == *b
+				} else {
+					let diff = index - b;
+					diff % a == 0 && diff / a >= 0
+				}
+			}
+		}
+	}
+}
+
+impl QuerySelectorList {
+	pub fn parse(input: &str) -> Result<Self, SelectorParseError> {
+		SelectorParser::new(input).parse_list()
+	}
+}
+
+impl QuerySelector {
+	pub fn parse(input: &str) -> Result<Self, SelectorParseError> {
+		SelectorParser::new(input).parse_selector()
+	}
+}
+
+#[derive(Debug)]
+pub struct SelectorParseError {
+	pub message: String,
+	pub offset: usize,
+}
+
+impl std::fmt::Display for SelectorParseError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{} at offset {}", self.message, self.offset)
+	}
+}
+
+impl std::error::Error for SelectorParseError {}
+
+struct SelectorParser<'a> {
+	input: &'a str,
+	pos: usize,
+}
+
+impl<'a> SelectorParser<'a> {
+	fn new(input: &'a str) -> Self {
+		Self { input, pos: 0 }
+	}
+
+	fn parse_list(&mut self) -> Result<QuerySelectorList, SelectorParseError> {
+		let mut selectors = vec![self.parse_selector()?];
+		self.skip_ws();
+		while self.peek() == Some(',') {
+			self.advance();
+			self.skip_ws();
+			selectors.push(self.parse_selector()?);
+			self.skip_ws();
+		}
+		Ok(QuerySelectorList { selectors })
+	}
+
+	fn parse_selector(&mut self) -> Result<QuerySelector, SelectorParseError> {
+		let mut parts = Vec::new();
+		self.skip_ws();
+
+		loop {
+			let simple = self.parse_simple_selector()?;
+			parts.push(QuerySelectorPart::Simple(simple));
+			self.skip_ws();
+
+			if let Some(comb) = self.try_combinator() {
+				parts.push(QuerySelectorPart::Combinator(comb));
+				self.skip_ws();
+			} else if self.peek().is_some_and(|c| c != ',' && c != ')') {
+				// Implicit descendant combinator
+				parts.push(QuerySelectorPart::Combinator(QueryCombinator::Descendant));
+			} else {
+				break;
+			}
+		}
+
+		if parts.is_empty() {
+			return Err(self.error("expected selector"));
+		}
+
+		Ok(QuerySelector { parts })
+	}
+
+	fn parse_simple_selector(&mut self) -> Result<QuerySimpleSelector, SelectorParseError> {
+		let (node_type, is_universal) = self.parse_type_selector()?;
+		let mut attributes = Vec::new();
+		let mut pseudo_classes = Vec::new();
+
+		loop {
+			match self.peek() {
+				Some('[') => {
+					self.advance();
+					attributes.push(self.parse_attribute()?);
+				}
+				Some(':') => {
+					self.advance();
+					pseudo_classes.push(self.parse_pseudo_class()?);
+				}
+				_ => break,
+			}
+		}
+
+		if node_type.is_none() && !is_universal && attributes.is_empty() && pseudo_classes.is_empty() {
+			return Err(self.error("expected type, attribute, or pseudo-class"));
+		}
+
+		Ok(QuerySimpleSelector { node_type, attributes, pseudo_classes })
+	}
+
+	fn parse_attribute(&mut self) -> Result<QueryAttribute, SelectorParseError> {
+		self.skip_ws();
+		let attr_start = self.pos;
+		while self.peek().is_some_and(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+			self.advance();
+		}
+		let attr_name = &self.input[attr_start..self.pos];
+		if attr_name.is_empty() {
+			return Err(self.error("expected attribute name"));
+		}
+		self.skip_ws();
+		if attr_name != "name" {
+			return Err(SelectorParseError {
+				message: format!("unknown attribute '{attr_name}', only 'name' is supported"),
+				offset: attr_start,
+			});
+		}
+		if self.peek() != Some('=') {
+			return Err(self.error("expected '=' after attribute name"));
+		}
+		self.advance();
+		self.skip_ws();
+		let value = self.parse_attribute_value()?;
+		self.skip_ws();
+		if self.peek() != Some(']') {
+			return Err(self.error("expected ']'"));
+		}
+		self.advance();
+		Ok(QueryAttribute::Name(value))
+	}
+
+	fn parse_attribute_value(&mut self) -> Result<String, SelectorParseError> {
+		let quote = self.peek();
+		if quote == Some('"') || quote == Some('\'') {
+			self.advance();
+			let start = self.pos;
+			while self.peek().is_some_and(|c| c != quote.unwrap()) {
+				self.advance();
+			}
+			let value = self.input[start..self.pos].to_string();
+			if self.peek() != quote {
+				return Err(self.error("unterminated string"));
+			}
+			self.advance();
+			Ok(value)
+		} else {
+			let start = self.pos;
+			while self.peek().is_some_and(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+				self.advance();
+			}
+			if start == self.pos {
+				return Err(self.error("expected attribute value"));
+			}
+			Ok(self.input[start..self.pos].to_string())
+		}
+	}
+
+	fn parse_type_selector(&mut self) -> Result<(Option<NodeId>, bool), SelectorParseError> {
+		if self.peek() == Some('*') {
+			self.advance();
+			return Ok((None, true)); // Universal
+		}
+
+		let start = self.pos;
+		while self.peek().is_some_and(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+			self.advance();
+		}
+
+		if start == self.pos {
+			return Ok((None, false));
+		}
+
+		let name = &self.input[start..self.pos];
+		match NodeId::from_tag_name(name) {
+			Some(id) => Ok((Some(id), false)),
+			None => Err(SelectorParseError { message: format!("unknown node type '{name}'"), offset: start }),
+		}
+	}
+
+	fn parse_pseudo_class(&mut self) -> Result<QueryPseudo, SelectorParseError> {
+		let start = self.pos;
+		while self.peek().is_some_and(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+			self.advance();
+		}
+
+		let name = &self.input[start..self.pos];
+		let atom = CsskitAtomSet::from_str(name);
+
+		match atom {
+			CsskitAtomSet::Important => Ok(QueryPseudo::Important),
+			CsskitAtomSet::Custom => Ok(QueryPseudo::Custom),
+			CsskitAtomSet::Unknown => Ok(QueryPseudo::Unknown),
+			CsskitAtomSet::Computed => Ok(QueryPseudo::Computed),
+			CsskitAtomSet::Shorthand => Ok(QueryPseudo::Shorthand),
+			CsskitAtomSet::Longhand => Ok(QueryPseudo::Longhand),
+			CsskitAtomSet::Empty => Ok(QueryPseudo::Empty),
+			CsskitAtomSet::Nested => Ok(QueryPseudo::Nested),
+			CsskitAtomSet::Root => Ok(QueryPseudo::Root),
+			CsskitAtomSet::FirstChild => Ok(QueryPseudo::FirstChild),
+			CsskitAtomSet::LastChild => Ok(QueryPseudo::LastChild),
+			CsskitAtomSet::OnlyChild => Ok(QueryPseudo::OnlyChild),
+			CsskitAtomSet::FirstOfType => Ok(QueryPseudo::FirstOfType),
+			CsskitAtomSet::LastOfType => Ok(QueryPseudo::LastOfType),
+			CsskitAtomSet::OnlyOfType => Ok(QueryPseudo::OnlyOfType),
+			CsskitAtomSet::AtRule => Ok(QueryPseudo::AtRule),
+			CsskitAtomSet::Rule => Ok(QueryPseudo::Rule),
+			CsskitAtomSet::Function => Ok(QueryPseudo::Function),
+			CsskitAtomSet::Block => Ok(QueryPseudo::Block),
+			CsskitAtomSet::NthChild => Ok(QueryPseudo::NthChild(self.parse_nth_pattern()?)),
+			CsskitAtomSet::NthLastChild => Ok(QueryPseudo::NthLastChild(self.parse_nth_pattern()?)),
+			CsskitAtomSet::NthOfType => Ok(QueryPseudo::NthOfType(self.parse_nth_pattern()?)),
+			CsskitAtomSet::NthLastOfType => Ok(QueryPseudo::NthLastOfType(self.parse_nth_pattern()?)),
+			CsskitAtomSet::Prefixed => {
+				if self.peek() == Some('(') {
+					self.advance();
+					let arg_start = self.pos;
+					while self.peek().is_some_and(|c| c != ')') {
+						self.advance();
+					}
+					let arg = self.input[arg_start..self.pos].trim().to_string();
+					if self.peek() != Some(')') {
+						return Err(self.error("expected ')'"));
+					}
+					self.advance();
+					Ok(QueryPseudo::Prefixed(Some(arg)))
+				} else {
+					Ok(QueryPseudo::Prefixed(None))
+				}
+			}
+			CsskitAtomSet::PropertyType => {
+				if self.peek() != Some('(') {
+					return Err(self.error("expected '(' after :property-type"));
+				}
+				self.advance();
+				self.skip_ws();
+				let arg_start = self.pos;
+				while self.peek().is_some_and(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+					self.advance();
+				}
+				let arg = &self.input[arg_start..self.pos];
+				if arg.is_empty() {
+					return Err(self.error("expected property group name"));
+				}
+				let group_atom = CsskitAtomSet::from_str(arg);
+				self.skip_ws();
+				if self.peek() != Some(')') {
+					return Err(self.error("expected ')'"));
+				}
+				self.advance();
+				Ok(QueryPseudo::PropertyType(group_atom))
+			}
+			CsskitAtomSet::Not => {
+				if self.peek() != Some('(') {
+					return Err(self.error("expected '(' after :not"));
+				}
+				self.advance();
+				self.skip_ws();
+				let inner = self.parse_selector()?;
+				self.skip_ws();
+				if self.peek() != Some(')') {
+					return Err(self.error("expected ')'"));
+				}
+				self.advance();
+				Ok(QueryPseudo::Not(Box::new(inner)))
+			}
+			_ => Err(SelectorParseError { message: format!("unknown pseudo-class ':{name}'"), offset: start }),
+		}
+	}
+
+	fn parse_nth_pattern(&mut self) -> Result<NthValue, SelectorParseError> {
+		if self.peek() != Some('(') {
+			return Err(self.error("expected '(' after :nth-child"));
+		}
+		self.advance();
+		self.skip_ws();
+
+		let pattern = self.parse_nth_expression()?;
+
+		self.skip_ws();
+		if self.peek() != Some(')') {
+			return Err(self.error("expected ')' after :nth-child(...)"));
+		}
+		self.advance();
+		Ok(pattern)
+	}
+
+	fn parse_nth_expression(&mut self) -> Result<NthValue, SelectorParseError> {
+		let start = self.pos;
+		while self.peek().is_some_and(|c| c.is_alphabetic()) {
+			self.advance();
+		}
+		let keyword = &self.input[start..self.pos];
+
+		if keyword.eq_ignore_ascii_case("odd") {
+			return Ok(NthValue::Odd);
+		}
+		if keyword.eq_ignore_ascii_case("even") {
+			return Ok(NthValue::Even);
+		}
+
+		self.pos = start;
+
+		let mut a: i32 = 0;
+		let mut b: i32 = 0;
+		let mut has_n = false;
+
+		let sign = match self.peek() {
+			Some('-') => {
+				self.advance();
+				-1
+			}
+			Some('+') => {
+				self.advance();
+				1
+			}
+			_ => 1,
+		};
+
+		self.skip_ws();
+
+		let num_start = self.pos;
+		while self.peek().is_some_and(|c| c.is_ascii_digit()) {
+			self.advance();
+		}
+		let num_str = &self.input[num_start..self.pos];
+
+		if self.peek() == Some('n') || self.peek() == Some('N') {
+			has_n = true;
+			a = if num_str.is_empty() { sign } else { sign * num_str.parse::<i32>().unwrap_or(1) };
+			self.advance();
+			self.skip_ws();
+
+			if self.peek() == Some('+') || self.peek() == Some('-') {
+				let b_sign = if self.peek() == Some('-') { -1 } else { 1 };
+				self.advance();
+				self.skip_ws();
+
+				let b_start = self.pos;
+				while self.peek().is_some_and(|c| c.is_ascii_digit()) {
+					self.advance();
+				}
+				let b_str = &self.input[b_start..self.pos];
+				if !b_str.is_empty() {
+					b = b_sign * b_str.parse::<i32>().unwrap_or(0);
+				}
+			}
+		} else if !num_str.is_empty() {
+			b = sign * num_str.parse::<i32>().unwrap_or(0);
+		} else {
+			return Err(self.error("expected number or 'n' in :nth-child()"));
+		}
+
+		if has_n { Ok(NthValue::AnPlusB(a, b)) } else { Ok(NthValue::Index(b)) }
+	}
+
+	fn try_combinator(&mut self) -> Option<QueryCombinator> {
+		match self.peek()? {
+			'>' => {
+				self.advance();
+				Some(QueryCombinator::Child)
+			}
+			'+' => {
+				self.advance();
+				Some(QueryCombinator::NextSibling)
+			}
+			'~' => {
+				self.advance();
+				Some(QueryCombinator::SubsequentSibling)
+			}
+			_ => None,
+		}
+	}
+
+	fn skip_ws(&mut self) {
+		while self.peek().is_some_and(|c| c.is_whitespace()) {
+			self.advance();
+		}
+	}
+
+	fn peek(&self) -> Option<char> {
+		self.input[self.pos..].chars().next()
+	}
+
+	fn advance(&mut self) {
+		if let Some(c) = self.peek() {
+			self.pos += c.len_utf8();
+		}
+	}
+
+	fn error(&self, msg: &str) -> SelectorParseError {
+		SelectorParseError { message: msg.to_string(), offset: self.pos }
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_simple_type() {
+		let sel = QuerySelector::parse("style-rule").unwrap();
+		assert_eq!(sel.parts.len(), 1);
+	}
+
+	#[test]
+	fn parse_universal() {
+		let sel = QuerySelector::parse("*").unwrap();
+		assert_eq!(sel.parts.len(), 1);
+		if let QuerySelectorPart::Simple(s) = &sel.parts[0] {
+			assert!(s.node_type.is_none());
+		} else {
+			panic!("expected simple selector");
+		}
+	}
+
+	#[test]
+	fn parse_pseudo_class() {
+		let sel = QuerySelector::parse("*:important").unwrap();
+		assert_eq!(sel.parts.len(), 1);
+		if let QuerySelectorPart::Simple(s) = &sel.parts[0] {
+			assert_eq!(s.pseudo_classes, vec![QueryPseudo::Important]);
+		}
+	}
+
+	#[test]
+	fn parse_descendant() {
+		let sel = QuerySelector::parse("style-rule *:important").unwrap();
+		assert_eq!(sel.parts.len(), 3); // type, combinator, simple
+	}
+
+	#[test]
+	fn parse_child() {
+		let sel = QuerySelector::parse("style-rule > *:important").unwrap();
+		assert_eq!(sel.parts.len(), 3);
+		assert!(matches!(sel.parts[1], QuerySelectorPart::Combinator(QueryCombinator::Child)));
+	}
+
+	#[test]
+	fn parse_list() {
+		let list = QuerySelectorList::parse("style-rule, media-rule").unwrap();
+		assert_eq!(list.selectors.len(), 2);
+	}
+
+	#[test]
+	fn parse_not() {
+		let sel = QuerySelector::parse("*:not(:important)").unwrap();
+		if let QuerySelectorPart::Simple(s) = &sel.parts[0] {
+			assert!(matches!(&s.pseudo_classes[0], QueryPseudo::Not(_)));
+		}
+	}
+
+	#[test]
+	fn parse_attribute_selector() {
+		let sel = QuerySelector::parse("[name=color]").unwrap();
+		assert_eq!(sel.parts.len(), 1);
+		if let QuerySelectorPart::Simple(s) = &sel.parts[0] {
+			assert_eq!(s.attributes.len(), 1);
+			assert!(matches!(&s.attributes[0], QueryAttribute::Name(n) if n == "color"));
+		}
+	}
+
+	#[test]
+	fn parse_attribute_selector_quoted() {
+		let sel = QuerySelector::parse("[name='background-color']").unwrap();
+		if let QuerySelectorPart::Simple(s) = &sel.parts[0] {
+			assert!(matches!(&s.attributes[0], QueryAttribute::Name(n) if n == "background-color"));
+		}
+	}
+
+	#[test]
+	fn parse_attribute_selector_double_quoted() {
+		let sel = QuerySelector::parse("[name=\"margin-top\"]").unwrap();
+		if let QuerySelectorPart::Simple(s) = &sel.parts[0] {
+			assert!(matches!(&s.attributes[0], QueryAttribute::Name(n) if n == "margin-top"));
+		}
+	}
+
+	#[test]
+	fn parse_attribute_unknown_attr() {
+		let result = QuerySelector::parse("[foo=bar]");
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn parse_universal_with_attribute() {
+		let sel = QuerySelector::parse("*[name=color]").unwrap();
+		if let QuerySelectorPart::Simple(s) = &sel.parts[0] {
+			assert!(s.node_type.is_none());
+			assert_eq!(s.attributes.len(), 1);
+		}
+	}
+}

--- a/crates/csskit_ast/src/test_helpers.rs
+++ b/crates/csskit_ast/src/test_helpers.rs
@@ -1,0 +1,36 @@
+/// Assert CSS selector query matches expected node count.
+#[macro_export]
+macro_rules! assert_query {
+	($source:expr, $selector:expr, $expected:expr) => {
+		$crate::assert_query!($source, $selector => css_ast::StyleSheet, $expected)
+	};
+
+	($source:expr, $selector:expr => $parse_type:ty, $expected:expr) => {{
+		use bumpalo::Bump;
+		use css_ast::CssAtomSet;
+		use css_lexer::Lexer;
+		use css_parse::Parser;
+
+		let bump = Bump::new();
+		let source = $source;
+		let lexer = Lexer::new(&CssAtomSet::ATOMS, source);
+		let mut parser = Parser::new(&bump, source, lexer);
+		let parsed = parser.parse::<$parse_type>().expect("failed to parse CSS");
+
+		let selectors = $crate::selector::QuerySelectorList::parse($selector).expect("failed to parse selector");
+		let matcher = $crate::selector::SelectorMatcher::new(&selectors, source);
+		let matches = matcher.run(&parsed);
+
+		assert_eq!(
+			matches.len(),
+			$expected,
+			"\n\nQuery {:?} on {:?} returned {} matches, expected {}\nMatches: {:?}",
+			$selector,
+			source,
+			matches.len(),
+			$expected,
+			matches
+		);
+		matches
+	}};
+}

--- a/crates/csskit_source_finder/src/lib.rs
+++ b/crates/csskit_source_finder/src/lib.rs
@@ -77,7 +77,7 @@ impl Sink for NodeMatcher<'_> {
 				VisitMode::Self_
 			} else if attrs_section.contains("visit") {
 				// Just `visit` (or `visit()`) means visit self AND children
-				VisitMode::All
+				VisitMode::Self_
 			} else {
 				// No visit attribute found - default is children only (not queryable)
 				VisitMode::Children


### PR DESCRIPTION
This adds a new csskit_ast crate for parsing query selectors OF csskit nodes themselves, which can drive a `csskit find` feature for searching in css files for specific nodes.

This will eventually drive new features like a linter.