### PR TITLE
css_ast: Parse error on nested :has()

### DIFF
--- a/crates/css_parse/src/parser.rs
+++ b/crates/css_parse/src/parser.rs
@@ -50,6 +50,8 @@ pub struct Parser<'a, I: Iterator<Item = Cursor> + Clone> {
 #[derive(Default)]
 pub enum State {
 	Nested = 0b0000_0001,
+	/// Disallow relative selectors (:has). Set when inside :has() since nested :has() is invalid.
+	DisallowRelativeSelector = 0b0000_0010,
 }
 
 #[inline]


### PR DESCRIPTION
:has() does not allow nesting of :has() inside of it. This should be a parse
error, rather than silently allowing it.

This change introduces a new State flag; DisallowRelativeSelector, which is set
when parsing the interior arguments of `:has()`, and also adds a guard to
FunctionalPseudoClass::parse to Err() when parsing has, if the flag is active.
