### PR TITLE
csskit_ast: Optimise selector & attribute matching

### DIFF
--- a/crates/csskit_ast/src/selector/matcher/tests.rs
+++ b/crates/csskit_ast/src/selector/matcher/tests.rs
@@ -119,6 +119,36 @@ fn attribute_name_case_insensitive() {
 }
 
 #[test]
+fn attribute_contains_empty_value() {
+	assert_query!("a { color: red; margin: 10px; }", "[name*=\"\"]", 2);
+}
+
+#[test]
+fn attribute_prefix_empty_value() {
+	assert_query!("a { color: red; margin: 10px; }", "[name^=\"\"]", 2);
+}
+
+#[test]
+fn attribute_suffix_empty_value() {
+	assert_query!("a { color: red; margin: 10px; }", "[name$=\"\"]", 2);
+}
+
+#[test]
+fn attribute_spacelist_empty_value() {
+	assert_query!("a { color: red; margin: 10px; }", "[name~=\"\"]", 0);
+}
+
+#[test]
+fn attribute_exact_empty_value() {
+	assert_query!("a { color: red; margin: 10px; }", "[name=\"\"]", 0);
+}
+
+#[test]
+fn attribute_langprefix_empty_value() {
+	assert_query!("a { color: red; margin: 10px; }", "[name|=\"\"]", 2);
+}
+
+#[test]
 fn first_child() {
 	assert_query!("a {} b {} c {}", "style-rule:first-child", 1);
 }


### PR DESCRIPTION
This change reworks attribute matching to be more sensible: comparing [u8]s
instead of string comparison, avoiding allocations. It also cached the whole
CompountSelector instead of using indices, and caches NodeIds to avoid repeat
lookups.
