### PR TITLE
csskit_highlight/csskit/chromashift: Support owo-colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,10 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chromashift"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anstyle",
+ "owo-colors",
 ]
 
 [[package]]
@@ -608,7 +609,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "css_ast"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -641,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "css_feature_data"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "browserslist-rs",
  "chrono",
@@ -650,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "css_lexer"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "allocator-api2",
  "bitmask-enum",
@@ -671,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "css_parse"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -689,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "css_value_definition_parser"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "css_lexer",
  "heck",
@@ -703,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csskit"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anstyle",
  "bumpalo",
@@ -717,6 +718,7 @@ dependencies = [
  "csskit_lsp",
  "itertools 0.14.0",
  "miette",
+ "owo-colors",
  "serde",
  "serde_json",
  "strsim",
@@ -726,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_ast"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -741,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_derives"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "heck",
  "insta",
@@ -754,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_highlight"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anstyle",
  "bitmask-enum",
@@ -765,13 +767,15 @@ dependencies = [
  "css_lexer",
  "css_parse",
  "insta",
+ "miette",
+ "owo-colors",
  "similar",
  "strum",
 ]
 
 [[package]]
 name = "csskit_lsp"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -802,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_proc_macro"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "css_lexer",
  "css_value_definition_parser",
@@ -817,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_source_finder"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "glob",
  "grep-matcher",
@@ -833,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_spec_generator"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -855,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_transform"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -870,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_wasm"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bumpalo",
  "console_error_panic_hook",
@@ -932,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "derive_atom_set"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "heck",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ clap = { version = "4.5.48" }
 glob = { version = "0.3.3" }
 project-root = { version = "0.2.2" }
 anstyle = { version = "1.0.13" }
+owo-colors = { version = "4" }
 strsim = { version = "0.11.1" }
 
 # LSP packages

--- a/crates/chromashift/Cargo.toml
+++ b/crates/chromashift/Cargo.toml
@@ -14,7 +14,9 @@ bench = false
 
 [dependencies]
 anstyle = { workspace = true, optional = true }
+owo-colors = { workspace = true, optional = true }
 
 [features]
 default = []
 anstyle = ["dep:anstyle"]
+owo-colors = ["dep:owo-colors"]

--- a/crates/chromashift/src/conversion.rs
+++ b/crates/chromashift/src/conversion.rs
@@ -280,3 +280,32 @@ simple_from!(Srgb to anstyle::Color, via anstyle::RgbColor);
 simple_from!(XyzD50 to anstyle::Color, via anstyle::RgbColor);
 #[cfg(feature = "anstyle")]
 simple_from!(XyzD65 to anstyle::Color, via anstyle::RgbColor);
+
+#[cfg(feature = "owo-colors")]
+simple_from!(Color to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(A98Rgb to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Hsv to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Hex to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Hsl to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Hwb to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Lab to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Lch to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(LinearRgb to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Named to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Oklab to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(Oklch to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(XyzD50 to owo_colors::Rgb, via Srgb);
+#[cfg(feature = "owo-colors")]
+simple_from!(XyzD65 to owo_colors::Rgb, via Srgb);

--- a/crates/chromashift/src/srgb.rs
+++ b/crates/chromashift/src/srgb.rs
@@ -82,3 +82,17 @@ impl From<anstyle::RgbColor> for Srgb {
 		Srgb::new(value.0, value.1, value.2, 100.0)
 	}
 }
+
+#[cfg(feature = "owo-colors")]
+impl From<Srgb> for owo_colors::Rgb {
+	fn from(value: Srgb) -> Self {
+		owo_colors::Rgb(value.red, value.green, value.blue)
+	}
+}
+
+#[cfg(feature = "owo-colors")]
+impl From<owo_colors::Rgb> for Srgb {
+	fn from(value: owo_colors::Rgb) -> Self {
+		Srgb::new(value.0, value.1, value.2, 100.0)
+	}
+}

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -15,14 +15,15 @@ css_ast = { workspace = true, features = ["chromashift", "visitable"] } # @relea
 css_parse = { workspace = true } # @release
 csskit_ast = { workspace = true, features = ["dynamic-atoms"] } # @release
 csskit_lsp = { workspace = true } # @release
-csskit_highlight = { workspace = true, features = ["ansi"] } # @release
-chromashift = { workspace = true, features = ["anstyle"] } # @release
+csskit_highlight = { workspace = true } # @release
+chromashift = { workspace = true } # @release
 
 itertools = { workspace = true }
 
 clap = { workspace = true, features = ["derive", "cargo"] }
 miette = { workspace = true }
-anstyle = { workspace = true }
+anstyle = { workspace = true, optional = true }
+owo-colors = { workspace = true, optional = true }
 strsim = { workspace = true }
 
 bumpalo = { workspace = true, features = ["collections", "boxed"] }
@@ -34,7 +35,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]
-default = ["fancy"]
+default = ["fancy", "owo-colors"]
+anstyle = ["dep:anstyle", "csskit_highlight/anstyle", "chromashift/anstyle"]
+owo-colors = ["dep:owo-colors", "csskit_highlight/owo-colors", "chromashift/owo-colors"]
 miette = ["css_parse/miette", "css_ast/miette"]
 fancy = ["miette", "miette/fancy"]
 

--- a/crates/csskit/src/color_ext.rs
+++ b/crates/csskit/src/color_ext.rs
@@ -1,0 +1,122 @@
+#[cfg(not(any(feature = "anstyle", feature = "owo-colors")))]
+compile_error!("At least one of 'anstyle' or 'owo-colors' features must be enabled");
+
+use chromashift::Srgb;
+
+/// Set foreground color on text using a chromashift color type
+#[cfg(feature = "anstyle")]
+pub fn fg<T, C>(text: T, color: C) -> String
+where
+	T: std::fmt::Display,
+	C: Into<Srgb>,
+{
+	use anstyle::Style;
+	let srgb: Srgb = color.into();
+	let color = anstyle::RgbColor(srgb.red, srgb.green, srgb.blue);
+	let style = Style::new().fg_color(Some(color.into()));
+	format!("{style}{text}{style:#}")
+}
+
+/// Set foreground color on text using a chromashift color type
+#[cfg(feature = "owo-colors")]
+#[cfg(not(feature = "anstyle"))]
+pub fn fg<T, C>(text: T, color: C) -> String
+where
+	T: std::fmt::Display,
+	C: Into<Srgb>,
+{
+	use owo_colors::OwoColorize;
+	let srgb: Srgb = color.into();
+	format!("{}", text.truecolor(srgb.red, srgb.green, srgb.blue))
+}
+
+/// Set background color on text using a chromashift color type
+#[cfg(feature = "anstyle")]
+pub fn bg<T, C>(text: T, color: C) -> String
+where
+	T: std::fmt::Display,
+	C: Into<Srgb>,
+{
+	use anstyle::Style;
+	let srgb: Srgb = color.into();
+	let color = anstyle::RgbColor(srgb.red, srgb.green, srgb.blue);
+	let style = Style::new().bg_color(Some(color.into()));
+	format!("{style}{text}{style:#}")
+}
+
+/// Set background color on text using a chromashift color type
+#[cfg(feature = "owo-colors")]
+#[cfg(not(feature = "anstyle"))]
+pub fn bg<T, C>(text: T, color: C) -> String
+where
+	T: std::fmt::Display,
+	C: Into<Srgb>,
+{
+	use owo_colors::OwoColorize;
+	let srgb: Srgb = color.into();
+	format!("{}", text.on_truecolor(srgb.red, srgb.green, srgb.blue))
+}
+
+/// Color text magenta
+#[cfg(feature = "anstyle")]
+pub fn magenta<T: std::fmt::Display>(text: T) -> String {
+	use anstyle::{AnsiColor, Style};
+	let style = Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Magenta)));
+	format!("{style}{text}{style:#}")
+}
+
+/// Color text magenta
+#[cfg(feature = "owo-colors")]
+#[cfg(not(feature = "anstyle"))]
+pub fn magenta<T: std::fmt::Display>(text: T) -> String {
+	use owo_colors::OwoColorize;
+	format!("{}", text.magenta())
+}
+
+/// Color text green
+#[cfg(feature = "anstyle")]
+pub fn green<T: std::fmt::Display>(text: T) -> String {
+	use anstyle::{AnsiColor, Style};
+	let style = Style::new().fg_color(Some(anstyle::Color::Ansi(AnsiColor::Green)));
+	format!("{style}{text}{style:#}")
+}
+
+/// Color text green
+#[cfg(feature = "owo-colors")]
+#[cfg(not(feature = "anstyle"))]
+pub fn green<T: std::fmt::Display>(text: T) -> String {
+	use owo_colors::OwoColorize;
+	format!("{}", text.green())
+}
+
+/// Make text bold
+#[cfg(feature = "anstyle")]
+pub fn bold<T: std::fmt::Display>(text: T) -> String {
+	use anstyle::Style;
+	let style = Style::new().bold();
+	format!("{style}{text}{style:#}")
+}
+
+/// Make text bold
+#[cfg(feature = "owo-colors")]
+#[cfg(not(feature = "anstyle"))]
+pub fn bold<T: std::fmt::Display>(text: T) -> String {
+	use owo_colors::OwoColorize;
+	format!("{}", text.bold())
+}
+
+/// Make text dimmed
+#[cfg(feature = "anstyle")]
+pub fn dimmed<T: std::fmt::Display>(text: T) -> String {
+	use anstyle::Style;
+	let style = Style::new().dimmed();
+	format!("{style}{text}{style:#}")
+}
+
+/// Make text dimmed
+#[cfg(feature = "owo-colors")]
+#[cfg(not(feature = "anstyle"))]
+pub fn dimmed<T: std::fmt::Display>(text: T) -> String {
+	use owo_colors::OwoColorize;
+	format!("{}", text.dimmed())
+}

