### PR TITLE
csskit_ast: Rewrite QuerySelector to use css_parse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "css_ast",
  "css_lexer",
  "css_parse",
+ "csskit_derives",
  "derive_atom_set",
 ]
 

--- a/crates/csskit_ast/Cargo.toml
+++ b/crates/csskit_ast/Cargo.toml
@@ -16,10 +16,12 @@ bench = false
 css_lexer = { workspace = true } # @release
 css_parse = { workspace = true } # @release
 css_ast = { workspace = true, features = ["visitable"] } # @release
+csskit_derives = { workspace = true } # @release
 derive_atom_set = { workspace = true } # @release
+bumpalo = { workspace = true, features = ["collections", "boxed"] }
 
 [dev-dependencies]
-bumpalo = { workspace = true, features = ["collections", "boxed"] }
+css_parse = { workspace = true, features = ["testing"] } # @release
 
 [features]
 default = []

--- a/crates/csskit_ast/src/diagnostics.rs
+++ b/crates/csskit_ast/src/diagnostics.rs
@@ -1,0 +1,30 @@
+use css_parse::{Diagnostic, DiagnosticMeta};
+
+pub trait QueryDiagnostic {
+	fn unknown_node_type(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+	fn unknown_functional_pseudo_class(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta;
+}
+
+impl QueryDiagnostic for Diagnostic {
+	fn unknown_node_type(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let name = cursor.str_slice(source);
+		DiagnosticMeta {
+			code: "UnknownNodeType",
+			message: format!("unknown node type '{name}'"),
+			help: "Use a valid CSS node type name like 'style-rule', 'media-rule', etc.".into(),
+			labels: vec![],
+		}
+	}
+
+	fn unknown_functional_pseudo_class(diagnostic: &Diagnostic, source: &str) -> DiagnosticMeta {
+		let cursor = diagnostic.start_cursor;
+		let name = cursor.str_slice(source);
+		DiagnosticMeta {
+			code: "UnknownFunctionalPseudoClass",
+			message: format!("unknown functional pseudo-class ':{name}()'"),
+			help: "Use a valid functional pseudo-class like :not(), :nth-child(), :property-type(), etc.".into(),
+			labels: vec![],
+		}
+	}
+}

--- a/crates/csskit_ast/src/lib.rs
+++ b/crates/csskit_ast/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! CSS AST query utilities using selector-like syntax.
 
+pub mod diagnostics;
 pub mod selector;
 #[cfg(test)]
 mod test_helpers;
@@ -10,8 +11,9 @@ use css_parse::AtomSet;
 use derive_atom_set::AtomSet;
 
 pub use selector::{
-	MatchOutput, NthValue, QueryAttribute, QueryCombinator, QueryPseudo, QuerySelector, QuerySelectorList,
-	QuerySelectorPart, QuerySimpleSelector, SelectorMatcher, SelectorParseError,
+	MatchOutput, QueryAttribute, QueryAttributeValue, QueryCombinator, QueryCompoundSelector,
+	QueryFunctionalPseudoClass, QueryNotPseudo, QueryNthPseudo, QueryPrefixedPseudo, QueryPropertyTypePseudo,
+	QueryPseudoClass, QuerySelectorComponent, QuerySelectorList, QueryType, QueryWildcard, SelectorMatcher,
 };
 
 #[derive(AtomSet, Debug, Default, Copy, Clone, PartialEq, Eq)]
@@ -157,4 +159,8 @@ pub enum CsskitAtomSet {
 	WillChange,
 	#[atom("writing-modes")]
 	WritingModes,
+}
+
+impl CsskitAtomSet {
+	pub const ATOMS: CsskitAtomSet = CsskitAtomSet::_None;
 }

--- a/crates/csskit_ast/src/selector/mod.rs
+++ b/crates/csskit_ast/src/selector/mod.rs
@@ -7,6 +7,7 @@ mod query;
 pub use matcher::SelectorMatcher;
 pub use output::MatchOutput;
 pub use query::{
-	NthValue, QueryAttribute, QueryCombinator, QueryPseudo, QuerySelector, QuerySelectorList, QuerySelectorPart,
-	QuerySimpleSelector, SelectorParseError,
+	QueryAttribute, QueryAttributeValue, QueryCombinator, QueryCompoundSelector, QueryFunctionalPseudoClass,
+	QueryNotPseudo, QueryNthPseudo, QueryPrefixedPseudo, QueryPropertyTypePseudo, QueryPseudoClass,
+	QuerySelectorComponent, QuerySelectorList, QueryType, QueryWildcard,
 };


### PR DESCRIPTION
QuerySelector was initially written as a rough prototype manual implementation
of selectors to get the matcher working, and work around the issues of adjacent
combinators which is now fixed in #723.

This change rewrites all of QuerySelector to know use the css_parse Selector
crate, which allows for a much simpler implementation. This also fixes up
find.rs to use the more traditional `parse_entirely` now it's using
conventional traits.
