### PR TITLE
csskit_ast: Optimise QuerySelectorComponent matching with single-pass…

### DIFF
--- a/crates/csskit_ast/src/lib.rs
+++ b/crates/csskit_ast/src/lib.rs
@@ -11,11 +11,7 @@ use css_ast::{PropertyGroup, PropertyKind, VendorPrefixes};
 use css_parse::AtomSet;
 use derive_atom_set::AtomSet;
 
-pub use selector::{
-	MatchOutput, QueryAttribute, QueryAttributeValue, QueryCombinator, QueryCompoundSelector,
-	QueryFunctionalPseudoClass, QueryNotPseudo, QueryNthPseudo, QueryPrefixedPseudo, QueryPropertyTypePseudo,
-	QueryPseudoClass, QuerySelectorComponent, QuerySelectorList, QueryType, QueryWildcard, SelectorMatcher,
-};
+pub use selector::*;
 
 #[derive(AtomSet, Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub enum CsskitAtomSet {

--- a/crates/csskit_ast/src/selector/metadata.rs
+++ b/crates/csskit_ast/src/selector/metadata.rs
@@ -26,6 +26,8 @@ pub struct QuerySelectorMetadata {
 	pub needs_type_tracking: bool,
 	/// True if selector contains :empty pseudo-class.
 	pub has_empty: bool,
+	/// For :not(type), the excluded type. None if :not() doesn't contain a simple type.
+	pub not_type: Option<NodeId>,
 }
 
 impl Default for QuerySelectorMetadata {
@@ -40,6 +42,7 @@ impl Default for QuerySelectorMetadata {
 			deferred: false,
 			needs_type_tracking: false,
 			has_empty: false,
+			not_type: None,
 		}
 	}
 }
@@ -59,6 +62,9 @@ impl NodeMetadata for QuerySelectorMetadata {
 		self.has_empty |= other.has_empty;
 		if other.rightmost_type_id.is_some() {
 			self.rightmost_type_id = other.rightmost_type_id;
+		}
+		if other.not_type.is_some() {
+			self.not_type = other.not_type;
 		}
 		self
 	}

--- a/crates/csskit_ast/src/selector/mod.rs
+++ b/crates/csskit_ast/src/selector/mod.rs
@@ -11,5 +11,5 @@ pub use output::MatchOutput;
 pub use query::{
 	QueryAttribute, QueryAttributeValue, QueryCombinator, QueryCompoundSelector, QueryFunctionalPseudoClass,
 	QueryNotPseudo, QueryNthPseudo, QueryPrefixedPseudo, QueryPropertyTypePseudo, QueryPseudoClass,
-	QuerySelectorComponent, QuerySelectorList, QueryType, QueryWildcard,
+	QuerySelectorComponent, QuerySelectorList, QueryType, QueryWildcard, SelectorSegment,
 };


### PR DESCRIPTION
… segmenting

This change builds metadata & segments in a single parse pass inside of QuerySelectorComponent by:

- Introducing parse_compound_selector_part in css_parse, which splits out the component parsing.
- Introduces a new SelectorSegment type to split selectors into segments (combinator based).
- Replaces combinator scanning in the matcher code with segments.
- Adds more metadata, e.g. a rightmost_type_id for `:not(type)`.

These changes ultimately mean slightly more work during parsing for less work during matching!