### PR TITLE
css_ast/csskit_ast: Implement efficient attribute selectors via PropertyKind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "css_parse",
  "csskit_derives",
  "derive_atom_set",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
 	AppliesTo, BoxPortion, BoxSide, CssAtomSet, CssMetadata, DeclarationKind, DeclarationMetadata, Inherits,
-	PropertyGroup, VendorPrefixes, values,
+	PropertyGroup, PropertyKind, VendorPrefixes, values,
 };
 use css_lexer::Kind;
 use css_parse::{
@@ -360,6 +360,8 @@ impl<'a> DeclarationValue<'a, CssMetadata> for StyleValue<'a> {
 		// Extract vendor prefix from property name cursor
 		let cursor: Cursor = decl.name.into();
 		meta.vendor_prefixes = CssAtomSet::from_bits(cursor.atom_bits()).try_into().unwrap_or(VendorPrefixes::none());
+		// Declarations always have a name property
+		meta.property_kinds |= PropertyKind::Name;
 		meta
 	}
 

--- a/crates/css_ast/src/rules/mod.rs
+++ b/crates/css_ast/src/rules/mod.rs
@@ -43,7 +43,7 @@ pub use webkit::*;
 mod prelude {
 	pub(crate) use crate::{
 		CssAtomSet, CssDiagnostic, CssMetadata, StyleValue,
-		metadata::{AtRuleId, NodeKinds, VendorPrefixes},
+		metadata::{AtRuleId, NodeKinds, PropertyKind, VendorPrefixes},
 		stylesheet::Rule,
 	};
 	pub(crate) use bumpalo::collections::Vec;

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -1,10 +1,12 @@
 use super::prelude::*;
+#[cfg(feature = "visitable")]
+use crate::visit::{NodeId, QueryableNode};
 use crate::{KeyframesName, KeyframesRuleBlock};
 
 // https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip), queryable(skip))]
 pub struct WebkitKeyframesRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::_WebkitKeyframes)]
@@ -19,12 +21,25 @@ impl<'a> NodeWithMetadata<CssMetadata> for WebkitKeyframesRule<'a> {
 			used_at_rules: AtRuleId::WebkitKeyframes,
 			vendor_prefixes: VendorPrefixes::WebKit,
 			node_kinds: NodeKinds::AtRule,
+			property_kinds: PropertyKind::Name,
 			..Default::default()
 		}
 	}
 
 	fn metadata(&self) -> CssMetadata {
 		self.block.0.metadata().merge(self.self_metadata())
+	}
+}
+
+#[cfg(feature = "visitable")]
+impl<'a> QueryableNode for WebkitKeyframesRule<'a> {
+	const NODE_ID: NodeId = NodeId::WebkitKeyframesRule;
+
+	fn get_property(&self, kind: PropertyKind) -> Option<Cursor> {
+		match kind {
+			PropertyKind::Name => Some(self.prelude.into()),
+			_ => None,
+		}
 	}
 }
 

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -8,7 +8,7 @@ pub use apply_visit_methods;
 
 use bumpalo::collections::Vec;
 use css_parse::{
-	Block, CommaSeparated, Comparison, ComponentValues, Declaration, DeclarationGroup, DeclarationList,
+	Block, CommaSeparated, Comparison, ComponentValues, Cursor, Declaration, DeclarationGroup, DeclarationList,
 	DeclarationOrBad, DeclarationValue, NoBlockAllowed, NodeMetadata, NodeWithMetadata, QualifiedRule, RuleList,
 	syntax::BadDeclaration, token_macros,
 };
@@ -76,6 +76,15 @@ pub trait QueryableNode: Visitable + NodeWithMetadata<CssMetadata> {
 
 	fn node_id(&self) -> NodeId {
 		Self::NODE_ID
+	}
+
+	/// Returns a cursor for the given property kind, if the node has that property.
+	/// Used by attribute selectors to extract values from nodes.
+	///
+	/// For `PropertyKind::Name`, returns a cursor to the node's name (e.g., property
+	/// name for declarations, animation name for `@keyframes`).
+	fn get_property(&self, _kind: PropertyKind) -> Option<Cursor> {
+		None
 	}
 }
 

--- a/crates/csskit_ast/Cargo.toml
+++ b/crates/csskit_ast/Cargo.toml
@@ -20,6 +20,7 @@ css_ast = { workspace = true, features = ["visitable"] } # @release
 csskit_derives = { workspace = true } # @release
 derive_atom_set = { workspace = true } # @release
 bumpalo = { workspace = true, features = ["collections", "boxed"] }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 css_parse = { workspace = true, features = ["testing"] } # @release

--- a/crates/csskit_ast/src/lib.rs
+++ b/crates/csskit_ast/src/lib.rs
@@ -7,7 +7,7 @@ pub mod selector;
 #[cfg(test)]
 mod test_helpers;
 
-use css_ast::{PropertyGroup, VendorPrefixes};
+use css_ast::{PropertyGroup, PropertyKind, VendorPrefixes};
 use css_parse::AtomSet;
 use derive_atom_set::AtomSet;
 
@@ -62,6 +62,7 @@ pub enum CsskitAtomSet {
 	#[atom("nth-last-of-type")]
 	NthLastOfType,
 	Not,
+	Name,
 	#[atom("at-rule")]
 	AtRule,
 	Rule,
@@ -260,6 +261,14 @@ impl CsskitAtomSet {
 			Self::Viewport => Some(PropertyGroup::Viewport),
 			Self::WillChange => Some(PropertyGroup::WillChange),
 			Self::WritingModes => Some(PropertyGroup::WritingModes),
+			_ => None,
+		}
+	}
+
+	/// Converts a CsskitAtomSet representing an attribute name to PropertyKind.
+	pub fn to_property_kind(self) -> Option<PropertyKind> {
+		match self {
+			Self::Name => Some(PropertyKind::Name),
 			_ => None,
 		}
 	}

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -50,7 +50,7 @@ pub fn derive_into_span(stream: TokenStream) -> TokenStream {
 	to_span::derive(input).into()
 }
 
-#[proc_macro_derive(Visitable, attributes(visit, metadata))]
+#[proc_macro_derive(Visitable, attributes(visit, metadata, queryable))]
 pub fn derive_visitable(stream: TokenStream) -> TokenStream {
 	let input = syn::parse(stream).unwrap();
 	visitable::derive(input).into()


### PR DESCRIPTION
This improves attribute selectors by:

- Adding the `[name=...]` attribute selector for more types.
- Add the ability to query nodes for presence, e.g. [name]
- Add the ability to use attribute matchers, e.g. `[name~=...]`
