### PR TITLE
css_parse/css_ast: Improve NodeWithMetadata to allow extracting self meta

### DIFF
--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -175,7 +175,7 @@ impl CssMetadata {
 
 impl NodeMetadata for CssMetadata {
 	#[inline]
-	fn merge(&mut self, other: &Self) {
+	fn merge(mut self, other: Self) -> Self {
 		self.property_groups |= other.property_groups;
 		self.applies_to |= other.applies_to;
 		self.box_sides |= other.box_sides;
@@ -185,6 +185,7 @@ impl NodeMetadata for CssMetadata {
 		self.used_at_rules |= other.used_at_rules;
 		self.vendor_prefixes |= other.vendor_prefixes;
 		self.node_kinds |= other.node_kinds;
+		self
 	}
 }
 
@@ -209,7 +210,7 @@ mod tests {
 	use super::*;
 	use crate::{CssAtomSet, StyleSheet};
 	use css_lexer::Lexer;
-	use css_parse::{NodeWithMetadata, Parser};
+	use css_parse::{NodeMetadata, NodeWithMetadata, Parser};
 
 	#[test]
 	fn test_block_metadata_merge() {
@@ -221,12 +222,12 @@ mod tests {
 		meta2.property_groups = PropertyGroup::Position;
 		meta2.declaration_kinds = DeclarationKind::Custom;
 
-		meta1.merge(&meta2);
+		let merged = meta1.merge(meta2);
 
-		assert!(meta1.property_groups.contains(PropertyGroup::Color));
-		assert!(meta1.property_groups.contains(PropertyGroup::Position));
-		assert!(meta1.declaration_kinds.contains(DeclarationKind::Important));
-		assert!(meta1.declaration_kinds.contains(DeclarationKind::Custom));
+		assert!(merged.property_groups.contains(PropertyGroup::Color));
+		assert!(merged.property_groups.contains(PropertyGroup::Position));
+		assert!(merged.declaration_kinds.contains(DeclarationKind::Important));
+		assert!(merged.declaration_kinds.contains(DeclarationKind::Custom));
 	}
 
 	#[test]

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -38,8 +38,12 @@ impl<'a> Parse<'a> for CharsetRule {
 }
 
 impl NodeWithMetadata<CssMetadata> for CharsetRule {
-	fn metadata(&self) -> CssMetadata {
+	fn self_metadata(&self) -> CssMetadata {
 		CssMetadata { used_at_rules: AtRuleId::Charset, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
+	fn metadata(&self) -> CssMetadata {
+		self.self_metadata()
 	}
 }
 

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -18,11 +18,12 @@ pub struct ContainerRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for ContainerRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::Container, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::Container;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -13,11 +13,12 @@ pub struct DocumentRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for DocumentRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::Document, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::Document;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -16,11 +16,12 @@ pub struct FontFaceRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for FontFaceRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::FontFace, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::FontFace;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -16,11 +16,12 @@ pub struct KeyframesRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for KeyframesRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::Keyframes, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::Keyframes;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -16,11 +16,13 @@ pub struct LayerRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for LayerRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::Layer, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = if let Some(block) = &self.block { block.0.metadata() } else { CssMetadata::default() };
-		meta.used_at_rules |= AtRuleId::Layer;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		let child = if let Some(block) = &self.block { block.0.metadata() } else { CssMetadata::default() };
+		child.merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -18,11 +18,12 @@ pub struct MediaRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for MediaRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::Media, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::Media;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -13,12 +13,17 @@ pub struct MozDocumentRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for MozDocumentRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata {
+			used_at_rules: AtRuleId::MozDocument,
+			vendor_prefixes: VendorPrefixes::Moz,
+			node_kinds: NodeKinds::AtRule,
+			..Default::default()
+		}
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::MozDocument;
-		meta.vendor_prefixes |= VendorPrefixes::Moz;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -17,11 +17,12 @@ pub struct PageRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for PageRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::Page, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::Page;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -16,11 +16,12 @@ pub struct PropertyRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for PropertyRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::Property, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::Property;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/starting_style.rs
+++ b/crates/css_ast/src/rules/starting_style.rs
@@ -17,11 +17,12 @@ pub struct StartingStyleRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for StartingStyleRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::StartingStyle, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::StartingStyle;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -45,11 +45,12 @@ pub struct SupportsRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for SupportsRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { used_at_rules: AtRuleId::Supports, node_kinds: NodeKinds::AtRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::Supports;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -14,12 +14,17 @@ pub struct WebkitKeyframesRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for WebkitKeyframesRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata {
+			used_at_rules: AtRuleId::WebkitKeyframes,
+			vendor_prefixes: VendorPrefixes::WebKit,
+			node_kinds: NodeKinds::AtRule,
+			..Default::default()
+		}
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.block.0.metadata();
-		meta.used_at_rules |= AtRuleId::WebkitKeyframes;
-		meta.vendor_prefixes |= VendorPrefixes::WebKit;
-		meta.node_kinds |= NodeKinds::AtRule;
-		meta
+		self.block.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -3,8 +3,8 @@ use crate::{
 	rules,
 };
 use css_parse::{
-	Cursor, DeclarationGroup, Diagnostic, NodeWithMetadata, Parse, Parser, QualifiedRule, Result as ParserResult,
-	RuleVariants,
+	Cursor, DeclarationGroup, Diagnostic, NodeMetadata, NodeWithMetadata, Parse, Parser, QualifiedRule,
+	Result as ParserResult, RuleVariants,
 };
 use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
 
@@ -22,10 +22,12 @@ pub struct StyleRule<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for StyleRule<'a> {
+	fn self_metadata(&self) -> CssMetadata {
+		CssMetadata { node_kinds: NodeKinds::StyleRule, ..Default::default() }
+	}
+
 	fn metadata(&self) -> CssMetadata {
-		let mut meta = self.rule.metadata();
-		meta.node_kinds |= NodeKinds::StyleRule;
-		meta
+		self.rule.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -77,7 +77,7 @@ where
 				if !decls.is_empty() {
 					let group = DeclarationGroup { declarations: std::mem::replace(&mut decls, Vec::new_in(p.bump())) };
 					if let Some(rule) = R::from_declaration_group(group) {
-						meta.merge(&rule.metadata());
+						meta = meta.merge(rule.metadata());
 						rules.push(rule);
 					}
 				}
@@ -106,7 +106,7 @@ where
 				let rule = p.parse::<R>();
 				p.set_state(old_state);
 				let rule = rule?;
-				meta.merge(&rule.metadata());
+				meta = meta.merge(rule.metadata());
 				rules.push(rule);
 			} else if let Ok(Some(decl)) = p.try_parse_if_peek::<Declaration<'a, D, M>>() {
 				// https://drafts.csswg.org/css-syntax-3/#consume-a-blocks-contents
@@ -133,7 +133,7 @@ where
 						// Successfully parsed as a known rule, use it instead of the unknown declaration
 						flush_decls!();
 						p.set_state(old_state);
-						meta.merge(&rule.metadata());
+						meta = meta.merge(rule.metadata());
 						rules.push(rule);
 						continue;
 					}
@@ -142,7 +142,7 @@ where
 					p.parse::<Declaration<'a, D, M>>().ok();
 				}
 				p.set_state(old_state);
-				meta.merge(&decl.metadata());
+				meta = meta.merge(decl.metadata());
 				declarations.push(decl);
 			} else {
 				// Not an at-rule, not a declaration - try parsing as a qualified rule
@@ -151,7 +151,7 @@ where
 				match result {
 					Ok(rule) => {
 						flush_decls!();
-						meta.merge(&rule.metadata());
+						meta = meta.merge(rule.metadata());
 						rules.push(rule);
 					}
 					Err(_) => {

--- a/crates/css_parse/src/syntax/declaration_group.rs
+++ b/crates/css_parse/src/syntax/declaration_group.rs
@@ -61,7 +61,7 @@ where
 	fn metadata(&self) -> M {
 		let mut meta = M::default();
 		for decl in &self.declarations {
-			meta.merge(&decl.metadata());
+			meta = meta.merge(decl.metadata());
 		}
 		meta
 	}

--- a/crates/css_parse/src/syntax/declaration_list.rs
+++ b/crates/css_parse/src/syntax/declaration_list.rs
@@ -75,7 +75,7 @@ where
 				return Ok(Self { open_curly, declarations, close_curly, meta });
 			}
 			let declaration = p.parse::<Declaration<'a, V, M>>()?;
-			meta.merge(&declaration.metadata());
+			meta = meta.merge(declaration.metadata());
 			declarations.push(declaration);
 		}
 	}

--- a/crates/css_parse/src/syntax/declaration_rule_list.rs
+++ b/crates/css_parse/src/syntax/declaration_rule_list.rs
@@ -87,7 +87,7 @@ where
 				at_rules.push(p.parse::<R>()?);
 			} else if <T![Ident]>::peek(p, c) {
 				let rule = p.parse::<Declaration<'a, D, M>>()?;
-				meta.merge(&rule.metadata());
+				meta = meta.merge(rule.metadata());
 				declarations.push(rule);
 			} else {
 				Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?;

--- a/crates/css_parse/src/syntax/rule_list.rs
+++ b/crates/css_parse/src/syntax/rule_list.rs
@@ -73,7 +73,7 @@ where
 				return Ok(Self { open_curly, rules, close_curly, meta });
 			}
 			let rule = p.parse::<R>()?;
-			meta.merge(&rule.metadata());
+			meta = meta.merge(rule.metadata());
 			rules.push(rule);
 		}
 	}

--- a/crates/css_parse/src/traits/node_metadata.rs
+++ b/crates/css_parse/src/traits/node_metadata.rs
@@ -1,24 +1,24 @@
 /// Aggregated metadata for nodes, that can propagate up a node tree.
 pub trait NodeMetadata: Sized + Copy + Default {
-	/// Merges another NodeMetadata into this one.
-	fn merge(&mut self, other: &Self);
+	/// Merges another NodeMetadata into this one, returning the result.
+	fn merge(self, other: Self) -> Self;
 }
 
 /// A Node that has NodeMetadata
 pub trait NodeWithMetadata<M: NodeMetadata> {
-	/// Returns the metadata contributed by this node itself plus and child meta.
-	/// Most nodes don't contribute metadata, so can simply return `child`.
-	/// Other nodes may want to alter the metadata; supplying their own modifications
-	/// to initial.
-	fn self_metadata(&self, initial: M) -> M {
-		initial
+	/// Returns the metadata contributed by this node itself, not including children.
+	/// Most nodes don't contribute metadata, so can simply return `M::default()`.
+	/// Nodes like StyleRule or AtRules should return their own node kind flags here.
+	fn self_metadata(&self) -> M {
+		M::default()
 	}
 
-	/// Returns the complete aggregated metadata for this node (self + children)
+	/// Returns the complete aggregated metadata for this node (self + children).
+	/// Default implementation merges children's metadata with self_metadata().
 	fn metadata(&self) -> M;
 }
 
 // Stub implementation allowing tests to use () for M
 impl NodeMetadata for () {
-	fn merge(&mut self, _: &Self) {}
+	fn merge(self, _: Self) -> Self {}
 }

--- a/crates/css_parse/src/traits/style_sheet.rs
+++ b/crates/css_parse/src/traits/style_sheet.rs
@@ -42,7 +42,7 @@ pub trait StyleSheet<'a, M: NodeMetadata>: Sized + Parse<'a> {
 				return Ok((rules, meta));
 			}
 			let rule = p.parse::<Self::Rule>()?;
-			meta.merge(&rule.metadata());
+			meta = meta.merge(rule.metadata());
 			rules.push(rule);
 		}
 	}


### PR DESCRIPTION
Prior to this change NodeWithMetadata had two methods: self_metadata and
metadata, without a particularly clear distinction on when to use either.

This change alters NodeWithMetadata so that self_metadata is more clearly just
the metadata that the Node itself would alter, while metadata is the Node's
metadata plus any child metadata, merged.

This change also goes and updates all implementations to follow this pattern -
so self_metadata generates the nodes own metadata.