--- a/crates/csskit/src/main.rs
+++ b/crates/csskit/src/main.rs
@@ -3,10 +3,12 @@ use clap::{Args, ColorChoice, Parser};
 pub use errors::{CliError, CliResult};
 use std::io::{IsTerminal, stderr};
 
+mod color_ext;
 mod commands;
 mod errors;
 mod input;
 
+pub use color_ext::{bg, bold, dimmed, fg, green, magenta};
 pub use input::{InputArgs, InputSource};
 
 #[derive(Debug, Args)]

--- a/crates/csskit_highlight/Cargo.toml
+++ b/crates/csskit_highlight/Cargo.toml
@@ -25,6 +25,8 @@ bitmask-enum = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 
 anstyle = { workspace = true, optional = true }
+owo-colors = { workspace = true, optional = true }
+miette = { workspace = true, optional = true }
 
 [dev-dependencies]
 css_parse = { workspace = true }
@@ -34,4 +36,6 @@ similar = { workspace = true }
 console = { workspace = true }
 
 [features]
-ansi = ["dep:anstyle"]
+anstyle = ["dep:anstyle", "chromashift/anstyle"]
+owo-colors = ["dep:owo-colors", "chromashift/owo-colors"]
+miette = ["dep:miette", "miette/fancy", "dep:owo-colors"]

