### PR TITLE
csskit_ast: Remove :block psuedo class

### DIFF
--- a/crates/csskit_ast/src/selector/matcher.rs
+++ b/crates/csskit_ast/src/selector/matcher.rs
@@ -540,7 +540,6 @@ impl<'a> SelectorMatcher<'a> {
 			QueryPseudo::AtRule => self.is_at_rule(node_id),
 			QueryPseudo::Rule => self.is_rule(node_id),
 			QueryPseudo::Function => self.is_function(node_id),
-			QueryPseudo::Block => self.is_block(node_id),
 			QueryPseudo::Important => context.is_important,
 			QueryPseudo::Custom => context.is_custom_property,
 			QueryPseudo::Computed => context.is_computed,
@@ -565,10 +564,6 @@ impl<'a> SelectorMatcher<'a> {
 	fn is_function(&self, node_id: NodeId) -> bool {
 		let name = node_id.tag_name();
 		name.ends_with("-function") || name.ends_with("-pseudo-function")
-	}
-
-	fn is_block(&self, node_id: NodeId) -> bool {
-		node_id.tag_name().ends_with("-block")
 	}
 
 	fn is_prefixed(&self, node_id: NodeId, context: &MatchContext, filter: Option<&str>) -> bool {

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -66,7 +66,6 @@ pub enum QueryPseudo {
 	AtRule,
 	Rule,
 	Function,
-	Block,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -303,7 +302,6 @@ impl<'a> SelectorParser<'a> {
 			CsskitAtomSet::AtRule => Ok(QueryPseudo::AtRule),
 			CsskitAtomSet::Rule => Ok(QueryPseudo::Rule),
 			CsskitAtomSet::Function => Ok(QueryPseudo::Function),
-			CsskitAtomSet::Block => Ok(QueryPseudo::Block),
 			CsskitAtomSet::NthChild => Ok(QueryPseudo::NthChild(self.parse_nth_pattern()?)),
 			CsskitAtomSet::NthLastChild => Ok(QueryPseudo::NthLastChild(self.parse_nth_pattern()?)),
 			CsskitAtomSet::NthOfType => Ok(QueryPseudo::NthOfType(self.parse_nth_pattern()?)),


### PR DESCRIPTION
I don't think this will work out in practice. Block nodes are not self visitable.
