### PR TITLE
css_parse: Consume whitespace as trivia around non-descendant combinators

### DIFF
--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -254,6 +254,11 @@ mod tests {
 		assert_visits!("*.foo#bar", CompoundSelector, Wildcard, Class, Id);
 		assert_visits!(".foo .bar", CompoundSelector, Class, Combinator, Class);
 		assert_visits!(".foo ", CompoundSelector, Class);
+		assert_visits!("a > b", CompoundSelector, Tag, HtmlTag, Combinator, Tag, HtmlTag);
+		assert_visits!("a>b", CompoundSelector, Tag, HtmlTag, Combinator, Tag, HtmlTag);
+		assert_visits!("a + b", CompoundSelector, Tag, HtmlTag, Combinator, Tag, HtmlTag);
+		assert_visits!("a ~ b", CompoundSelector, Tag, HtmlTag, Combinator, Tag, HtmlTag);
+		assert_visits!(".foo > .bar + .baz", CompoundSelector, Class, Combinator, Class, Combinator, Class);
 	}
 
 	#[test]

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
@@ -10474,21 +10474,11 @@ StyleSheet(
               offset: SourceOffset(7374),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(7375),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(7376),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(7377),
-              len: 1,
-            )))),
             Tag(Html(Code(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(7378),
@@ -12242,21 +12232,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(8641),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(8642),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(8643),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -12287,21 +12267,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(8661),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(8662),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(8663),
-              len: 1,
-            )))),
             Attribute(Attribute(
               open: LeftSquare(Cursor(
                 kind: "LeftSquare",
@@ -13953,21 +13923,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9685),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9686),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9687),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9688),
@@ -14135,21 +14095,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9765),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9766),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9767),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9768),
@@ -14317,21 +14267,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9842),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9843),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9844),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9845),
@@ -14499,21 +14439,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9940),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9941),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9942),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9943),
@@ -14681,21 +14611,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10017),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(10018),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10019),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(10020),
@@ -14863,21 +14783,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10094),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(10095),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10096),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(10097),
@@ -19372,21 +19282,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12600),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12601),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12602),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12603),
@@ -19554,21 +19454,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12692),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12693),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12694),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12695),
@@ -19736,21 +19626,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12781),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12782),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12783),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12784),
@@ -19918,21 +19798,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12891),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12892),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12893),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12894),
@@ -20100,21 +19970,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12980),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12981),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(12982),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(12983),
@@ -20282,21 +20142,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(13069),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(13070),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(13071),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(13072),
@@ -24857,21 +24707,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16022),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16023),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16024),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16025),
@@ -25039,21 +24879,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16114),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16115),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16116),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16117),
@@ -25221,21 +25051,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16203),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16204),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16205),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16206),
@@ -25403,21 +25223,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16313),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16314),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16315),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16316),
@@ -25585,21 +25395,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16402),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16403),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16404),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16405),
@@ -25767,21 +25567,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16491),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16492),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(16493),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(16494),
@@ -30342,21 +30132,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19444),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19445),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19446),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19447),
@@ -30524,21 +30304,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19536),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19537),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19538),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19539),
@@ -30706,21 +30476,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19625),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19626),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19627),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19628),
@@ -30888,21 +30648,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19735),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19736),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19737),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19738),
@@ -31070,21 +30820,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19824),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19825),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19826),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19827),
@@ -31252,21 +30992,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19913),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19914),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19915),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19916),
@@ -35827,21 +35557,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22867),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22868),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22869),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22870),
@@ -36009,21 +35729,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22959),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22960),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22961),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22962),
@@ -36191,21 +35901,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23048),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23049),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23050),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23051),
@@ -36373,21 +36073,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23158),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23159),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23160),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23161),
@@ -36555,21 +36245,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23247),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23248),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23249),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23250),
@@ -36737,21 +36417,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23336),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23337),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23338),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23339),
@@ -41501,21 +41171,11 @@ StyleSheet(
               offset: SourceOffset(26373),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(26378),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(26379),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(26380),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(26381),
@@ -42085,21 +41745,11 @@ StyleSheet(
               offset: SourceOffset(26773),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(26778),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(26779),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(26780),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(26781),
@@ -42467,21 +42117,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27015),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27016),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27017),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27018),
@@ -42505,21 +42145,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27036),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27037),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27038),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27039),
@@ -42687,21 +42317,11 @@ StyleSheet(
               offset: SourceOffset(27154),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27159),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27160),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27161),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27162),
@@ -42884,21 +42504,11 @@ StyleSheet(
               offset: SourceOffset(27294),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27299),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27300),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27301),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27302),
@@ -42948,21 +42558,11 @@ StyleSheet(
               offset: SourceOffset(27334),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27339),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27340),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27341),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27342),
@@ -43044,21 +42644,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27413),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27414),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27415),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27416),
@@ -43082,21 +42672,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27436),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27437),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27438),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27439),
@@ -43264,21 +42844,11 @@ StyleSheet(
               offset: SourceOffset(27562),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27567),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27568),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27569),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27570),
@@ -43461,21 +43031,11 @@ StyleSheet(
               offset: SourceOffset(27706),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27711),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27712),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27713),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27714),
@@ -43525,21 +43085,11 @@ StyleSheet(
               offset: SourceOffset(27748),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27753),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27754),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27755),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27756),
@@ -43621,21 +43171,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27823),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27824),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27825),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27826),
@@ -43659,21 +43199,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27844),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27845),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27846),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27847),
@@ -43841,21 +43371,11 @@ StyleSheet(
               offset: SourceOffset(27962),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27967),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27968),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27969),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27970),
@@ -44038,21 +43558,11 @@ StyleSheet(
               offset: SourceOffset(28102),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28107),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28108),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28109),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28110),
@@ -44102,21 +43612,11 @@ StyleSheet(
               offset: SourceOffset(28142),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28147),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28148),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28149),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28150),
@@ -44198,21 +43698,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28211),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28212),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28213),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28214),
@@ -44236,21 +43726,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28229),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28230),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28231),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28232),
@@ -44418,21 +43898,11 @@ StyleSheet(
               offset: SourceOffset(28335),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28340),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28341),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28342),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28343),
@@ -44615,21 +44085,11 @@ StyleSheet(
               offset: SourceOffset(28469),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28474),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28475),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28476),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28477),
@@ -44679,21 +44139,11 @@ StyleSheet(
               offset: SourceOffset(28506),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28511),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28512),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28513),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28514),
@@ -44775,21 +44225,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28581),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28582),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28583),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28584),
@@ -44813,21 +44253,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28602),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28603),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28604),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28605),
@@ -44995,21 +44425,11 @@ StyleSheet(
               offset: SourceOffset(28720),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28725),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28726),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28727),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28728),
@@ -45192,21 +44612,11 @@ StyleSheet(
               offset: SourceOffset(28860),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28865),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28866),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28867),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28868),
@@ -45256,21 +44666,11 @@ StyleSheet(
               offset: SourceOffset(28900),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28905),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28906),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28907),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28908),
@@ -45352,21 +44752,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28973),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28974),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28975),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28976),
@@ -45390,21 +44780,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28993),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(28994),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(28995),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(28996),
@@ -45572,21 +44952,11 @@ StyleSheet(
               offset: SourceOffset(29107),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29112),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29113),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29114),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29115),
@@ -45769,21 +45139,11 @@ StyleSheet(
               offset: SourceOffset(29245),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29250),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29251),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29252),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29253),
@@ -45833,21 +45193,11 @@ StyleSheet(
               offset: SourceOffset(29284),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29289),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29290),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29291),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29292),
@@ -45929,21 +45279,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29355),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29356),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29357),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29358),
@@ -45967,21 +45307,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29374),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29375),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29376),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29377),
@@ -46149,21 +45479,11 @@ StyleSheet(
               offset: SourceOffset(29484),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29489),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29490),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29491),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29492),
@@ -46346,21 +45666,11 @@ StyleSheet(
               offset: SourceOffset(29620),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29625),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29626),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29627),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29628),
@@ -46410,21 +45720,11 @@ StyleSheet(
               offset: SourceOffset(29658),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29663),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29664),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29665),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29666),
@@ -46506,21 +45806,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29727),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29728),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29729),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29730),
@@ -46544,21 +45834,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29745),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29746),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29747),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29748),
@@ -46726,21 +46006,11 @@ StyleSheet(
               offset: SourceOffset(29851),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29856),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29857),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29858),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29859),
@@ -46923,21 +46193,11 @@ StyleSheet(
               offset: SourceOffset(29985),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29990),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29991),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29992),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(29993),
@@ -46987,21 +46247,11 @@ StyleSheet(
               offset: SourceOffset(30022),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30027),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(30028),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30029),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(30030),
@@ -47083,21 +46333,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30095),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(30096),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30097),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(30098),
@@ -47121,21 +46361,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30115),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(30116),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30117),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(30118),
@@ -47381,21 +46611,11 @@ StyleSheet(
               offset: SourceOffset(30275),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30280),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(30281),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30282),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(30283),
@@ -47445,21 +46665,11 @@ StyleSheet(
               offset: SourceOffset(30314),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30319),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(30320),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30321),
-              len: 1,
-            )))),
             Tag(Html(Th(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(30322),
@@ -48630,21 +47840,11 @@ StyleSheet(
                       len: 19,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31148),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(31149),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31150),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -48914,21 +48114,11 @@ StyleSheet(
                       len: 19,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31371),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(31372),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31373),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -49198,21 +48388,11 @@ StyleSheet(
                       len: 19,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31594),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(31595),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31596),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -49482,21 +48662,11 @@ StyleSheet(
                       len: 19,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31818),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(31819),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31820),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -49724,21 +48894,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31991),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31992),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31993),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -54122,21 +53282,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(35155),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(35156),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(35157),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -54167,21 +53317,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(35173),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(35174),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(35175),
-              len: 1,
-            )))),
             Attribute(Attribute(
               open: LeftSquare(Cursor(
                 kind: "LeftSquare",
@@ -54534,21 +53674,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(35441),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(35442),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(35443),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -54588,21 +53718,11 @@ StyleSheet(
               offset: SourceOffset(35481),
               len: 8,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(35489),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(35490),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(35491),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -55644,21 +54764,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36289),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36290),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36291),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -55671,21 +54781,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36296),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36297),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36298),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -55716,21 +54816,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36324),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36325),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36326),
-              len: 1,
-            )))),
             Attribute(Attribute(
               open: LeftSquare(Cursor(
                 kind: "LeftSquare",
@@ -55764,21 +54854,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36342),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36343),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36344),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -55863,21 +54943,11 @@ StyleSheet(
               offset: SourceOffset(36394),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36399),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36400),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36401),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -55922,21 +54992,11 @@ StyleSheet(
               offset: SourceOffset(36435),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36440),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36441),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36442),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -55967,21 +55027,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36468),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36469),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36470),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -56012,21 +55062,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36497),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36498),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36499),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58123,21 +57163,11 @@ StyleSheet(
               offset: SourceOffset(38535),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38540),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38541),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38542),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58180,21 +57210,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38588),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38589),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38590),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58291,21 +57311,11 @@ StyleSheet(
               offset: SourceOffset(38665),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38670),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38671),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38672),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58362,21 +57372,11 @@ StyleSheet(
               offset: SourceOffset(38723),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38728),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38729),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38730),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58419,21 +57419,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38773),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38774),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38775),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58476,21 +57466,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38819),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38820),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38821),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58596,21 +57576,11 @@ StyleSheet(
               offset: SourceOffset(38897),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38902),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38903),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38904),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58653,21 +57623,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38958),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38959),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38960),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58764,21 +57724,11 @@ StyleSheet(
               offset: SourceOffset(39043),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39048),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39049),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39050),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58834,21 +57784,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39112),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39113),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39114),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -58976,21 +57916,11 @@ StyleSheet(
               offset: SourceOffset(39218),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39225),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39226),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39227),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -59055,21 +57985,11 @@ StyleSheet(
               offset: SourceOffset(39290),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39297),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39298),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39299),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -59220,21 +58140,11 @@ StyleSheet(
               offset: SourceOffset(39432),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39437),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39438),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39439),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -59299,21 +58209,11 @@ StyleSheet(
               offset: SourceOffset(39502),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39507),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39508),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39509),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -59572,21 +58472,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39659),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39660),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39661),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -59681,21 +58571,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39743),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39744),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39745),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -59814,21 +58694,11 @@ StyleSheet(
               offset: SourceOffset(39840),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39845),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39846),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39847),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -59871,21 +58741,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39895),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39896),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39897),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -60000,21 +58860,11 @@ StyleSheet(
               offset: SourceOffset(39987),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39992),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39993),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39994),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -60066,21 +58916,11 @@ StyleSheet(
               offset: SourceOffset(40043),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40048),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40049),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40050),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -60853,21 +59693,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40573),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40574),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40575),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -60880,21 +59710,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40580),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40581),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40582),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -60925,21 +59745,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40610),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40611),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40612),