--- a/crates/csskit_highlight/src/ansi_highlight_cursor_stream.rs
+++ b/crates/csskit_highlight/src/ansi_highlight_cursor_stream.rs
@@ -1,9 +1,14 @@
-use crate::{SemanticDecoration, SemanticKind, SemanticModifier, TokenHighlighter};
-use anstyle::{AnsiColor, Color, Effects, Style};
+use crate::{AnsiTheme, SemanticDecoration, TokenHighlighter};
 use chromashift::{Named, WcagColorContrast};
 use css_lexer::{ToSpan, Token};
 use css_parse::{SourceCursor, SourceCursorSink};
 use std::fmt::{Result, Write};
+
+#[cfg(feature = "anstyle")]
+use anstyle::Style;
+#[cfg(feature = "owo-colors")]
+#[cfg(not(feature = "anstyle"))]
+use owo_colors::OwoColorize;
 
 pub struct AnsiHighlightCursorStream<'h, W: Write, T: AnsiTheme> {
 	writer: W,
@@ -37,88 +42,42 @@ impl<'a, 'h, W: Write, T: AnsiTheme> SourceCursorSink<'a> for AnsiHighlightCurso
 				} else {
 					Named::Black
 				};
-				let color_style = Style::new().bg_color(Some(bg.into())).fg_color(Some(fg.into()));
-				self.err = write!(&mut self.writer, "{color_style}{c}{color_style:#}");
+				#[cfg(feature = "anstyle")]
+				{
+					let style = Style::new().bg_color(Some(bg.into())).fg_color(Some(fg.into()));
+					self.err = write!(&mut self.writer, "{style}{c}{style:#}");
+				}
+				#[cfg(feature = "owo-colors")]
+				#[cfg(not(feature = "anstyle"))]
+				{
+					use chromashift::Srgb;
+					let bg_srgb: Srgb = bg.into();
+					let fg_srgb: Srgb = fg.into();
+					self.err = write!(
+						&mut self.writer,
+						"{}",
+						c.to_string().truecolor(fg_srgb.red, fg_srgb.green, fg_srgb.blue).on_truecolor(
+							bg_srgb.red,
+							bg_srgb.green,
+							bg_srgb.blue
+						)
+					);
+				}
 			} else {
-				let style = self.theme.get_style(highlight.kind(), highlight.modifier());
-				self.err = write!(&mut self.writer, "{style}{c}{style:#}");
+				#[cfg(feature = "anstyle")]
+				{
+					let style = self.theme.get_anstyle(highlight.kind(), highlight.modifier());
+					self.err = write!(&mut self.writer, "{style}{c}{style:#}");
+				}
+				#[cfg(feature = "owo-colors")]
+				#[cfg(not(feature = "anstyle"))]
+				{
+					let style = self.theme.get_owo_style(highlight.kind(), highlight.modifier());
+					self.err = write!(&mut self.writer, "{}", style.style(c.to_string()));
+				}
 			}
 		} else {
 			self.err = write!(&mut self.writer, "{c}");
 		}
