### PR TITLE
csskit_ast: Ensure invalid selectors never match

### DIFF
--- a/crates/csskit_ast/src/selector/matcher/selector_matcher.rs
+++ b/crates/csskit_ast/src/selector/matcher/selector_matcher.rs
@@ -96,7 +96,7 @@ impl<'a, 'b> SelectorMatcher<'a, 'b> {
 		let css_meta = root.metadata();
 		self.selectors.retain(|s| {
 			let m = s.metadata();
-			m.can_match(&css_meta) || m.requirements.contains(SelectorRequirements::Prefixed)
+			!m.is_invalid && (m.can_match(&css_meta) || m.requirements.contains(SelectorRequirements::Prefixed))
 		});
 		if self.selectors.is_empty() {
 			return self.matches.into_iter();

--- a/crates/csskit_ast/src/selector/matcher/tests.rs
+++ b/crates/csskit_ast/src/selector/matcher/tests.rs
@@ -1420,3 +1420,10 @@ fn size_pseudo_combinations_match() {
 		[NodeId::SelectorList]
 	);
 }
+
+#[test]
+fn unknown_type_selector_matches_nothing() {
+	assert_query!(".a {} #foo {} .b {}", "foo", 0);
+	assert_query!(".a {} #foo {} .b {}", "unknown-node-type", 0);
+	assert_query!("@media screen {}", "media-rule-invalid", 0);
+}

--- a/crates/csskit_ast/src/selector/metadata.rs
+++ b/crates/csskit_ast/src/selector/metadata.rs
@@ -41,6 +41,8 @@ pub struct QuerySelectorMetadata {
 	pub not_type: Option<NodeId>,
 	/// True if selector is just a single type (e.g., "style-rule") with no other components.
 	pub is_type_only: bool,
+	/// True if selector contains an unknown/invalid type selector that should never match.
+	pub is_invalid: bool,
 }
 
 impl Default for QuerySelectorMetadata {
@@ -61,6 +63,7 @@ impl Default for QuerySelectorMetadata {
 			needs_type_tracking: false,
 			not_type: None,
 			is_type_only: false,
+			is_invalid: false,
 		}
 	}
 }
@@ -82,6 +85,7 @@ impl NodeMetadata for QuerySelectorMetadata {
 		self.self_attribute_filter |= other.self_attribute_filter;
 		self.deferred |= other.deferred;
 		self.needs_type_tracking |= other.needs_type_tracking;
+		self.is_invalid |= other.is_invalid;
 		if other.rightmost_type_id.is_some() {
 			self.rightmost_type_id = other.rightmost_type_id;
 		}

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -165,6 +165,10 @@ impl<'a> Parse<'a> for QueryCompoundSelector<'a> {
 					if rightmost_type.is_none() {
 						rightmost_type = node_id;
 					}
+					// Mark selector as invalid if type is unknown
+					if node_id.is_none() {
+						metadata.is_invalid = true;
+					}
 					// Accumulate at-rule filter for all type selectors in the compound selector
 					if let Some(at_rule_id) = node_id.and_then(|id| id.to_at_rule_id()) {
 						metadata.at_rule_filter |= at_rule_id;


### PR DESCRIPTION
csskit_ast's QueryCompoundSelector is able to parse unknown selector nodes, like
unknown NodeIds, without failing the entire parse, but this resulted in the
matcher treating unknown ids like wildcard selectors, meaning e.g. `foo` would
match like `*`.

This change introduces an `is_invalid` boolean on selectors, allowing the
selector to be completely invalidated during parse time (even if it can still
parse) if it's _known_ during parse time that it won't match. The matcher also
now discards such invalid selectors without evaluation.