-              len: 1,
-            )))),
             Attribute(Attribute(
               open: LeftSquare(Cursor(
                 kind: "LeftSquare",
@@ -60973,21 +59783,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40628),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40629),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40630),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -61072,21 +59872,11 @@ StyleSheet(
               offset: SourceOffset(40682),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40689),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40690),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40691),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -61131,21 +59921,11 @@ StyleSheet(
               offset: SourceOffset(40727),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40734),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40735),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40736),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -61176,21 +59956,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40766),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40767),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40768),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -61221,21 +59991,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40799),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40800),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40801),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -63332,21 +62092,11 @@ StyleSheet(
               offset: SourceOffset(42981),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(42988),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(42989),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(42990),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -63389,21 +62139,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43038),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43039),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43040),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -63500,21 +62240,11 @@ StyleSheet(
               offset: SourceOffset(43115),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43122),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43123),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43124),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -63571,21 +62301,11 @@ StyleSheet(
               offset: SourceOffset(43177),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43184),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43185),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43186),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -63628,21 +62348,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43233),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43234),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43235),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -63685,21 +62395,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43283),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43284),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43285),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -63805,21 +62505,11 @@ StyleSheet(
               offset: SourceOffset(43363),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43370),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43371),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43372),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -63862,21 +62552,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43428),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43429),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43430),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -63973,21 +62653,11 @@ StyleSheet(
               offset: SourceOffset(43513),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43520),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43521),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43522),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -64043,21 +62713,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43586),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43587),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43588),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -64185,21 +62845,11 @@ StyleSheet(
               offset: SourceOffset(43694),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43701),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43702),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43703),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -64264,21 +62914,11 @@ StyleSheet(
               offset: SourceOffset(43768),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43775),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43776),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43777),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -64429,21 +63069,11 @@ StyleSheet(
               offset: SourceOffset(43912),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43917),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43918),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43919),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -64508,21 +63138,11 @@ StyleSheet(
               offset: SourceOffset(43984),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43989),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(43990),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(43991),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -64781,21 +63401,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44143),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(44144),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44145),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -64890,21 +63500,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44229),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(44230),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44231),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -65023,21 +63623,11 @@ StyleSheet(
               offset: SourceOffset(44326),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44333),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(44334),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44335),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -65080,21 +63670,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44385),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(44386),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44387),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -65209,21 +63789,11 @@ StyleSheet(
               offset: SourceOffset(44479),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44484),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(44485),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44486),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -65275,21 +63845,11 @@ StyleSheet(
               offset: SourceOffset(44537),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44542),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(44543),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(44544),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -69775,21 +68335,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(47708),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(47709),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(47710),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -70128,21 +68678,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(47933),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(47934),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(47935),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -71199,21 +69739,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(48616),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(48617),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(48618),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -71552,21 +70082,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(48847),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(48848),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(48849),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72623,21 +71143,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49515),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49516),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49517),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72976,21 +71486,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49740),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49741),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49742),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -74047,21 +72547,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50381),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(50382),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50383),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -74400,21 +72890,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50597),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(50598),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50599),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -75471,21 +73951,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51272),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(51273),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51274),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -75824,21 +74294,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51500),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(51501),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51502),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -76895,21 +75355,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52157),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52158),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52159),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77248,21 +75698,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52379),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52380),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52381),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78319,21 +76759,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53040),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53041),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53042),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78672,21 +77102,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53262),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53263),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53264),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -79743,21 +78163,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53901),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53902),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53903),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -80096,21 +78506,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54117),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54118),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54119),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -81034,21 +79434,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54728),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54729),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54730),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -81387,21 +79777,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54977),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54978),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54979),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -82325,21 +80705,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55618),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55619),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55620),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -82678,21 +81048,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55873),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55874),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55875),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83616,21 +81976,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56500),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56501),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56502),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83969,21 +82319,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56749),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56750),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56751),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -84907,21 +83247,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57349),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(57350),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57351),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -85260,21 +83590,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57589),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(57590),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57591),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -86198,21 +84518,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(58213),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(58214),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(58215),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -86551,21 +84861,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(58465),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(58466),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(58467),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -87489,21 +85789,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(59080),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(59081),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(59082),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -87842,21 +86132,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(59326),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(59327),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(59328),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -88780,21 +87060,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(59937),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(59938),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(59939),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -89133,21 +87403,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60183),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60184),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60185),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -90071,21 +88331,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60781),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60782),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60783),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -90424,21 +88674,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61021),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(61022),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61023),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -91096,21 +89336,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61442),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(61443),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61444),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -91281,21 +89511,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61568),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(61569),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61570),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -91538,21 +89758,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61735),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(61736),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61737),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -98668,21 +96878,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66878),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(66879),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66880),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -98713,21 +96913,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66906),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(66907),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66908),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -98902,21 +97092,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66991),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(66992),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66993),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -98956,21 +97136,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67025),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67026),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67027),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -99059,21 +97229,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67068),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67069),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67070),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -99113,21 +97273,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67093),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67094),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67095),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -99167,21 +97317,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67119),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67120),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67121),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -99224,21 +97364,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67154),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67155),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67156),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -99278,21 +97408,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67188),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67189),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67190),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -99332,21 +97452,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67223),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67224),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67225),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -99731,21 +97841,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67469),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67470),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67471),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -99806,21 +97906,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67506),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67507),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67508),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -99921,21 +98011,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67574),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67575),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67576),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100029,21 +98109,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67632),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67633),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67634),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100086,21 +98156,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67662),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67663),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67664),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100194,21 +98254,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67748),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67749),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67750),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100269,21 +98319,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67785),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67786),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67787),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100326,21 +98366,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67816),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(67817),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(67818),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100770,21 +98800,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68179),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68180),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68181),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100815,21 +98835,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68219),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68220),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68221),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100842,21 +98852,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68226),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68227),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68228),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100950,21 +98950,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68317),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68318),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68319),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -100995,21 +98985,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68357),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68358),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68359),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -101022,21 +99002,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68364),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68365),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68366),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -101348,21 +99318,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68650),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68651),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68652),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -101393,21 +99353,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68678),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68679),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68680),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -101478,21 +99428,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68731),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68732),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68733),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -101553,21 +99493,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68777),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68778),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68779),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -101668,21 +99598,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68853),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68854),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68855),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -101776,21 +99696,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68920),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68921),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68922),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -101833,21 +99743,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68950),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(68951),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(68952),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -101941,21 +99841,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69047),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69048),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69049),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102016,21 +99906,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69093),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69094),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69095),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102073,21 +99953,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69124),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69125),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69126),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102181,21 +100051,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69213),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69214),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69215),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102226,21 +100086,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69239),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69240),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69241),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102253,21 +100103,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69252),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69253),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69254),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102338,21 +100178,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69302),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69303),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69304),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102422,21 +100252,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69348),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69349),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69350),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102506,21 +100326,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69397),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69398),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69399),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102533,21 +100343,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69410),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69411),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69412),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102617,21 +100417,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69456),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69457),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69458),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -102644,21 +100434,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69469),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69470),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69471),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103148,21 +100928,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69778),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69779),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69780),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103193,21 +100963,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69808),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69809),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69810),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103238,21 +100998,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69848),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69849),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69850),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103283,21 +101033,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69879),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(69880),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(69881),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103541,21 +101281,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70023),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70024),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70025),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103568,21 +101298,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70039),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70040),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70041),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103613,21 +101333,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70069),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70070),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70071),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103640,21 +101350,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70085),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70086),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70087),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103685,21 +101385,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70116),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70117),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70118),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103712,21 +101402,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70132),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70133),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70134),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103757,21 +101437,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70161),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70162),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70163),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103784,21 +101454,11 @@ StyleSheet(
                 len: 22,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70187),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70188),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70189),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103829,21 +101489,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70217),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70218),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70219),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103856,21 +101506,11 @@ StyleSheet(
                 len: 22,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70243),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70244),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70245),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103901,21 +101541,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70274),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70275),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70276),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103928,21 +101558,11 @@ StyleSheet(
                 len: 22,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70300),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70301),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70302),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103973,21 +101593,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70329),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70330),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70331),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104000,21 +101610,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70346),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70347),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70348),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104045,21 +101645,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70376),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70377),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70378),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104072,21 +101662,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70393),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70394),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70395),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104117,21 +101697,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70424),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70425),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70426),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104144,21 +101714,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70441),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70442),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70443),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104189,21 +101749,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70470),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70471),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70472),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104216,21 +101766,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70485),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70486),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70487),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104261,21 +101801,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70515),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70516),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70517),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104288,21 +101818,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70530),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70531),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70532),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104333,21 +101853,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70561),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70562),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70563),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104360,21 +101870,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70576),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70577),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70578),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104445,21 +101945,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70630),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70631),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70632),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104499,21 +101989,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70666),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70667),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70668),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104553,21 +102033,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70703),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70704),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70705),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104606,21 +102076,11 @@ StyleSheet(
               offset: SourceOffset(70738),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70743),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70744),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70745),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104700,21 +102160,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70796),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70797),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70798),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104820,21 +102270,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70868),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70869),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70870),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -104895,21 +102335,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70916),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(70917),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(70918),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -105033,21 +102463,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71030),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71031),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71032),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -105223,21 +102643,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71153),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71154),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71155),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -105315,21 +102725,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71218),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71219),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71220),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -105483,21 +102883,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71357),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71358),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71359),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -105671,21 +103061,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71509),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71510),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71511),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -105779,21 +103159,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71577),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71578),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71579),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -105887,21 +103257,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71646),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71647),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71648),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -106012,21 +103372,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71732),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71733),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71734),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -106192,21 +103542,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71886),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71887),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71888),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -106279,21 +103619,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71953),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(71954),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(71955),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -106366,21 +103696,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72021),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72022),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72023),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -106470,21 +103790,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72106),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72107),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72108),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -107051,21 +104361,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72527),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72528),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72529),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -107113,21 +104413,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72561),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72562),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72563),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -107175,21 +104465,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72621),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72622),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72623),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -107237,21 +104517,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72681),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72682),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72683),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -107299,21 +104569,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72714),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72715),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72716),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -107361,21 +104621,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72747),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72748),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72749),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -107423,21 +104673,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72806),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72807),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72808),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -107485,21 +104725,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72865),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(72866),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(72867),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108290,21 +105520,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73478),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73479),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73480),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108361,21 +105581,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73525),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73526),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73527),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108511,21 +105721,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73599),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73600),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73601),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108556,21 +105756,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73632),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73633),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73634),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108601,21 +105791,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73666),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73667),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73668),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108628,21 +105808,11 @@ StyleSheet(
                 len: 19,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73689),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73690),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73691),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108673,21 +105843,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73726),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73727),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73728),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108700,21 +105860,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73748),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73749),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73750),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108745,21 +105895,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73785),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73786),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73787),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108772,21 +105912,11 @@ StyleSheet(
                 len: 19,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73808),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73809),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73810),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108817,21 +105947,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73832),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73833),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73834),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -108844,21 +105964,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73854),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73855),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73856),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109011,21 +106121,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73973),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(73974),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(73975),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109082,21 +106182,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74020),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74021),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74022),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109232,21 +106322,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74096),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74097),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74098),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109277,21 +106357,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74129),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74130),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74131),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109322,21 +106392,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74163),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74164),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74165),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109349,21 +106409,11 @@ StyleSheet(
                 len: 19,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74186),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74187),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74188),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109394,21 +106444,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74223),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74224),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74225),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109421,21 +106461,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74245),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74246),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74247),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109466,21 +106496,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74282),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74283),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74284),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109493,21 +106513,11 @@ StyleSheet(
                 len: 19,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74305),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74306),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74307),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109538,21 +106548,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74329),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74330),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74331),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109565,21 +106565,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74351),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74352),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74353),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109732,21 +106722,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74474),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74475),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74476),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109777,21 +106757,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74508),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74509),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74510),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109862,21 +106832,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74569),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74570),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74571),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109889,21 +106849,11 @@ StyleSheet(
                 len: 19,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74592),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74593),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74594),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109934,21 +106884,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74613),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74614),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74615),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -109961,21 +106901,11 @@ StyleSheet(
                 len: 19,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74636),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74637),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74638),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110039,21 +106969,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74691),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74692),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74693),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110096,21 +107016,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74730),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74731),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74732),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110174,21 +107084,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74772),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74773),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74774),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110231,21 +107131,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74811),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74812),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74813),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110288,21 +107178,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74860),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74861),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74862),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110345,21 +107225,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74904),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74905),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74906),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110402,21 +107272,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74940),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74941),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74942),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110459,21 +107319,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74984),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(74985),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(74986),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110504,21 +107354,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75018),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75019),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75020),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110540,21 +107380,11 @@ StyleSheet(
               offset: SourceOffset(75041),
               len: 10,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75051),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75052),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75053),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110648,21 +107478,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75111),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75112),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75113),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110684,21 +107504,11 @@ StyleSheet(
               offset: SourceOffset(75134),
               len: 10,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75144),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75145),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75146),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110822,21 +107632,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75262),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75263),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75264),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110849,21 +107649,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75284),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75285),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75286),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110894,21 +107684,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75305),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75306),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75307),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110921,21 +107701,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75327),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75328),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75329),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -110966,21 +107736,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75361),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75362),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75363),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -111023,21 +107783,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75402),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75403),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75404),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -111068,21 +107818,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75423),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75424),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75425),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -111125,21 +107865,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75464),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75465),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75466),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -111170,21 +107900,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75498),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75499),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75500),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -111206,21 +107926,11 @@ StyleSheet(
               offset: SourceOffset(75522),
               len: 11,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75533),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75534),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75535),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -111281,21 +107991,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75572),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75573),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75574),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -111317,21 +108017,11 @@ StyleSheet(
               offset: SourceOffset(75596),
               len: 11,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75607),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(75608),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(75609),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -112014,21 +108704,11 @@ StyleSheet(
               offset: SourceOffset(76172),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76179),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76180),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76181),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -112176,21 +108856,11 @@ StyleSheet(
               offset: SourceOffset(76308),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76313),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76314),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76315),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -112423,21 +109093,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76444),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76445),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76446),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -112569,21 +109229,11 @@ StyleSheet(
               offset: SourceOffset(76544),
               len: 6,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76550),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76551),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76552),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -112743,21 +109393,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76688),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76689),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76690),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -112797,21 +109437,11 @@ StyleSheet(
               offset: SourceOffset(76736),
               len: 8,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76744),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76745),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76746),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -112903,21 +109533,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76823),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76824),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76825),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -112970,21 +109590,11 @@ StyleSheet(
               offset: SourceOffset(76879),
               len: 8,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76887),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76888),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76889),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -113911,21 +110521,11 @@ StyleSheet(
               offset: SourceOffset(77588),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(77595),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(77596),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(77597),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114045,21 +110645,11 @@ StyleSheet(
               offset: SourceOffset(77901),
               len: 13,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(77914),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(77915),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(77916),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114201,21 +110791,11 @@ StyleSheet(
               offset: SourceOffset(78045),
               len: 13,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78058),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(78059),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78060),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114344,21 +110924,11 @@ StyleSheet(
               offset: SourceOffset(78322),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78329),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(78330),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78331),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114513,21 +111083,11 @@ StyleSheet(
               offset: SourceOffset(78459),
               len: 13,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78472),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(78473),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78474),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114770,21 +111330,11 @@ StyleSheet(
               offset: SourceOffset(78661),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78668),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(78669),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78670),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114913,21 +111463,11 @@ StyleSheet(
               offset: SourceOffset(78928),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78935),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(78936),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(78937),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116191,21 +112731,11 @@ StyleSheet(
               offset: SourceOffset(80036),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(80043),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(80044),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(80045),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116409,21 +112939,11 @@ StyleSheet(
               offset: SourceOffset(80228),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(80235),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(80236),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(80237),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -118939,21 +115459,11 @@ StyleSheet(
               offset: SourceOffset(82104),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82109),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(82110),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82111),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -119187,21 +115697,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82241),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(82242),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82243),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -119241,21 +115741,11 @@ StyleSheet(
               offset: SourceOffset(82283),
               len: 8,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82291),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(82292),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82293),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -119350,21 +115840,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82374),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(82375),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82376),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -119457,21 +115937,11 @@ StyleSheet(
                 len: 17,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82447),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(82448),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(82449),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -127048,21 +123518,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88363),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(88364),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88365),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -127156,21 +123616,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88434),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(88435),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88436),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -127380,21 +123830,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88549),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(88550),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88551),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -127610,21 +124050,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88714),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(88715),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88716),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -127704,21 +124134,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88761),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(88762),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(88763),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -130344,21 +126764,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90739),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(90740),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90741),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -130389,21 +126799,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90773),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(90774),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90775),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -130434,21 +126834,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90811),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(90812),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90813),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -130479,21 +126869,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90846),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(90847),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90848),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -130524,21 +126904,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90881),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(90882),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90883),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -130569,21 +126939,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90916),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(90917),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(90918),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -131212,21 +127572,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91445),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(91446),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91447),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -131257,21 +127607,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91479),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(91480),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91481),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -131302,21 +127642,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91517),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(91518),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91519),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -131347,21 +127677,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91552),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(91553),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91554),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -131392,21 +127712,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91587),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(91588),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91589),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -131437,21 +127747,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91622),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(91623),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(91624),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -131964,21 +128264,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92044),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92045),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92046),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -132009,21 +128299,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92078),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92079),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92080),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -132054,21 +128334,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92116),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92117),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92118),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -132099,21 +128369,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92151),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92152),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92153),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -132144,21 +128404,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92186),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92187),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92188),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -132189,21 +128439,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92221),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92222),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92223),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -132832,21 +129072,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92750),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92751),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92752),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -132877,21 +129107,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92784),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92785),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92786),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -132922,21 +129142,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92822),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92823),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92824),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -132967,21 +129177,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92857),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92858),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92859),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -133012,21 +129212,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92892),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92893),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92894),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -133057,21 +129247,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92927),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(92928),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(92929),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -133584,21 +129764,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93349),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(93350),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93351),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -133629,21 +129799,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93383),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(93384),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93385),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -133674,21 +129834,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93421),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(93422),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93423),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -133719,21 +129869,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93456),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(93457),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93458),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -133764,21 +129904,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93491),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(93492),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93493),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -133809,21 +129939,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93526),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(93527),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(93528),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -134452,21 +130572,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94055),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94056),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94057),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -134497,21 +130607,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94089),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94090),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94091),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -134542,21 +130642,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94127),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94128),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94129),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -134587,21 +130677,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94162),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94163),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94164),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -134632,21 +130712,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94197),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94198),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94199),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -134677,21 +130747,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94232),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94233),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94234),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -135204,21 +131264,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94655),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94656),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94657),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -135249,21 +131299,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94689),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94690),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94691),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -135294,21 +131334,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94727),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94728),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94729),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -135339,21 +131369,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94762),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94763),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94764),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -135384,21 +131404,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94797),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94798),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94799),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -135429,21 +131439,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94832),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(94833),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(94834),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -136072,21 +132072,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95362),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(95363),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95364),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -136117,21 +132107,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95396),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(95397),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95398),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -136162,21 +132142,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95434),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(95435),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95436),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -136207,21 +132177,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95469),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(95470),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95471),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -136252,21 +132212,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95504),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(95505),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95506),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -136297,21 +132247,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95539),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(95540),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(95541),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -136953,21 +132893,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96054),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96055),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96056),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -136998,21 +132928,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96083),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96084),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96085),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137043,21 +132963,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96118),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96119),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96120),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137088,21 +132998,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96150),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96151),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96152),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137133,21 +133033,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96182),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96183),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96184),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137178,21 +133068,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96214),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96215),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96216),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137600,21 +133480,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96531),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96532),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96533),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137645,21 +133515,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96560),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96561),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96562),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137690,21 +133550,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96595),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96596),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96597),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137735,21 +133585,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96627),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96628),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96629),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137780,21 +133620,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96659),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96660),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96661),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137825,21 +133655,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96691),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(96692),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(96693),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -139077,21 +134897,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(97489),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(97490),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(97491),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -139156,21 +134966,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(97536),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(97537),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(97538),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -140813,21 +136613,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(98765),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(98766),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(98767),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -140892,21 +136682,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(98811),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(98812),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(98813),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -142112,21 +137892,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(99867),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(99868),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(99869),