-	}
-}
-
-pub trait AnsiTheme {
-	fn get_style(&self, kind: SemanticKind, modifier: SemanticModifier) -> Style;
-}
-
-pub struct DefaultAnsiTheme;
-impl AnsiTheme for DefaultAnsiTheme {
-	fn get_style(&self, kind: SemanticKind, modifier: SemanticModifier) -> Style {
-		let color = match kind {
-			SemanticKind::None => Color::Ansi(AnsiColor::White),
-			SemanticKind::Id => Color::Ansi256(214.into()),
-			SemanticKind::Tag => Color::Ansi256(203.into()),
-			// Bright green
-			SemanticKind::Class => Color::Ansi256(149.into()),
-			// Salmon/pink
-			SemanticKind::Wildcard => Color::Ansi256(203.into()),
-			// Bright green
-			SemanticKind::Attribute => Color::Ansi256(149.into()),
-			// Cyan
-			SemanticKind::Namespace => Color::Ansi256(81.into()),
-			// White
-			SemanticKind::Combinator => Color::Ansi(AnsiColor::White),
-			// Bright green
-			SemanticKind::PseudoClass => Color::Ansi256(149.into()),
-			// Bright green
-			SemanticKind::PseudoElement => Color::Ansi256(149.into()),
-			// Bright green
-			SemanticKind::LegacyPseudoElement => Color::Ansi256(149.into()),
-			// Bright green
-			SemanticKind::FunctionalPseudoClass => Color::Ansi256(149.into()),
-			// Bright green
-			SemanticKind::FunctionalPseudoElement => Color::Ansi256(149.into()),
-
-			// Rule Elements
-			// Salmon/pink
-			SemanticKind::AtKeyword => Color::Ansi256(203.into()),
-			// Bright green
-			SemanticKind::Prelude => Color::Ansi256(149.into()),
-
-			// Property Declarations
-			// Cyan
-			SemanticKind::Declaration => Color::Ansi256(81.into()),
-			// Cyan
-			SemanticKind::StyleValueKeyword => Color::Ansi256(81.into()),
-			// Purple
-			SemanticKind::StyleValueDimension => Color::Ansi256(141.into()),
-			// Purple
-			SemanticKind::StyleValueNumber => Color::Ansi256(141.into()),
-			// Yellow/Gold for strings
-			SemanticKind::StyleValueString => Color::Ansi256(220.into()),
-			// Blue for URLs
-			SemanticKind::StyleValueUrl => Color::Ansi256(39.into()),
-			// Magenta for colors
-			SemanticKind::StyleValueColor => Color::Ansi256(201.into()),
-			// Cyan for functions
-			SemanticKind::StyleValueFunction => Color::Ansi256(51.into()),
-			// Red for !important
-			SemanticKind::StyleValueImportant => Color::Ansi256(196.into()),
-			SemanticKind::Punctuation => Color::Ansi(AnsiColor::White),
-		};
-
-		let mut effects = Effects::new();
-		if modifier.contains(SemanticModifier::Deprecated) {
-			effects |= Effects::STRIKETHROUGH;
-		}
-		if modifier.contains(SemanticModifier::Experimental) {
-			effects |= Effects::UNDERLINE;
-		}
-		if modifier.contains(SemanticModifier::Unknown) {
-			effects |= Effects::CURLY_UNDERLINE;
-		}
-		Style::new().fg_color(Some(color)).effects(effects)
 	}
 }

