### PR TITLE
css_ast: Make Declarations QueryableNodes.

### DIFF
--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -235,14 +235,34 @@ where
 	}
 }
 
+impl<'a, T> QueryableNode for Declaration<'a, T, CssMetadata>
+where
+	T: DeclarationValue<'a, CssMetadata> + QueryableNode,
+{
+	const NODE_ID: NodeId = NodeId::StyleValue;
+
+	fn node_id(&self) -> NodeId {
+		T::NODE_ID
+	}
+
+	fn get_property(&self, kind: PropertyKind) -> Option<Cursor> {
+		match kind {
+			PropertyKind::Name => Some(self.name.into()),
+			_ => None,
+		}
+	}
+}
+
 impl<'a, T> Visitable for Declaration<'a, T, CssMetadata>
 where
 	T: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 {
 	fn accept<V: Visit>(&self, v: &mut V) {
+		v.visit_queryable_node(self);
 		v.visit_declaration::<T>(self);
 		self.value.accept(v);
 		v.exit_declaration::<T>(self);
+		v.exit_queryable_node(self);
 	}
 }
 

--- a/crates/css_parse/src/syntax/declaration.rs
+++ b/crates/css_parse/src/syntax/declaration.rs
@@ -57,6 +57,12 @@ where
 	V: DeclarationValue<'a, M>,
 	M: NodeMetadata,
 {
+	fn self_metadata(&self) -> M {
+		// Declaration's self_metadata should return the declaration-specific metadata
+		// (includes !important, property info, etc.) for selector matching.
+		DeclarationValue::declaration_metadata(self)
+	}
+
 	fn metadata(&self) -> M {
 		DeclarationValue::declaration_metadata(self)
 	}


### PR DESCRIPTION
This allows Declaration nodes to be visited with the generic
visit_queryable_node rather than just StyleValues.
