### PR TITLE
csskit_ast: Implement :size() pseudo

### DIFF
--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -174,6 +174,8 @@ pub struct CssMetadata {
 	pub node_kinds: NodeKinds,
 	/// Bitwise OR of queryable properties present
 	pub property_kinds: PropertyKind,
+	/// Size of vector-based nodes (e.g., number of declarations, selector list length)
+	pub size: u16,
 }
 
 impl Default for CssMetadata {
@@ -188,6 +190,7 @@ impl Default for CssMetadata {
 			vendor_prefixes: VendorPrefixes::none(),
 			node_kinds: NodeKinds::none(),
 			property_kinds: PropertyKind::none(),
+			size: 0,
 		}
 	}
 }
@@ -205,6 +208,7 @@ impl CssMetadata {
 			&& self.vendor_prefixes == VendorPrefixes::none()
 			&& self.node_kinds == NodeKinds::none()
 			&& self.property_kinds == PropertyKind::none()
+			&& self.size == 0
 	}
 
 	/// Returns true if this block modifies any positioning-related properties.
@@ -350,6 +354,13 @@ impl NodeMetadata for CssMetadata {
 		self.vendor_prefixes |= other.vendor_prefixes;
 		self.node_kinds |= other.node_kinds;
 		self.property_kinds |= other.property_kinds;
+		self.size = self.size.max(other.size);
+		self
+	}
+
+	#[inline]
+	fn with_size(mut self, size: u16) -> Self {
+		self.size = size;
 		self
 	}
 }

--- a/crates/css_parse/src/syntax/declaration_list.rs
+++ b/crates/css_parse/src/syntax/declaration_list.rs
@@ -65,13 +65,15 @@ where
 	{
 		let open_curly = p.parse::<T!['{']>()?;
 		let mut declarations = Vec::new_in(p.bump());
-		let mut meta = Default::default();
+		let mut meta: M = Default::default();
 		loop {
 			if p.at_end() {
+				meta = meta.with_size(declarations.len().min(u16::MAX as usize) as u16);
 				return Ok(Self { open_curly, declarations, close_curly: None, meta });
 			}
 			let close_curly = p.parse_if_peek::<T!['}']>()?;
 			if close_curly.is_some() {
+				meta = meta.with_size(declarations.len().min(u16::MAX as usize) as u16);
 				return Ok(Self { open_curly, declarations, close_curly, meta });
 			}
 			let declaration = p.parse::<Declaration<'a, V, M>>()?;

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -781,6 +781,12 @@ pub mod double {
 		/// [T![*=]][crate::T] to refer to this.
 		StarEqual, '*', '='
 	}
+	custom_double_delim! {
+		/// Represents a two consecutive tokens with [Kind::Delim][crate::Kind::Delim] that cannot be separated by any
+		/// other token. The first token has the char `!` while the second has the char `=`, representing `!=`. Use
+		/// [T![!=]][crate::T] to refer to this.
+		BangEqual, '*', '='
+	}
 
 	/// Represents a two consecutive tokens with [Kind::Colon] that cannot be separated by any other token, representing
 	/// `::`. Use [T![::]][crate::T] to refer to this.
@@ -980,6 +986,7 @@ macro_rules! T {
 	[^=] => { $crate::token_macros::double::CaretEqual };
 	["$="] => { $crate::token_macros::double::DollarEqual };
 	[*=] => { $crate::token_macros::double::StarEqual };
+	[!=] => { $crate::token_macros::double::BangEqual };
 
 	[Dimension::$ident: ident] => { $crate::token_macros::dimension::$ident };
 

--- a/crates/css_parse/src/traits/node_metadata.rs
+++ b/crates/css_parse/src/traits/node_metadata.rs
@@ -2,6 +2,12 @@
 pub trait NodeMetadata: Sized + Copy + Default {
 	/// Merges another NodeMetadata into this one, returning the result.
 	fn merge(self, other: Self) -> Self;
+
+	/// Sets the size of this metadata (e.g., number of declarations, selector list length).
+	/// Default implementation is a no-op for metadata types that don't track size.
+	fn with_size(self, _size: u16) -> Self {
+		self
+	}
 }
 
 /// A Node that has NodeMetadata

--- a/crates/csskit_ast/src/lib.rs
+++ b/crates/csskit_ast/src/lib.rs
@@ -59,6 +59,7 @@ pub enum CsskitAtomSet {
 	NthLastOfType,
 	Not,
 	Has,
+	Size,
 	Name,
 	#[atom("at-rule")]
 	AtRule,

--- a/crates/csskit_ast/src/selector/matcher/matchers.rs
+++ b/crates/csskit_ast/src/selector/matcher/matchers.rs
@@ -94,6 +94,7 @@ impl<'a, 'b> Matcher<'a, 'b> for QueryFunctionalPseudoClass<'b> {
 			QueryFunctionalPseudoClass::NthLastOfType(nth) => nth.value.matches(ctx.type_index_from_end()),
 			QueryFunctionalPseudoClass::PropertyType(pt) => pt.matches(ctx),
 			QueryFunctionalPseudoClass::Prefixed(pf) => pf.matches(ctx),
+			QueryFunctionalPseudoClass::Size(sz) => sz.matches(ctx.node.metadata.size),
 		}
 	}
 }

--- a/crates/csskit_ast/src/selector/matcher/tests.rs
+++ b/crates/csskit_ast/src/selector/matcher/tests.rs
@@ -1348,3 +1348,75 @@ fn has_pseudo_nested_anchor_boundaries() {
 		0
 	);
 }