-              len: 1,
-            )))),
             Tag(Html(Hr(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(99870),
@@ -142213,21 +137983,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(99920),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(99921),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(99922),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -142321,21 +138081,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(99994),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(99995),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(99996),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -142551,21 +138301,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100149),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(100150),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100151),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -142781,21 +138521,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100312),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(100313),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100314),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -142808,21 +138538,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100327),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(100328),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100329),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -142853,21 +138573,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100348),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(100349),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100350),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -142880,21 +138590,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100362),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(100363),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100364),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -143436,21 +139136,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100707),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(100708),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(100709),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -145831,21 +141521,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(102323),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(102324),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(102325),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -146129,21 +141809,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102520),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(102521),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102522),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -146318,21 +141988,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102610),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(102611),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102612),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -146345,21 +142005,11 @@ StyleSheet(
                       len: 4,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102618),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(102619),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102620),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -146457,21 +142107,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102686),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(102687),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102688),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -146595,21 +142235,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102798),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(102799),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102800),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -146687,21 +142317,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102852),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(102853),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102854),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -146819,21 +142439,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102942),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(102943),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102944),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -146911,21 +142521,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(102999),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(103000),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103001),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -147043,21 +142643,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103092),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(103093),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103094),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -147181,21 +142771,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103203),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(103204),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103205),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -147273,21 +142853,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103258),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(103259),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103260),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -147405,21 +142975,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103348),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(103349),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103350),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -147497,21 +143057,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103406),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(103407),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(103408),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -148182,21 +143732,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(103911),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(103912),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(103913),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -148267,21 +143807,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(103955),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(103956),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(103957),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -148432,21 +143962,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104083),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104084),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104085),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -148570,21 +144090,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104186),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104187),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104188),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -148597,21 +144107,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104194),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104195),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104196),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -149005,21 +144505,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104497),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104498),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104499),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -149090,21 +144580,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104562),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104563),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104564),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -149266,21 +144746,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104685),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104686),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104687),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -149382,21 +144852,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104770),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104771),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104772),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -162476,21 +157936,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114324),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(114325),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114326),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -162561,21 +158011,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114388),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(114389),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114390),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -162771,21 +158211,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114565),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(114566),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114567),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -162888,21 +158318,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114692),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(114693),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114694),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -163005,21 +158425,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114818),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(114819),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114820),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -163102,21 +158512,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114889),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(114890),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114891),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -163129,21 +158529,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114908),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(114909),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(114910),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -163237,21 +158627,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(115004),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(115005),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(115006),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -163264,21 +158644,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(115023),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(115024),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(115025),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -163516,21 +158886,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115245),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(115246),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115247),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163633,21 +158993,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115382),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(115383),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115384),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163750,21 +159100,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115518),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(115519),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115520),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163847,21 +159187,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115597),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(115598),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115599),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163874,21 +159204,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115616),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(115617),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115618),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163982,21 +159302,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115722),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(115723),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115724),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164009,21 +159319,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115741),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(115742),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115743),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164269,21 +159569,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115971),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(115972),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(115973),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164386,21 +159676,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116108),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(116109),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116110),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164503,21 +159783,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116244),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(116245),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116246),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164600,21 +159870,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116323),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(116324),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116325),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164627,21 +159887,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116342),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(116343),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116344),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164735,21 +159985,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116448),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(116449),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116450),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164762,21 +160002,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116467),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(116468),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116469),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165022,21 +160252,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116697),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(116698),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116699),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165139,21 +160359,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116834),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(116835),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116836),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165256,21 +160466,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116970),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(116971),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(116972),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165353,21 +160553,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117049),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117050),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117051),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165380,21 +160570,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117068),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117069),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117070),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165488,21 +160668,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117174),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117175),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117176),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165515,21 +160685,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117193),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117194),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117195),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165775,21 +160935,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117424),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117425),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117426),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165892,21 +161042,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117561),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117562),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117563),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166009,21 +161149,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117697),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117698),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117699),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166106,21 +161236,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117776),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117777),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117778),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166133,21 +161253,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117795),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117796),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117797),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166241,21 +161351,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117901),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117902),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117903),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166268,21 +161368,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117920),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(117921),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(117922),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166463,21 +161553,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(118067),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(118068),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(118069),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -166556,21 +161636,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(118134),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(118135),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(118136),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -176328,21 +171398,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(125864),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(125865),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(125866),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(125867),
@@ -182196,21 +177256,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130334),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(130335),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130336),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -182274,21 +177324,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130381),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(130382),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130383),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -182404,21 +177444,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130442),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(130443),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130444),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -182495,21 +177525,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130497),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(130498),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130499),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -182683,21 +177703,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130622),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(130623),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130624),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -182774,21 +177784,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130676),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(130677),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130678),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -183035,21 +178035,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130875),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(130876),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130877),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -183113,21 +178103,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130924),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(130925),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(130926),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -183316,21 +178296,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131038),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131039),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131040),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -183407,21 +178377,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131095),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131096),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131097),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -183599,21 +178559,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131229),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131230),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131231),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -183690,21 +178640,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131285),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131286),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131287),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -183955,21 +178895,11 @@ StyleSheet(
                 len: 17,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131493),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131494),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131495),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -184033,21 +178963,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131543),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131544),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131545),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -184163,21 +179083,11 @@ StyleSheet(
                 len: 17,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131604),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131605),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131606),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -184254,21 +179164,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131662),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131663),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131664),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -184446,21 +179346,11 @@ StyleSheet(
                 len: 17,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131797),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131798),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131799),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -184537,21 +179427,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131854),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(131855),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(131856),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -185162,21 +180042,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132324),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(132325),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132326),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -185240,21 +180110,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132372),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(132373),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132374),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -185443,21 +180303,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132486),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(132487),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132488),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -185534,21 +180384,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132542),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(132543),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132544),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -185726,21 +180566,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132675),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(132676),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132677),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -185817,21 +180647,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132730),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(132731),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132732),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
@@ -12289,21 +12289,11 @@ StyleSheet(
               offset: SourceOffset(9185),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9186),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9187),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9188),
-              len: 1,
-            )))),
             Tag(Html(Code(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(9189),
@@ -15233,21 +15223,11 @@ StyleSheet(
               offset: SourceOffset(11008),
               len: 6,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(11014),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(11015),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(11016),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(11017),
@@ -18437,21 +18417,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(13402),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(13403),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(13404),
-              len: 1,
-            )))),
             PseudoClass(LastChild(Colon(Cursor(
               kind: "Colon",
               offset: SourceOffset(13405),
@@ -21229,21 +21199,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15363),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15364),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15365),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15366),
@@ -21656,21 +21616,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15596),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15597),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15598),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15599),
@@ -21786,21 +21736,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15650),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15651),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15652),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15653),
@@ -21916,21 +21856,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15704),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15705),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15706),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15707),
@@ -22046,21 +21976,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15757),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15758),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15759),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15760),
@@ -22176,21 +22096,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15821),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15822),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15823),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15824),
@@ -22306,21 +22216,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15874),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15875),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15876),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15877),
@@ -22436,21 +22336,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15927),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15928),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(15929),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(15930),
@@ -25783,21 +25673,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17658),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17659),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17660),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17661),
@@ -25913,21 +25793,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17722),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17723),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17724),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17725),
@@ -26043,21 +25913,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17786),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17787),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17788),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17789),
@@ -26173,21 +26033,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17849),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17850),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17851),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17852),
@@ -26303,21 +26153,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17923),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17924),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17925),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17926),
@@ -26433,21 +26273,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17986),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17987),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(17988),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(17989),
@@ -26563,21 +26393,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(18049),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(18050),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(18051),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(18052),
@@ -29976,21 +29796,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20202),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20203),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20204),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20205),
@@ -30106,21 +29916,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20266),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20267),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20268),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20269),
@@ -30236,21 +30036,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20330),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20331),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20332),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20333),
@@ -30366,21 +30156,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20393),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20394),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20395),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20396),
@@ -30496,21 +30276,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20467),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20468),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20469),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20470),
@@ -30626,21 +30396,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20530),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20531),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20532),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20533),
@@ -30756,21 +30516,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20593),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20594),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(20595),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(20596),
@@ -34169,21 +33919,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22746),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22747),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22748),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22749),
@@ -34299,21 +34039,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22810),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22811),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22812),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22813),
@@ -34429,21 +34159,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22874),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22875),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22876),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22877),
@@ -34559,21 +34279,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22937),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22938),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(22939),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(22940),
@@ -34689,21 +34399,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23011),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23012),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23013),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23014),
@@ -34819,21 +34519,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23074),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23075),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23076),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23077),
@@ -34949,21 +34639,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23137),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23138),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(23139),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(23140),
@@ -38362,21 +38042,11 @@ StyleSheet(
                       len: 16,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25291),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25292),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25293),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25294),
@@ -38492,21 +38162,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25355),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25356),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25357),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25358),
@@ -38622,21 +38282,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25419),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25420),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25421),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25422),
@@ -38752,21 +38402,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25482),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25483),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25484),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25485),
@@ -38882,21 +38522,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25556),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25557),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25558),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25559),
@@ -39012,21 +38642,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25619),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25620),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25621),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25622),
@@ -39142,21 +38762,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25682),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25683),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(25684),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(25685),
@@ -42555,21 +42165,11 @@ StyleSheet(
                       len: 17,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27838),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27839),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27840),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27841),
@@ -42685,21 +42285,11 @@ StyleSheet(
                       len: 14,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27903),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27904),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27905),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27906),
@@ -42815,21 +42405,11 @@ StyleSheet(
                       len: 14,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27968),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27969),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27970),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27971),
