### PR TITLE
csskit_ast: Ensure build script is isolated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,6 @@ dependencies = [
  "css_lexer",
  "css_parse",
  "csskit_derives",
- "csskit_source_finder",
  "derive_atom_set",
  "indexmap",
  "smallvec",

--- a/crates/css_ast/build.rs
+++ b/crates/css_ast/build.rs
@@ -55,6 +55,12 @@ fn main() {
 			quote! { Self::#ident }
 		});
 
+		let display_arms = queryable.iter().map(|node| {
+			let ident = node.ident();
+			let ident_str = ident.to_string();
+			quote! { Self::#ident => write!(f, #ident_str) }
+		});
+
 		#[rustfmt::skip]
 		let source = quote! {
 			/// Unique identifier for each AST node type that can be queried.
@@ -66,6 +72,14 @@ fn main() {
 			#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 			pub enum NodeId {
 				#(#variants),*
+			}
+
+			impl std::fmt::Display for NodeId {
+				fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+					match self {
+						#(#display_arms),*
+					}
+				}
 			}
 
 			impl NodeId {

--- a/crates/csskit_ast/Cargo.toml
+++ b/crates/csskit_ast/Cargo.toml
@@ -27,7 +27,7 @@ smallvec = { workspace = true }
 css_parse = { workspace = true, features = ["testing"] } # @release
 
 [build-dependencies]
-csskit_source_finder = { workspace = true } # @release
+css_ast = { workspace = true, features = ["visitable"] } # @release
 
 [features]
 default = []

--- a/crates/csskit_ast/build.rs
+++ b/crates/csskit_ast/build.rs
@@ -1,25 +1,16 @@
-use csskit_source_finder::find_queryable_nodes;
-use std::{
-	collections::HashSet,
-	env, fs,
-	path::{Path, PathBuf},
-};
+use std::{env, fs, path::Path};
 
 fn main() {
 	println!("cargo::rerun-if-changed=build.rs");
-	let mut queryable = HashSet::new();
-	find_queryable_nodes("../css_ast/src/**/*.rs", &mut queryable, |path: &PathBuf| {
-		println!("cargo::rerun-if-changed={}", path.display());
-	});
-	let mut queryable: Vec<_> = queryable.into_iter().collect();
-	queryable.sort_by_key(|node| node.ident().to_string());
-
 	let mut node_type_variants = String::new();
 	let mut match_arms = String::new();
-	for node in &queryable {
-		let ident = node.ident();
-		node_type_variants.push_str(&format!("\t{},\n", ident));
-		match_arms.push_str(&format!("\t\t\tSelf::{} => Some(NodeId::{}),\n", ident, ident));
+	for name in css_ast::NodeId::all_variants() {
+		node_type_variants.push_str(&format!("\t{},\n", name));
+		match_arms.push_str(&format!("\t\t\tSelf::{} => Some(NodeId::{}),\n", name, name));
+	}
+
+	if node_type_variants.is_empty() {
+		panic!("node_type_variants is empty!");
 	}
 
 	let content = format!(


### PR DESCRIPTION
The current build script implicitly depends on `css_ast` as a sibling
dependency. This fails cargo publish.

This change makes csskit_ast's build _depend_ on css_ast, and makes css_ast's
NodeId impl Display, so that csskit_ast's build.rs can simply iterate over
`all_variants()` to get the name of each NodeId, without scanning the source.
