### PR TITLE
csskit_ast: Rework matcher, using Metadata to propagate up SelectorRequirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
 name = "csskit_ast"
 version = "0.0.8"
 dependencies = [
+ "bitmask-enum",
  "bumpalo",
  "css_ast",
  "css_lexer",

--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -171,6 +171,82 @@ impl CssMetadata {
 	pub fn has_colors(&self) -> bool {
 		self.property_groups.intersects(PropertyGroup::Color | PropertyGroup::ColorHdr | PropertyGroup::ColorAdjust)
 	}
+
+	/// Returns true if metadata contains important declarations.
+	#[inline]
+	pub fn has_important(&self) -> bool {
+		self.declaration_kinds.contains(DeclarationKind::Important)
+	}
+
+	/// Returns true if metadata contains custom properties.
+	#[inline]
+	pub fn has_custom_properties(&self) -> bool {
+		self.declaration_kinds.contains(DeclarationKind::Custom)
+	}
+
+	/// Returns true if metadata contains computed values.
+	#[inline]
+	pub fn has_computed(&self) -> bool {
+		self.declaration_kinds.contains(DeclarationKind::Computed)
+	}
+
+	/// Returns true if metadata contains shorthand properties.
+	#[inline]
+	pub fn has_shorthands(&self) -> bool {
+		self.declaration_kinds.contains(DeclarationKind::Shorthands)
+	}
+
+	/// Returns true if metadata contains longhand properties.
+	#[inline]
+	pub fn has_longhands(&self) -> bool {
+		self.declaration_kinds.contains(DeclarationKind::Longhands)
+	}
+
+	/// Returns true if metadata contains unknown declarations.
+	#[inline]
+	pub fn has_unknown(&self) -> bool {
+		self.declaration_kinds.contains(DeclarationKind::Unknown)
+	}
+
+	/// Returns true if metadata contains vendor-prefixed properties.
+	#[inline]
+	pub fn has_vendor_prefixes(&self) -> bool {
+		!self.vendor_prefixes.is_none()
+	}
+
+	/// Returns the vendor prefix if exactly one is present, None otherwise.
+	#[inline]
+	pub fn single_vendor_prefix(&self) -> Option<VendorPrefixes> {
+		if self.vendor_prefixes.is_none() || self.vendor_prefixes.bits().count_ones() != 1 {
+			None
+		} else {
+			Some(self.vendor_prefixes)
+		}
+	}
+
+	/// Returns true if metadata contains any rule nodes.
+	#[inline]
+	pub fn has_rules(&self) -> bool {
+		self.node_kinds.intersects(NodeKinds::StyleRule | NodeKinds::AtRule)
+	}
+
+	/// Returns true if metadata contains style rules.
+	#[inline]
+	pub fn has_style_rules(&self) -> bool {
+		self.node_kinds.contains(NodeKinds::StyleRule)
+	}
+
+	/// Returns true if metadata contains at-rules.
+	#[inline]
+	pub fn has_at_rules(&self) -> bool {
+		self.node_kinds.contains(NodeKinds::AtRule)
+	}
+
+	/// Returns true if metadata contains function nodes.
+	#[inline]
+	pub fn has_functions(&self) -> bool {
+		self.node_kinds.contains(NodeKinds::Function)
+	}
 }
 
 impl NodeMetadata for CssMetadata {
@@ -244,7 +320,7 @@ mod tests {
 		assert!(metadata.property_groups.contains(PropertyGroup::Sizing));
 		assert!(metadata.modifies_box());
 		assert!(metadata.has_colors());
-		assert!(metadata.declaration_kinds.contains(DeclarationKind::Longhands));
+		assert!(metadata.has_longhands());
 	}
 
 	#[test]
@@ -257,7 +333,7 @@ mod tests {
 
 		let metadata = stylesheet.metadata();
 
-		assert!(metadata.declaration_kinds.contains(DeclarationKind::Important));
+		assert!(metadata.has_important());
 		assert!(metadata.property_groups.contains(PropertyGroup::Color));
 	}
 
@@ -271,7 +347,7 @@ mod tests {
 
 		let metadata = stylesheet.metadata();
 
-		assert!(metadata.declaration_kinds.contains(DeclarationKind::Custom));
+		assert!(metadata.has_custom_properties());
 	}
 
 	#[test]

--- a/crates/csskit_ast/Cargo.toml
+++ b/crates/csskit_ast/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 bench = false
 
 [dependencies]
+bitmask-enum = { workspace = true }
 css_lexer = { workspace = true } # @release
 css_parse = { workspace = true } # @release
 css_ast = { workspace = true, features = ["visitable"] } # @release

--- a/crates/csskit_ast/src/lib.rs
+++ b/crates/csskit_ast/src/lib.rs
@@ -7,6 +7,7 @@ pub mod selector;
 #[cfg(test)]
 mod test_helpers;
 
+use css_ast::{PropertyGroup, VendorPrefixes};
 use css_parse::AtomSet;
 use derive_atom_set::AtomSet;
 
@@ -163,4 +164,103 @@ pub enum CsskitAtomSet {
 
 impl CsskitAtomSet {
 	pub const ATOMS: CsskitAtomSet = CsskitAtomSet::_None;
+}
+
+impl CsskitAtomSet {
+	/// Converts VendorPrefixes bitmask to CsskitAtomSet.
+	/// Returns None if no prefix or multiple prefixes are set.
+	pub fn from_vendor_prefix(prefix: VendorPrefixes) -> Option<Self> {
+		if prefix.bits().count_ones() != 1 {
+			return None;
+		}
+		if prefix.contains(VendorPrefixes::WebKit) {
+			Some(Self::Webkit)
+		} else if prefix.contains(VendorPrefixes::Moz) {
+			Some(Self::Moz)
+		} else if prefix.contains(VendorPrefixes::Ms) {
+			Some(Self::Ms)
+		} else if prefix.contains(VendorPrefixes::O) {
+			Some(Self::O)
+		} else {
+			None
+		}
+	}
+
+	/// Converts a CsskitAtomSet representing a vendor name to VendorPrefixes.
+	pub fn to_vendor_prefix(self) -> Option<VendorPrefixes> {
+		match self {
+			Self::Webkit => Some(VendorPrefixes::WebKit),
+			Self::Moz => Some(VendorPrefixes::Moz),
+			Self::Ms => Some(VendorPrefixes::Ms),
+			Self::O => Some(VendorPrefixes::O),
+			_ => None,
+		}
+	}
+
+	/// Converts a CsskitAtomSet representing a property group name to PropertyGroup.
+	pub fn to_property_group(self) -> Option<PropertyGroup> {
+		match self {
+			Self::Align => Some(PropertyGroup::Align),
+			Self::Anchor | Self::AnchorPosition => Some(PropertyGroup::AnchorPosition),
+			Self::Animation | Self::Animations => Some(PropertyGroup::Animations),
+			Self::Background | Self::Backgrounds => Some(PropertyGroup::Backgrounds),
+			Self::Border | Self::Borders => Some(PropertyGroup::Borders),
+			Self::Box => Some(PropertyGroup::Box),
+			Self::Break => Some(PropertyGroup::Break),
+			Self::Cascade => Some(PropertyGroup::Cascade),
+			Self::Color => Some(PropertyGroup::Color),
+			Self::ColorAdjust => Some(PropertyGroup::ColorAdjust),
+			Self::ColorHdr => Some(PropertyGroup::ColorHdr),
+			Self::Conditional => Some(PropertyGroup::Conditional),
+			Self::Contain => Some(PropertyGroup::Contain),
+			Self::Content => Some(PropertyGroup::Content),
+			Self::Display => Some(PropertyGroup::Display),
+			Self::Exclusions => Some(PropertyGroup::Exclusions),
+			Self::Flex | Self::Flexbox => Some(PropertyGroup::Flexbox),
+			Self::Font | Self::Fonts => Some(PropertyGroup::Fonts),
+			Self::Forms => Some(PropertyGroup::Forms),
+			Self::Gap | Self::Gaps => Some(PropertyGroup::Gaps),
+			Self::Gcpm => Some(PropertyGroup::Gcpm),
+			Self::Grid => Some(PropertyGroup::Grid),
+			Self::Image | Self::Images => Some(PropertyGroup::Images),
+			Self::Inline => Some(PropertyGroup::Inline),
+			Self::LineGrid => Some(PropertyGroup::LineGrid),
+			Self::LinkParams => Some(PropertyGroup::LinkParams),
+			Self::List | Self::Lists => Some(PropertyGroup::Lists),
+			Self::Logical => Some(PropertyGroup::Logical),
+			Self::Mask | Self::Masking => Some(PropertyGroup::Masking),
+			Self::Multicol => Some(PropertyGroup::Multicol),
+			Self::Nav => Some(PropertyGroup::Nav),
+			Self::Overflow => Some(PropertyGroup::Overflow),
+			Self::Overscroll => Some(PropertyGroup::Overscroll),
+			Self::Page => Some(PropertyGroup::Page),
+			Self::PageFloats => Some(PropertyGroup::PageFloats),
+			Self::Position => Some(PropertyGroup::Position),
+			Self::Regions => Some(PropertyGroup::Regions),
+			Self::Rhythm => Some(PropertyGroup::Rhythm),
+			Self::RoundDisplay => Some(PropertyGroup::RoundDisplay),
+			Self::Ruby => Some(PropertyGroup::Ruby),
+			Self::ScrollAnchoring => Some(PropertyGroup::ScrollAnchoring),
+			Self::ScrollSnap => Some(PropertyGroup::ScrollSnap),
+			Self::Scrollbar | Self::Scrollbars => Some(PropertyGroup::Scrollbars),
+			Self::Shaders => Some(PropertyGroup::Shaders),
+			Self::Shape | Self::Shapes => Some(PropertyGroup::Shapes),
+			Self::SizeAdjust => Some(PropertyGroup::SizeAdjust),
+			Self::Sizing => Some(PropertyGroup::Sizing),
+			Self::Speech => Some(PropertyGroup::Speech),
+			Self::Table | Self::Tables => Some(PropertyGroup::Tables),
+			Self::Text => Some(PropertyGroup::Text),
+			Self::TextDecor | Self::TextDecoration => Some(PropertyGroup::TextDecor),
+			Self::Transform | Self::Transforms => Some(PropertyGroup::Transforms),
+			Self::Transition | Self::Transitions => Some(PropertyGroup::Transitions),
+			Self::Ui => Some(PropertyGroup::Ui),
+			Self::Values => Some(PropertyGroup::Values),
+			Self::Variables => Some(PropertyGroup::Variables),
+			Self::ViewTransitions => Some(PropertyGroup::ViewTransitions),
+			Self::Viewport => Some(PropertyGroup::Viewport),
+			Self::WillChange => Some(PropertyGroup::WillChange),
+			Self::WritingModes => Some(PropertyGroup::WritingModes),
+			_ => None,
+		}
+	}
 }

--- a/crates/csskit_ast/src/selector/mod.rs
+++ b/crates/csskit_ast/src/selector/mod.rs
@@ -1,10 +1,12 @@
 //! CSS AST selector query engine.
 
 mod matcher;
+mod metadata;
 mod output;
 mod query;
 
 pub use matcher::SelectorMatcher;
+pub use metadata::{QuerySelectorMetadata, SelectorRequirements, SelectorStructure};
 pub use output::MatchOutput;
 pub use query::{
 	QueryAttribute, QueryAttributeValue, QueryCombinator, QueryCompoundSelector, QueryFunctionalPseudoClass,

--- a/crates/csskit_ast/src/test_helpers.rs
+++ b/crates/csskit_ast/src/test_helpers.rs
@@ -1,4 +1,5 @@
 /// Assert CSS selector query matches expected node count.
+/// Matching uses metadata-based early filtering to skip selectors that can't match.
 #[macro_export]
 macro_rules! assert_query {
 	($source:expr, $selector:expr, $expected:expr) => {


### PR DESCRIPTION
This is a significant rework of the matcher to allow early returns or skipping
nodes when selectors won't match any deeper/further.