@@ -42945,21 +42525,11 @@ StyleSheet(
                       len: 14,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28032),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28033),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28034),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28035),
@@ -43075,21 +42645,11 @@ StyleSheet(
                       len: 14,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28107),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28108),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28109),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28110),
@@ -43205,21 +42765,11 @@ StyleSheet(
                       len: 14,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28171),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28172),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28173),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28174),
@@ -43335,21 +42885,11 @@ StyleSheet(
                       len: 14,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28235),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28236),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28237),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28238),
@@ -47507,21 +47047,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31060),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31061),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31062),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -47548,41 +47078,21 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31076),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31077),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31078),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31079),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31080),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31081),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31082),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31083),
@@ -48016,21 +47526,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31408),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31409),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31410),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(31411),
@@ -48094,21 +47594,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31454),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31455),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31456),
-              len: 1,
-            )))),
             Tag(Html(Thead(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(31457),
@@ -48378,21 +47868,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31635),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31636),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31637),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -48419,41 +47899,21 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31651),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31652),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31653),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31654),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31655),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31656),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31657),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31658),
@@ -48521,21 +47981,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31708),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31709),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31710),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -48562,21 +48012,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31724),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31725),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31726),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31727),
@@ -48675,21 +48115,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31790),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31791),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31792),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -48716,41 +48146,21 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31806),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31807),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31808),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31809),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31810),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31811),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31812),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31813),
@@ -48849,21 +48259,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31879),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31880),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31881),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -48890,41 +48290,21 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31895),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31896),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31897),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31898),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31899),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31900),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31901),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31902),
@@ -48988,21 +48368,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31951),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31952),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31953),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -49091,41 +48461,21 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32015),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32016),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32017),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(32018),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32023),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32024),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32025),
-              len: 1,
-            )))),
             Tag(Html(Tr(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(32026),
@@ -49153,21 +48503,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32045),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32046),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32047),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32048),
@@ -49304,21 +48644,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32183),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32184),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32185),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -49345,41 +48675,21 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32199),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32200),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32201),
-              len: 1,
-            )))),
             Tag(Html(Tr(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(32202),
               len: 2,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32204),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32205),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32206),
-              len: 1,
-            )))),
             FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -49664,41 +48974,21 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32472),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32473),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32474),
-              len: 1,
-            )))),
             Tag(Html(Tbody(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(32475),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32480),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32481),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32482),
-              len: 1,
-            )))),
             Tag(Html(Tr(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(32483),
@@ -49713,21 +49003,11 @@ StyleSheet(
               offset: SourceOffset(32486),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32491),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32492),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(32493),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(32494),
@@ -66131,21 +65411,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(46660),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(46661),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(46662),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -66185,21 +65455,11 @@ StyleSheet(
               offset: SourceOffset(46700),
               len: 8,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(46708),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(46709),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(46710),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -67539,21 +66799,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(48112),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(48113),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(48114),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -67593,21 +66843,11 @@ StyleSheet(
               offset: SourceOffset(48132),
               len: 8,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(48140),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(48141),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(48142),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -70997,21 +70237,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50913),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(50914),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50915),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -71042,21 +70272,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50945),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(50946),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50947),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -71087,21 +70307,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50987),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(50988),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(50989),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -71412,21 +70622,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51164),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(51165),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51166),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(51167),
@@ -71965,21 +71165,11 @@ StyleSheet(
                       len: 13,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(51593),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(51594),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(51595),
-                    len: 1,
-                  )))),
                   Tag(Html(Label(Ident(Cursor(
                     kind: "Ident",
                     offset: SourceOffset(51596),
@@ -72059,21 +71249,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51646),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(51647),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51648),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72104,21 +71284,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51678),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(51679),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51680),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72193,21 +71363,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51748),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(51749),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51750),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72251,21 +71411,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51798),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(51799),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51800),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72349,21 +71499,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51883),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(51884),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51885),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72407,21 +71547,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51928),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(51929),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(51930),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72505,21 +71635,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52008),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52009),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52010),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72580,21 +71700,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52069),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52070),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52071),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72718,21 +71828,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52196),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52197),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52198),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72772,21 +71872,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52234),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52235),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52236),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72847,21 +71937,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52290),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52291),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52292),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -72901,21 +71981,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52338),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52339),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52340),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -73039,21 +72109,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52460),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52461),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52462),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -73093,21 +72153,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52509),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52510),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52511),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -73210,21 +72260,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52624),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52625),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52626),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -73318,21 +72358,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52711),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52712),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52713),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -73375,21 +72405,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52756),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52757),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52758),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(52759),
@@ -73580,21 +72600,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52896),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52897),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52898),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -73616,21 +72626,11 @@ StyleSheet(
               offset: SourceOffset(52913),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52918),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52919),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52920),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(52921),
@@ -73654,21 +72654,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52942),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52943),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52944),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -73711,21 +72701,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52982),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(52983),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(52984),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(52985),
@@ -73749,21 +72729,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53006),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53007),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53008),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -73776,21 +72746,11 @@ StyleSheet(
                 len: 22,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53032),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53033),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53034),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(53035),
@@ -73814,21 +72774,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53056),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53057),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53058),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -73841,21 +72791,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53071),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53072),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53073),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(53074),
@@ -74046,21 +72986,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53211),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53212),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53213),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -74103,21 +73033,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53256),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53257),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53258),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(53259),
@@ -74404,21 +73324,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53464),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53465),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53466),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -74440,21 +73350,11 @@ StyleSheet(
               offset: SourceOffset(53481),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53486),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53487),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53488),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(53489),
@@ -74491,21 +73391,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53517),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53518),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53519),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -74548,21 +73438,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53557),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53558),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53559),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(53560),
@@ -74599,21 +73479,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53588),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53589),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53590),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -74626,21 +73496,11 @@ StyleSheet(
                 len: 22,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53614),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53615),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53616),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(53617),
@@ -74677,21 +73537,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53645),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53646),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53647),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -74704,21 +73554,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53660),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53661),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53662),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(53663),
@@ -75005,21 +73845,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53868),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53869),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53870),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -75041,21 +73871,11 @@ StyleSheet(
               offset: SourceOffset(53885),
               len: 16,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53901),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(53902),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(53903),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(53904),
@@ -75246,21 +74066,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54041),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54042),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54043),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -75273,21 +74083,11 @@ StyleSheet(
                 len: 22,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54067),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54068),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54069),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(54070),
@@ -75386,21 +74186,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54136),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54137),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54138),
-              len: 1,
-            )))),
             PseudoClass(Disabled(Colon(Cursor(
               kind: "Colon",
               offset: SourceOffset(54139),
@@ -75410,21 +74200,11 @@ StyleSheet(
               offset: SourceOffset(54140),
               len: 8,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54148),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54149),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54150),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(54151),
@@ -75488,21 +74268,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54193),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54194),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54195),
-              len: 1,
-            )))),
             PseudoClass(Disabled(Colon(Cursor(
               kind: "Colon",
               offset: SourceOffset(54196),
@@ -75512,21 +74282,11 @@ StyleSheet(
               offset: SourceOffset(54197),
               len: 8,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54205),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54206),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54207),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(54208),
@@ -75796,21 +74556,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54396),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54397),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54398),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -75841,21 +74591,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54426),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54427),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54428),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -75886,21 +74626,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54455),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54456),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54457),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -76069,21 +74799,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54558),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54559),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54560),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -76123,21 +74843,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54594),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54595),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54596),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -76177,21 +74887,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54629),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(54630),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(54631),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -76958,21 +75658,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55169),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55170),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55171),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77003,21 +75693,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55202),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55203),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55204),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77048,21 +75728,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55234),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55235),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55236),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77093,21 +75763,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55271),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55272),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55273),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77253,21 +75913,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55390),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55391),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55392),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77298,21 +75948,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55423),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55424),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55425),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77343,21 +75983,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55455),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55456),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55457),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77388,21 +76018,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55492),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55493),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55494),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77548,21 +76168,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55615),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55616),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55617),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77593,21 +76203,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55647),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55648),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55649),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -77711,21 +76311,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55724),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55725),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55726),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -77906,21 +76496,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55841),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55842),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55843),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78010,21 +76590,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55915),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55916),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55917),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78067,21 +76637,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55949),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(55950),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(55951),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78145,21 +76705,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56000),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56001),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56002),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78202,21 +76752,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56034),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56035),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56036),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78322,21 +76862,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56144),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56145),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56146),
-              len: 1,
-            )))),
             FunctionalPseudoClass(NthLastChild(NthLastChildPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -78492,21 +77022,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56258),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56259),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56260),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78575,21 +77095,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56326),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56327),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56328),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78628,21 +77138,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56363),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56364),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56365),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78685,21 +77185,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56408),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56409),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56410),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78738,21 +77228,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56445),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56446),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56447),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -78846,21 +77326,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56540),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56541),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56542),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -79221,21 +77691,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56795),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56796),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56797),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -79278,21 +77738,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56830),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56831),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56832),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -79323,21 +77773,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56860),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56861),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56862),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -79380,21 +77820,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56895),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(56896),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(56897),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -80046,21 +78476,11 @@ StyleSheet(
               offset: SourceOffset(57401),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57406),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(57407),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57408),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -80105,21 +78525,11 @@ StyleSheet(
               offset: SourceOffset(57442),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57447),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(57448),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57449),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -80150,21 +78560,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57475),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(57476),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57477),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -80195,21 +78595,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57504),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(57505),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(57506),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83267,21 +81657,11 @@ StyleSheet(
               offset: SourceOffset(60033),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60038),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60039),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60040),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83324,21 +81704,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60086),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60087),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60088),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83451,21 +81821,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60185),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60186),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60187),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83553,21 +81913,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60258),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60259),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60260),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83637,21 +81987,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60306),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60307),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60308),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83741,21 +82081,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60372),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60373),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60374),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83825,21 +82155,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60419),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60420),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60421),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -83929,21 +82249,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60484),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60485),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60486),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -84013,21 +82323,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60540),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(60541),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(60542),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -84707,21 +83007,11 @@ StyleSheet(
               offset: SourceOffset(61034),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61041),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(61042),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61043),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -84766,21 +83056,11 @@ StyleSheet(
               offset: SourceOffset(61079),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61086),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(61087),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61088),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -84811,21 +83091,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61118),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(61119),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61120),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -84856,21 +83126,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61151),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(61152),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(61153),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -87928,21 +86188,11 @@ StyleSheet(
               offset: SourceOffset(63897),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(63904),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(63905),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(63906),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -87985,21 +86235,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(63954),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(63955),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(63956),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -88112,21 +86352,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64055),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(64056),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64057),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -88214,21 +86444,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64130),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(64131),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64132),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -88298,21 +86518,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64180),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(64181),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64182),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -88402,21 +86612,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64248),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(64249),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64250),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -88486,21 +86686,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64297),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(64298),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64299),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -88590,21 +86780,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64364),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(64365),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64366),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -88674,21 +86854,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64422),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(64423),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(64424),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -90791,21 +88961,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66112),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(66113),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66114),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -91278,21 +89438,11 @@ StyleSheet(
               offset: SourceOffset(66466),
               len: 13,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66479),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(66480),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66481),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -91472,21 +89622,11 @@ StyleSheet(
               offset: SourceOffset(66612),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66619),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(66620),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66621),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -91538,21 +89678,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66644),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(66645),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66646),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -91858,21 +89988,11 @@ StyleSheet(
               offset: SourceOffset(66856),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66863),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(66864),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66865),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -91933,21 +90053,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66902),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(66903),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(66904),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103095,21 +101205,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76428),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76429),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76430),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -103319,21 +101419,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76606),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(76607),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(76608),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -113902,21 +111992,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85182),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85183),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85184),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -113947,21 +112027,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85210),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85211),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85212),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114084,21 +112154,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85272),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85273),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85274),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114120,21 +112180,11 @@ StyleSheet(
               offset: SourceOffset(85286),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85293),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85294),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85295),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114165,21 +112215,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85312),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85313),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85314),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114201,21 +112241,11 @@ StyleSheet(
               offset: SourceOffset(85326),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85331),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85332),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85333),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114246,21 +112276,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85350),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85351),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85352),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114300,21 +112320,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85375),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85376),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85377),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114354,21 +112364,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85400),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85401),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85402),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114408,21 +112408,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85426),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85427),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85428),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114465,21 +112455,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85461),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85462),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85463),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114501,21 +112481,11 @@ StyleSheet(
               offset: SourceOffset(85475),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85482),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85483),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85484),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114546,21 +112516,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85510),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85511),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85512),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114582,21 +112542,11 @@ StyleSheet(
               offset: SourceOffset(85524),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85529),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85530),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85531),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114627,21 +112577,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85557),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85558),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85559),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114681,21 +112621,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85591),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85592),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85593),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114735,21 +112665,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85625),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85626),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85627),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -114789,21 +112709,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85660),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85661),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85662),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -115175,21 +113085,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85891),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85892),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85893),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -115232,21 +113132,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85922),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85923),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85924),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -115277,21 +113167,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85941),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(85942),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(85943),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -115453,21 +113333,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86037),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86038),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86039),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -115561,21 +113431,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86095),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86096),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86097),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -115627,21 +113487,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86148),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86149),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86150),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -115684,21 +113534,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86178),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86179),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86180),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -115792,21 +113632,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86263),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86264),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86265),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -115863,21 +113693,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86297),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86298),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86299),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -115911,21 +113731,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86316),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86317),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86318),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -115956,21 +113766,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86335),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86336),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86337),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116013,21 +113813,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86366),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86367),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86368),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116457,21 +114247,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86726),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86727),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86728),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116502,21 +114282,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86766),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86767),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86768),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116529,21 +114299,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86773),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86774),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86775),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116637,21 +114397,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86864),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86865),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86866),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116682,21 +114432,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86904),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86905),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86906),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116709,21 +114449,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86911),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(86912),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(86913),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116939,21 +114669,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87116),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87117),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87118),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -116984,21 +114704,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87144),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87145),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87146),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -117069,21 +114779,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87196),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87197),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87198),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -117144,21 +114844,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87242),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87243),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87244),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -117320,21 +115010,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87346),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87347),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87348),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -117428,21 +115108,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87413),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87414),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87415),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -117485,21 +115155,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87443),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87444),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87445),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -117593,21 +115253,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87539),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87540),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87541),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -117620,21 +115270,11 @@ StyleSheet(
                 len: 3,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87546),