+
+#[test]
+fn size_pseudo_match() {
+	assert_query!(".a, .b, .c {}", "selector-list:size(3)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b {}", "selector-list:size(2)", 1, [NodeId::SelectorList]);
+	assert_query!(".a {}", "selector-list:size(1)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c {} .x, .y {}", "selector-list:size(3)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c {} .x, .y {}", "selector-list:size(2)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c {}", "selector-list:size(>2)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c {}", "selector-list:size(>1)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b {}", "selector-list:size(>1)", 1, [NodeId::SelectorList]);
+	assert_query!(
+		".a, .b, .c {} .x, .y, .z {}",
+		"selector-list:size(>2)",
+		2,
+		[NodeId::SelectorList, NodeId::SelectorList]
+	);
+	assert_query!(".a {}", "selector-list:size(<2)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b {}", "selector-list:size(<3)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c {}", "selector-list:size(<5)", 1, [NodeId::SelectorList]);
+	assert_query!(".a {} .x, .y {}", "selector-list:size(<3)", 2, [NodeId::SelectorList, NodeId::SelectorList]);
+	assert_query!(".a, .b, .c {}", "selector-list:size(>=3)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b {}", "selector-list:size(>=2)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c {}", "selector-list:size(>=2)", 1, [NodeId::SelectorList]);
+	assert_query!(
+		".a, .b {} .x, .y, .z {}",
+		"selector-list:size(>=2)",
+		2,
+		[NodeId::SelectorList, NodeId::SelectorList]
+	);
+	assert_query!(".a {}", "selector-list:size(<=1)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b {}", "selector-list:size(<=2)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c {}", "selector-list:size(<=3)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c {}", "selector-list:size(<=5)", 1, [NodeId::SelectorList]);
+	assert_query!(".a {} .x, .y {}", "selector-list:size(<=2)", 2, [NodeId::SelectorList, NodeId::SelectorList]);
+}
+
+#[test]
+fn size_pseudo_no_match() {
+	assert_query!(".a, .b {}", "selector-list:size(3)", 0);
+	assert_query!(".a {}", "selector-list:size(2)", 0);
+	assert_query!(".a, .b, .c {} .x, .y {}", "selector-list:size(5)", 0);
+	assert_query!(".a {}", "selector-list:size(>1)", 0);
+	assert_query!(".a, .b {}", "selector-list:size(>2)", 0);
+	assert_query!(".a, .b, .c {}", "selector-list:size(>5)", 0);
+	assert_query!(".a, .b {}", "selector-list:size(<2)", 0);
+	assert_query!(".a, .b, .c {}", "selector-list:size(<3)", 0);
+	assert_query!(".a, .b, .c {}", "selector-list:size(<1)", 0);
+	assert_query!(".a {}", "selector-list:size(>=2)", 0);
+	assert_query!(".a, .b {}", "selector-list:size(>=3)", 0);
+	assert_query!(".a, .b {}", "selector-list:size(<=1)", 0);
+	assert_query!(".a, .b, .c {}", "selector-list:size(<=2)", 0);
+}
+
+#[test]
+fn size_pseudo_combinations_match() {
+	assert_query!(".a, .b, .c {} .x, .y {}", "style-rule > selector-list:size(3)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c { color: red; }", "style-rule > selector-list:size(3)", 1, [NodeId::SelectorList]);
+	assert_query!(".a, .b, .c { color: red; }", "style-rule:has(selector-list:size(3))", 1, [NodeId::StyleRule]);
+	assert_query!(
+		".a {} .b, .c {} .d, .e, .f {}",
+		"selector-list:not(:size(2))",
+		2,
+		[NodeId::SelectorList, NodeId::SelectorList]
+	);
+	assert_query!(
+		"@media screen { .a, .b, .c {} .x {} }",
+		"media-rule selector-list:size(3)",
+		1,
+		[NodeId::SelectorList]
+	);
+}


### PR DESCRIPTION
This pseudo function class will be useful for querying information about nodes
hat have vector like properties, for example SelectorList, DeclarationList, and
so on. This just implements on SelectorList for now as a proof of concept,
we can extend to other types in follow up PRs.
