### PR TITLE
css_ast: Add NodeKinds to CssMetadata

### DIFF
--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -90,6 +90,19 @@ pub enum RuleKind {
 	NestedStyleRules,
 }
 
+/// Categories of nodes present in metadata, used for selector filtering.
+#[bitmask(u8)]
+#[bitmask_config(vec_debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum NodeKinds {
+	/// Contains style rules
+	StyleRule,
+	/// Contains at-rules (media, keyframes, etc.)
+	AtRule,
+	/// Contains function nodes
+	Function,
+}
+
 /// Aggregated metadata computed from declarations within a block.
 /// This allows efficient checking of what types of properties a block contains
 /// without iterating through all declarations.
@@ -112,6 +125,8 @@ pub struct CssMetadata {
 	pub used_at_rules: AtRuleId,
 	/// Bitwise OR of all VendorPrefixes in a Node
 	pub vendor_prefixes: VendorPrefixes,
+	/// Bitwise OR of node categories present
+	pub node_kinds: NodeKinds,
 }
 
 impl Default for CssMetadata {
@@ -125,6 +140,7 @@ impl Default for CssMetadata {
 			rule_kinds: RuleKind::none(),
 			used_at_rules: AtRuleId::none(),
 			vendor_prefixes: VendorPrefixes::none(),
+			node_kinds: NodeKinds::none(),
 		}
 	}
 }
@@ -141,6 +157,7 @@ impl CssMetadata {
 			&& self.rule_kinds == RuleKind::none()
 			&& self.used_at_rules == AtRuleId::none()
 			&& self.vendor_prefixes == VendorPrefixes::none()
+			&& self.node_kinds == NodeKinds::none()
 	}
 
 	/// Returns true if this block modifies any positioning-related properties.
@@ -167,6 +184,7 @@ impl NodeMetadata for CssMetadata {
 		self.rule_kinds |= other.rule_kinds;
 		self.used_at_rules |= other.used_at_rules;
 		self.vendor_prefixes |= other.vendor_prefixes;
+		self.node_kinds |= other.node_kinds;
 	}
 }
 

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -39,7 +39,7 @@ impl<'a> Parse<'a> for CharsetRule {
 
 impl NodeWithMetadata<CssMetadata> for CharsetRule {
 	fn metadata(&self) -> CssMetadata {
-		CssMetadata { used_at_rules: AtRuleId::Charset, ..Default::default() }
+		CssMetadata { used_at_rules: AtRuleId::Charset, node_kinds: NodeKinds::AtRule, ..Default::default() }
 	}
 }
 

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -21,6 +21,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for ContainerRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::Container;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -16,6 +16,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for DocumentRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::Document;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -19,6 +19,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for FontFaceRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::FontFace;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -19,6 +19,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for KeyframesRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::Keyframes;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -19,6 +19,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for LayerRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = if let Some(block) = &self.block { block.0.metadata() } else { CssMetadata::default() };
 		meta.used_at_rules |= AtRuleId::Layer;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -21,6 +21,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for MediaRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::Media;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/mod.rs
+++ b/crates/css_ast/src/rules/mod.rs
@@ -43,7 +43,7 @@ pub use webkit::*;
 mod prelude {
 	pub(crate) use crate::{
 		CssAtomSet, CssDiagnostic, CssMetadata, StyleValue,
-		metadata::{AtRuleId, VendorPrefixes},
+		metadata::{AtRuleId, NodeKinds, VendorPrefixes},
 		stylesheet::Rule,
 	};
 	pub(crate) use bumpalo::collections::Vec;

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -17,6 +17,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for MozDocumentRule<'a> {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::MozDocument;
 		meta.vendor_prefixes |= VendorPrefixes::Moz;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -20,6 +20,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for PageRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::Page;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -19,6 +19,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for PropertyRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::Property;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/starting_style.rs
+++ b/crates/css_ast/src/rules/starting_style.rs
@@ -20,6 +20,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for StartingStyleRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::StartingStyle;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -48,6 +48,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for SupportsRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::Supports;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -18,6 +18,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for WebkitKeyframesRule<'a> {
 		let mut meta = self.block.0.metadata();
 		meta.used_at_rules |= AtRuleId::WebkitKeyframes;
 		meta.vendor_prefixes |= VendorPrefixes::WebKit;
+		meta.node_kinds |= NodeKinds::AtRule;
 		meta
 	}
 }

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -1,5 +1,6 @@
 use crate::{
-	CssAtomSet, CssDiagnostic, CssMetadata, SelectorList, StyleValue, UnknownAtRule, UnknownQualifiedRule, rules,
+	CssAtomSet, CssDiagnostic, CssMetadata, NodeKinds, SelectorList, StyleValue, UnknownAtRule, UnknownQualifiedRule,
+	rules,
 };
 use css_parse::{
 	Cursor, DeclarationGroup, Diagnostic, NodeWithMetadata, Parse, Parser, QualifiedRule, Result as ParserResult,
@@ -22,7 +23,9 @@ pub struct StyleRule<'a> {
 
 impl<'a> NodeWithMetadata<CssMetadata> for StyleRule<'a> {
 	fn metadata(&self) -> CssMetadata {
-		self.rule.metadata()
+		let mut meta = self.rule.metadata();
+		meta.node_kinds |= NodeKinds::StyleRule;
+		meta
 	}
 }
 


### PR DESCRIPTION
This change introduces a bitflags set of categories of nodes (StyleRule, AtRule, Function) are present in the AST metadata.