-              len: 1,
-            )))),
             Combinator(SubsequentSibling(Tilde(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87547),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87548),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -117665,21 +115305,11 @@ StyleSheet(
                 len: 18,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87574),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87575),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87576),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -117722,21 +115352,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87605),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(87606),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(87607),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -121452,21 +119072,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(90769),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(90770),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(90771),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -122163,21 +119773,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91387),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(91388),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91389),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -122319,21 +119919,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91523),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(91524),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91525),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -122491,21 +120081,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91616),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(91617),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91618),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -122801,21 +120381,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91813),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(91814),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91815),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -122895,21 +120465,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91859),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(91860),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(91861),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -124261,21 +121821,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93368),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(93369),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93370),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -124306,21 +121856,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93390),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(93391),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93392),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -124351,21 +121891,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93418),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(93419),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93420),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -124396,21 +121926,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93443),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(93444),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93445),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -124441,21 +121961,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93468),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(93469),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93470),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -124486,21 +121996,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93493),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(93494),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93495),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -124531,21 +122031,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93518),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(93519),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(93520),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137630,21 +135120,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104750),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104751),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104752),
-              len: 1,
-            )))),
             Tag(Html(Hr(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(104753),
@@ -137731,21 +135211,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104802),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104803),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104804),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -137839,21 +135309,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104875),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(104876),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(104877),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -138029,21 +135489,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105059),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(105060),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105061),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -138219,21 +135669,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105251),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(105252),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105253),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -138246,21 +135686,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105266),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(105267),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105268),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -138291,21 +135721,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105287),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(105288),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105289),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -138318,21 +135738,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105301),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(105302),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105303),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -139004,21 +136414,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105761),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(105762),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(105763),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -141306,21 +138706,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(107633),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(107634),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(107635),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -141555,21 +138945,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(107797),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(107798),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(107799),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -141692,21 +139072,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(107865),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(107866),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(107867),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -141719,21 +139089,11 @@ StyleSheet(
                       len: 4,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(107873),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(107874),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(107875),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -141831,21 +139191,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(107941),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(107942),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(107943),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -141969,21 +139319,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108053),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(108054),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108055),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -142061,21 +139401,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108107),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(108108),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108109),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -142193,21 +139523,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108197),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(108198),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108199),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -142285,21 +139605,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108254),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(108255),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108256),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -142417,21 +139727,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108347),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(108348),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108349),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -142555,21 +139855,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108458),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(108459),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108460),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -142647,21 +139937,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108513),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(108514),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108515),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -142779,21 +140059,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108603),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(108604),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108605),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -142871,21 +140141,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108661),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(108662),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(108663),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -148813,21 +146073,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(115184),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(115185),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(115186),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -148923,21 +146173,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(115277),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(115278),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(115279),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -151491,21 +148731,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(117695),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(117696),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(117697),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -151759,21 +148989,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(117911),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(117912),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(117913),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -158105,21 +155325,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(123730),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(123731),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(123732),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -158190,21 +155400,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(123786),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(123787),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(123788),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -158217,21 +155417,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(123798),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(123799),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(123800),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -159526,21 +156716,11 @@ StyleSheet(
                 len: 19,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(125138),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(125139),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(125140),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -161178,21 +158358,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(126652),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(126653),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(126654),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -161263,21 +158433,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(126715),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(126716),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(126717),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -161527,21 +158687,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(126934),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(126935),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(126936),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -161699,21 +158849,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127104),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(127105),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127106),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -161871,21 +159011,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127274),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(127275),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127276),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -161968,21 +159098,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127344),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(127345),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127346),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -161995,21 +159115,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127363),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(127364),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127365),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -162128,21 +159238,11 @@ StyleSheet(
                 len: 21,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127488),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(127489),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127490),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -162155,21 +159255,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127507),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(127508),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(127509),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -162461,21 +159551,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(127770),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(127771),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(127772),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -162633,21 +159713,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(127951),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(127952),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(127953),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -162805,21 +159875,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128132),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(128133),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128134),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -162902,21 +159962,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128211),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(128212),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128213),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -162929,21 +159979,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128230),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(128231),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128232),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163062,21 +160102,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128366),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(128367),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128368),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163089,21 +160119,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128385),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(128386),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128387),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163403,21 +160423,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128655),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(128656),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128657),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163575,21 +160585,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128836),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(128837),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(128838),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163747,21 +160747,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129017),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(129018),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129019),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163844,21 +160834,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129096),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(129097),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129098),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -163871,21 +160851,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129115),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(129116),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129117),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164004,21 +160974,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129251),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(129252),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129253),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164031,21 +160991,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129270),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(129271),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129272),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164345,21 +161295,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129540),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(129541),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129542),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164517,21 +161457,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129721),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(129722),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129723),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164689,21 +161619,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129902),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(129903),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129904),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164786,21 +161706,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129981),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(129982),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(129983),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164813,21 +161723,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130000),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(130001),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130002),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164946,21 +161846,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130136),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(130137),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130138),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -164973,21 +161863,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130155),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(130156),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130157),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165287,21 +162167,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130426),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(130427),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130428),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165459,21 +162329,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130607),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(130608),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130609),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165631,21 +162491,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130788),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(130789),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130790),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165728,21 +162578,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130867),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(130868),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130869),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165755,21 +162595,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130886),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(130887),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(130888),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165888,21 +162718,11 @@ StyleSheet(
                       len: 24,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131022),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(131023),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131024),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -165915,21 +162735,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131041),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(131042),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131043),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166229,21 +163039,11 @@ StyleSheet(
                       len: 25,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131314),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(131315),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131316),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166401,21 +163201,11 @@ StyleSheet(
                       len: 25,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131496),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(131497),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131498),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166573,21 +163363,11 @@ StyleSheet(
                       len: 25,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131678),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(131679),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131680),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166670,21 +163450,11 @@ StyleSheet(
                       len: 25,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131758),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(131759),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131760),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166697,21 +163467,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131777),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(131778),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131779),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166830,21 +163590,11 @@ StyleSheet(
                       len: 25,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131914),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(131915),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131916),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -166857,21 +163607,11 @@ StyleSheet(
                       len: 15,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131933),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(131934),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(131935),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -167138,21 +163878,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132148),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(132149),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132150),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -167268,21 +163998,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132244),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(132245),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(132246),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -174656,21 +171376,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(140489),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(140490),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(140491),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -180601,21 +177311,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(145254),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(145255),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(145256),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(145257),
@@ -190896,21 +187596,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(153736),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(153737),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(153738),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -190974,21 +187664,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(153799),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(153800),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(153801),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -191172,21 +187852,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(153924),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(153925),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(153926),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -191263,21 +187933,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(153995),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(153996),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(153997),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -191321,21 +187981,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154037),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154038),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154039),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -191412,21 +188062,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154107),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154108),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154109),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -191607,21 +188247,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154243),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154244),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154245),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -191698,21 +188328,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154314),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154315),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154316),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -191844,21 +188464,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154424),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154425),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154426),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -191935,21 +188545,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154494),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154495),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154496),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -192106,21 +188706,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154646),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154647),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154648),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -192184,21 +188774,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154711),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154712),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154713),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -192478,21 +189058,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154916),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154917),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154918),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -192569,21 +189139,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154989),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(154990),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(154991),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -192627,21 +189187,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155031),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155032),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155033),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -192718,21 +189268,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155103),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155104),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155105),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -192975,21 +189515,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155281),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155282),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155283),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -193066,21 +189596,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155354),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155355),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155356),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -193212,21 +189732,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155464),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155465),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155466),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -193303,21 +189813,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155536),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155537),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155538),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -193474,21 +189974,11 @@ StyleSheet(
                 len: 17,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155689),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155690),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155691),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -193552,21 +190042,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155755),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155756),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155757),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -193750,21 +190230,11 @@ StyleSheet(
                 len: 17,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155880),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155881),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155882),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -193841,21 +190311,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155954),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(155955),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155956),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -193899,21 +190359,11 @@ StyleSheet(
                 len: 17,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(155999),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(156000),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156001),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -193990,21 +190440,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156072),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(156073),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156074),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -194185,21 +190625,11 @@ StyleSheet(
                 len: 17,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156211),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(156212),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156213),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -194276,21 +190706,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156285),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(156286),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156287),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -194422,21 +190842,11 @@ StyleSheet(
                 len: 17,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156398),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(156399),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156400),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -194513,21 +190923,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156471),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(156472),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(156473),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -195179,21 +191579,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157005),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157006),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157007),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -195257,21 +191647,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157069),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157070),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157071),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -195551,21 +191931,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157277),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157278),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157279),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -195642,21 +192012,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157349),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157350),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157351),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -195700,21 +192060,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157393),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157394),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157395),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -195791,21 +192141,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157464),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157465),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157466),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -196048,21 +192388,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157644),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157645),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157646),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -196139,21 +192469,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157716),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157717),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157718),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -196285,21 +192605,11 @@ StyleSheet(
                 len: 16,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157828),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157829),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157830),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -196376,21 +192686,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157899),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(157900),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(157901),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -232542,21 +228842,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(186589),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(186590),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(186591),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -232786,21 +229076,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(186765),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(186766),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(186767),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -232896,21 +229176,11 @@ StyleSheet(
               offset: SourceOffset(186820),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(186825),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(186826),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(186827),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -232950,21 +229220,11 @@ StyleSheet(
               offset: SourceOffset(186850),
               len: 13,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(186863),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(186864),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(186865),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -233362,21 +229622,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(187091),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(187092),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(187093),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(187094),

--- a/crates/css_ast/tests/snapshots/popular_snapshots__font-awesome-all.5.15.4.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__font-awesome-all.5.15.4.snap
@@ -1345,21 +1345,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(1005),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(1006),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(1007),
-              len: 1,
-            )))),
             Tag(Html(Li(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(1008),

--- a/crates/css_ast/tests/snapshots/popular_snapshots__inuitcss.6.0.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__inuitcss.6.0.0.snap
@@ -4958,21 +4958,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19882),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19883),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19884),
-              len: 1,
-            )))),
             Tag(Html(Li(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(19885),
@@ -5606,21 +5596,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(20213),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(20214),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(20215),
-              len: 1,
-            )))),
             Tag(Html(Li(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(20216),
@@ -10354,21 +10334,11 @@ StyleSheet(
               offset: SourceOffset(27199),
               len: 6,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27205),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27206),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27207),
-              len: 1,
-            )))),
             Tag(Html(Img(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27208),
@@ -10434,21 +10404,11 @@ StyleSheet(
               offset: SourceOffset(27382),
               len: 2,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27384),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27385),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27386),
-              len: 1,
-            )))),
             Tag(Html(Ul(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27387),
@@ -10465,21 +10425,11 @@ StyleSheet(
               offset: SourceOffset(27391),
               len: 2,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27393),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27394),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27395),
-              len: 1,
-            )))),
             Tag(Html(Ol(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(27396),
@@ -13460,21 +13410,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31833),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31834),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31835),
-              len: 1,
-            )))),
             Tag(Html(Li(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(31836),
@@ -14134,21 +14074,11 @@ StyleSheet(
               offset: SourceOffset(34093),
               len: 6,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(34099),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(34100),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(34101),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -14188,21 +14118,11 @@ StyleSheet(
               offset: SourceOffset(34127),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(34132),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(34133),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(34134),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
@@ -6929,21 +6929,11 @@ StyleSheet(
                 len: 1,
               ))),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(4809),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(4810),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(4811),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(4812),
@@ -7183,21 +7173,11 @@ StyleSheet(
                 len: 7,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(4933),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(4934),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(4935),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(4936),
@@ -7337,21 +7317,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5020),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5021),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5022),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5023),
@@ -7526,21 +7496,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5142),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5143),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5144),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5145),
@@ -7715,21 +7675,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5273),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5274),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5275),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5276),
@@ -7904,21 +7854,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5393),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5394),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5395),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5396),
@@ -8093,21 +8033,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5519),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5520),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5521),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5522),
@@ -8282,21 +8212,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5651),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5652),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5653),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5654),
@@ -8471,21 +8391,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5771),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5772),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5773),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5774),
@@ -8660,21 +8570,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5897),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5898),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(5899),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(5900),
@@ -8849,21 +8749,11 @@ StyleSheet(
                 len: 9,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(6029),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(6030),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(6031),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(6032),
@@ -9038,21 +8928,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(6151),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(6152),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(6153),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(6154),
@@ -9227,21 +9107,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(6279),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(6280),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(6281),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(6282),
@@ -9416,21 +9286,11 @@ StyleSheet(
                 len: 10,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(6414),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(6415),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(6416),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(6417),
@@ -9928,21 +9788,11 @@ StyleSheet(
                       len: 1,
                     ))),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(6742),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(6743),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(6744),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(6745),
@@ -10182,21 +10032,11 @@ StyleSheet(
                       len: 7,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(6877),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(6878),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(6879),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(6880),
@@ -10336,21 +10176,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(6975),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(6976),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(6977),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(6978),
@@ -10525,21 +10355,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7111),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7112),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7113),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7114),
@@ -10714,21 +10534,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7256),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7257),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7258),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7259),
@@ -10903,21 +10713,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7390),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7391),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7392),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7393),
@@ -11092,21 +10892,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7530),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7531),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7532),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7533),
@@ -11281,21 +11071,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7676),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7677),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7678),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7679),
@@ -11470,21 +11250,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7810),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7811),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7812),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7813),
@@ -11659,21 +11429,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7950),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7951),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(7952),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(7953),
@@ -11848,21 +11608,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8096),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8097),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8098),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8099),
@@ -12037,21 +11787,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8232),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8233),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8234),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8235),
@@ -12226,21 +11966,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8374),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8375),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8376),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8377),
@@ -12415,21 +12145,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8523),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8524),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8525),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8526),
@@ -12935,21 +12655,11 @@ StyleSheet(
                       len: 1,
                     ))),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8880),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8881),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(8882),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(8883),
@@ -13189,21 +12899,11 @@ StyleSheet(
                       len: 7,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9015),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9016),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9017),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9018),
