### PR TITLE
css_ast: Rework CssMetadata to remove RuleKind

### DIFF
--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-	AppliesTo, BoxPortion, BoxSide, CssAtomSet, CssMetadata, DeclarationKind, DeclarationMetadata, Inherits,
+	AppliesTo, BoxPortion, BoxSide, CssAtomSet, CssMetadata, DeclarationKind, DeclarationMetadata, Inherits, NodeKinds,
 	PropertyGroup, PropertyKind, VendorPrefixes, values,
 };
 use css_lexer::Kind;
@@ -130,7 +130,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for StyleValue<'a> {
 					},
 					Self::Unknown(_) => {
 						CssMetadata {
-							declaration_kinds: DeclarationKind::Unknown,
+							node_kinds: NodeKinds::Unknown,
 							..Default::default()
 						}
 					},

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -98,8 +98,12 @@ impl<'a> DeclarationValue<'a, CssMetadata> for FontFaceRuleStyleValue<'a> {
 }
 
 impl<'a> NodeWithMetadata<CssMetadata> for FontFaceRuleStyleValue<'a> {
-	fn metadata(&self) -> CssMetadata {
+	fn self_metadata(&self) -> CssMetadata {
 		CssMetadata::default()
+	}
+
+	fn metadata(&self) -> CssMetadata {
+		self.0.metadata().merge(self.self_metadata())
 	}
 }
 

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -19,7 +19,13 @@ pub struct MediaRule<'a> {
 
 impl<'a> NodeWithMetadata<CssMetadata> for MediaRule<'a> {
 	fn self_metadata(&self) -> CssMetadata {
-		CssMetadata { used_at_rules: AtRuleId::Media, node_kinds: NodeKinds::AtRule, ..Default::default() }
+		let child_meta = self.block.0.metadata();
+		let is_empty = child_meta.declaration_kinds.is_none() && !child_meta.has_rules();
+		let mut node_kinds = NodeKinds::AtRule;
+		if is_empty {
+			node_kinds |= NodeKinds::EmptyBlock;
+		}
+		CssMetadata { used_at_rules: AtRuleId::Media, node_kinds, ..Default::default() }
 	}
 
 	fn metadata(&self) -> CssMetadata {

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -23,7 +23,13 @@ pub struct StyleRule<'a> {
 
 impl<'a> NodeWithMetadata<CssMetadata> for StyleRule<'a> {
 	fn self_metadata(&self) -> CssMetadata {
-		CssMetadata { node_kinds: NodeKinds::StyleRule, ..Default::default() }
+		let child_meta = self.rule.metadata();
+		let is_empty = child_meta.declaration_kinds.is_none() && !child_meta.has_rules();
+		let mut node_kinds = NodeKinds::StyleRule;
+		if is_empty {
+			node_kinds |= NodeKinds::EmptyBlock;
+		}
+		CssMetadata { node_kinds, ..Default::default() }
 	}
 
 	fn metadata(&self) -> CssMetadata {

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -1,4 +1,4 @@
-use crate::{CssAtomSet, CssMetadata, RuleKind, StyleValue, rules, stylerule::StyleRule};
+use crate::{CssAtomSet, CssMetadata, NodeKinds, StyleValue, rules, stylerule::StyleRule};
 use bumpalo::collections::Vec;
 use css_parse::{
 	ComponentValues, Cursor, Diagnostic, NodeWithMetadata, Parse, Parser, QualifiedRule, Result as ParserResult,
@@ -86,7 +86,7 @@ pub struct UnknownAtRule<'a> {
 
 impl<'a> NodeWithMetadata<CssMetadata> for UnknownAtRule<'a> {
 	fn metadata(&self) -> CssMetadata {
-		CssMetadata { rule_kinds: RuleKind::Unknown, ..Default::default() }
+		CssMetadata { node_kinds: NodeKinds::Unknown, ..Default::default() }
 	}
 }
 
@@ -106,7 +106,7 @@ pub struct UnknownQualifiedRule<'a>(
 impl<'a> NodeWithMetadata<CssMetadata> for UnknownQualifiedRule<'a> {
 	fn metadata(&self) -> CssMetadata {
 		let mut meta = self.0.metadata();
-		meta.rule_kinds |= RuleKind::Unknown;
+		meta.node_kinds |= NodeKinds::Unknown;
 		meta
 	}
 }


### PR DESCRIPTION
In #639 we introduced RuleKind but it isn't really necessary; all of the flags
in RuleKind can be merged into NodeKind.