--- a/crates/csskit_highlight/src/default_ansi_theme.rs
+++ b/crates/csskit_highlight/src/default_ansi_theme.rs
@@ -1,0 +1,134 @@
+pub trait AnsiTheme: Sized {
+	#[cfg(feature = "anstyle")]
+	fn get_anstyle(&self, kind: crate::SemanticKind, modifier: crate::SemanticModifier) -> anstyle::Style;
+
+	#[cfg(feature = "owo-colors")]
+	fn get_owo_style(&self, kind: crate::SemanticKind, modifier: crate::SemanticModifier) -> owo_colors::Style;
+}
+
+pub struct DefaultAnsiTheme;
+
+impl AnsiTheme for DefaultAnsiTheme {
+	#[cfg(feature = "anstyle")]
+	fn get_anstyle(&self, kind: crate::SemanticKind, modifier: crate::SemanticModifier) -> anstyle::Style {
+		use crate::SemanticKind;
+		use anstyle::{AnsiColor, Color, Effects, Style};
+
+		let color = match kind {
+			SemanticKind::None => Color::Ansi(AnsiColor::White),
+			SemanticKind::Id => Color::Ansi256(214.into()),
+			SemanticKind::Tag => Color::Ansi256(203.into()),
+			// Bright green
+			SemanticKind::Class => Color::Ansi256(149.into()),
+			// Salmon/pink
+			SemanticKind::Wildcard => Color::Ansi256(203.into()),
+			// Bright green
+			SemanticKind::Attribute => Color::Ansi256(149.into()),
+			// Cyan
+			SemanticKind::Namespace => Color::Ansi256(81.into()),
+			// White
+			SemanticKind::Combinator => Color::Ansi(AnsiColor::White),
+			// Bright green
+			SemanticKind::PseudoClass => Color::Ansi256(149.into()),
+			// Bright green
+			SemanticKind::PseudoElement => Color::Ansi256(149.into()),
+			// Bright green
+			SemanticKind::LegacyPseudoElement => Color::Ansi256(149.into()),
+			// Bright green
+			SemanticKind::FunctionalPseudoClass => Color::Ansi256(149.into()),
+			// Bright green
+			SemanticKind::FunctionalPseudoElement => Color::Ansi256(149.into()),
+
+			// Rule Elements
+			// Salmon/pink
+			SemanticKind::AtKeyword => Color::Ansi256(203.into()),
+			// Bright green
+			SemanticKind::Prelude => Color::Ansi256(149.into()),
+
+			// Property Declarations
+			// Cyan
+			SemanticKind::Declaration => Color::Ansi256(81.into()),
+			// Cyan
+			SemanticKind::StyleValueKeyword => Color::Ansi256(81.into()),
+			// Purple
+			SemanticKind::StyleValueDimension => Color::Ansi256(141.into()),
+			// Purple
+			SemanticKind::StyleValueNumber => Color::Ansi256(141.into()),
+			// Yellow/Gold for strings
+			SemanticKind::StyleValueString => Color::Ansi256(220.into()),
+			// Blue for URLs
+			SemanticKind::StyleValueUrl => Color::Ansi256(39.into()),
+			// Magenta for colors
+			SemanticKind::StyleValueColor => Color::Ansi256(201.into()),
+			// Cyan for functions
+			SemanticKind::StyleValueFunction => Color::Ansi256(51.into()),
+			// Red for !important
+			SemanticKind::StyleValueImportant => Color::Ansi256(196.into()),
+			SemanticKind::Punctuation => Color::Ansi(AnsiColor::White),
+		};
+
+		let mut effects = Effects::new();
+		if modifier.contains(crate::SemanticModifier::Deprecated) {
+			effects |= Effects::STRIKETHROUGH;
+		}
+		if modifier.contains(crate::SemanticModifier::Experimental) {
+			effects |= Effects::UNDERLINE;
+		}
+		if modifier.contains(crate::SemanticModifier::Unknown) {
+			effects |= Effects::CURLY_UNDERLINE;
+		}
+		Style::new().fg_color(Some(color)).effects(effects)
+	}
+
+	#[cfg(feature = "owo-colors")]
+	fn get_owo_style(&self, kind: crate::SemanticKind, modifier: crate::SemanticModifier) -> owo_colors::Style {
+		use crate::SemanticKind;
+		use owo_colors::{Style, XtermColors};
+
+		// Map semantic kind to owo-colors style (matching anstyle colors)
+		let mut style = match kind {
+			SemanticKind::None => Style::new(),
+			SemanticKind::Id => Style::new().color(XtermColors::UserBrightYellow),
+			SemanticKind::Tag => Style::new().color(XtermColors::UserBrightMagenta),
+			SemanticKind::Class => Style::new().color(XtermColors::UserBrightCyan),
+			SemanticKind::Wildcard => Style::new().color(XtermColors::UserBrightMagenta),
+			SemanticKind::Attribute => Style::new().color(XtermColors::UserBrightGreen),
+			SemanticKind::Namespace => Style::new().color(XtermColors::UserCyan),
+			SemanticKind::Combinator => Style::new(),
+			SemanticKind::PseudoClass => Style::new().color(XtermColors::UserBrightGreen),
+			SemanticKind::PseudoElement => Style::new().color(XtermColors::UserBrightGreen),
+			SemanticKind::LegacyPseudoElement => Style::new().color(XtermColors::UserBrightGreen),
+			SemanticKind::FunctionalPseudoClass => Style::new().color(XtermColors::UserBrightGreen),
+			SemanticKind::FunctionalPseudoElement => Style::new().color(XtermColors::UserBrightGreen),
+
+			// Rule Elements
+			SemanticKind::AtKeyword => Style::new().color(XtermColors::UserBrightMagenta),
+			SemanticKind::Prelude => Style::new().color(XtermColors::UserBrightGreen),
+
+			// Property Declarations
+			SemanticKind::Declaration => Style::new().color(XtermColors::UserCyan),
+			SemanticKind::StyleValueKeyword => Style::new().color(XtermColors::UserCyan),
+			SemanticKind::StyleValueDimension => Style::new().color(XtermColors::UserMagenta),
+			SemanticKind::StyleValueNumber => Style::new().color(XtermColors::UserMagenta),
+			SemanticKind::StyleValueString => Style::new().color(XtermColors::UserYellow),
+			SemanticKind::StyleValueUrl => Style::new().color(XtermColors::UserBlue),
+			SemanticKind::StyleValueColor => Style::new().color(XtermColors::UserBrightMagenta),
+			SemanticKind::StyleValueFunction => Style::new().color(XtermColors::UserCyan),
+			SemanticKind::StyleValueImportant => Style::new().color(XtermColors::UserRed),
+			SemanticKind::Punctuation => Style::new(),
+		};
+
+		// Apply effects based on modifiers
+		if modifier.contains(crate::SemanticModifier::Deprecated) {
+			style = style.strikethrough();
+		}
+		if modifier.contains(crate::SemanticModifier::Experimental) {
+			style = style.underline();
+		}
+		if modifier.contains(crate::SemanticModifier::Unknown) {
+			style = style.underline(); // TODO: owo-colors doesn't have curly underline
+		}
+
+		style
+	}
+}