@@ -13343,21 +13043,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9113),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9114),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9115),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9116),
@@ -13532,21 +13222,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9249),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9250),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9251),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9252),
@@ -13721,21 +13401,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9394),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9395),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9396),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9397),
@@ -13910,21 +13580,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9528),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9529),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9530),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9531),
@@ -14099,21 +13759,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9668),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9669),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9670),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9671),
@@ -14288,21 +13938,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9814),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9815),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9816),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9817),
@@ -14477,21 +14117,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9948),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9949),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(9950),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(9951),
@@ -14666,21 +14296,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10088),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10089),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10090),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10091),
@@ -14855,21 +14475,11 @@ StyleSheet(
                       len: 9,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10234),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10235),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10236),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10237),
@@ -15044,21 +14654,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10370),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10371),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10372),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10373),
@@ -15233,21 +14833,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10512),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10513),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10514),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10515),
@@ -15422,21 +15012,11 @@ StyleSheet(
                       len: 10,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10661),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10662),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(10663),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(10664),
@@ -16481,21 +16061,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(11491),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(11492),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(11493),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -16883,21 +16453,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(11767),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(11768),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(11769),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -17067,21 +16627,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(11871),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(11872),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(11873),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -17768,21 +17318,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(12376),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(12377),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(12378),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -17874,21 +17414,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(12433),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(12434),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(12435),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -19852,21 +19382,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(13995),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(13996),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(13997),
-              len: 1,
-            )))),
             Tag(Html(Input(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(13998),
@@ -20282,21 +19802,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(14301),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(14302),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(14303),
-              len: 1,
-            )))),
             Tag(Html(Input(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(14304),
@@ -27847,21 +27357,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19006),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19007),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19008),
-              len: 1,
-            )))),
             Tag(Html(Button(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(19009),
@@ -27937,21 +27437,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19061),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19062),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19063),
-              len: 1,
-            )))),
             Attribute(Attribute(
               open: LeftSquare(Cursor(
                 kind: "LeftSquare",
@@ -27999,21 +27489,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19094),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19095),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19096),
-              len: 1,
-            )))),
             Attribute(Attribute(
               open: LeftSquare(Cursor(
                 kind: "LeftSquare",
@@ -28061,21 +27541,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19126),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19127),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19128),
-              len: 1,
-            )))),
             Class(Class(
               dot: Dot(Delim(Cursor(
                 kind: "Delim",
@@ -28106,21 +27576,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19151),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19152),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19153),
-              len: 1,
-            )))),
             Attribute(Attribute(
               open: LeftSquare(Cursor(
                 kind: "LeftSquare",
@@ -28397,21 +27857,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19313),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19314),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19315),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -28653,21 +28103,11 @@ StyleSheet(
                       len: 12,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19509),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(19510),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(19511),
-                    len: 1,
-                  )))),
                   FunctionalPseudoClass(Not(NotPseudoFunction(
                     colon: Colon(Cursor(
                       kind: "Colon",
@@ -39470,21 +38910,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(26652),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(26653),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(26654),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(26655),
@@ -39985,21 +39415,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(26999),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27000),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27001),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27002),
@@ -40460,21 +39880,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27332),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27333),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27334),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27335),
@@ -40801,21 +40211,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27569),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27570),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27571),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27572),
@@ -40894,21 +40294,11 @@ StyleSheet(
                 len: 6,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27619),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27620),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27621),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27622),
@@ -41102,21 +40492,11 @@ StyleSheet(
                       len: 6,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27760),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27761),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27762),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27763),
@@ -41226,21 +40606,11 @@ StyleSheet(
               offset: SourceOffset(27816),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27823),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27824),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(27825),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(27826),
@@ -41416,21 +40786,11 @@ StyleSheet(
                       len: 1,
                     ))),
                   ))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27927),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27928),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27929),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(27930),
@@ -41611,21 +40971,11 @@ StyleSheet(
                       len: 1,
                     ))),
                   ))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28040),
-                    len: 1,
-                  )))),
                   Combinator(NextSibling(Plus(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28041),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(28042),
-                    len: 1,
-                  )))),
                   Wildcard(Wildcard(Star(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(28043),
@@ -48934,21 +48284,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(33042),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(33043),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(33044),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(33045),
@@ -49345,21 +48685,11 @@ StyleSheet(
               offset: SourceOffset(33332),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(33337),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(33338),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(33339),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(33340),
@@ -49449,21 +48779,11 @@ StyleSheet(
               offset: SourceOffset(33389),
               len: 5,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(33394),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(33395),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(33396),
-              len: 1,
-            )))),
             Tag(Html(Td(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(33397),
@@ -49668,21 +48988,11 @@ StyleSheet(
                     offset: SourceOffset(33541),
                     len: 5,
                   )))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(33546),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(33547),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(33548),
-                    len: 1,
-                  )))),
                   Tag(Html(Td(Ident(Cursor(
                     kind: "Ident",
                     offset: SourceOffset(33549),
@@ -49772,21 +49082,11 @@ StyleSheet(
                     offset: SourceOffset(33598),
                     len: 5,
                   )))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(33603),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(33604),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(33605),
-                    len: 1,
-                  )))),
                   Tag(Html(Td(Ident(Cursor(
                     kind: "Ident",
                     offset: SourceOffset(33606),
@@ -54022,21 +53322,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36422),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36423),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36424),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(36425),
@@ -54301,21 +53591,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36589),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36590),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36591),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(36592),
@@ -54475,21 +53755,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36686),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36687),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36688),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(36689),
@@ -54885,21 +54155,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36970),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(36971),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(36972),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(36973),
@@ -55243,21 +54503,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(37215),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(37216),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(37217),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(37218),
@@ -55353,21 +54603,11 @@ StyleSheet(
                 len: 5,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(37271),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(37272),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(37273),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(37274),
@@ -55537,21 +54777,11 @@ StyleSheet(
               offset: SourceOffset(37378),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(37385),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(37386),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(37387),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(37388),
@@ -55746,21 +54976,11 @@ StyleSheet(
               offset: SourceOffset(37473),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(37480),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(37481),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(37482),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(37483),
@@ -56436,21 +55656,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38056),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38057),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38058),
-              len: 1,
-            )))),
             Attribute(Attribute(
               open: LeftSquare(Cursor(
                 kind: "LeftSquare",
@@ -56498,21 +55708,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38084),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38085),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38086),
-              len: 1,
-            )))),
             Attribute(Attribute(
               open: LeftSquare(Cursor(
                 kind: "LeftSquare",
@@ -56866,21 +56066,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38289),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38290),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38291),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(38292),
@@ -57305,21 +56495,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38617),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38618),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38619),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(38620),
@@ -57352,21 +56532,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38642),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38643),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38644),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(38645),
@@ -57464,41 +56634,21 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38725),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38726),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38727),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(38728),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38733),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38734),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38735),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(38736),
@@ -57909,21 +57059,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38994),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(38995),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(38996),
-              len: 1,
-            )))),
             PseudoClass(Checked(Colon(Cursor(
               kind: "Colon",
               offset: SourceOffset(38997),
@@ -57933,21 +57073,11 @@ StyleSheet(
               offset: SourceOffset(38998),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39005),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39006),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39007),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(39008),
@@ -58084,21 +57214,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39153),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39154),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39155),
-              len: 1,
-            )))),
             PseudoClass(Checked(Colon(Cursor(
               kind: "Colon",
               offset: SourceOffset(39156),
@@ -58108,41 +57228,21 @@ StyleSheet(
               offset: SourceOffset(39157),
               len: 7,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39164),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39165),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39166),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(39167),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39172),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39173),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39174),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(39175),
@@ -58663,21 +57763,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39554),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39555),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39556),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(39557),
@@ -58775,21 +57865,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39614),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39615),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39616),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(39617),
@@ -58933,21 +58013,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39735),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39736),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39737),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(39738),
@@ -59121,21 +58191,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39875),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39876),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39877),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(39878),
@@ -59242,21 +58302,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39974),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(39975),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(39976),
-              len: 1,
-            )))),
             PseudoClass(Checked(Colon(Cursor(
               kind: "Colon",
               offset: SourceOffset(39977),
@@ -59305,21 +58355,11 @@ StyleSheet(
                 len: 1,
               ))),
             ))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40018),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40019),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40020),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(40021),
@@ -59392,21 +58432,11 @@ StyleSheet(
                 len: 8,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40061),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40062),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40063),
-              len: 1,
-            )))),
             PseudoClass(Checked(Colon(Cursor(
               kind: "Colon",
               offset: SourceOffset(40064),
@@ -59425,41 +58455,21 @@ StyleSheet(
               offset: SourceOffset(40073),
               len: 12,
             )))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40085),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40086),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40087),
-              len: 1,
-            )))),
             Tag(Html(Label(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(40088),
               len: 5,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40093),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(40094),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(40095),
-              len: 1,
-            )))),
             Tag(Html(Div(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(40096),

--- a/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
@@ -2286,21 +2286,11 @@ StyleSheet(
               offset: SourceOffset(1551),
               len: 7,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(1558),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(1559),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(1560),
-              len: 1,
-            )))),
             Tag(Html(Summary(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(1561),
@@ -10832,11 +10822,6 @@ StyleSheet(
                       offset: SourceOffset(7479),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(7480),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(7481),
@@ -10975,21 +10960,11 @@ StyleSheet(
               offset: SourceOffset(7556),
               len: 7,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(7563),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(7564),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(7565),
-              len: 1,
-            )))),
             Tag(Html(Section(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(7566),
@@ -11126,11 +11101,6 @@ StyleSheet(
                       offset: SourceOffset(7624),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(7625),
-                      len: 1,
-                    )))),
                     FunctionalPseudoClass(Is(IsPseudoFunction(
                       colon: Colon(Cursor(
                         kind: "Colon",
@@ -12082,11 +12052,6 @@ StyleSheet(
                       offset: SourceOffset(8183),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(8184),
-                      len: 1,
-                    )))),
                     Tag(Html(H1(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(8185),
@@ -12103,11 +12068,6 @@ StyleSheet(
                       offset: SourceOffset(8191),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(8192),
-                      len: 1,
-                    )))),
                     Tag(Html(H2(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(8193),
@@ -12124,11 +12084,6 @@ StyleSheet(
                       offset: SourceOffset(8199),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(8200),
-                      len: 1,
-                    )))),
                     Tag(Html(H3(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(8201),
@@ -12145,11 +12100,6 @@ StyleSheet(
                       offset: SourceOffset(8207),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(8208),
-                      len: 1,
-                    )))),
                     Tag(Html(H4(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(8209),
@@ -12166,11 +12116,6 @@ StyleSheet(
                       offset: SourceOffset(8215),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(8216),
-                      len: 1,
-                    )))),
                     Tag(Html(H5(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(8217),
@@ -12187,11 +12132,6 @@ StyleSheet(
                       offset: SourceOffset(8223),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(8224),
-                      len: 1,
-                    )))),
                     Tag(Html(H6(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(8225),
@@ -14099,21 +14039,11 @@ StyleSheet(
               offset: SourceOffset(9377),
               len: 2,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9379),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9380),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9381),
-              len: 1,
-            )))),
             Tag(Html(H2(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(9382),
@@ -14130,21 +14060,11 @@ StyleSheet(
               offset: SourceOffset(9386),
               len: 2,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9388),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9389),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9390),
-              len: 1,
-            )))),
             Tag(Html(H3(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(9391),
@@ -14161,21 +14081,11 @@ StyleSheet(
               offset: SourceOffset(9395),
               len: 2,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9397),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9398),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9399),
-              len: 1,
-            )))),
             Tag(Html(H4(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(9400),
@@ -14192,21 +14102,11 @@ StyleSheet(
               offset: SourceOffset(9404),
               len: 2,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9406),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9407),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9408),
-              len: 1,
-            )))),
             Tag(Html(H5(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(9409),
@@ -14223,21 +14123,11 @@ StyleSheet(
               offset: SourceOffset(9413),
               len: 2,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9415),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9416),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9417),
-              len: 1,
-            )))),
             Tag(Html(H6(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(9418),
@@ -15343,21 +15233,11 @@ StyleSheet(
               offset: SourceOffset(10175),
               len: 4,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10179),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(10180),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10181),
-              len: 1,
-            )))),
             Tag(Html(Header(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(10182),
@@ -15374,21 +15254,11 @@ StyleSheet(
               offset: SourceOffset(10190),
               len: 4,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10194),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(10195),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10196),
-              len: 1,
-            )))),
             Tag(Html(Footer(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(10197),
@@ -15405,21 +15275,11 @@ StyleSheet(
               offset: SourceOffset(10205),
               len: 4,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10209),
-              len: 1,
-            )))),
             Combinator(NextSibling(Plus(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(10210),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(10211),
-              len: 1,
-            )))),
             Tag(Html(Footer(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(10212),
@@ -16908,11 +16768,6 @@ StyleSheet(
                       offset: SourceOffset(11202),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(11203),
-                      len: 1,
-                    )))),
                     Tag(Html(Em(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(11204),
@@ -16929,11 +16784,6 @@ StyleSheet(
                       offset: SourceOffset(11210),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(11211),
-                      len: 1,
-                    )))),
                     Tag(Html(Cite(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(11212),
@@ -16950,11 +16800,6 @@ StyleSheet(
                       offset: SourceOffset(11220),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(11221),
-                      len: 1,
-                    )))),
                     Tag(Html(Dfn(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(11222),
@@ -16971,11 +16816,6 @@ StyleSheet(
                       offset: SourceOffset(11229),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(11230),
-                      len: 1,
-                    )))),
                     Tag(Html(Var(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(11231),
@@ -16992,11 +16832,6 @@ StyleSheet(
                       offset: SourceOffset(11238),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(11239),
-                      len: 1,
-                    )))),
                     Tag(Html(I(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(11240),
@@ -17013,11 +16848,6 @@ StyleSheet(
                       offset: SourceOffset(11245),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(11246),
-                      len: 1,
-                    )))),
                     Tag(Html(Address(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(11247),
@@ -17074,11 +16904,6 @@ StyleSheet(
                       offset: SourceOffset(11287),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(11288),
-                      len: 1,
-                    )))),
                     Tag(Html(Footer(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(11289),
@@ -17309,11 +17134,6 @@ StyleSheet(
                       offset: SourceOffset(11432),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(11433),
-                      len: 1,
-                    )))),
                     Combinator(Nesting(And(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(11434),
@@ -18845,11 +18665,6 @@ StyleSheet(
                         len: 13,
                       )),
                     )),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(12412),
