### PR TITLE
css_ast: Queryable now requires NodeWithMetadata<CssMetada>, derives default

### DIFF
--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -73,7 +73,7 @@ macro_rules! style_value {
 	( $( $name: ident: $ty: ident$(<$a: lifetime>)? = $str: tt,)+ ) => {
 		#[derive(ToSpan, ToCursors, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 		pub enum StyleValue<'a> {
 			#[cfg_attr(feature = "visitable", visit(skip))]
 			Initial(T![Ident]),

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 // https://drafts.csswg.org/css-syntax-3/#charset-rule
 #[derive(ToSpan, ToCursors, SemanticEq, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.charset"))]
 pub struct CharsetRule {
 	at_keyword: T![AtKeyword],

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -7,7 +7,7 @@ pub use features::*;
 // https://drafts.csswg.org/css-contain-3/#container-rule
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.container"))]
 pub struct ContainerRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 // https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 pub struct DocumentRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Document)]

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -6,7 +6,7 @@ use crate::{Computed, CssMetadata};
 // https://drafts.csswg.org/css-fonts/#font-face-rule
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.font-face"))]
 pub struct FontFaceRule<'a> {
 	#[atom(CssAtomSet::FontFace)]

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -5,7 +5,7 @@ use css_parse::NoBlockAllowed;
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.keyframes"))]
 pub struct KeyframesRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
@@ -63,7 +63,7 @@ pub struct KeyframesRuleBlock<'a>(pub RuleList<'a, Keyframe<'a>, CssMetadata>);
 
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 pub struct Keyframe<'a>(
 	QualifiedRule<'a, KeyframeSelectors<'a>, StyleValue<'a>, NoBlockAllowed<StyleValue<'a>, CssMetadata>, CssMetadata>,
 );

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 // https://drafts.csswg.org/css-cascade-5/#layering
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.layer"))]
 pub struct LayerRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -8,7 +8,7 @@ pub use features::*;
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.media"))]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 pub struct MediaRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Media)]

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -3,7 +3,7 @@ use crate::{DocumentMatcherList, DocumentRuleBlock};
 
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 pub struct MozDocumentRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::_MozDocument)]

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -6,7 +6,7 @@ use css_parse::RuleVariants;
 // https://drafts.csswg.org/css-page-3/#at-page-rule
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.page"))]
 pub struct PageRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
@@ -102,7 +102,7 @@ pub struct PageRuleBlock<'a>(Block<'a, StyleValue<'a>, MarginRule<'a>, CssMetada
 // https://drafts.csswg.org/cssom-1/#cssmarginrule
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 pub enum MarginRule<'a> {
 	#[atom(CssAtomSet::TopLeftCorner)]
 	TopLeftCorner(#[cfg_attr(feature = "visitable", visit(skip))] T![AtKeyword], MarginRuleBlock<'a>),

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -5,7 +5,7 @@ use crate::Computed;
 // https://drafts.csswg.org/css-page-3/#at-page-rule
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.property"))]
 pub struct PropertyRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/css_ast/src/rules/starting_style.rs
+++ b/crates/css_ast/src/rules/starting_style.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 // https://drafts.csswg.org/css-transitions-2/#at-ruledef-starting-style
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 #[cfg_attr(
 	feature = "css_feature_data",
 	derive(::csskit_derives::ToCSSFeature),

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -34,7 +34,7 @@ use crate::selector::ComplexSelector;
 /// <https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports>
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.property"))]
 pub struct SupportsRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -4,7 +4,7 @@ use crate::{KeyframesName, KeyframesRuleBlock};
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 pub struct WebkitKeyframesRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::_WebkitKeyframes)]

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -16,7 +16,7 @@ use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
 /// [1]: https://drafts.csswg.org/cssom-1/#the-cssstylerule-interface
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 pub struct StyleRule<'a> {
 	pub rule: QualifiedRule<'a, SelectorList<'a>, StyleValue<'a>, NestedGroupRule<'a>, CssMetadata>,
 }

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -9,7 +9,7 @@ use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
 // https://drafts.csswg.org/cssom-1/#the-cssstylesheet-interface
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 pub struct StyleSheet<'a> {
 	pub rules: Vec<'a, Rule<'a>>,
 	#[to_cursors(skip)]
