### PR TITLE
css_ast/csskit_highlight/csskit_ast: Simplify code with visit_queryable_node

### DIFF
--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -105,7 +105,7 @@ pub enum DeclarationKind {
 }
 
 /// Categories of nodes present in metadata, used for selector filtering.
-#[bitmask(u8)]
+#[bitmask(u16)]
 #[bitmask_config(vec_debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum NodeKinds {
@@ -125,6 +125,16 @@ pub enum NodeKinds {
 	EmptyBlock,
 	/// Node is nested within another node
 	Nested,
+	/// Node is deprecated (non-conforming, obsolete)
+	Deprecated,
+	/// Node is experimental (not yet standardized)
+	Experimental,
+	/// Node is non-standard (vendor-specific, not in spec)
+	NonStandard,
+	/// Node is a dimension value (length, angle, time, flex, etc.)
+	Dimension,
+	/// Node is a custom element or custom property
+	Custom,
 }
 
 /// Queryable properties a node exposes for selector matching.
@@ -283,6 +293,30 @@ impl CssMetadata {
 	#[inline]
 	pub fn has_functions(&self) -> bool {
 		self.node_kinds.contains(NodeKinds::Function)
+	}
+
+	/// Returns true if metadata contains deprecated nodes.
+	#[inline]
+	pub fn is_deprecated(&self) -> bool {
+		self.node_kinds.contains(NodeKinds::Deprecated)
+	}
+
+	/// Returns true if metadata contains experimental nodes.
+	#[inline]
+	pub fn is_experimental(&self) -> bool {
+		self.node_kinds.contains(NodeKinds::Experimental)
+	}
+
+	/// Returns true if metadata contains non-standard nodes.
+	#[inline]
+	pub fn is_non_standard(&self) -> bool {
+		self.node_kinds.contains(NodeKinds::NonStandard)
+	}
+
+	/// Returns true if metadata contains dimension values.
+	#[inline]
+	pub fn is_dimension(&self) -> bool {
+		self.node_kinds.contains(NodeKinds::Dimension)
 	}
 
 	/// Returns true if metadata contains nodes with the given property kind.

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -354,8 +354,18 @@ impl<'a> DeclarationValue<'a, CssMetadata> for StyleValue<'a> {
 
 	fn declaration_metadata(decl: &Declaration<'a, Self, CssMetadata>) -> CssMetadata {
 		let mut meta = decl.value.metadata();
+		// Mark this node as a declaration
+		meta.node_kinds |= NodeKinds::Declaration;
 		if decl.important.is_some() {
 			meta.declaration_kinds |= DeclarationKind::Important;
+		}
+		// Check if this is a custom property (dashed ident)
+		if decl.name.is_dashed_ident() {
+			meta.node_kinds |= NodeKinds::Custom;
+		}
+		// Check if the value is unknown
+		if decl.value.is_unknown() {
+			meta.node_kinds |= NodeKinds::Unknown;
 		}
 		// Extract vendor prefix from property name cursor
 		let cursor: Cursor = decl.name.into();

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -14,7 +14,11 @@ pub struct DocumentRule<'a> {
 
 impl<'a> NodeWithMetadata<CssMetadata> for DocumentRule<'a> {
 	fn self_metadata(&self) -> CssMetadata {
-		CssMetadata { used_at_rules: AtRuleId::Document, node_kinds: NodeKinds::AtRule, ..Default::default() }
+		CssMetadata {
+			used_at_rules: AtRuleId::Document,
+			node_kinds: NodeKinds::AtRule | NodeKinds::Deprecated,
+			..Default::default()
+		}
 	}
 
 	fn metadata(&self) -> CssMetadata {

--- a/crates/css_ast/src/rules/moz.rs
+++ b/crates/css_ast/src/rules/moz.rs
@@ -17,7 +17,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for MozDocumentRule<'a> {
 		CssMetadata {
 			used_at_rules: AtRuleId::MozDocument,
 			vendor_prefixes: VendorPrefixes::Moz,
-			node_kinds: NodeKinds::AtRule,
+			node_kinds: NodeKinds::AtRule | NodeKinds::Deprecated | NodeKinds::NonStandard,
 			..Default::default()
 		}
 	}

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -20,7 +20,7 @@ impl<'a> NodeWithMetadata<CssMetadata> for WebkitKeyframesRule<'a> {
 		CssMetadata {
 			used_at_rules: AtRuleId::WebkitKeyframes,
 			vendor_prefixes: VendorPrefixes::WebKit,
-			node_kinds: NodeKinds::AtRule,
+			node_kinds: NodeKinds::AtRule | NodeKinds::Deprecated | NodeKinds::NonStandard,
 			property_kinds: PropertyKind::Name,
 			..Default::default()
 		}

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 #[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.types.angle"))]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 pub enum Angle {
 	#[atom(CssAtomSet::Grad)]
 	Grad(T![Dimension]),
@@ -45,6 +45,13 @@ impl Angle {
 			Self::Turn(d) => Into::<f32>::into(*d) * Self::DEG_TURN,
 			Self::Deg(d) => (*d).into(),
 		}
+	}
+}
+
+#[cfg(feature = "visitable")]
+impl css_parse::NodeWithMetadata<crate::CssMetadata> for Angle {
+	fn metadata(&self) -> crate::CssMetadata {
+		crate::CssMetadata { node_kinds: crate::NodeKinds::Dimension, ..Default::default() }
 	}
 }
 

--- a/crates/css_ast/src/units/decibel.rs
+++ b/crates/css_ast/src/units/decibel.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 
 #[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 pub struct Decibel(#[atom(CssAtomSet::Db)] T![Dimension]);
 
 impl From<Decibel> for f32 {
@@ -14,6 +14,13 @@ impl From<Decibel> for f32 {
 impl ToNumberValue for Decibel {
 	fn to_number_value(&self) -> Option<f32> {
 		Some((*self).into())
+	}
+}
+
+#[cfg(feature = "visitable")]
+impl css_parse::NodeWithMetadata<crate::CssMetadata> for Decibel {
+	fn metadata(&self) -> crate::CssMetadata {
+		crate::CssMetadata { node_kinds: crate::NodeKinds::Dimension, ..Default::default() }
 	}
 }
 

--- a/crates/css_ast/src/units/flex.rs
+++ b/crates/css_ast/src/units/flex.rs
@@ -3,12 +3,19 @@ use super::prelude::*;
 // https://www.w3.org/TR/css-grid-2/#typedef-flex
 #[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 pub struct Flex(#[atom(CssAtomSet::Fr)] T![Dimension]);
 
 impl ToNumberValue for Flex {
 	fn to_number_value(&self) -> Option<f32> {
 		Some(self.0.into())
+	}
+}
+
+#[cfg(feature = "visitable")]
+impl css_parse::NodeWithMetadata<crate::CssMetadata> for Flex {
+	fn metadata(&self) -> crate::CssMetadata {
+		crate::CssMetadata { node_kinds: crate::NodeKinds::Dimension, ..Default::default() }
 	}
 }
 

--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -68,7 +68,7 @@ macro_rules! define_length {
 	( $($name: ident),+ $(,)* ) => {
 		#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 		pub enum Length {
 			Zero(#[in_range(0.0..0.0)] T![Number]),
 			$(
@@ -126,6 +126,13 @@ impl PartialEq<f32> for Length {
 impl ToNumberValue for Length {
 	fn to_number_value(&self) -> Option<f32> {
 		Some((*self).into())
+	}
+}
+
+#[cfg(feature = "visitable")]
+impl css_parse::NodeWithMetadata<crate::CssMetadata> for Length {
+	fn metadata(&self) -> crate::CssMetadata {
+		crate::CssMetadata { node_kinds: crate::NodeKinds::Dimension, ..Default::default() }
 	}
 }
 

--- a/crates/css_ast/src/units/percentage.rs
+++ b/crates/css_ast/src/units/percentage.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 
 #[derive(Peek, Parse, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 pub struct Percentage(#[atom(CssAtomSet::Percentage)] T![Dimension]);
 
 impl Percentage {
@@ -29,9 +29,16 @@ impl ToNumberValue for Percentage {
 	}
 }
 
+#[cfg(feature = "visitable")]
+impl css_parse::NodeWithMetadata<crate::CssMetadata> for Percentage {
+	fn metadata(&self) -> crate::CssMetadata {
+		crate::CssMetadata { node_kinds: crate::NodeKinds::Dimension, ..Default::default() }
+	}
+}
+
 #[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 pub enum NumberPercentage {
 	Number(T![Number]),
 	Percentage(Percentage),
@@ -49,6 +56,13 @@ impl From<NumberPercentage> for f32 {
 impl ToNumberValue for NumberPercentage {
 	fn to_number_value(&self) -> Option<f32> {
 		Some((*self).into())
+	}
+}
+
+#[cfg(feature = "visitable")]
+impl css_parse::NodeWithMetadata<crate::CssMetadata> for NumberPercentage {
+	fn metadata(&self) -> crate::CssMetadata {
+		crate::CssMetadata { node_kinds: crate::NodeKinds::Dimension, ..Default::default() }
 	}
 }
 

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -3,7 +3,7 @@ use super::prelude::*;
 // https://drafts.csswg.org/css-values/#resolution
 #[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
+#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self), metadata(skip))]
 pub enum Time {
 	Zero(#[in_range(0.0..0.0)] T![Number]),
 	#[atom(CssAtomSet::Ms)]
@@ -25,6 +25,13 @@ impl From<Time> for f32 {
 impl ToNumberValue for Time {
 	fn to_number_value(&self) -> Option<f32> {
 		Some((*self).into())
+	}
+}
+
+#[cfg(feature = "visitable")]
+impl css_parse::NodeWithMetadata<crate::CssMetadata> for Time {
+	fn metadata(&self) -> crate::CssMetadata {
+		crate::CssMetadata { node_kinds: crate::NodeKinds::Dimension, ..Default::default() }
 	}
 }
 

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -41,6 +41,14 @@ macro_rules! visit_trait {
 		$name: ident$(<$($gen:tt),+>)?($obj: ty),
 	)+ ) => {
 		pub trait Visit: Sized {
+			/// Generic method for visiting queryable nodes. Override this to handle all queryable nodes uniformly.
+			/// Individual visit methods will delegate to this by default.
+			fn visit_queryable_node<T: QueryableNode>(&mut self, _node: &T) {}
+
+			/// Generic method for exiting queryable nodes. Override this to handle all queryable nodes uniformly.
+			/// Individual exit methods will delegate to this by default.
+			fn exit_queryable_node<T: QueryableNode>(&mut self, _node: &T) {}
+
 			fn visit_declaration<'a, T: DeclarationValue<'a, CssMetadata> + QueryableNode>(&mut self, _rule: &Declaration<'a, T, CssMetadata>) {}
 			fn exit_declaration<'a, T: DeclarationValue<'a, CssMetadata> + QueryableNode>(&mut self, _rule: &Declaration<'a, T, CssMetadata>) {}
 			fn visit_bad_declaration<'a>(&mut self, _rule: &BadDeclaration<'a>) {}
@@ -70,7 +78,7 @@ pub trait Visitable {
 /// This trait extends `Visitable` and adds a unique identifier for the node type.
 /// It is automatically implemented by `#[derive(Visitable)]` for all nodes that
 /// are not marked with `#[visit(skip)]` or `#[visit(children)]`.
-pub trait QueryableNode: Visitable + NodeWithMetadata<CssMetadata> {
+pub trait QueryableNode: Visitable + NodeWithMetadata<CssMetadata> + ToSpan {
 	/// Unique identifier for this node type.
 	const NODE_ID: NodeId;
 

--- a/crates/csskit_highlight/src/ansi_highlight_cursor_stream.rs
+++ b/crates/csskit_highlight/src/ansi_highlight_cursor_stream.rs
@@ -57,6 +57,7 @@ pub struct DefaultAnsiTheme;
 impl AnsiTheme for DefaultAnsiTheme {
 	fn get_style(&self, kind: SemanticKind, modifier: SemanticModifier) -> Style {
 		let color = match kind {
+			SemanticKind::None => Color::Ansi(AnsiColor::White),
 			SemanticKind::Id => Color::Ansi256(214.into()),
 			SemanticKind::Tag => Color::Ansi256(203.into()),
 			// Bright green

--- a/crates/csskit_highlight/src/lib.rs
+++ b/crates/csskit_highlight/src/lib.rs
@@ -21,6 +21,8 @@ mod tests;
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokenTypes
 #[derive(Display, VariantNames, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SemanticKind {
+	None,
+
 	/* Selector Elements */
 	Id,
 	Tag,


### PR DESCRIPTION
Both csskit_highlight and csskit_ast visit a lot of nodes. csskit_ast uses the
gen_visit_methods/gen_exit_methods which produced a _lot_ of boilerplate to call
into the check_match/exit_node methods, and csskit_highlight didn't have
fantastic coverage as it had to visit each rule to add semantic modifiers and
kind.

This change introduces the visit_queryable_node/exit_queryable_node, and adds a
bit more metadata to various nodes to allow:

- csskit_ast to simply use these methods rather than gen_visit|exit_methods.
- csskit_highlight can convert CssMetadata into SemanticModifier/SemanticKind.
- csskit_highlight can generically use visit_queryable_node to highlight.

This makes for much smaller code in both modules, while providing more
interesting rich data for further improvements to the query engine.
