### PR TITLE
css_ast: Ensure visit_declaration provides a QueryableNode

### DIFF
--- a/crates/css_ast/build.rs
+++ b/crates/css_ast/build.rs
@@ -168,6 +168,9 @@ fn main() {
 	{
 		let variants = all_visitable.iter().filter_map(|node| {
 			let ident = node.ident();
+			if ident == "FontFaceRuleStyleValue" {
+				return None;
+			}
 			node.ident().to_string().strip_suffix("StyleValue").and_then(|name| {
 				let generics = node.generics();
 				if name.is_empty() {

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -32,8 +32,8 @@ pub struct FontFaceRuleBlock<'a>(DeclarationList<'a, FontFaceRuleStyleValue<'a>,
 
 #[derive(ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
-struct FontFaceRuleStyleValue<'a>(StyleValue<'a>);
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
+pub struct FontFaceRuleStyleValue<'a>(pub StyleValue<'a>);
 
 impl<'a> DeclarationValue<'a, CssMetadata> for FontFaceRuleStyleValue<'a> {
 	type ComputedValue = Computed<'a>;

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -61,7 +61,7 @@ pub struct PropertyRuleBlock<'a>(DeclarationList<'a, PropertyRuleValue<'a>, CssM
 
 #[derive(ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, metadata(skip))]
 pub enum PropertyRuleValue<'a> {
 	InitialValue(ComponentValues<'a>),
 	Syntax(SyntaxValue),

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -41,8 +41,8 @@ macro_rules! visit_trait {
 		$name: ident$(<$($gen:tt),+>)?($obj: ty),
 	)+ ) => {
 		pub trait Visit: Sized {
-			fn visit_declaration<'a, T: DeclarationValue<'a, CssMetadata>>(&mut self, _rule: &Declaration<'a, T, CssMetadata>) {}
-			fn exit_declaration<'a, T: DeclarationValue<'a, CssMetadata>>(&mut self, _rule: &Declaration<'a, T, CssMetadata>) {}
+			fn visit_declaration<'a, T: DeclarationValue<'a, CssMetadata> + QueryableNode>(&mut self, _rule: &Declaration<'a, T, CssMetadata>) {}
+			fn exit_declaration<'a, T: DeclarationValue<'a, CssMetadata> + QueryableNode>(&mut self, _rule: &Declaration<'a, T, CssMetadata>) {}
 			fn visit_bad_declaration<'a>(&mut self, _rule: &BadDeclaration<'a>) {}
 			fn exit_bad_declaration<'a>(&mut self, _rule: &BadDeclaration<'a>) {}
 			fn visit_string(&mut self, _str: &token_macros::String) {}
@@ -229,7 +229,7 @@ where
 
 impl<'a, T> Visitable for Declaration<'a, T, CssMetadata>
 where
-	T: Visitable + DeclarationValue<'a, CssMetadata>,
+	T: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		v.visit_declaration::<T>(self);
@@ -251,7 +251,7 @@ where
 
 impl<'a, T> Visitable for DeclarationList<'a, T, CssMetadata>
 where
-	T: Visitable + DeclarationValue<'a, CssMetadata>,
+	T: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		for declaration in &self.declarations {
@@ -296,7 +296,7 @@ where
 impl<'a, P, D, R> Visitable for QualifiedRule<'a, P, D, R, CssMetadata>
 where
 	P: Visitable + Peek<'a> + Parse<'a> + ToCursors + ToSpan,
-	D: Visitable + DeclarationValue<'a, CssMetadata>,
+	D: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 	R: Visitable + Parse<'a> + ToCursors + ToSpan,
 	Block<'a, D, R, CssMetadata>: Parse<'a> + ToCursors + ToSpan,
 {
@@ -323,7 +323,7 @@ where
 
 impl<'a, D, R> Visitable for Block<'a, D, R, CssMetadata>
 where
-	D: Visitable + DeclarationValue<'a, CssMetadata>,
+	D: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 	R: Visitable + Parse<'a> + ToCursors + ToSpan,
 {
 	fn accept<V: Visit>(&self, v: &mut V) {
@@ -401,7 +401,7 @@ where
 
 impl<'a, D> Visitable for DeclarationGroup<'a, D, CssMetadata>
 where
-	D: Visitable + DeclarationValue<'a, CssMetadata>,
+	D: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		for declaration in &self.declarations {
@@ -424,7 +424,7 @@ where
 
 impl<'a, D> Visitable for DeclarationOrBad<'a, D, CssMetadata>
 where
-	D: Visitable + DeclarationValue<'a, CssMetadata>,
+	D: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 {
 	fn accept<V: Visit>(&self, v: &mut V) {
 		match self {

--- a/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
+++ b/crates/csskit_source_finder/src/snapshots/csskit_source_finder__all_visitable_nodes.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/csskit_source_finder/src/lib.rs
 expression: "matches.iter().map(|node|\nnode.input.to_token_stream().to_string()).sorted().collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
   "pub enum AbsoluteSize { }",
@@ -592,6 +591,7 @@ snapshot_kind: text
   "pub struct FlowFromStyleValue { }",
   "pub struct FontFaceRule < \'a > { }",
   "pub struct FontFaceRuleBlock < \'a > { }",
+  "pub struct FontFaceRuleStyleValue < \'a > { }",
   "pub struct FontFamilyStyleValue < \'a > { }",
   "pub struct GapStyleValue { }",
   "pub struct GridAutoColumnsStyleValue < \'a > { }",


### PR DESCRIPTION
Currently using visit_declaration means opting out of the QueryableNode
infrastructure, despite StyleValue implementing QueryableNode.

This change incorporates a QueryableNode constraint on visit_declaration and
extends FontFaceRuleStyleValue and PropertyRuleValue to impl QueryableNode,
which satisfies this new constraint.
