### PR TITLE
csskit: Add a `tree` command which shows selector tree

### DIFF
--- a/.mise-tasks/csskit-acceptance
+++ b/.mise-tasks/csskit-acceptance
@@ -31,7 +31,7 @@ should_skip() {
 	local file="$2"
 	local skip_list=""
 	case "$variant" in
-		min) skip_list="$skip_min" ;;
+	min) skip_list="$skip_min" ;;
 	esac
 	for skip in $skip_list; do
 		[ "$file" = "$skip" ] && return 0
@@ -41,7 +41,7 @@ should_skip() {
 
 check_parse() {
 	css_file="$1"
-	if $CSSKIT fmt "$css_file" > /dev/null 2>&1; then
+	if $CSSKIT fmt "$css_file" >/dev/null 2>&1; then
 		echo " $PASS parse $css_file"
 		passed=$((passed + 1))
 	else
@@ -108,6 +108,7 @@ for css in coverage/basic/*.css coverage/popular/*.css; do
 	check_parse "$css"
 	check_variant "fmt" "$css" "$base"
 	check_variant "min" "$css" "$base"
+	check_variant "tree" "$css" "$base"
 
 	# Check find tests (*.find.N.txt files)
 	for find_file in "$base".find.*.txt; do

--- a/coverage/basic/media.tree.txt
+++ b/coverage/basic/media.tree.txt
@@ -1,0 +1,12 @@
+style-sheet
+╰─ media-rule:at-rule:rule
+   ├─ media-type
+   ╰─ style-rule:rule
+      ├─ selector-list:size(1)
+      │  ╰─ compound-selector
+      │     ╰─ tag
+      │        ╰─ html-tag
+      ╰─ style-value[name=color]:longhand
+         ╰─ style-value
+            ╰─ color-style-value
+               ╰─ color

--- a/coverage/basic/nth.tree.txt
+++ b/coverage/basic/nth.tree.txt
@@ -1,0 +1,6 @@
+style-sheet
+╰─ style-rule:rule:empty
+   ╰─ selector-list:size(1)
+      ╰─ compound-selector
+         ╰─ nth-child-pseudo-function
+            ╰─ nth

--- a/coverage/basic/rule.tree.txt
+++ b/coverage/basic/rule.tree.txt
@@ -1,0 +1,11 @@
+style-sheet
+╰─ style-rule:rule
+   ├─ selector-list:size(1)
+   │  ╰─ compound-selector
+   │     ╰─ tag
+   │        ╰─ html-tag
+   ╰─ style-value[name=min-width]:longhand
+      ╰─ style-value
+         ╰─ min-width-style-value
+            ╰─ length-percentage
+               ╰─ length

--- a/coverage/basic/vars.tree.txt
+++ b/coverage/basic/vars.tree.txt
@@ -1,0 +1,8 @@
+style-sheet
+╰─ style-rule:rule:empty
+   ├─ selector-list:size(1)
+   │  ╰─ compound-selector
+   │     ╰─ tag
+   │        ╰─ html-tag
+   ╰─ style-value[name=background]:unknown
+      ╰─ style-value

--- a/coverage/popular/960.tree.txt
+++ b/coverage/popular/960.tree.txt
@@ -1,0 +1,1603 @@
+style-sheet
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ╰─ tag
+│  │        ╰─ html-tag
+│  ╰─ style-value[name=min-width]:longhand
+│     ╰─ style-value
+│        ╰─ min-width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ╰─ class
+│  ├─ style-value[name=margin-left]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ margin-left-style-value
+│  ├─ style-value[name=margin-right]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ margin-right-style-value
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(16)
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ╰─ class
+│  ├─ style-value[name=display]:unknown
+│  │  ╰─ style-value
+│  ├─ style-value[name=float]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ float-style-value
+│  ├─ style-value[name=margin-left]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ margin-left-style-value
+│  │        ╰─ length-percentage
+│  │           ╰─ length
+│  ╰─ style-value[name=margin-right]:longhand
+│     ╰─ style-value
+│        ╰─ margin-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(30)
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ├─ compound-selector
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ╰─ class
+│  ╰─ style-value[name=position]:longhand
+│     ╰─ style-value
+│        ╰─ position-style-value
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ╰─ class
+│  ╰─ style-value[name=margin-left]:longhand
+│     ╰─ style-value
+│        ╰─ margin-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ╰─ class
+│  ╰─ style-value[name=margin-right]:longhand
+│     ╰─ style-value
+│        ╰─ margin-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=width]:longhand
+│     ╰─ style-value
+│        ╰─ width-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-left]:longhand
+│     ╰─ style-value
+│        ╰─ padding-left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=padding-right]:longhand
+│     ╰─ style-value
+│        ╰─ padding-right-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(2)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ├─ combinator
+│  │  │  ╰─ class
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ├─ combinator
+│  │     ╰─ class
+│  ╰─ style-value[name=left]:longhand
+│     ╰─ style-value
+│        ╰─ left-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(1)
+│  │  ╰─ compound-selector
+│  │     ╰─ class
+│  ├─ style-value[name=clear]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ clear-style-value
+│  ├─ style-value[name=display]:unknown
+│  │  ╰─ style-value
+│  ├─ style-value[name=overflow]:shorthand
+│  │  ╰─ style-value
+│  │     ╰─ overflow-style-value
+│  │        ╰─ overflow-block-style-value
+│  ├─ style-value[name=visibility]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ visibility-style-value
+│  ├─ style-value[name=width]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ width-style-value
+│  │        ╰─ length-percentage
+│  │           ╰─ length
+│  ╰─ style-value[name=height]:longhand
+│     ╰─ style-value
+│        ╰─ height-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(6)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ╰─ legacy-pseudo-element
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ╰─ legacy-pseudo-element
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ╰─ legacy-pseudo-element
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ╰─ legacy-pseudo-element
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ╰─ legacy-pseudo-element
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ╰─ legacy-pseudo-element
+│  ├─ style-value[name=content]:unknown
+│  │  ╰─ style-value
+│  ├─ style-value[name=display]:unknown
+│  │  ╰─ style-value
+│  ├─ style-value[name=overflow]:shorthand
+│  │  ╰─ style-value
+│  │     ╰─ overflow-style-value
+│  │        ╰─ overflow-block-style-value
+│  ├─ style-value[name=visibility]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ visibility-style-value
+│  ├─ style-value[name=font-size]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ font-size-style-value
+│  │        ╰─ length-percentage
+│  │           ╰─ length
+│  ├─ style-value[name=line-height]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ line-height-style-value
+│  │        ╰─ length-percentage
+│  │           ╰─ length
+│  ├─ style-value[name=width]:longhand
+│  │  ╰─ style-value
+│  │     ╰─ width-style-value
+│  │        ╰─ length-percentage
+│  │           ╰─ length
+│  ╰─ style-value[name=height]:longhand
+│     ╰─ style-value
+│        ╰─ height-style-value
+│           ╰─ length-percentage
+│              ╰─ length
+├─ style-rule:rule
+│  ├─ selector-list:size(3)
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ╰─ legacy-pseudo-element
+│  │  ├─ compound-selector
+│  │  │  ├─ class
+│  │  │  ╰─ legacy-pseudo-element
+│  │  ╰─ compound-selector
+│  │     ├─ class
+│  │     ╰─ legacy-pseudo-element
+│  ╰─ style-value[name=clear]:longhand
+│     ╰─ style-value
+│        ╰─ clear-style-value
+╰─ style-rule:rule
+   ├─ selector-list:size(3)
+   │  ├─ compound-selector
+   │  │  ╰─ class
+   │  ├─ compound-selector
+   │  │  ╰─ class
+   │  ╰─ compound-selector
+   │     ╰─ class
+   ╰─ style-value[name=zoom]:longhand
+      ╰─ style-value
+         ╰─ zoom-style-value
+            ╰─ number-percentage

--- a/crates/csskit/src/commands/mod.rs
+++ b/crates/csskit/src/commands/mod.rs
@@ -11,6 +11,7 @@ mod find;
 mod fmt;
 mod lsp;
 mod min;
+mod tree;
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
@@ -19,6 +20,9 @@ pub enum Commands {
 
 	/// Find AST nodes matching a selector pattern
 	Find(find::Find),
+
+	/// Display CSS AST as a tree structure
+	Tree(tree::Tree),
 
 	/// Format CSS files to make them more readable.
 	Fmt(fmt::Fmt),
@@ -53,6 +57,7 @@ impl Commands {
 		match self {
 			Commands::Check(cmd) => cmd.run(config),
 			Commands::Find(cmd) => cmd.run(config),
+			Commands::Tree(cmd) => cmd.run(config),
 			Commands::Fmt(cmd) => cmd.run(config),
 			Commands::Min(cmd) => cmd.run(config),
 			Commands::Colors(cmd) => cmd.run(config),

--- a/crates/csskit/src/commands/tree.rs
+++ b/crates/csskit/src/commands/tree.rs
@@ -1,0 +1,183 @@
+use std::io::Read;
+
+use bumpalo::Bump;
+use clap::Args;
+use css_ast::visit::{QueryableNode, Visit, Visitable};
+use css_ast::{CssAtomSet, PROPERTY_KIND_VARIANTS, PropertyKind, StyleSheet};
+use css_lexer::Lexer;
+use css_parse::{Cursor, Parser, ToSpan};
+use csskit_ast::{QueryFunctionalPseudoClass, QueryPseudoClass};
+
+use crate::{CliError, CliResult, GlobalConfig, InputArgs};
+
+/// Display CSS AST as a tree structure
+///
+/// Shows the hierarchical structure of CSS with QuerySelector-like annotations.
+/// Useful for understanding how to select nodes with csskit find.
+///
+/// Examples:
+///   csskit tree style.css
+///   csskit tree -c '.button { color: red; }'
+#[derive(Debug, Args)]
+pub struct Tree {
+	#[command(flatten)]
+	input: InputArgs,
+}
+
+#[derive(Clone, Debug)]
+struct NodeInfo {
+	/// Pre-formatted display string: `type[attrs]:pseudos`
+	display: String,
+	depth: usize,
+	child_start_idx: usize,
+}
+
+struct CollectionVisitor<'a> {
+	source: &'a str,
+	nodes: Vec<NodeInfo>,
+	depth: usize,
+}
+
+impl<'a> CollectionVisitor<'a> {
+	fn new(source: &'a str) -> Self {
+		Self { source, nodes: Vec::new(), depth: 0 }
+	}
+
+	fn build_display<T: QueryableNode>(&self, node: &T) -> String {
+		let meta = node.self_metadata();
+		let mut display = node.node_id().tag_name().to_string();
+
+		// Attributes
+		for &kind in PROPERTY_KIND_VARIANTS {
+			if !meta.property_kinds.contains(kind) {
+				continue;
+			}
+			if let Some(cursor) = node.get_property(kind) {
+				let value = self.cursor_to_str(cursor);
+				let attr_name = match kind {
+					PropertyKind::Name => "name",
+					_ => continue,
+				};
+				display.push_str(&format!("[{}={}]", attr_name, value));
+			}
+		}
+
+		// Pseudos
+		for name in QueryPseudoClass::matching_metadata_pseudos(&meta) {
+			display.push(':');
+			display.push_str(name);
+		}
+		if let Some(size) = QueryFunctionalPseudoClass::matching_size(&meta) {
+			display.push_str(&format!(":size({})", size));
+		}
+
+		display
+	}
+
+	fn cursor_to_str(&self, cursor: Cursor) -> &str {
+		let span = cursor.to_span();
+		&self.source[span.start().0 as usize..span.end().0 as usize]
+	}
+
+	/// Find the index of the ancestor at the given depth, searching backwards from `start_idx`.
+	fn find_ancestor_at_depth(&self, start_idx: usize, target_depth: usize) -> Option<usize> {
+		(0..start_idx).rev().find(|&j| self.nodes[j].depth == target_depth)
+	}
+
+	/// Check if `node_idx` is the last direct child of its parent.
+	fn is_last_child(&self, node_idx: usize) -> bool {
+		let node_depth = self.nodes[node_idx].depth;
+		if node_depth == 0 {
+			return false;
+		}
+
+		let Some(parent_idx) = self.find_ancestor_at_depth(node_idx, node_depth - 1) else {
+			return false;
+		};
+
+		let parent = &self.nodes[parent_idx];
+		let parent_depth = parent.depth;
+
+		// Find the last direct child of the parent
+		let mut last_child_idx = None;
+		for j in parent.child_start_idx..self.nodes.len() {
+			if self.nodes[j].depth == parent_depth + 1 {
+				last_child_idx = Some(j);
+			} else if self.nodes[j].depth <= parent_depth {
+				break;
+			}
+		}
+
+		last_child_idx == Some(node_idx)
+	}
+}
+
+impl<'a> Visit for CollectionVisitor<'a> {
+	fn visit_queryable_node<T: QueryableNode>(&mut self, node: &T) {
+		let display = self.build_display(node);
+		let node_info = NodeInfo { display, depth: self.depth, child_start_idx: self.nodes.len() + 1 };
+		self.nodes.push(node_info);
+		self.depth += 1;
+	}
+
+	fn exit_queryable_node<T: QueryableNode>(&mut self, _node: &T) {
+		self.depth -= 1;
+	}
+}
+
+impl Tree {
+	pub fn run(&self, _config: GlobalConfig) -> CliResult {
+		let bump = Bump::default();
+
+		for (filename, mut source) in self.input.sources()? {
+			let mut src = String::new();
+			source.read_to_string(&mut src)?;
+
+			let lexer = Lexer::new(&CssAtomSet::ATOMS, &src);
+			let mut parser = Parser::new(&bump, &src, lexer);
+			let result = parser.parse_entirely::<StyleSheet>();
+
+			let Some(stylesheet) = result.output.as_ref() else {
+				for err in result.errors {
+					eprintln!("{}", crate::commands::format_diagnostic_error(&err, &src, filename));
+				}
+				return Err(CliError::ParseFailed);
+			};
+
+			// Collect all nodes
+			let mut visitor = CollectionVisitor::new(&src);
+			stylesheet.accept(&mut visitor);
+
+			// Print root
+			if let Some(root) = visitor.nodes.first() {
+				println!("{}", root.display);
+			}
+
+			// Print tree (skip the first node which is the root we just printed)
+			for (i, node) in visitor.nodes.iter().enumerate().skip(1) {
+				let prefix = self.build_prefix(&visitor, i, node.depth);
+				println!("{}{}", prefix, node.display);
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Build the tree prefix (vertical bars and connectors) for a node.
+	fn build_prefix(&self, visitor: &CollectionVisitor, node_idx: usize, node_depth: usize) -> String {
+		let mut prefix = String::new();
+
+		// For each ancestor level, determine if we need a vertical bar
+		for d in 0..node_depth.saturating_sub(1) {
+			let ancestor_idx = visitor.find_ancestor_at_depth(node_idx, d + 1);
+			let show_bar = ancestor_idx.is_none_or(|idx| !visitor.is_last_child(idx));
+			prefix.push_str(if show_bar { "│  " } else { "   " });
+		}
+
+		// Add the connector for this node
+		let connector = if visitor.is_last_child(node_idx) { "╰─ " } else { "├─ " };
+		prefix.push_str(connector);
+
+		prefix
+	}
+}


### PR DESCRIPTION
This new command will be useful for people intending to write selectors for
`csskit find`