@@ -77,7 +77,7 @@ macro_rules! apply_rules {
 
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 pub struct UnknownAtRule<'a> {
 	name: T![AtKeyword],
 	prelude: ComponentValues<'a>,
@@ -92,7 +92,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for UnknownAtRule<'a> {
 
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 pub struct UnknownQualifiedRule<'a>(
 	QualifiedRule<
 		'a,

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -70,7 +70,7 @@ pub trait Visitable {
 /// This trait extends `Visitable` and adds a unique identifier for the node type.
 /// It is automatically implemented by `#[derive(Visitable)]` for all nodes that
 /// are not marked with `#[visit(skip)]` or `#[visit(children)]`.
-pub trait QueryableNode: Visitable {
+pub trait QueryableNode: Visitable + NodeWithMetadata<CssMetadata> {
 	/// Unique identifier for this node type.
 	const NODE_ID: NodeId;
 

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -50,7 +50,7 @@ pub fn derive_into_span(stream: TokenStream) -> TokenStream {
 	to_span::derive(input).into()
 }
 
-#[proc_macro_derive(Visitable, attributes(visit))]
+#[proc_macro_derive(Visitable, attributes(visit, metadata))]
 pub fn derive_visitable(stream: TokenStream) -> TokenStream {
 	let input = syn::parse(stream).unwrap();
 	visitable::derive(input).into()

--- a/crates/csskit_derives/src/visitable.rs
+++ b/crates/csskit_derives/src/visitable.rs
@@ -55,6 +55,21 @@ impl From<&Vec<Attribute>> for VisitStyle {
 	}
 }
 
+/// Check if the type has a #[metadata(skip)] attribute, indicating it has a manual
+/// NodeWithMetadata implementation.
+fn has_metadata_skip(attrs: &[Attribute]) -> bool {
+	attrs.iter().any(|attr| {
+		if attr.path().is_ident("metadata") {
+			match &attr.meta {
+				Meta::List(meta) => meta.parse_args::<Ident>().map(|i| i == "skip").unwrap_or(false),
+				_ => false,
+			}
+		} else {
+			false
+		}
+	})
+}
+
 pub fn derive(input: DeriveInput) -> TokenStream {
 	let mut where_collector = WhereCollector::new();
 	let ident = input.ident;
@@ -118,6 +133,27 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 	let where_clause = where_collector.extend_where_clause(&mut generics, parse_quote! { crate::Visitable });
 	let mut_where_clause = where_collector.extend_where_clause(&mut generics, parse_quote! { crate::VisitableMut });
 
+	// Check if we should skip generating NodeWithMetadata (type has manual implementation)
+	let skip_metadata = has_metadata_skip(&input.attrs);
+
+	// Generate NodeWithMetadata implementation for queryable nodes
+	// This is needed because QueryableNode: Visitable + NodeWithMetadata<CssMetadata>
+	// Most queryable nodes just return default metadata - the important metadata (like
+	// at-rule IDs, property groups) is set by manual implementations for key types like
+	// StyleRule, MediaRule, StyleValue, etc.
+	let metadata_impl = if style.visit_self() && !skip_metadata {
+		quote! {
+			#[automatically_derived]
+			impl #impl_generics css_parse::NodeWithMetadata<crate::CssMetadata> for #ident #type_generics #where_clause {
+				fn metadata(&self) -> crate::CssMetadata {
+					crate::CssMetadata::default()
+				}
+			}
+		}
+	} else {
+		quote! {}
+	};
+
 	// Implement QueryableNode for nodes that visit themselves (not just children)
 	// This matches the types that get NodeId variants generated in build.rs
 	let queryable_impl = if style.visit_self() {
@@ -152,6 +188,7 @@ pub fn derive(input: DeriveInput) -> TokenStream {
 			}
 		}
 
+		#metadata_impl
 		#queryable_impl
 	}
 }


### PR DESCRIPTION
This allows all Queryable nodes to have some kind of metadata emission,
allowing the selector matcher to query metadata for each node, without having
to write monomorphic code for each visit/exit.