-                      len: 1,
-                    )))),
                     Combinator(Nesting(And(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(12413),
@@ -20587,11 +20402,6 @@ StyleSheet(
                       offset: SourceOffset(13703),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(13704),
-                      len: 1,
-                    )))),
                     Tag(Html(Em(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(13705),
@@ -20608,11 +20418,6 @@ StyleSheet(
                       offset: SourceOffset(13711),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(13712),
-                      len: 1,
-                    )))),
                     Tag(Html(Cite(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(13713),
@@ -20629,11 +20434,6 @@ StyleSheet(
                       offset: SourceOffset(13721),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(13722),
-                      len: 1,
-                    )))),
                     Tag(Html(Dfn(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(13723),
@@ -20650,11 +20450,6 @@ StyleSheet(
                       offset: SourceOffset(13730),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(13731),
-                      len: 1,
-                    )))),
                     Tag(Html(Var(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(13732),
@@ -20671,11 +20466,6 @@ StyleSheet(
                       offset: SourceOffset(13739),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(13740),
-                      len: 1,
-                    )))),
                     Tag(Html(I(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(13741),
@@ -20692,11 +20482,6 @@ StyleSheet(
                       offset: SourceOffset(13746),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(13747),
-                      len: 1,
-                    )))),
                     Tag(Html(Address(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(13748),
@@ -26078,21 +25863,11 @@ StyleSheet(
               offset: SourceOffset(17175),
               len: 6,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(17181),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(17182),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(17183),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Where(WherePseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -29181,21 +28956,11 @@ StyleSheet(
               offset: SourceOffset(19166),
               len: 6,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19172),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19173),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19174),
-              len: 1,
-            )))),
             Tag(Html(Input(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(19175),
@@ -29393,21 +29158,11 @@ StyleSheet(
               offset: SourceOffset(19310),
               len: 6,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19316),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19317),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19318),
-              len: 1,
-            )))),
             Tag(Html(Input(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(19319),
@@ -29655,21 +29410,11 @@ StyleSheet(
               offset: SourceOffset(19449),
               len: 6,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19455),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(19456),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(19457),
-              len: 1,
-            )))),
             Tag(Html(Input(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(19458),
@@ -32181,11 +31926,6 @@ StyleSheet(
                       offset: SourceOffset(20892),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(20893),
-                      len: 1,
-                    )))),
                     Tag(Html(Option(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(20894),
@@ -38006,41 +37746,21 @@ StyleSheet(
                       offset: SourceOffset(25256),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(25257),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(25258),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(25259),
-                      len: 1,
-                    )))),
                     Tag(Html(Legend(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(25260),
                       len: 6,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(25266),
-                      len: 1,
-                    )))),
                     Combinator(NextSibling(Plus(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(25267),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(25268),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(25269),
@@ -39739,21 +39459,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(26754),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(26755),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(26756),
-              len: 1,
-            )))),
             Tag(Html(Header(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(26757),
@@ -41031,11 +40741,6 @@ StyleSheet(
                       offset: SourceOffset(27697),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(27698),
-                      len: 1,
-                    )))),
                     Tag(Html(A(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(27699),
@@ -41183,11 +40888,6 @@ StyleSheet(
                     offset: SourceOffset(27753),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(27754),
-                    len: 1,
-                  )))),
                   Class(Class(
                     dot: Dot(Delim(Cursor(
                       kind: "Delim",
@@ -41616,21 +41316,11 @@ StyleSheet(
                       offset: SourceOffset(27988),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(27989),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(27990),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(27991),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(27992),
@@ -41722,11 +41412,6 @@ StyleSheet(
                       offset: SourceOffset(28037),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(28038),
-                      len: 1,
-                    )))),
                     Tag(Html(Header(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(28039),
@@ -41751,11 +41436,6 @@ StyleSheet(
                               offset: SourceOffset(28052),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(28053),
-                              len: 1,
-                            )))),
                             Tag(Html(Li(Ident(Cursor(
                               kind: "Ident",
                               offset: SourceOffset(28054),
@@ -41873,11 +41553,6 @@ StyleSheet(
                               offset: SourceOffset(28112),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(28113),
-                              len: 1,
-                            )))),
                             Tag(Html(A(Ident(Cursor(
                               kind: "Ident",
                               offset: SourceOffset(28114),
@@ -42083,21 +41758,11 @@ StyleSheet(
                             offset: SourceOffset(28257),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(28258),
-                            len: 1,
-                          )))),
                           Combinator(Child(Gt(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(28259),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(28260),
-                            len: 1,
-                          )))),
                           Tag(Html(Header(Ident(Cursor(
                             kind: "Ident",
                             offset: SourceOffset(28261),
@@ -42208,21 +41873,11 @@ StyleSheet(
                             offset: SourceOffset(28356),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(28357),
-                            len: 1,
-                          )))),
                           Combinator(Child(Gt(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(28358),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(28359),
-                            len: 1,
-                          )))),
                           FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
                             colon: Colon(Cursor(
                               kind: "Colon",
@@ -42800,11 +42455,6 @@ StyleSheet(
                       offset: SourceOffset(28729),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(28730),
-                      len: 1,
-                    )))),
                     Tag(Html(Ul(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(28731),
@@ -42821,11 +42471,6 @@ StyleSheet(
                       offset: SourceOffset(28737),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(28738),
-                      len: 1,
-                    )))),
                     Tag(Html(Ol(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(28739),
@@ -42882,11 +42527,6 @@ StyleSheet(
                       offset: SourceOffset(28779),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(28780),
-                      len: 1,
-                    )))),
                     FunctionalPseudoClass(Is(IsPseudoFunction(
                       colon: Colon(Cursor(
                         kind: "Colon",
@@ -43017,11 +42657,6 @@ StyleSheet(
                       offset: SourceOffset(28838),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(28839),
-                      len: 1,
-                    )))),
                     Tag(Html(Li(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(28840),
@@ -43379,11 +43014,6 @@ StyleSheet(
                       offset: SourceOffset(29062),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(29063),
-                      len: 1,
-                    )))),
                     Attribute(Attribute(
                       open: LeftSquare(Cursor(
                         kind: "LeftSquare",
@@ -43424,11 +43054,6 @@ StyleSheet(
                       offset: SourceOffset(29087),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(29088),
-                      len: 1,
-                    )))),
                     Attribute(Attribute(
                       open: LeftSquare(Cursor(
                         kind: "LeftSquare",
@@ -44665,11 +44290,6 @@ StyleSheet(
                               offset: SourceOffset(29873),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(29874),
-                              len: 1,
-                            )))),
                             Tag(Html(Ul(Ident(Cursor(
                               kind: "Ident",
                               offset: SourceOffset(29875),
@@ -44767,11 +44387,6 @@ StyleSheet(
                       offset: SourceOffset(29928),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(29929),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(29930),
@@ -44903,21 +44518,11 @@ StyleSheet(
                               offset: SourceOffset(30004),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30005),
-                              len: 1,
-                            )))),
                             Combinator(Child(Gt(Delim(Cursor(
                               kind: "Delim",
                               offset: SourceOffset(30006),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30007),
-                              len: 1,
-                            )))),
                             PseudoClass(FirstChild(Colon(Cursor(
                               kind: "Colon",
                               offset: SourceOffset(30008),
@@ -44938,31 +44543,16 @@ StyleSheet(
                               offset: SourceOffset(30026),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30027),
-                              len: 1,
-                            )))),
                             Tag(Html(Nav(Ident(Cursor(
                               kind: "Ident",
                               offset: SourceOffset(30028),
                               len: 3,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30031),
-                              len: 1,
-                            )))),
                             Combinator(Child(Gt(Delim(Cursor(
                               kind: "Delim",
                               offset: SourceOffset(30032),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30033),
-                              len: 1,
-                            )))),
                             PseudoClass(FirstChild(Colon(Cursor(
                               kind: "Colon",
                               offset: SourceOffset(30034),
@@ -45023,21 +44613,11 @@ StyleSheet(
                               offset: SourceOffset(30092),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30093),
-                              len: 1,
-                            )))),
                             Combinator(Child(Gt(Delim(Cursor(
                               kind: "Delim",
                               offset: SourceOffset(30094),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30095),
-                              len: 1,
-                            )))),
                             PseudoClass(LastChild(Colon(Cursor(
                               kind: "Colon",
                               offset: SourceOffset(30096),
@@ -45058,31 +44638,16 @@ StyleSheet(
                               offset: SourceOffset(30113),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30114),
-                              len: 1,
-                            )))),
                             Tag(Html(Nav(Ident(Cursor(
                               kind: "Ident",
                               offset: SourceOffset(30115),
                               len: 3,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30118),
-                              len: 1,
-                            )))),
                             Combinator(Child(Gt(Delim(Cursor(
                               kind: "Delim",
                               offset: SourceOffset(30119),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30120),
-                              len: 1,
-                            )))),
                             PseudoClass(LastChild(Colon(Cursor(
                               kind: "Colon",
                               offset: SourceOffset(30121),
@@ -45152,11 +44717,6 @@ StyleSheet(
                       offset: SourceOffset(30178),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(30179),
-                      len: 1,
-                    )))),
                     Tag(Html(Hr(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(30180),
@@ -45213,11 +44773,6 @@ StyleSheet(
                       offset: SourceOffset(30216),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(30217),
-                      len: 1,
-                    )))),
                     Tag(Html(Nav(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(30218),
@@ -45403,11 +44958,6 @@ StyleSheet(
                               offset: SourceOffset(30311),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(30312),
-                              len: 1,
-                            )))),
                             Wildcard(Wildcard(Star(Delim(Cursor(
                               kind: "Delim",
                               offset: SourceOffset(30313),
@@ -45473,11 +45023,6 @@ StyleSheet(
                       offset: SourceOffset(30351),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(30352),
-                      len: 1,
-                    )))),
                     Tag(Html(Nav(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(30353),
@@ -45573,11 +45118,6 @@ StyleSheet(
                       offset: SourceOffset(30408),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(30409),
-                      len: 1,
-                    )))),
                     FunctionalPseudoClass(Is(IsPseudoFunction(
                       colon: Colon(Cursor(
                         kind: "Colon",
@@ -45869,11 +45409,6 @@ StyleSheet(
                       offset: SourceOffset(30600),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(30601),
-                      len: 1,
-                    )))),
                     Attribute(Attribute(
                       open: LeftSquare(Cursor(
                         kind: "LeftSquare",
@@ -45954,11 +45489,6 @@ StyleSheet(
                       offset: SourceOffset(30654),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(30655),
-                      len: 1,
-                    )))),
                     Attribute(Attribute(
                       open: LeftSquare(Cursor(
                         kind: "LeftSquare",
@@ -46618,21 +46148,11 @@ StyleSheet(
                       offset: SourceOffset(31041),
                       len: 5,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(31046),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(31047),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(31048),
-                      len: 1,
-                    )))),
                     Combinator(Nesting(And(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(31049),
@@ -50941,11 +50461,6 @@ StyleSheet(
                               offset: SourceOffset(33828),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(33829),
-                              len: 1,
-                            )))),
                             Wildcard(Wildcard(Star(Delim(Cursor(
                               kind: "Delim",
                               offset: SourceOffset(33830),
@@ -53184,21 +52699,11 @@ StyleSheet(
                             offset: SourceOffset(35435),
                             len: 5,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(35440),
-                            len: 1,
-                          )))),
                           Combinator(Child(Gt(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(35441),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(35442),
-                            len: 1,
-                          )))),
                           Wildcard(Wildcard(Star(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(35443),
@@ -53307,21 +52812,11 @@ StyleSheet(
                             offset: SourceOffset(35511),
                             len: 5,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(35516),
-                            len: 1,
-                          )))),
                           Combinator(Child(Gt(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(35517),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(35518),
-                            len: 1,
-                          )))),
                           Wildcard(Wildcard(Star(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(35519),
@@ -53585,11 +53080,6 @@ StyleSheet(
                                   offset: SourceOffset(35619),
                                   len: 1,
                                 ))))),
-                                Combinator(Descendant(Whitespace(Cursor(
-                                  kind: "Whitespace",
-                                  offset: SourceOffset(35620),
-                                  len: 1,
-                                )))),
                                 Combinator(Nesting(And(Delim(Cursor(
                                   kind: "Delim",
                                   offset: SourceOffset(35621),
@@ -53773,11 +53263,6 @@ StyleSheet(
                                   offset: SourceOffset(35712),
                                   len: 1,
                                 ))))),
-                                Combinator(Descendant(Whitespace(Cursor(
-                                  kind: "Whitespace",
-                                  offset: SourceOffset(35713),
-                                  len: 1,
-                                )))),
                                 Combinator(Nesting(And(Delim(Cursor(
                                   kind: "Delim",
                                   offset: SourceOffset(35714),
@@ -62180,11 +61665,6 @@ StyleSheet(
                       offset: SourceOffset(41773),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(41774),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(41775),
@@ -62350,11 +61830,6 @@ StyleSheet(
                                     offset: SourceOffset(41895),
                                     len: 1,
                                   ))))),
-                                  Combinator(Descendant(Whitespace(Cursor(
-                                    kind: "Whitespace",
-                                    offset: SourceOffset(41896),
-                                    len: 1,
-                                  )))),
                                   Tag(Html(Dt(Ident(Cursor(
                                     kind: "Ident",
                                     offset: SourceOffset(41897),
@@ -62480,11 +61955,6 @@ StyleSheet(
                                     offset: SourceOffset(42026),
                                     len: 1,
                                   ))))),
-                                  Combinator(Descendant(Whitespace(Cursor(
-                                    kind: "Whitespace",
-                                    offset: SourceOffset(42027),
-                                    len: 1,
-                                  )))),
                                   Tag(Html(Dd(Ident(Cursor(
                                     kind: "Ident",
                                     offset: SourceOffset(42028),
@@ -62618,11 +62088,6 @@ StyleSheet(
                               offset: SourceOffset(42162),
                               len: 1,
                             ))))),
-                            Combinator(Descendant(Whitespace(Cursor(
-                              kind: "Whitespace",
-                              offset: SourceOffset(42163),
-                              len: 1,
-                            )))),
                             Tag(Html(Div(Ident(Cursor(
                               kind: "Ident",
                               offset: SourceOffset(42164),
@@ -63950,21 +63415,11 @@ StyleSheet(
                       len: 14,
                     )),
                   )),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(43039),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(43040),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(43041),
-                    len: 1,
-                  )))),
                   Tag(Html(Header(Ident(Cursor(
                     kind: "Ident",
                     offset: SourceOffset(43042),
@@ -64120,21 +63575,11 @@ StyleSheet(
                       offset: SourceOffset(43125),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43126),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43127),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43128),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43129),
@@ -64182,21 +63627,11 @@ StyleSheet(
                       offset: SourceOffset(43181),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43182),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43183),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43184),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43185),
@@ -64206,21 +63641,11 @@ StyleSheet(
                       offset: SourceOffset(43186),
                       len: 11,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43197),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43198),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43199),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43200),
@@ -64259,21 +63684,11 @@ StyleSheet(
                       offset: SourceOffset(43240),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43241),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43242),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43243),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43244),
@@ -64283,21 +63698,11 @@ StyleSheet(
                       offset: SourceOffset(43245),
                       len: 11,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43256),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43257),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43258),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43259),
@@ -64307,21 +63712,11 @@ StyleSheet(
                       offset: SourceOffset(43260),
                       len: 11,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43271),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43272),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43273),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43274),
@@ -64351,21 +63746,11 @@ StyleSheet(
                       offset: SourceOffset(43302),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43303),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43304),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43305),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43306),
@@ -64375,21 +63760,11 @@ StyleSheet(
                       offset: SourceOffset(43307),
                       len: 11,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43318),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43319),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43320),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43321),
@@ -64399,21 +63774,11 @@ StyleSheet(
                       offset: SourceOffset(43322),
                       len: 11,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43333),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43334),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43335),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43336),