--- a/crates/csskit_highlight/src/highlight.rs
+++ b/crates/csskit_highlight/src/highlight.rs
@@ -1,0 +1,132 @@
+use crate::{AnsiHighlightCursorStream, AnsiTheme, DefaultAnsiTheme, SemanticDecoration, TokenHighlighter};
+use css_ast::{CssAtomSet, StyleSheet, Visitable};
+use css_lexer::{Lexer, SourceOffset, Span};
+use css_parse::{SourceCursor, SourceCursorSink};
+use miette::SpanContents;
+use miette::highlighters::{Highlighter, HighlighterState};
+use owo_colors::Style;
+
+/// Highlight CSS source code with ANSI color codes
+///
+/// This function is used by the `find` command to highlight matched lines.
+pub fn highlight_css(source: &str, stylesheet: &StyleSheet) -> String {
+	let mut highlighter = TokenHighlighter::new();
+	stylesheet.accept(&mut highlighter);
+
+	let lexer = Lexer::new(&CssAtomSet::ATOMS, source);
+	let mut highlighted = String::new();
+	let mut stream = AnsiHighlightCursorStream::new(&mut highlighted, &highlighter, DefaultAnsiTheme);
+
+	for cursor in lexer {
+		stream.append(SourceCursor::from(cursor, cursor.str_slice(source)));
+	}
+
+	highlighted
+}
+
+/// Miette highlighter for CSS syntax highlighting
+pub struct CssHighlighter {
+	source: String,
+	token_colors: TokenHighlighter,
+}
+
+impl CssHighlighter {
+	pub fn new(source: String, stylesheet: &StyleSheet) -> Self {
+		let mut token_colors = TokenHighlighter::new();
+		stylesheet.accept(&mut token_colors);
+		Self { source, token_colors }
+	}
+}
+
+impl Highlighter for CssHighlighter {
+	fn start_highlighter_state<'h>(&'h self, _source: &dyn SpanContents<'_>) -> Box<dyn HighlighterState + 'h> {
+		Box::new(CssHighlighterState::new(&self.source, &self.token_colors))
+	}
+}
+
+struct CssHighlighterState<'a> {
+	source: &'a str,
+	token_colors: &'a TokenHighlighter,
+	current_line: usize,
+	theme: DefaultAnsiTheme,
+}
+
+impl<'a> CssHighlighterState<'a> {
+	fn new(source: &'a str, token_colors: &'a TokenHighlighter) -> Self {
+		Self { source, token_colors, current_line: 0, theme: DefaultAnsiTheme }
+	}
+}
+
+impl<'a> HighlighterState for CssHighlighterState<'a> {
+	fn highlight_line<'s>(&mut self, line: &'s str) -> Vec<owo_colors::Styled<&'s str>> {
+		let mut result = Vec::new();
+
+		// Find the byte offset of this line in the source
+		let line_offset: usize = self.source.lines().take(self.current_line).map(|l| l.len() + 1).sum();
+		self.current_line += 1;
+
+		// Lex just this line
+		let lexer = Lexer::new(&CssAtomSet::ATOMS, line);
+		let mut last_end = 0;
+
+		for cursor in lexer {
+			let start = cursor.offset().0 as usize;
+			let token_str = cursor.str_slice(line);
+			let end = start + token_str.len();
+
+			// Get the color for this token based on its global position
+			let global_offset = line_offset + start;
+			let span =
+				Span::new(SourceOffset(global_offset as u32), SourceOffset((global_offset + token_str.len()) as u32));
+			let color = self.token_colors.get(span);
+
+			// Add any whitespace before this token
+			if start > last_end {
+				result.push(Style::default().style(&line[last_end..start]));
+			}
+
+			// Add the colored token - use csskit_highlight color if available
+			let token_str = &line[start..end];
+
+			// Check for background color decoration first (for color values)
+			let style = if let Some(highlight) = color
+				&& let SemanticDecoration::BackgroundColor(bg) = highlight.decoration()
+			{
+				use chromashift::{Named, Srgb, WcagColorContrast};
+
+				// Choose contrasting foreground color
+				let fg = if bg.wcag_contrast_ratio(Named::White) > bg.wcag_contrast_ratio(Named::Black) {
+					Named::White
+				} else {
+					Named::Black
+				};
+
+				// Convert to Srgb to get RGB components
+				let bg_srgb: Srgb = bg.into();
+				let fg_srgb: Srgb = fg.into();
+
+				Style::new().truecolor(fg_srgb.red, fg_srgb.green, fg_srgb.blue).on_truecolor(
+					bg_srgb.red,
+					bg_srgb.green,
+					bg_srgb.blue,
+				)
+			} else if let Some(highlight) = color {
+				// Use the theme to get the owo-colors style
+				self.theme.get_owo_style(highlight.kind(), highlight.modifier())
+			} else {
+				// Fallback: just return unstyled
+				Style::default()
+			};
+
+			result.push(style.style(token_str));
+			last_end = end;
+		}
+
+		// Add any remaining text
+		if last_end < line.len() {
+			result.push(Style::default().style(&line[last_end..]));
+		}
+
+		result
+	}
+}