@@ -64423,21 +63788,11 @@ StyleSheet(
                       offset: SourceOffset(43337),
                       len: 11,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43348),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43349),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43350),
-                      len: 1,
-                    )))),
                     PseudoClass(FirstChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43351),
@@ -64498,21 +63853,11 @@ StyleSheet(
                       offset: SourceOffset(43399),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43400),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43401),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43402),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43403),
@@ -64560,21 +63905,11 @@ StyleSheet(
                       offset: SourceOffset(43451),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43452),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43453),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43454),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43455),
@@ -64584,21 +63919,11 @@ StyleSheet(
                       offset: SourceOffset(43456),
                       len: 10,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43466),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43467),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43468),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43469),
@@ -64637,21 +63962,11 @@ StyleSheet(
                       offset: SourceOffset(43506),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43507),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43508),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43509),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43510),
@@ -64661,21 +63976,11 @@ StyleSheet(
                       offset: SourceOffset(43511),
                       len: 10,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43521),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43522),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43523),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43524),
@@ -64685,21 +63990,11 @@ StyleSheet(
                       offset: SourceOffset(43525),
                       len: 10,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43535),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43536),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43537),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43538),
@@ -64729,21 +64024,11 @@ StyleSheet(
                       offset: SourceOffset(43564),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43565),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43566),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43567),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43568),
@@ -64753,21 +64038,11 @@ StyleSheet(
                       offset: SourceOffset(43569),
                       len: 10,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43579),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43580),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43581),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43582),
@@ -64777,21 +64052,11 @@ StyleSheet(
                       offset: SourceOffset(43583),
                       len: 10,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43593),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43594),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43595),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43596),
@@ -64801,21 +64066,11 @@ StyleSheet(
                       offset: SourceOffset(43597),
                       len: 10,
                     )))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43607),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(43608),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(43609),
-                      len: 1,
-                    )))),
                     PseudoClass(LastChild(Colon(Cursor(
                       kind: "Colon",
                       offset: SourceOffset(43610),
@@ -69335,21 +68590,11 @@ StyleSheet(
                       offset: SourceOffset(46763),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(46764),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(46765),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(46766),
-                      len: 1,
-                    )))),
                     FunctionalPseudoClass(Not(NotPseudoFunction(
                       colon: Colon(Cursor(
                         kind: "Colon",
@@ -69804,21 +69049,11 @@ StyleSheet(
                 len: 4,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(46987),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(46988),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(46989),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(46990),
@@ -69948,21 +69183,11 @@ StyleSheet(
                         len: 1,
                       ))),
                     ))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(47060),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(47061),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(47062),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(47063),
@@ -70044,21 +69269,11 @@ StyleSheet(
                       offset: SourceOffset(47104),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(47105),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(47106),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(47107),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(47108),
@@ -70198,41 +69413,21 @@ StyleSheet(
                       offset: SourceOffset(47192),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(47193),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(47194),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(47195),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(47196),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(47197),
-                      len: 1,
-                    )))),
                     Combinator(NextSibling(Plus(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(47198),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(47199),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(47200),
@@ -72673,11 +71868,6 @@ StyleSheet(
                                 offset: SourceOffset(48712),
                                 len: 1,
                               ))))),
-                              Combinator(Descendant(Whitespace(Cursor(
-                                kind: "Whitespace",
-                                offset: SourceOffset(48713),
-                                len: 1,
-                              )))),
                               Wildcard(Wildcard(Star(Delim(Cursor(
                                 kind: "Delim",
                                 offset: SourceOffset(48714),
@@ -73421,21 +72611,11 @@ StyleSheet(
                 len: 11,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49141),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49142),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49143),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49144),
@@ -73508,21 +72688,11 @@ StyleSheet(
                 len: 15,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49182),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49183),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49184),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49185),
@@ -73595,21 +72765,11 @@ StyleSheet(
                 len: 12,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49220),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49221),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49222),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49223),
@@ -73682,21 +72842,11 @@ StyleSheet(
                 len: 14,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49260),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49261),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49262),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49263),
@@ -73769,21 +72919,11 @@ StyleSheet(
                 len: 13,
               )),
             )),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49300),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49301),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(49302),
-              len: 1,
-            )))),
             Wildcard(Wildcard(Star(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(49303),
@@ -74520,11 +73660,6 @@ StyleSheet(
                       offset: SourceOffset(49707),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(49708),
-                      len: 1,
-                    )))),
                     Tag(Html(Em(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(49709),
@@ -74541,11 +73676,6 @@ StyleSheet(
                       offset: SourceOffset(49715),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(49716),
-                      len: 1,
-                    )))),
                     Tag(Html(Cite(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(49717),
@@ -74562,11 +73692,6 @@ StyleSheet(
                       offset: SourceOffset(49725),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(49726),
-                      len: 1,
-                    )))),
                     Tag(Html(Dfn(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(49727),
@@ -74583,11 +73708,6 @@ StyleSheet(
                       offset: SourceOffset(49734),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(49735),
-                      len: 1,
-                    )))),
                     Tag(Html(Var(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(49736),
@@ -74604,11 +73724,6 @@ StyleSheet(
                       offset: SourceOffset(49743),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(49744),
-                      len: 1,
-                    )))),
                     Tag(Html(I(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(49745),
@@ -74625,11 +73740,6 @@ StyleSheet(
                       offset: SourceOffset(49750),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(49751),
-                      len: 1,
-                    )))),
                     Tag(Html(Address(Ident(Cursor(
                       kind: "Ident",
                       offset: SourceOffset(49752),
@@ -76098,11 +75208,6 @@ StyleSheet(
                             offset: SourceOffset(50678),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(50679),
-                            len: 1,
-                          )))),
                           Wildcard(Wildcard(Star(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(50680),
@@ -76467,11 +75572,6 @@ StyleSheet(
                             offset: SourceOffset(50875),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(50876),
-                            len: 1,
-                          )))),
                           Wildcard(Wildcard(Star(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(50877),
@@ -76605,11 +75705,6 @@ StyleSheet(
                             offset: SourceOffset(50954),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(50955),
-                            len: 1,
-                          )))),
                           FunctionalPseudoClass(Is(IsPseudoFunction(
                             colon: Colon(Cursor(
                               kind: "Colon",
@@ -76751,21 +75846,11 @@ StyleSheet(
                               len: 1,
                             ))),
                           ))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(51032),
-                            len: 1,
-                          )))),
                           Combinator(Child(Gt(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(51033),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(51034),
-                            len: 1,
-                          )))),
                           Wildcard(Wildcard(Star(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(51035),
@@ -77092,11 +76177,6 @@ StyleSheet(
                             offset: SourceOffset(51302),
                             len: 1,
                           ))))),
-                          Combinator(Descendant(Whitespace(Cursor(
-                            kind: "Whitespace",
-                            offset: SourceOffset(51303),
-                            len: 1,
-                          )))),
                           Wildcard(Wildcard(Star(Delim(Cursor(
                             kind: "Delim",
                             offset: SourceOffset(51304),
@@ -77318,21 +76398,11 @@ StyleSheet(
                       offset: SourceOffset(51453),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(51454),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(51455),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(51456),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(51457),
@@ -77546,21 +76616,11 @@ StyleSheet(
                       offset: SourceOffset(51569),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(51570),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(51571),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(51572),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(51573),
@@ -77854,21 +76914,11 @@ StyleSheet(
                       offset: SourceOffset(51765),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(51766),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(51767),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(51768),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(51769),
@@ -80332,21 +79382,11 @@ StyleSheet(
                       offset: SourceOffset(53519),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(53520),
-                      len: 1,
-                    )))),
                     Combinator(Child(Gt(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(53521),
                       len: 1,
                     ))))),
-                    Combinator(Descendant(Whitespace(Cursor(
-                      kind: "Whitespace",
-                      offset: SourceOffset(53522),
-                      len: 1,
-                    )))),
                     Wildcard(Wildcard(Star(Delim(Cursor(
                       kind: "Delim",
                       offset: SourceOffset(53523),

--- a/crates/css_ast/tests/snapshots/popular_snapshots__sakura.1.5.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__sakura.1.5.1.snap
@@ -2618,21 +2618,11 @@ StyleSheet(
               offset: SourceOffset(2108),
               len: 3,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(2111),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(2112),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(2113),
-              len: 1,
-            )))),
             Tag(Html(Code(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(2114),

--- a/crates/css_ast/tests/snapshots/popular_snapshots__water.2.1.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__water.2.1.1.snap
@@ -9419,21 +9419,11 @@ StyleSheet(
               offset: SourceOffset(8588),
               len: 10,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(8598),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(8599),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(8600),
-              len: 1,
-            )))),
             Tag(Html(Footer(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(8601),
@@ -10285,21 +10275,11 @@ StyleSheet(
               offset: SourceOffset(9136),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9137),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9138),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9139),
-              len: 1,
-            )))),
             Tag(Html(Code(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(9140),
@@ -10316,21 +10296,11 @@ StyleSheet(
               offset: SourceOffset(9146),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9147),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(9148),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(9149),
-              len: 1,
-            )))),
             Tag(Html(Strong(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(9150),
@@ -30406,21 +30376,11 @@ StyleSheet(
               offset: SourceOffset(24764),
               len: 3,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(24767),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(24768),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(24769),
-              len: 1,
-            )))),
             Tag(Html(Code(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(24770),
@@ -36923,21 +36883,11 @@ StyleSheet(
               offset: SourceOffset(29476),
               len: 7,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29483),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29484),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29485),
-              len: 1,
-            )))),
             PseudoClass(LastChild(Colon(Cursor(
               kind: "Colon",
               offset: SourceOffset(29486),
@@ -37553,21 +37503,11 @@ StyleSheet(
               offset: SourceOffset(29944),
               len: 7,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29951),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(29952),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(29953),
-              len: 1,
-            )))),
             FunctionalPseudoClass(Not(NotPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
@@ -38711,21 +38651,11 @@ StyleSheet(
               offset: SourceOffset(30788),
               len: 6,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30794),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(30795),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(30796),
-              len: 1,
-            )))),
             Tag(Html(Header(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(30797),
@@ -39020,21 +38950,11 @@ StyleSheet(
                     offset: SourceOffset(31027),
                     len: 6,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31033),
-                    len: 1,
-                  )))),
                   Combinator(Child(Gt(Delim(Cursor(
                     kind: "Delim",
                     offset: SourceOffset(31034),
                     len: 1,
                   ))))),
-                  Combinator(Descendant(Whitespace(Cursor(
-                    kind: "Whitespace",
-                    offset: SourceOffset(31035),
-                    len: 1,
-                  )))),
                   Tag(Html(Header(Ident(Cursor(
                     kind: "Ident",
                     offset: SourceOffset(31036),
@@ -40049,21 +39969,11 @@ StyleSheet(
               offset: SourceOffset(31769),
               len: 4,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31773),
-              len: 1,
-            )))),
             Combinator(Child(Gt(Delim(Cursor(
               kind: "Delim",
               offset: SourceOffset(31774),
               len: 1,
             ))))),
-            Combinator(Descendant(Whitespace(Cursor(
-              kind: "Whitespace",
-              offset: SourceOffset(31775),
-              len: 1,
-            )))),
             Tag(Html(Footer(Ident(Cursor(
               kind: "Ident",
               offset: SourceOffset(31776),

--- a/crates/css_parse/src/parser.rs
+++ b/crates/css_parse/src/parser.rs
@@ -357,6 +357,18 @@ where
 		}
 	}
 
+	/// Consume trivia and attach it to the next content token for output preservation.
+	/// This should be called when you want to consume whitespace/comments but preserve
+	/// them for round-trip output fidelity.
+	pub fn consume_trivia_as_leading(&mut self) {
+		let trivia = self.consume_trivia();
+		if !trivia.is_empty() {
+			// Peek the next content token to attach trivia to it
+			let next = self.peek_n(1);
+			self.trivia.push((trivia, next));
+		}
+	}
+
 	#[allow(clippy::should_implement_trait)]
 	pub fn next(&mut self) -> Cursor {
 		// Collect trivia that should be associated with the next content token


### PR DESCRIPTION
A selector like `a > b` is comprised of three parts: a tag selector, a child
combinator, and another tag selector. The whitespace around the `>` should be
treated as whitespace, but at current it is treated as a descendant combinator.

This change improves parsing of the Selector trait so that it consumes
whitespace if it can peek ahead to an adjacent combinator, and consumes
whitespace _after_ parsing a combinator. Adjacent combinators are disallowed so
this change improves correctness of selector parsing.