--- a/crates/csskit_highlight/src/lib.rs
+++ b/crates/csskit_highlight/src/lib.rs
@@ -8,10 +8,20 @@ use strum::{Display, VariantNames};
 
 mod css;
 
-#[cfg(feature = "ansi")]
+#[cfg(any(feature = "anstyle", feature = "owo-colors"))]
+mod default_ansi_theme;
+#[cfg(any(feature = "anstyle", feature = "owo-colors"))]
+pub use default_ansi_theme::{AnsiTheme, DefaultAnsiTheme};
+
+#[cfg(any(feature = "anstyle", feature = "owo-colors"))]
 mod ansi_highlight_cursor_stream;
-#[cfg(feature = "ansi")]
-pub use ansi_highlight_cursor_stream::{AnsiHighlightCursorStream, DefaultAnsiTheme};
+#[cfg(any(feature = "anstyle", feature = "owo-colors"))]
+pub use ansi_highlight_cursor_stream::AnsiHighlightCursorStream;
+
+#[cfg(feature = "miette")]
+mod highlight;
+#[cfg(feature = "miette")]
+pub use highlight::{CssHighlighter, highlight_css};
 
 #[cfg(test)]
 mod test_helpers;


### PR DESCRIPTION
While we've traditionally used anstyle for ascii styling, miette supports owo-colors, and to add syntax highlighting it
requires data returned with the owo-colors `Style` struct. Both libraries are
fairly similar and we don't have a particular allegiance to one, but given
miette has a requirement, we need to support owo-colors.

This change implements `owo-colors` as an optional feature flag for chromashift,
which enables turning `chromashift::Srgb` into `owo-colors::Rgb`. The same flag
in csskit_highlight enables `get_owo_style()` on `DefaultAnsiTheme` which the
`AnsiHighlightCursorStream` uses if the flag is enabled. Lastly, csskit gets the
same flag and will switch from using anstyle to owo-colors. We'll likely keep
both around for a while just in case, but eventually drop anstyle if owo-colors
works out fine.
