### PR TITLE
csskit_ast/csskit: Implement Rule sheets, `csskit check` command

### DIFF
--- a/.mise-tasks/csskit-acceptance
+++ b/.mise-tasks/csskit-acceptance
@@ -100,6 +100,56 @@ check_find() {
 	fi
 }
 
+check_check() {
+	css_file="$1"
+	check_file="$2"
+
+	# Parse front-matter: first line is .cks basename, second is ---, rest is expected stderr
+	cks_basename=$(head -n1 "$check_file")
+	expected=$(tail -n +3 "$check_file")
+
+	# Determine directory and construct .cks path
+	dir=$(dirname "$css_file")
+	cks_file="$dir/$cks_basename.cks"
+
+	if [ ! -f "$cks_file" ]; then
+		echo " $FAIL check $cks_basename $css_file (.cks file not found)"
+		failed=$((failed + 1))
+		return
+	fi
+
+	if actual=$($CSSKIT --color never check "$cks_file" "$css_file" 2>&1); then
+		if [ "$actual" = "$expected" ]; then
+			echo " $PASS check $cks_basename $css_file"
+			passed=$((passed + 1))
+		else
+			echo " $FAIL check $cks_basename $css_file"
+			if ! $QUIET; then
+				echo "Expected:"
+				echo "$expected"
+				echo "Actual:"
+				echo "$actual"
+			fi
+			failed=$((failed + 1))
+		fi
+	else
+		# Command failed - compare stderr with expected
+		if [ "$actual" = "$expected" ]; then
+			echo " $PASS check $cks_basename $css_file"
+			passed=$((passed + 1))
+		else
+			echo " $FAIL check $cks_basename $css_file (command failed)"
+			if ! $QUIET; then
+				echo "Expected:"
+				echo "$expected"
+				echo "Actual:"
+				echo "$actual"
+			fi
+			failed=$((failed + 1))
+		fi
+	fi
+}
+
 for css in coverage/basic/*.css coverage/popular/*.css; do
 	[ -f "$css" ] || continue
 	case "$css" in *.min.css | *.fmt.css) continue ;; esac
@@ -114,6 +164,12 @@ for css in coverage/basic/*.css coverage/popular/*.css; do
 	for find_file in "$base".find.*.txt; do
 		[ -f "$find_file" ] || continue
 		check_find "$css" "$find_file"
+	done
+
+	# Check check tests (*.check.N.txt files)
+	for check_file in "$base".check.*.txt; do
+		[ -f "$check_file" ] || continue
+		check_check "$css" "$check_file"
 	done
 done
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ dependencies = [
  "csskit_derives",
  "derive_atom_set",
  "indexmap",
+ "miette",
  "smallvec",
 ]
 

--- a/coverage/basic/basic-stats.cks
+++ b/coverage/basic/basic-stats.cks
@@ -1,0 +1,5 @@
+@stat --total-rules { type: counter; }
+
+style-rule {
+  collect: --total-rules;
+}

--- a/coverage/basic/error-prefixed.cks
+++ b/coverage/basic/error-prefixed.cks
@@ -1,0 +1,4 @@
+:prefixed {
+  level: error;
+  diagnostic: "Do not use prefixed properties";
+}

--- a/coverage/basic/many-rules.check.1.txt
+++ b/coverage/basic/many-rules.check.1.txt
@@ -1,0 +1,12 @@
+warn-many-rules
+---
+  ⚠ Too many rules: 3
+   ╭─[coverage/basic/many-rules.css:1:1]
+ 1 │ ╭─▶ .foo { color: red; }
+ 2 │ │   .bar { color: blue; }
+ 3 │ ├─▶ .baz { color: green; }
+   · ╰──── Too many rules: 3
+   ╰────
+
+Statistics:
+  --rule-count: 3

--- a/coverage/basic/many-rules.check.2.txt
+++ b/coverage/basic/many-rules.check.2.txt
@@ -1,0 +1,27 @@
+warn-color-usage
+---
+  ☞ Color property found
+   ╭─[coverage/basic/many-rules.css:1:8]
+ 1 │ .foo { color: red; }
+   ·        ─────┬─────
+   ·             ╰── Color property found
+ 2 │ .bar { color: blue; }
+   ╰────
+  ☞ Color property found
+   ╭─[coverage/basic/many-rules.css:2:8]
+ 1 │ .foo { color: red; }
+ 2 │ .bar { color: blue; }
+   ·        ──────┬─────
+   ·              ╰── Color property found
+ 3 │ .baz { color: green; }
+   ╰────
+  ☞ Color property found
+   ╭─[coverage/basic/many-rules.css:3:8]
+ 2 │ .bar { color: blue; }
+ 3 │ .baz { color: green; }
+   ·        ──────┬──────
+   ·              ╰── Color property found
+   ╰────
+
+Statistics:
+  --color-props: 3

--- a/coverage/basic/many-rules.css
+++ b/coverage/basic/many-rules.css
@@ -1,0 +1,3 @@
+.foo { color: red; }
+.bar { color: blue; }
+.baz { color: green; }

--- a/coverage/basic/rule.check.1.txt
+++ b/coverage/basic/rule.check.1.txt
@@ -1,0 +1,5 @@
+basic-stats
+---
+
+Statistics:
+  --total-rules: 1

--- a/coverage/basic/warn-color-usage.cks
+++ b/coverage/basic/warn-color-usage.cks
@@ -1,0 +1,7 @@
+@stat --color-props { type: counter; }
+
+style-rule [name=color] {
+  collect: --color-props;
+  diagnostic: "Color property found";
+  level: advice;
+}

--- a/coverage/basic/warn-many-rules.cks
+++ b/coverage/basic/warn-many-rules.cks
@@ -1,0 +1,10 @@
+@stat --rule-count { type: counter; }
+
+style-rule {
+  collect: --rule-count;
+}
+
+@when (--rule-count > 2) {
+  level: warning;
+  diagnostic: "Too many rules: " --rule-count;
+}

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -11,11 +11,11 @@ repository.workspace = true
 
 [dependencies]
 css_lexer = { workspace = true } # @release
-css_ast = { workspace = true, features = ["chromashift", "visitable"] } # @release
-css_parse = { workspace = true } # @release
-csskit_ast = { workspace = true, features = ["dynamic-atoms"] } # @release
+css_ast = { workspace = true, features = ["chromashift", "visitable", "miette"] } # @release
+css_parse = { workspace = true, features = ["miette"] } # @release
+csskit_ast = { workspace = true, features = ["dynamic-atoms", "miette"] } # @release
 csskit_lsp = { workspace = true } # @release
-csskit_highlight = { workspace = true } # @release
+csskit_highlight = { workspace = true, features = ["miette"] } # @release
 chromashift = { workspace = true } # @release
 
 itertools = { workspace = true }

--- a/crates/csskit/src/commands/check.rs
+++ b/crates/csskit/src/commands/check.rs
@@ -1,10 +1,22 @@
-use crate::{CliResult, GlobalConfig};
+use crate::{CliError, CliResult, GlobalConfig, commands::format_diagnostic_error};
+use bumpalo::Bump;
 use clap::Args;
+use css_ast::CssAtomSet;
+use css_lexer::{DynAtomSet, Lexer, RegisteredAtomSet};
+use css_parse::Parser;
+use csskit_ast::{Collector, CsskitAtomSet, ResolvedDiagnosticLevel, StatType, sheet::Sheet};
+use csskit_highlight::CssHighlighter;
+use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource, Report};
+use std::{collections::HashMap, fs};
 
 /// Report potential issues around some CSS files
 #[derive(Debug, Args)]
 pub struct Check {
-	/// A list of CSS files to build. Each input will result in one output file. If no files are provided, reads from STDIN.
+	/// The csskit sheet file (.cks)
+	#[arg(value_parser)]
+	sheet: String,
+
+	/// A list of CSS files to check
 	#[arg(value_parser)]
 	input: Vec<String>,
 
@@ -15,8 +27,95 @@ pub struct Check {
 
 impl Check {
 	pub fn run(&self, config: GlobalConfig) -> CliResult {
-		let GlobalConfig { .. } = config;
-		let Self { input, fix } = self;
-		todo!("Check ({:?}, {:?})", input, fix);
+		let Self { sheet, input, fix } = self;
+
+		if *fix {
+			todo!()
+		}
+
+		let bump = Bump::new();
+
+		// Read and parse the csskit sheet
+		let rule_source = fs::read_to_string(sheet)?;
+		let rule_lexer = Lexer::new(CsskitAtomSet::get_dyn_set(), &rule_source);
+		let mut rule_parser = Parser::new(&bump, &rule_source, rule_lexer);
+		let rule_result = rule_parser.parse_entirely::<Sheet>();
+		let parsed_rules = rule_result.output.ok_or_else(|| {
+			if let Some(e) = rule_result.errors.first() {
+				eprintln!("{}", format_diagnostic_error(e, &rule_source, sheet));
+			}
+			CliError::ParseFailed
+		})?;
+
+		// Aggregate statistics across all files
+		let mut aggregated_stats = HashMap::new();
+		let mut error_count = 0;
+
+		for css_file_path in input.iter() {
+			let css_source = fs::read_to_string(css_file_path)?;
+			let css_lexer = Lexer::new(&CssAtomSet::ATOMS, &css_source);
+			let mut css_parser = Parser::new(&bump, &css_source, css_lexer);
+			let css_result = css_parser.parse_entirely();
+
+			let stylesheet = css_result.output.ok_or_else(|| {
+				if let Some(e) = css_result.errors.first() {
+					eprintln!("{}", format_diagnostic_error(e, &css_source, css_file_path));
+				}
+				CliError::ParseFailed
+			})?;
+
+			let mut collector = Collector::new(&parsed_rules, &rule_source, &bump);
+			collector.collect(&stylesheet, &css_source);
+
+			let mut file_failed = false;
+
+			for diagnostic in collector.diagnostics(&css_source) {
+				if matches!(diagnostic.severity, ResolvedDiagnosticLevel::Error) && !file_failed {
+					error_count += 1;
+					file_failed = true;
+				}
+
+				let handler = if config.colors() {
+					let highlighter = CssHighlighter::new(css_source.clone(), &stylesheet);
+					GraphicalReportHandler::new_themed(GraphicalTheme::unicode()).with_syntax_highlighting(highlighter)
+				} else {
+					GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor())
+				};
+
+				let miette_diag = diagnostic.into_miette();
+				let named_source = NamedSource::new(css_file_path, css_source.clone());
+				let report = Report::new(miette_diag).with_source_code(named_source);
+				let mut output = String::new();
+				if handler.render_report(&mut output, &*report).is_ok() {
+					eprint!("{}", output);
+				}
+			}
+
+			for (stat_name, (stat_type, count)) in collector.stats() {
+				let entry = aggregated_stats.entry(*stat_name).or_insert((*stat_type, 0));
+				entry.1 += count;
+			}
+		}
+
+		// Output aggregated statistics summary
+		if !aggregated_stats.is_empty() {
+			println!("\nStatistics:");
+			let mut stat_entries: Vec<_> = aggregated_stats
+				.iter()
+				.map(|(name, val)| (CsskitAtomSet::get_dyn_set().bits_to_str(name.as_bits()), val))
+				.collect();
+			stat_entries.sort_by_key(|(name, _)| *name);
+			for (name, (stat_type, count)) in stat_entries {
+				let type_label = match stat_type {
+					StatType::Counter => "",
+					StatType::Bytes => " bytes",
+					StatType::Lines => " lines",
+				};
+				println!("  --{}: {}{}", name, count, type_label);
+			}
+		}
+
+		// Return error if we encountered any error-level diagnostics
+		if error_count > 0 { Err(CliError::Checks(error_count)) } else { Ok(()) }
 	}
 }

--- a/crates/csskit/src/commands/mod.rs
+++ b/crates/csskit/src/commands/mod.rs
@@ -71,17 +71,14 @@ impl Commands {
 }
 
 pub fn format_diagnostic_error(err: &Diagnostic, source: &str, file_name: &str) -> String {
-	#[cfg(feature = "miette")]
-	{
-		use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
-		let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
-		let mut report = String::new();
-		let named = NamedSource::new(file_name, source.to_string());
-		let miette_err = err.into_diagnostic(source);
-		let err_with_source = miette::Report::new(miette_err).with_source_code(named);
-		if handler.render_report(&mut report, &*err_with_source).is_ok() {
-			return report;
-		}
+	use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource};
+	let handler = GraphicalReportHandler::new_themed(GraphicalTheme::unicode_nocolor());
+	let mut report = String::new();
+	let named = NamedSource::new(file_name, source.to_string());
+	let miette_err = err.into_diagnostic(source);
+	let err_with_source = miette::Report::new(miette_err).with_source_code(named);
+	if handler.render_report(&mut report, &*err_with_source).is_ok() {
+		return report;
 	}
 	let DiagnosticMeta { code, message, help, .. } = (err.formatter)(err, source);
 	format!("Error [{code}]: {message}\nHelp: {help}\n")

--- a/crates/csskit_ast/Cargo.toml
+++ b/crates/csskit_ast/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 
 [dependencies]
 bitmask-enum = { workspace = true }
-css_lexer = { workspace = true } # @release
+css_lexer = { workspace = true, features = ["dynamic-atoms"] } # @release
 css_parse = { workspace = true } # @release
 css_ast = { workspace = true, features = ["visitable"] } # @release
 csskit_derives = { workspace = true } # @release
@@ -22,6 +22,7 @@ derive_atom_set = { workspace = true } # @release
 bumpalo = { workspace = true, features = ["collections", "boxed"] }
 indexmap = { workspace = true }
 smallvec = { workspace = true }
+miette = { workspace = true, optional = true }
 
 [dev-dependencies]
 css_parse = { workspace = true, features = ["testing"] } # @release
@@ -33,3 +34,4 @@ css_ast = { workspace = true, features = ["visitable"] } # @release
 default = []
 # Enables dynamic atom interning via CssLexer's DynAtomRegistry
 dynamic-atoms = ["css_lexer/dynamic-atoms"]
+miette = ["dep:miette", "css_lexer/miette"]

--- a/crates/csskit_ast/build.rs
+++ b/crates/csskit_ast/build.rs
@@ -26,6 +26,28 @@ pub enum CsskitAtomSet {{
 	Ms,
 	O,
 
+	// Boolean operators
+	And,
+	Or,
+	True,
+	False,
+
+	// Stats atoms
+	Advice,
+	Attr,
+	Bytes,
+	Collect,
+	Counter,
+	Diagnostic,
+	Error,
+	Level,
+	Lines,
+	Stat,
+	Type,
+	Unique,
+	Warning,
+	When,
+
 	// Pseudo-classes
 	Important,
 	Custom,

--- a/crates/csskit_ast/src/collector/mod.rs
+++ b/crates/csskit_ast/src/collector/mod.rs
@@ -1,0 +1,522 @@
+use crate::{
+	CsskitAtomSet, StatDeclarationValue, StatTypeValue,
+	rule_block::{
+		DiagnosticComponent, DiagnosticFunction, DiagnosticLevel as RuleDiagnosticLevel, NestedRule,
+		RuleDeclarationValue,
+	},
+	selector::{MatchOutput, QuerySelectorList, SelectorMatcher},
+	sheet::{Rule, Sheet},
+	when_rule::{ComparisonOperator, WhenCondition, WhenFeature},
+};
+use bumpalo::{Bump, collections::Vec, vec};
+use css_ast::{AtomSet, PropertyKind, StyleSheet};
+use css_lexer::{Atom, Cursor, RegisteredAtomSet, SourceCursor, SourceOffset, Span, ToSpan};
+#[cfg(feature = "miette")]
+use miette::{LabeledSpan, MietteDiagnostic, Severity as MietteSeverity};
+use smallvec::SmallVec;
+use std::collections::{HashMap, HashSet};
+
+#[cfg(test)]
+mod tests;
+
+/// Diagnostic severity level for collector diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedDiagnosticLevel {
+	Error,
+	Warning,
+	Advice,
+}
+
+#[cfg(feature = "miette")]
+impl From<ResolvedDiagnosticLevel> for MietteSeverity {
+	fn from(value: ResolvedDiagnosticLevel) -> Self {
+		match value {
+			ResolvedDiagnosticLevel::Error => MietteSeverity::Error,
+			ResolvedDiagnosticLevel::Warning => MietteSeverity::Warning,
+			ResolvedDiagnosticLevel::Advice => MietteSeverity::Advice,
+		}
+	}
+}
+
+/// A diagnostic produced by the collector for a matched rule.
+#[derive(Debug, Clone)]
+pub struct CollectorDiagnostic {
+	/// Severity of the diagnostic
+	pub severity: ResolvedDiagnosticLevel,
+	/// Span of the matched node in the CSS source
+	pub span: Span,
+	/// Resolved diagnostic message
+	pub message: String,
+}
+
+impl CollectorDiagnostic {
+	/// Create a new collector diagnostic.
+	pub fn new(severity: ResolvedDiagnosticLevel, span: Span, message: String) -> Self {
+		Self { severity, span, message }
+	}
+
+	/// Convert to a Miette diagnostic for display.
+	#[cfg(feature = "miette")]
+	pub fn into_miette(self) -> MietteDiagnostic {
+		let label = LabeledSpan::new_with_span(Some(self.message.clone()), self.span);
+		MietteDiagnostic::new(self.message).with_severity(self.severity.into()).with_labels(std::vec![label])
+	}
+}
+
+/// The type of a stat, determining how values are collected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatType {
+	/// Counts matching nodes
+	Counter,
+	/// Sums byte sizes of matching nodes
+	Bytes,
+	/// Counts lines in matching nodes
+	Lines,
+}
+
+pub type Stats = HashMap<Atom<CsskitAtomSet>, (StatType, usize)>;
+
+/// Extracted rule data from rule block declarations.
+struct ExtractedRuleData<'a> {
+	/// Stats to collect when this rule matches
+	collectors: SmallVec<[Atom<CsskitAtomSet>; 1]>,
+	/// Optional diagnostic to emit (level, message template components)
+	diagnostic: Option<(ResolvedDiagnosticLevel, &'a [DiagnosticComponent])>,
+	/// Stats referenced in diagnostic message (as atom bits) - need to be snapshotted
+	diagnostic_stats: HashSet<u32>,
+}
+
+/// A rule that may be a selector-based rule or a standalone conditional diagnostic.
+#[derive(Debug, Clone)]
+pub struct CollectionRule<'a> {
+	/// The selector to match against CSS nodes (None for conditional diagnostics without selectors)
+	pub selector: Option<&'a QuerySelectorList<'a>>,
+	/// The stat names to collect when nodes match
+	pub collectors: SmallVec<[Atom<CsskitAtomSet>; 1]>,
+	/// Per-match diagnostics to emit (level, message template components)
+	pub diagnostic: Option<(ResolvedDiagnosticLevel, &'a [DiagnosticComponent])>,
+	/// Stats referenced in the diagnostic message (as atom bits) - need to be snapshotted
+	pub diagnostic_stats: HashSet<u32>,
+	/// Conditions that must all be true for this rule to execute (AND conjunction)
+	/// Empty vec means unconditional.
+	pub conditions: Vec<'a, &'a WhenCondition<'a>>,
+	/// Span context for selectorless rules (from parent NodeRule or StyleSheet root)
+	/// Used for bytes/lines collection when there's no selector to match against
+	pub parent_span: Span,
+	/// A collection of matches with stat snapshots for diagnostic message resolution
+	matches: Vec<'a, MatchOutput>,
+}
+
+/// The main collector that executes collection rules against CSS.
+pub struct Collector<'a> {
+	/// The Collector sheet source
+	source: &'a str,
+	/// Stat definitions from @stat rules
+	stats: Stats,
+	/// All collection rules (both with and without selectors)
+	collection_rules: Vec<'a, CollectionRule<'a>>,
+	/// Allocator for string parsing
+	allocator: &'a Bump,
+}
+
+impl<'a> Collector<'a> {
+	/// Extract collection rule data from rule block declarations.
+	fn extract_rule_data(
+		&mut self,
+		declarations: &'a [css_parse::Declaration<'a, RuleDeclarationValue<'a>, ()>],
+	) -> ExtractedRuleData<'a> {
+		let mut collectors = SmallVec::new();
+		let mut diagnostic_level = ResolvedDiagnosticLevel::Advice;
+		let mut diagnostic_components = None;
+
+		for decl in declarations {
+			match &decl.value {
+				RuleDeclarationValue::Collect(dashed_ident) => {
+					let name = CsskitAtomSet::get_dyn_set().atom_from_bits(Cursor::from(*dashed_ident).atom_bits());
+					collectors.push(name);
+					self.stats.entry(name).or_insert((StatType::Counter, 0));
+				}
+				RuleDeclarationValue::Diagnostic(components) => diagnostic_components = Some(components.as_slice()),
+				RuleDeclarationValue::Level(level) => {
+					diagnostic_level = match level {
+						RuleDiagnosticLevel::Warning(_) => ResolvedDiagnosticLevel::Warning,
+						RuleDiagnosticLevel::Advice(_) => ResolvedDiagnosticLevel::Advice,
+						RuleDiagnosticLevel::Error(_) => ResolvedDiagnosticLevel::Error,
+					}
+				}
+			}
+		}
+
+		let diagnostic = diagnostic_components.map(|c| (diagnostic_level, c));
+		let mut diagnostic_stats = HashSet::new();
+		if let Some((_, components)) = &diagnostic {
+			for component in *components {
+				if let DiagnosticComponent::DashedIdent(dashed_ident) = component {
+					diagnostic_stats.insert(Cursor::from(*dashed_ident).atom_bits());
+				}
+			}
+		}
+
+		ExtractedRuleData { collectors, diagnostic, diagnostic_stats }
+	}
+
+	/// Process nested rules and add them to collection rules.
+	/// The `conditions` parameter contains all conditions that must be true for nested rules to execute.
+	/// The `parent_span` parameter provides span context for selectorless rules (from parent NodeRule or StyleSheet).
+	fn process_nested_rules(
+		&mut self,
+		nested_rules: &'a [NestedRule<'a>],
+		conditions: &Vec<'a, &'a WhenCondition<'a>>,
+		parent_span: Span,
+	) {
+		for nested_rule in nested_rules {
+			match nested_rule {
+				NestedRule::NodeRule(node_rule) => {
+					let rule_data = self.extract_rule_data(&node_rule.block.declarations);
+					let node_span = node_rule.to_span();
+
+					self.collection_rules.push(CollectionRule {
+						selector: Some(&node_rule.selector),
+						collectors: rule_data.collectors,
+						diagnostic: rule_data.diagnostic,
+						diagnostic_stats: rule_data.diagnostic_stats,
+						conditions: conditions.clone(),
+						parent_span: node_span,
+						matches: vec![in self.allocator],
+					});
+
+					self.process_nested_rules(&node_rule.block.rules, conditions, node_span);
+				}
+				NestedRule::WhenRule(when_rule) => {
+					if !when_rule.condition.is_valid(self.source) {
+						continue;
+					}
+
+					let mut combined_conditions = conditions.clone();
+					combined_conditions.push(&when_rule.condition);
+
+					let rule_data = self.extract_rule_data(&when_rule.block.declarations);
+					if !rule_data.collectors.is_empty() || rule_data.diagnostic.is_some() {
+						self.collection_rules.push(CollectionRule {
+							selector: None,
+							collectors: rule_data.collectors,
+							diagnostic: rule_data.diagnostic,
+							diagnostic_stats: rule_data.diagnostic_stats,
+							conditions: combined_conditions.clone(),
+							parent_span,
+							matches: vec![in self.allocator],
+						});
+					}
+
+					self.process_nested_rules(&when_rule.block.rules, &combined_conditions, parent_span);
+				}
+				NestedRule::Unknown(_) => {}
+			}
+		}
+	}
+
+	/// Create a new Collector from a parsed Sheet.
+	pub fn new(sheet: &'a Sheet<'a>, source: &'a str, allocator: &'a Bump) -> Self {
+		let stats = HashMap::new();
+		let collection_rules = vec![in allocator];
+		let mut collector = Self { source, stats, collection_rules, allocator };
+
+		for rule in sheet.rules.iter() {
+			match rule {
+				Rule::Stat(stat_rule) => {
+					let cursor = Cursor::from(stat_rule.name);
+					let name = CsskitAtomSet::get_dyn_set().atom_from_bits(cursor.atom_bits());
+					let mut stat_type = StatType::Counter;
+					for decl in &stat_rule.block.declarations {
+						match &decl.value {
+							StatDeclarationValue::Type(type_value) => {
+								stat_type = match type_value {
+									StatTypeValue::Counter(_) => StatType::Counter,
+									StatTypeValue::Bytes(_) => StatType::Bytes,
+									StatTypeValue::Lines(_) => StatType::Lines,
+								};
+							}
+						}
+					}
+					collector.stats.insert(name, (stat_type, 0));
+				}
+				Rule::NodeRule(node_rule) => {
+					let rule_data = collector.extract_rule_data(&node_rule.block.declarations);
+					let node_span = node_rule.to_span();
+
+					collector.collection_rules.push(CollectionRule {
+						selector: Some(&node_rule.selector),
+						collectors: rule_data.collectors,
+						diagnostic: rule_data.diagnostic,
+						diagnostic_stats: rule_data.diagnostic_stats,
+						conditions: vec![in allocator],
+						parent_span: node_span,
+						matches: vec![in allocator],
+					});
+
+					collector.process_nested_rules(&node_rule.block.rules, &vec![in allocator], node_span);
+				}
+				Rule::WhenRule(when_rule) => {
+					if !when_rule.condition.is_valid(source) {
+						continue;
+					}
+
+					let conditions = vec![in allocator; &when_rule.condition];
+
+					let rule_data = collector.extract_rule_data(&when_rule.block.declarations);
+					if !rule_data.collectors.is_empty() || rule_data.diagnostic.is_some() {
+						collector.collection_rules.push(CollectionRule {
+							selector: None,
+							collectors: rule_data.collectors,
+							diagnostic: rule_data.diagnostic,
+							diagnostic_stats: rule_data.diagnostic_stats,
+							conditions: conditions.clone(),
+							// Use a placeholder span - will be updated with stylesheet span in collect()
+							parent_span: Span::new(SourceOffset(0), SourceOffset(0)),
+							matches: vec![in allocator],
+						});
+					}
+
+					collector.process_nested_rules(
+						&when_rule.block.rules,
+						&conditions,
+						Span::new(SourceOffset(0), SourceOffset(0)),
+					);
+				}
+				_ => {}
+			}
+		}
+
+		collector
+	}
+
+	/// Resolve a diagnostic message template for a specific match.
+	fn resolve_diagnostic_message(
+		&self,
+		components: &[DiagnosticComponent],
+		match_output: &MatchOutput,
+		css_source: &str,
+	) -> String {
+		let mut message = String::new();
+		for component in components {
+			match component {
+				DiagnosticComponent::String(string_token) => {
+					let cursor = Cursor::from(*string_token);
+					let source_slice = cursor.str_slice(self.source);
+					let source_cursor = SourceCursor::from(cursor, source_slice);
+					message.push_str(source_cursor.parse(self.allocator).as_str());
+				}
+				DiagnosticComponent::DashedIdent(dashed_ident) => {
+					let stat_bits = Cursor::from(*dashed_ident).atom_bits();
+					let count = match_output
+						.stat_snapshot
+						.iter()
+						.find(|(bits, _)| *bits == stat_bits)
+						.map(|(_, count)| *count)
+						.unwrap_or(0);
+					message.push_str(&count.to_string());
+				}
+				DiagnosticComponent::Function(func) => match func {
+					DiagnosticFunction::Attr(attr_func) => {
+						let atom = CsskitAtomSet::from_bits(Cursor::from(attr_func.name).atom_bits());
+						let property_kind = atom.to_property_kind();
+						let value = match property_kind {
+							Some(PropertyKind::Name) => match_output.properties.name,
+							_ => None,
+						};
+						if let Some(cursor) = value {
+							message.push_str(cursor.str_slice(css_source));
+						}
+					}
+					DiagnosticFunction::Size(_size_func) => {
+						message.push_str(&match_output.size.to_string());
+					}
+				},
+			}
+		}
+		message
+	}
+
+	/// Evaluate a single if condition feature against stats.
+	fn evaluate_if_feature(&self, feature: &WhenFeature) -> bool {
+		let stat_bits = Cursor::from(feature.stat).atom_bits();
+		let stat_name = CsskitAtomSet::get_dyn_set().atom_from_bits(stat_bits);
+		let stat_value = self.stats.get(&stat_name).map(|(_, count)| *count).unwrap_or(0);
+
+		let threshold_cursor = Cursor::from(feature.value);
+		let threshold_str = threshold_cursor.str_slice(self.source);
+		let threshold = threshold_str.parse::<usize>().unwrap_or(0);
+
+		match feature.operator {
+			ComparisonOperator::GreaterThan(_) => stat_value > threshold,
+			ComparisonOperator::LessThan(_) => stat_value < threshold,
+			ComparisonOperator::GreaterThanOrEqual(_) => stat_value >= threshold,
+			ComparisonOperator::LessThanOrEqual(_) => stat_value <= threshold,
+			ComparisonOperator::Equal(_) => stat_value == threshold,
+		}
+	}
+
+	/// Evaluate an if condition (supporting and/or/not).
+	fn evaluate_if_condition(&self, condition: &WhenCondition) -> bool {
+		match condition {
+			WhenCondition::Is(feature) => self.evaluate_if_feature(feature),
+			WhenCondition::Not(_, feature) => !self.evaluate_if_feature(feature),
+			WhenCondition::And(features) => features.iter().all(|(f, _)| self.evaluate_if_feature(f)),
+			WhenCondition::Or(features) => features.iter().any(|(f, _)| self.evaluate_if_feature(f)),
+		}
+	}
+
+	/// Process a single rule, collecting matches and updating stats.
+	/// Returns true if rule had any effect (matches or is a non-selector diagnostic).
+	fn process_rule(&mut self, rule_idx: usize, stylesheet: &StyleSheet<'_>, css_source: &str) -> bool {
+		let (selector, diagnostic_stats, collectors) = {
+			let rule = &self.collection_rules[rule_idx];
+			(rule.selector, rule.diagnostic_stats.clone(), rule.collectors.clone())
+		};
+
+		let Some(selector) = selector else {
+			let parent_span = self.collection_rules[rule_idx].parent_span;
+
+			let mut match_output = MatchOutput {
+				span: parent_span,
+				node_id: css_ast::NodeId::StyleRule,
+				properties: Default::default(),
+				size: 0,
+				stat_snapshot: SmallVec::new(),
+			};
+
+			for &stat_bits in &diagnostic_stats {
+				if let Some((name, &(_, count))) = self.stats.iter().find(|(name, _)| name.as_bits() == stat_bits) {
+					match_output.stat_snapshot.push((name.as_bits(), count));
+				}
+			}
+
+			self.collection_rules[rule_idx].matches.push(match_output);
+
+			for collector_name in &collectors {
+				if let Some(&mut (stat_type, ref mut count)) = self.stats.get_mut(collector_name) {
+					match stat_type {
+						StatType::Counter => {
+							*count += 1;
+						}
+						StatType::Bytes => {
+							*count += (parent_span.end().0 - parent_span.start().0) as usize;
+						}
+						StatType::Lines => {
+							let text = &css_source[parent_span.start().0 as usize..parent_span.end().0 as usize];
+							if !text.is_empty() {
+								*count += text.lines().count();
+							}
+						}
+					}
+				}
+			}
+
+			return true;
+		};
+
+		let matcher = SelectorMatcher::new(selector, self.source, css_source);
+		let mut had_matches = false;
+
+		for mut match_output in matcher.run(stylesheet) {
+			had_matches = true;
+			let span = match_output.span;
+
+			for &stat_bits in &diagnostic_stats {
+				if let Some((name, &(_, count))) = self.stats.iter().find(|(name, _)| name.as_bits() == stat_bits) {
+					match_output.stat_snapshot.push((name.as_bits(), count));
+				}
+			}
+
+			self.collection_rules[rule_idx].matches.push(match_output);
+			for collector_name in &collectors {
+				if let Some(&mut (stat_type, ref mut count)) = self.stats.get_mut(collector_name) {
+					match stat_type {
+						StatType::Counter => {
+							*count += 1;
+						}
+						StatType::Bytes => {
+							*count += (span.end().0 - span.start().0) as usize;
+						}
+						StatType::Lines => {
+							let text = &css_source[span.start().0 as usize..span.end().0 as usize];
+							if !text.is_empty() {
+								*count += text.lines().count();
+							}
+						}
+					}
+				}
+			}
+		}
+
+		had_matches
+	}
+
+	/// Collect diagnostics & stats on a CSS stylesheet.
+	pub fn collect(&mut self, stylesheet: &StyleSheet<'_>, css_source: &str) {
+		let stylesheet_span = stylesheet.to_span();
+		let zero_span = Span::new(SourceOffset(0), SourceOffset(0));
+		for rule in &mut self.collection_rules {
+			if rule.parent_span == zero_span {
+				rule.parent_span = stylesheet_span;
+			}
+		}
+
+		let mut processed = vec![in self.allocator; false; self.collection_rules.len()];
+
+		// First, execute all unconditional rules (conditions is empty)
+		for idx in 0..self.collection_rules.len() {
+			if self.collection_rules[idx].conditions.is_empty() {
+				self.process_rule(idx, stylesheet, css_source);
+				processed[idx] = true;
+			}
+		}
+
+		loop {
+			let mut made_progress = false;
+
+			for idx in 0..self.collection_rules.len() {
+				if processed[idx] {
+					continue;
+				}
+				let rule = &self.collection_rules[idx];
+				if rule.conditions.iter().all(|cond| self.evaluate_if_condition(cond)) {
+					self.process_rule(idx, stylesheet, css_source);
+					processed[idx] = true;
+					made_progress = true;
+				}
+			}
+
+			// If no rules became active, we're done
+			if !made_progress {
+				break;
+			}
+		}
+	}
+
+	/// Get all diagnostics from matched rules.
+	///
+	/// This method should be called after `collect()` to retrieve diagnostics
+	/// for all rules that had diagnostic templates and matched nodes.
+	pub fn diagnostics<'b>(&'b self, css_source: &'b str) -> impl Iterator<Item = CollectorDiagnostic> + 'b {
+		self.collection_rules.iter().flat_map(move |rule| {
+			let Some((severity, components)) = &rule.diagnostic else {
+				return vec![in self.allocator].into_iter();
+			};
+
+			let mut diagnostics = vec![in self.allocator];
+			for match_output in rule.matches.iter() {
+				let message = self.resolve_diagnostic_message(components, match_output, css_source);
+				diagnostics.push(CollectorDiagnostic::new(*severity, match_output.span, message));
+			}
+			diagnostics.into_iter()
+		})
+	}
+
+	/// Get the collected statistics.
+	///
+	/// Returns a reference to the statistics map containing stat names and their (type, count) values.
+	pub fn stats(&self) -> &Stats {
+		&self.stats
+	}
+}

--- a/crates/csskit_ast/src/collector/tests.rs
+++ b/crates/csskit_ast/src/collector/tests.rs
@@ -1,0 +1,689 @@
+use super::*;
+use bumpalo::Bump;
+use css_ast::CssAtomSet;
+use css_lexer::Lexer;
+use css_parse::Parser;
+
+fn run<'a>(bump: &'a Bump, source: &'a str, css_source: &'a str) -> (Stats, Vec<'a, CollectorDiagnostic>) {
+	let sheet = {
+		let lexer = Lexer::new(CsskitAtomSet::get_dyn_set(), source);
+		let mut parser = Parser::new(bump, source, lexer);
+		parser.parse_entirely::<crate::sheet::Sheet>().with_trivia().output.unwrap()
+	};
+	let stylesheet = {
+		let lexer = Lexer::new(&CssAtomSet::ATOMS, css_source);
+		let mut parser = Parser::new(bump, css_source, lexer);
+		parser.parse_entirely::<StyleSheet>().with_trivia().output.unwrap()
+	};
+	let mut collector = Collector::new(&sheet, source, bump);
+	collector.collect(&stylesheet, css_source);
+	let mut diagnostics = bumpalo::vec![in bump];
+	for diagnostic in collector.diagnostics(css_source) {
+		diagnostics.push(diagnostic);
+	}
+	(collector.stats, diagnostics)
+}
+
+#[test]
+fn test_basic() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --total-rules { type: counter; }
+		style-rule { collect: --total-rules; }
+	"#;
+	let css_source = r#"
+		.foo {}
+		#bar {}
+		.baz {}
+	"#;
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("total-rules");
+	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
+	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
+}
+
+#[test]
+fn test_implicit_counter() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --total-rules; }
+	"#;
+	let css_source = r#"
+		.foo {}
+		#bar {}
+		.baz {}
+	"#;
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("total-rules");
+	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
+	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
+}
+
+#[test]
+fn test_bytes() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --rule-bytes { type: bytes; }
+		style-rule { collect: --rule-bytes; }
+	"#;
+	let css_source = ".a{}.bb{}";
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	// .a{} = 4 bytes, .bb{} = 5 bytes, total = 9 bytes
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rule-bytes");
+	assert_eq!(counters.get(&a), Some(&(StatType::Bytes, 9)));
+	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
+}
+
+#[test]
+fn test_lines() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --rule-lines { type: lines; }
+		style-rule { collect: --rule-lines; }
+	"#;
+	let css_source = r"
+.a{
+
+}
+.bb{}";
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rule-lines");
+	assert_eq!(counters.get(&a), Some(&(StatType::Lines, 4)));
+	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
+}
+
+#[test]
+fn test_diagnostics_with_string() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule {
+			level: warning;
+			diagnostic: "Found a style rule";
+		}
+	"#;
+	let css_source = ".foo {} .bar {}";
+
+	let (_, diagnostics) = run(&bump, source, css_source);
+	assert_eq!(diagnostics.len(), 2);
+	assert_eq!(diagnostics[0].message, "Found a style rule");
+	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Warning);
+	assert_eq!(diagnostics[1].message, "Found a style rule");
+	assert_eq!(diagnostics[1].severity, ResolvedDiagnosticLevel::Warning);
+}
+
+#[test]
+fn test_diagnostics_with_attr() {
+	let bump = Bump::new();
+	let source = r#"
+		[name] {
+			level: error;
+			diagnostic: "Property " attr(name) " found";
+		}
+	"#;
+	let css_source = ".foo { color: red; margin: 0; }";
+
+	let (_, diagnostics) = run(&bump, source, css_source);
+	assert_eq!(diagnostics.len(), 2);
+	assert_eq!(diagnostics[0].message, "Property color found");
+	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Error);
+	assert_eq!(diagnostics[1].message, "Property margin found");
+	assert_eq!(diagnostics[1].severity, ResolvedDiagnosticLevel::Error);
+}
+
+#[test]
+fn test_diagnostics_with_size() {
+	let bump = Bump::new();
+	let source = r#"
+		selector-list {
+			level: advice;
+			diagnostic: "Selector list has " size() " selectors";
+		}
+	"#;
+	let css_source = ".foo {}";
+
+	let (_, diagnostics) = run(&bump, source, css_source);
+	assert_eq!(diagnostics.len(), 1);
+	assert_eq!(diagnostics[0].message, "Selector list has 1 selectors");
+	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Advice);
+}
+
+#[test]
+fn test_diagnostics_with_size_various() {
+	let bump = Bump::new();
+	let source = r#"
+		selector-list {
+			level: error;
+			diagnostic: size() " selectors";
+		}
+	"#;
+	let css_source = r#"
+		.a {}
+		.b, .c {}
+		.d, .e, .f {}
+	"#;
+
+	let (_, diagnostics) = run(&bump, source, css_source);
+	assert_eq!(diagnostics.len(), 3);
+	assert_eq!(diagnostics[0].message, "1 selectors");
+	assert_eq!(diagnostics[1].message, "2 selectors");
+	assert_eq!(diagnostics[2].message, "3 selectors");
+}
+
+#[test]
+fn test_diagnostics_with_stat_reference() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --total { type: counter; }
+		style-rule {
+			collect: --total;
+			level: warning;
+			diagnostic: "Found " --total " rules so far";
+		}
+	"#;
+	let css_source = ".a {} .b {} .c {}";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("total");
+	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
+
+	assert_eq!(diagnostics.len(), 3);
+	assert_eq!(diagnostics[0].message, "Found 0 rules so far");
+	assert_eq!(diagnostics[1].message, "Found 1 rules so far");
+	assert_eq!(diagnostics[2].message, "Found 2 rules so far");
+}
+
+#[test]
+fn test_when_rule_true_condition() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --rules; }
+		@when (--rules > 1) {
+			level: error;
+			diagnostic: "Too many rules: " --rules;
+		}
+	"#;
+	let css_source = ".a {} .b {} .c {}";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
+	assert_eq!(diagnostics.len(), 1);
+	assert_eq!(diagnostics[0].message, "Too many rules: 3");
+	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Error);
+}
+
+#[test]
+fn test_when_rule_false_condition() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --rules; }
+		@when (--rules > 10) {
+			level: error;
+			diagnostic: "Too many rules";
+		}
+	"#;
+	let css_source = ".a {} .b {}";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 2)));
+	assert_eq!(diagnostics.len(), 0);
+}
+
+#[test]
+fn test_when_rule_with_nested_selector() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --rules; }
+		@when (--rules > 1) {
+			id {
+				collect: --id-selectors;
+				level: warning;
+				diagnostic: "ID selector found";
+			}
+		}
+	"#;
+	let css_source = ".a {} #foo {} .b {}";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	let ids = CsskitAtomSet::get_dyn_set().atom_from_str("id-selectors");
+	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
+	assert_eq!(counters.get(&ids), Some(&(StatType::Counter, 1)));
+	assert_eq!(diagnostics.len(), 1);
+	assert_eq!(diagnostics[0].message, "ID selector found");
+	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Warning);
+}
+
+#[test]
+fn test_when_rule_equal_comparison() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --rules; }
+		@when (--rules = 2) {
+			level: advice;
+			diagnostic: "Exactly 2 rules";
+		}
+	"#;
+	let css_source = ".a {} .b {}";
+
+	let (_, diagnostics) = run(&bump, source, css_source);
+	assert_eq!(diagnostics.len(), 1);
+	assert_eq!(diagnostics[0].message, "Exactly 2 rules");
+}
+
+#[test]
+fn test_nested_if_in_style_rule() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule {
+			collect: --foo;
+			@when (--foo > 1) {
+				level: warning;
+				diagnostic: "bar";
+			}
+		}
+	"#;
+	let css_source = ".a {} .b {} .c {}";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let foo = CsskitAtomSet::get_dyn_set().atom_from_str("foo");
+	assert_eq!(counters.get(&foo), Some(&(StatType::Counter, 3)));
+	assert_eq!(diagnostics.len(), 1);
+	assert_eq!(diagnostics[0].message, "bar");
+	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Warning);
+}
+
+#[test]
+fn test_nested_selector_in_style_rule() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --color-decls { type: counter; }
+		style-rule {
+			[name=color] {
+				collect: --color-decls;
+				level: warning;
+				diagnostic: "color declaration found";
+			}
+		}
+	"#;
+	let css_source = ".a { color: red; } .b { background: blue; } .c { color: green; }";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+
+	// Verify stats - only color declarations should be counted
+	let color_decls = CsskitAtomSet::get_dyn_set().atom_from_str("color-decls");
+	assert_eq!(counters.get(&color_decls), Some(&(StatType::Counter, 2)));
+
+	// Verify diagnostics for each color declaration
+	assert_eq!(diagnostics.len(), 2);
+	assert_eq!(diagnostics[0].message, "color declaration found");
+	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Warning);
+}
+
+#[test]
+fn test_nested_if_with_combined_conditions() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --rules { type: counter; }
+		@stat --decls { type: counter; }
+		style-rule { collect: --rules; }
+		style-value[name] { collect: --decls; }
+		@when (--rules > 1) {
+			@when (--decls > 2) {
+				level: error;
+				diagnostic: "Hit";
+			}
+		}
+	"#;
+	let css_source = ".a { color: red; } .b { background: blue; font-size: 12px; }";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	let decls = CsskitAtomSet::get_dyn_set().atom_from_str("decls");
+	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 2)));
+	assert_eq!(counters.get(&decls), Some(&(StatType::Counter, 3)));
+	assert_eq!(diagnostics.len(), 1);
+	assert_eq!(diagnostics[0].message, "Hit");
+}
+
+#[test]
+fn test_conditional_nested_selector() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --rules { type: counter; }
+		@stat --color-decls { type: counter; }
+		style-rule { collect: --rules; }
+		@when (--rules > 1) {
+			style-rule {
+				[name=color] {
+					collect: --color-decls;
+					level: warning;
+					diagnostic: "color declaration in conditional context";
+				}
+			}
+		}
+	"#;
+	let css_source = ".a { color: red; } .b { background: blue; } .c { color: green; }";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	let color_decls = CsskitAtomSet::get_dyn_set().atom_from_str("color-decls");
+	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
+	assert_eq!(counters.get(&color_decls), Some(&(StatType::Counter, 2)));
+	assert_eq!(diagnostics.len(), 2);
+	assert_eq!(diagnostics[0].message, "color declaration in conditional context");
+	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Warning);
+}
+
+#[test]
+fn test_reactive_conditional_chain() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --rules { type: counter; }
+		@stat --warnings { type: counter; }
+		@stat --critical { type: counter; }
+
+		style-rule { collect: --rules; }
+
+		@when (--rules > 1) {
+			style-rule {
+				collect: --warnings;
+				level: warning;
+				diagnostic: "Many rules";
+			}
+		}
+
+		@when (--warnings > 0) {
+			style-rule {
+				collect: --critical;
+				level: error;
+				diagnostic: "Warnings triggered, now critical";
+			}
+		}
+	"#;
+	let css_source = ".a {} .b {} .c {}";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	let warnings = CsskitAtomSet::get_dyn_set().atom_from_str("warnings");
+	let critical = CsskitAtomSet::get_dyn_set().atom_from_str("critical");
+	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
+	assert_eq!(counters.get(&warnings), Some(&(StatType::Counter, 3)));
+	assert_eq!(counters.get(&critical), Some(&(StatType::Counter, 3)));
+	assert_eq!(diagnostics.len(), 6);
+	let warning_count = diagnostics.iter().filter(|d| d.severity == ResolvedDiagnosticLevel::Warning).count();
+	let error_count = diagnostics.iter().filter(|d| d.severity == ResolvedDiagnosticLevel::Error).count();
+	assert_eq!(warning_count, 3);
+	assert_eq!(error_count, 3);
+}
+
+#[test]
+fn test_nested_not_condition_preserved() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --rules { type: counter; }
+		@stat --nested-matches { type: counter; }
+
+		style-rule { collect: --rules; }
+
+		@when not (--rules > 10) {
+			@when (--rules > 2) {
+				style-rule {
+					collect: --nested-matches;
+					level: warning;
+					diagnostic: "Nested match";
+				}
+			}
+		}
+	"#;
+	let css_source = ".a {} .b {} .c {}";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	let nested = CsskitAtomSet::get_dyn_set().atom_from_str("nested-matches");
+	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
+	assert_eq!(counters.get(&nested), Some(&(StatType::Counter, 3)));
+	assert_eq!(diagnostics.len(), 3);
+}
+
+#[test]
+fn test_nested_not_condition_unmatched() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --rules { type: counter; }
+		@stat --nested-matches { type: counter; }
+
+		style-rule { collect: --rules; }
+
+		@when not (--rules > 1) {
+			style-rule {
+				collect: --nested-matches;
+				level: warning;
+				diagnostic: "Nested match";
+			}
+		}
+	"#;
+	let css_source = ".a {} .b {} .c {}";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	let nested = CsskitAtomSet::get_dyn_set().atom_from_str("nested-matches");
+	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
+	assert_eq!(counters.get(&nested), Some(&(StatType::Counter, 0)));
+	assert_eq!(diagnostics.len(), 0);
+}
+
+#[test]
+fn test_cycles_direct() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --a; }
+		@when (--a > 0) {
+			style-rule { collect: --b; }
+		}
+		@when (--b > 0) {
+			style-rule { collect: --a; }
+		}
+	"#;
+	let css_source = ".x {} .y {} .z {}";
+
+	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("a");
+	let b = CsskitAtomSet::get_dyn_set().atom_from_str("b");
+	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 6))); // 3 unconditional + 3 from second @when
+	assert_eq!(counters.get(&b), Some(&(StatType::Counter, 3))); // 3 from first @when
+}
+
+#[test]
+fn test_cycle_prevention_indirect() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --a; }
+		@when (--a > 0) {
+			style-rule { collect: --b; }
+		}
+		@when (--b > 0) {
+			style-rule { collect: --c; }
+		}
+		@when (--c > 0) {
+			style-rule { collect: --a; }
+		}
+	"#;
+	let css_source = ".x {} .y {}";
+
+	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let a = CsskitAtomSet::get_dyn_set().atom_from_str("a");
+	let b = CsskitAtomSet::get_dyn_set().atom_from_str("b");
+	let c = CsskitAtomSet::get_dyn_set().atom_from_str("c");
+	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 4)));
+	assert_eq!(counters.get(&b), Some(&(StatType::Counter, 2)));
+	assert_eq!(counters.get(&c), Some(&(StatType::Counter, 2)));
+}
+
+#[test]
+fn test_cycle_prevention_self_referential() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --count; }
+		@when (--count > 1) {
+			style-rule { collect: --count; }
+		}
+	"#;
+	let css_source = ".a {} .b {} .c {}";
+
+	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
+	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 6)));
+}
+
+#[test]
+fn test_equality_vs_range_semantics() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --rules; }
+		@when (--rules = 1) {
+			style-rule { collect: --equal-triggered; }
+		}
+		@when (--rules > 1) {
+			style-rule { collect: --greater-triggered; }
+		}
+	"#;
+	let css_source = ".a {} .b {}";
+
+	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
+	let equal = CsskitAtomSet::get_dyn_set().atom_from_str("equal-triggered");
+	let greater = CsskitAtomSet::get_dyn_set().atom_from_str("greater-triggered");
+	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 2)));
+	assert_eq!(counters.get(&equal), Some(&(StatType::Counter, 0))); // Created but never triggered
+	assert_eq!(counters.get(&greater), Some(&(StatType::Counter, 2)));
+}
+
+#[test]
+fn test_equality_intermediate_value_does_not_trigger() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --count; }
+		@when (--count = 2) {
+			style-rule { collect: --triggered; }
+		}
+	"#;
+	let css_source = ".a {} .b {} .c {}";
+
+	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
+	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("triggered");
+	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 3)));
+	assert_eq!(counters.get(&triggered), Some(&(StatType::Counter, 0))); // Never triggered
+}
+
+#[test]
+fn test_equality_does_trigger_on_exact_match() {
+	let bump = Bump::new();
+	let source = r#"
+		style-rule { collect: --count; }
+		@when (--count = 2) {
+			style-rule { collect: --triggered; }
+		}
+	"#;
+	let css_source = ".a {} .b {}"; // Exactly 2 rules
+
+	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
+	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("triggered");
+	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 2)));
+	assert_eq!(counters.get(&triggered), Some(&(StatType::Counter, 2)));
+}
+
+#[test]
+fn test_equality_triggers_once_then_becomes_false() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --count { type: counter; }
+		@stat --trigger { type: counter; }
+		@stat --hit { type: counter; }
+
+		style-rule {
+			collect: --count;
+			collect: --trigger;
+		}
+
+		@when (--trigger = 2) {
+			collect: --count;
+		}
+
+		@when (--count = 2) {
+			diagnostic: "Foo"
+			collect: --hit;
+		}
+	"#;
+	let css_source = ".a {} .b {}";
+
+	let (counters, diagnostics) = run(&bump, source, css_source);
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
+	let hit = CsskitAtomSet::get_dyn_set().atom_from_str("hit");
+	assert_eq!(counters.get(&hit), Some(&(StatType::Counter, 0)));
+	assert_eq!(diagnostics.len(), 0);
+	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 3)));
+}
+
+#[test]
+fn test_when_only_rules_with_bytes_and_lines() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --trigger { type: counter; }
+		@stat --byte-count { type: bytes; }
+		@stat --line-count { type: lines; }
+		@stat --counter { type: counter; }
+
+		style-rule { collect: --trigger; }
+
+		@when (--trigger > 1) {
+			collect: --byte-count;
+			collect: --line-count;
+			collect: --counter;
+		}
+	"#;
+	let css_source = ".a {} .b {}";
+
+	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let trigger = CsskitAtomSet::get_dyn_set().atom_from_str("trigger");
+	let bytes = CsskitAtomSet::get_dyn_set().atom_from_str("byte-count");
+	let lines = CsskitAtomSet::get_dyn_set().atom_from_str("line-count");
+	let counter = CsskitAtomSet::get_dyn_set().atom_from_str("counter");
+
+	assert_eq!(counters.get(&trigger), Some(&(StatType::Counter, 2)));
+	// For @when-only rules without selectors:
+	// - Counter increments by 1 (event counting)
+	// - Bytes/lines use the parent span (stylesheet root for top-level @when)
+	let css_bytes = css_source.len();
+	assert_eq!(counters.get(&bytes), Some(&(StatType::Bytes, css_bytes)));
+	assert_eq!(counters.get(&lines), Some(&(StatType::Lines, 1))); // CSS is one line
+	assert_eq!(counters.get(&counter), Some(&(StatType::Counter, 1)));
+}
+
+#[test]
+fn test_invalid_when_threshold_skipped() {
+	let bump = Bump::new();
+	let source = r#"
+		@stat --count { type: counter; }
+		@stat --triggered { type: counter; }
+
+		style-rule { collect: --count; }
+
+		@when (--count > invalid) {
+			collect: --triggered;
+		}
+	"#;
+	let css_source = ".a {} .b {}";
+
+	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
+	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("triggered");
+
+	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 2)));
+	// Invalid threshold should skip the @when rule entirely, so --triggered should not exist or be 0
+	assert_eq!(counters.get(&triggered), Some(&(StatType::Counter, 0)));
+}

--- a/crates/csskit_ast/src/lib.rs
+++ b/crates/csskit_ast/src/lib.rs
@@ -2,11 +2,25 @@
 
 //! CSS AST query utilities using selector-like syntax.
 
+mod collector;
 pub mod csskit_atom_set;
 pub mod diagnostics;
+pub mod node_rule;
+pub mod rule_block;
 pub mod selector;
+pub mod sheet;
+pub mod stat_rule;
 #[cfg(test)]
 mod test_helpers;
+pub mod when_rule;
 
+pub use collector::*;
 pub use csskit_atom_set::*;
+pub use node_rule::*;
+pub use rule_block::*;
 pub use selector::*;
+pub use stat_rule::*;
+pub use when_rule::*;
+
+// Re-export for derive macros
+pub use css_parse::Diagnostic;

--- a/crates/csskit_ast/src/node_rule.rs
+++ b/crates/csskit_ast/src/node_rule.rs
@@ -1,0 +1,36 @@
+use crate::{QuerySelectorList, rule_block::RuleBlock};
+use css_lexer::Cursor;
+use css_parse::{Parse, Parser, Result as ParserResult};
+use csskit_derives::*;
+
+/// A node rule for collecting stats.
+///
+/// # Syntax
+///
+/// ```css
+/// selector {
+///   collect: --stat-name;
+///   diagnostic: "message";
+///   level: warning;
+///
+///   nested-selector {
+///     collect: --another-stat;
+///   }
+/// }
+/// ```
+#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeRule<'a> {
+	pub selector: QuerySelectorList<'a>,
+	pub block: RuleBlock<'a>,
+}
+
+impl<'a> Parse<'a> for NodeRule<'a> {
+	fn parse<I>(p: &mut Parser<'a, I>) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		let selector = p.parse::<QuerySelectorList>()?;
+		let block = p.parse::<RuleBlock>()?;
+		Ok(Self { selector, block })
+	}
+}

--- a/crates/csskit_ast/src/rule_block.rs
+++ b/crates/csskit_ast/src/rule_block.rs
@@ -1,0 +1,264 @@
+use crate::{CsskitAtomSet, WhenRule};
+use bumpalo::collections::Vec;
+use css_lexer::{Cursor, Kind, KindSet};
+use css_parse::{
+	Block, ComponentValues, DeclarationValue, Diagnostic, NodeWithMetadata, Parse, Parser, Peek,
+	Result as ParserResult, RuleVariants, T,
+};
+use csskit_derives::*;
+
+/// A block containing declarations and optionally nested node rules.
+///
+/// Used by both `NodeRule` and `WhenRule`.
+pub type RuleBlock<'a> = Block<'a, RuleDeclarationValue<'a>, NestedRule<'a>, ()>;
+
+/// A nested rule within a block.
+#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum NestedRule<'a> {
+	/// A nested node rule.
+	NodeRule(NestedNodeRule<'a>),
+	/// A nested @when rule.
+	WhenRule(WhenRule<'a>),
+	/// Unknown rule (for error recovery).
+	Unknown(ComponentValues<'a>),
+}
+
+impl<'a> Parse<'a> for NestedRule<'a> {
+	fn parse<I>(p: &mut Parser<'a, I>) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		Self::parse_rule_variants(p)
+	}
+}
+
+impl<'a> RuleVariants<'a> for NestedRule<'a> {
+	type DeclarationValue = RuleDeclarationValue<'a>;
+	type Metadata = ();
+
+	fn parse_at_rule<I>(p: &mut Parser<'a, I>, c: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		let atom = p.to_atom::<CsskitAtomSet>(c);
+		match atom {
+			CsskitAtomSet::When => Ok(Self::WhenRule(p.parse::<WhenRule>()?)),
+			_ => Err(Diagnostic::new(c, Diagnostic::unexpected))?,
+		}
+	}
+
+	fn parse_unknown_at_rule<I>(p: &mut Parser<'a, I>, _c: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		Ok(Self::Unknown(p.parse::<ComponentValues>()?))
+	}
+
+	fn parse_qualified_rule<I>(p: &mut Parser<'a, I>, _c: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		Ok(Self::NodeRule(p.parse::<NestedNodeRule>()?))
+	}
+
+	fn parse_unknown_qualified_rule<I>(p: &mut Parser<'a, I>, _c: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		Ok(Self::Unknown(p.parse::<ComponentValues>()?))
+	}
+
+	fn is_unknown(&self) -> bool {
+		matches!(self, Self::Unknown(_))
+	}
+}
+
+impl<'a> Peek<'a> for NestedRule<'a> {
+	fn peek<I>(_p: &Parser<'a, I>, c: Cursor) -> bool
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		c != Kind::Eof && c != Kind::RightCurly
+	}
+}
+
+impl NodeWithMetadata<()> for NestedRule<'_> {
+	fn metadata(&self) {}
+}
+
+/// A nested node rule (selector + block).
+#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NestedNodeRule<'a> {
+	pub selector: crate::QuerySelectorList<'a>,
+	pub block: RuleBlock<'a>,
+}
+
+impl<'a> Parse<'a> for NestedNodeRule<'a> {
+	fn parse<I>(p: &mut Parser<'a, I>) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		let selector = p.parse::<crate::QuerySelectorList>()?;
+		let block = p.parse::<RuleBlock>()?;
+		Ok(Self { selector, block })
+	}
+}
+
+/// A component of a diagnostic message template.
+///
+/// Diagnostic messages can be composed of:
+/// - String literals: `"text"`
+/// - Dashed identifiers (stat references): `--stat-name`
+/// - Diagnostic functions: `attr(name)`
+#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiagnosticComponent {
+	/// A string literal.
+	String(T![String]),
+	/// A dashed identifier (stat reference).
+	DashedIdent(T![DashedIdent]),
+	/// A diagnostic function.
+	Function(DiagnosticFunction),
+}
+
+/// A diagnostic function component.
+///
+/// Supported functions:
+/// - `attr(name)` - Get an attribute value from the matched node
+/// - `size()` - Get the size of the matched node
+#[derive(ToCursors, ToSpan, Peek, Parse, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiagnosticFunction {
+	/// The `attr(name)` function.
+	Attr(DiagnosticAttrFunction),
+	/// The `size()` function.
+	Size(DiagnosticSizeFunction),
+}
+
+/// The `attr(name)` diagnostic function.
+#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DiagnosticAttrFunction {
+	#[atom(CsskitAtomSet::Attr)]
+	pub open: T![Function],
+	pub name: T![Ident],
+	pub close: T![')'],
+}
+
+/// The `size()` diagnostic function.
+#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DiagnosticSizeFunction {
+	#[atom(CsskitAtomSet::Size)]
+	pub open: T![Function],
+	pub close: T![')'],
+}
+
+/// The value of a declaration within a rule block.
+///
+/// Declarations can be:
+/// - `collect: --stat-name;` - collect stats (value is a `--stat-name`)
+/// - `diagnostic: [ <string> | <ident> | <dashed-ident> | <diagnostic-function> ]+;` - diagnostic message template
+/// - `level: warning | error | help;` - diagnostic severity level
+#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RuleDeclarationValue<'a> {
+	/// A stat name reference (e.g., `--stat-name`).
+	Collect(T![DashedIdent]),
+	/// A diagnostic message template composed of multiple components.
+	Diagnostic(Vec<'a, DiagnosticComponent>),
+	/// A diagnostic severity level.
+	Level(DiagnosticLevel),
+}
+
+/// Diagnostic severity level: `warning`, `error`, or `advice`.
+#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DiagnosticLevel {
+	#[atom(CsskitAtomSet::Warning)]
+	Warning(T![Ident]),
+	#[atom(CsskitAtomSet::Error)]
+	Error(T![Ident]),
+	#[atom(CsskitAtomSet::Advice)]
+	Advice(T![Ident]),
+}
+
+impl<'a> NodeWithMetadata<()> for RuleDeclarationValue<'a> {
+	fn metadata(&self) {}
+}
+
+impl<'a> DeclarationValue<'a, ()> for RuleDeclarationValue<'a> {
+	type ComputedValue = T![Eof];
+
+	fn is_initial(&self) -> bool {
+		false
+	}
+
+	fn is_inherit(&self) -> bool {
+		false
+	}
+
+	fn is_unset(&self) -> bool {
+		false
+	}
+
+	fn is_revert(&self) -> bool {
+		false
+	}
+
+	fn is_revert_layer(&self) -> bool {
+		false
+	}
+
+	fn needs_computing(&self) -> bool {
+		false
+	}
+
+	fn valid_declaration_name<I>(p: &Parser<'a, I>, c: Cursor) -> bool
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		if c != Kind::Ident {
+			return false;
+		}
+		let atom = p.to_atom::<CsskitAtomSet>(c);
+		matches!(atom, CsskitAtomSet::Collect | CsskitAtomSet::Diagnostic | CsskitAtomSet::Level)
+	}
+
+	fn parse_specified_declaration_value<I>(p: &mut Parser<'a, I>, name: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		let atom = p.to_atom::<CsskitAtomSet>(name);
+		match atom {
+			CsskitAtomSet::Collect => Ok(Self::Collect(p.parse::<T![DashedIdent]>()?)),
+			CsskitAtomSet::Diagnostic => Ok(Self::Diagnostic(p.parse::<Vec<'_, DiagnosticComponent>>()?)),
+			CsskitAtomSet::Level => Ok(Self::Level(p.parse::<DiagnosticLevel>()?)),
+			_ => Err(Diagnostic::new(name, Diagnostic::unexpected))?,
+		}
+	}
+}
+
+impl<'a> Peek<'a> for RuleDeclarationValue<'a> {
+	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Ident, Kind::String]);
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use css_parse::assert_parse;
+
+	#[test]
+	fn test_diagnostic_single_string() {
+		assert_parse!(CsskitAtomSet::ATOMS, Vec<'_, DiagnosticComponent>, r#""message""#, _);
+	}
+
+	#[test]
+	fn test_diagnostic_multiple_components() {
+		assert_parse!(CsskitAtomSet::ATOMS, Vec<'_, DiagnosticComponent>, r#""Foo" --times " times""#, _);
+	}
+
+	#[test]
+	fn test_diagnostic_with_attr_function() {
+		assert_parse!(CsskitAtomSet::ATOMS, Vec<'_, DiagnosticComponent>, r#""Foo" attr(name)"#, _);
+	}
+
+	#[test]
+	fn test_diagnostic_with_size_function() {
+		assert_parse!(CsskitAtomSet::ATOMS, Vec<'_, DiagnosticComponent>, r#""Size: " size()"#, _);
+	}
+}

--- a/crates/csskit_ast/src/selector/matcher/output.rs
+++ b/crates/csskit_ast/src/selector/matcher/output.rs
@@ -1,14 +1,23 @@
+use super::PropertyValues;
 use css_ast::NodeId;
 use css_lexer::Span;
 use indexmap::IndexSet;
+use smallvec::SmallVec;
 
 /// A unique match identified by span and node type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MatchOutput {
 	/// The source span of the matched node.
 	pub span: Span,
 	/// The type of the matched node.
 	pub node_id: NodeId,
+	/// Property values for the matched node (used for diagnostic attr() function).
+	pub properties: PropertyValues,
+	/// Size of the matched node (number of children, declarations, selectors, etc.).
+	pub size: u16,
+	/// Snapshot of stat counter values at match time (for diagnostic interpolation).
+	/// Only contains stats referenced in the diagnostic message. Empty during matching, populated during collection.
+	pub stat_snapshot: SmallVec<[(u32, usize); 1]>,
 }
 
 pub type Matches = IndexSet<MatchOutput>;

--- a/crates/csskit_ast/src/selector/matcher/selector_matcher.rs
+++ b/crates/csskit_ast/src/selector/matcher/selector_matcher.rs
@@ -6,6 +6,7 @@ use crate::{
 use css_ast::visit::{NodeId, Visitable};
 use css_ast::{CssMetadata, PropertyKind};
 use css_parse::NodeWithMetadata;
+use smallvec::SmallVec;
 
 /// Prefilter for :has() candidate nodes based on the first-matched segment's metadata.
 /// Allows skipping nodes that definitely can't match before doing full matching.
@@ -113,7 +114,13 @@ impl<'a, 'b> SelectorMatcher<'a, 'b> {
 		for (idx, node) in nodes.iter().enumerate() {
 			for selector in buckets.selectors_for_node(&node.data) {
 				if self.matches_selector(selector, idx, &nodes) {
-					self.matches.insert(MatchOutput { span: node.data.span, node_id: node.data.node_id });
+					self.matches.insert(MatchOutput {
+						span: node.data.span,
+						node_id: node.data.node_id,
+						properties: node.data.properties,
+						size: node.data.metadata.size,
+						stat_snapshot: SmallVec::new(),
+					});
 				}
 			}
 		}

--- a/crates/csskit_ast/src/sheet.rs
+++ b/crates/csskit_ast/src/sheet.rs
@@ -1,0 +1,157 @@
+use bumpalo::collections::Vec;
+use css_lexer::{Cursor, Kind, SourceOffset, Span};
+use css_parse::{
+	ComponentValues, CursorSink, NodeWithMetadata, Parse, Parser, Peek, Result as ParserResult, RuleVariants,
+	SemanticEq, StyleSheet, ToCursors, ToSpan,
+};
+use csskit_derives::*;
+
+use crate::CsskitAtomSet;
+use crate::node_rule::NodeRule;
+use crate::stat_rule::StatRule;
+use crate::when_rule::WhenRule;
+
+/// A stats stylesheet containing rules for collecting statistics and diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Sheet<'a> {
+	pub rules: Vec<'a, Rule<'a>>,
+}
+
+impl<'a> Parse<'a> for Sheet<'a> {
+	fn parse<I>(p: &mut Parser<'a, I>) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		let (rules, _) = Self::parse_stylesheet(p)?;
+		Ok(Self { rules })
+	}
+}
+
+impl<'a> StyleSheet<'a, ()> for Sheet<'a> {
+	type Rule = Rule<'a>;
+}
+
+impl ToCursors for Sheet<'_> {
+	fn to_cursors(&self, s: &mut impl CursorSink) {
+		for rule in &self.rules {
+			rule.to_cursors(s);
+		}
+	}
+}
+
+impl ToSpan for Sheet<'_> {
+	fn to_span(&self) -> Span {
+		if self.rules.is_empty() {
+			return Span::new(SourceOffset(0), SourceOffset(0));
+		}
+		let start = self.rules.first().map(|r| r.to_span().start()).unwrap_or(SourceOffset(0));
+		let end = self.rules.last().map(|r| r.to_span().end()).unwrap_or(SourceOffset(0));
+		Span::new(start, end)
+	}
+}
+
+impl SemanticEq for Sheet<'_> {
+	fn semantic_eq(&self, other: &Self) -> bool {
+		if self.rules.len() != other.rules.len() {
+			return false;
+		}
+		self.rules.iter().zip(other.rules.iter()).all(|(a, b)| a.semantic_eq(b))
+	}
+}
+
+/// A rule within a stats stylesheet.
+#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Rule<'a> {
+	/// A `@stat` rule defining a statistic.
+	Stat(StatRule<'a>),
+	/// A node rule for collecting stats (e.g., `selector { collect: --foo; }`).
+	NodeRule(NodeRule<'a>),
+	/// An `@when` rule for conditional validation.
+	WhenRule(WhenRule<'a>),
+	/// Unknown rule.
+	Unknown(ComponentValues<'a>),
+}
+
+impl<'a> Parse<'a> for Rule<'a> {
+	fn parse<I>(p: &mut Parser<'a, I>) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		Self::parse_rule_variants(p)
+	}
+}
+
+impl<'a> RuleVariants<'a> for Rule<'a> {
+	type DeclarationValue = ComponentValues<'a>;
+	type Metadata = ();
+
+	fn parse_at_rule<I>(p: &mut Parser<'a, I>, c: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		let atom = p.to_atom::<CsskitAtomSet>(c);
+		match atom {
+			CsskitAtomSet::Stat => Ok(Self::Stat(p.parse::<StatRule>()?)),
+			CsskitAtomSet::When => Ok(Self::WhenRule(p.parse::<WhenRule>()?)),
+			_ => Err(css_parse::Diagnostic::new(c, css_parse::Diagnostic::unexpected))?,
+		}
+	}
+
+	fn parse_unknown_at_rule<I>(p: &mut Parser<'a, I>, _c: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		Ok(Self::Unknown(p.parse::<ComponentValues>()?))
+	}
+
+	fn parse_qualified_rule<I>(p: &mut Parser<'a, I>, _c: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		Ok(Self::NodeRule(p.parse::<NodeRule>()?))
+	}
+
+	fn parse_unknown_qualified_rule<I>(p: &mut Parser<'a, I>, _c: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		Ok(Self::Unknown(p.parse::<ComponentValues>()?))
+	}
+
+	fn is_unknown(&self) -> bool {
+		matches!(self, Self::Unknown(_))
+	}
+}
+
+impl<'a> Peek<'a> for Rule<'a> {
+	fn peek<I>(_p: &Parser<'a, I>, c: Cursor) -> bool
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		c != Kind::Eof
+	}
+}
+
+impl NodeWithMetadata<()> for Rule<'_> {
+	fn metadata(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use css_parse::assert_parse;
+
+	#[test]
+	fn test_stats_sheet_with_stat_rules() {
+		assert_parse!(
+			CsskitAtomSet::ATOMS,
+			Sheet,
+			"@stat --total-selectors{type:counter}@stat --unique-selectors{type:unique;normalize:true}"
+		);
+	}
+
+	#[test]
+	fn test_stats_rule_stat() {
+		assert_parse!(CsskitAtomSet::ATOMS, Rule, "@stat --total-selectors{type:counter}", Rule::Stat(_));
+	}
+}

--- a/crates/csskit_ast/src/stat_rule.rs
+++ b/crates/csskit_ast/src/stat_rule.rs
@@ -1,0 +1,136 @@
+use css_lexer::{Cursor, Kind, KindSet};
+use css_parse::{DeclarationList, DeclarationValue, NodeWithMetadata, Parser, Peek, Result as ParserResult, T};
+use csskit_derives::*;
+
+use crate::CsskitAtomSet;
+
+/// The `@stat` rule defines a named statistic for collecting CSS metrics.
+///
+/// # Syntax
+///
+/// ```css
+/// @stat --stat-name {
+///   type: counter | bytes | lines | unique | list;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```css
+/// @stat --total-selectors { type: counter; }
+/// @stat --unique-selectors { type: unique; }
+/// @stat --complexity-values { type: list; }
+/// ```
+#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StatRule<'a> {
+	#[atom(CsskitAtomSet::Stat)]
+	pub at_keyword: T![AtKeyword],
+	pub name: T![DashedIdent],
+	pub block: StatRuleBlock<'a>,
+}
+
+/// The block of a `@stat` rule containing declarations.
+///
+/// Declarations can be:
+/// - `type: counter | bytes | lines | unique | list`
+pub type StatRuleBlock<'a> = DeclarationList<'a, StatDeclarationValue, ()>;
+
+/// A declaration value within a `@stat` rule block.
+#[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StatDeclarationValue {
+	/// The `type:` declaration specifying the stat type.
+	Type(StatTypeValue),
+}
+
+impl NodeWithMetadata<()> for StatDeclarationValue {
+	fn metadata(&self) {}
+}
+
+impl<'a> DeclarationValue<'a, ()> for StatDeclarationValue {
+	type ComputedValue = T![Eof];
+
+	fn is_initial(&self) -> bool {
+		false
+	}
+
+	fn is_inherit(&self) -> bool {
+		false
+	}
+
+	fn is_unset(&self) -> bool {
+		false
+	}
+
+	fn is_revert(&self) -> bool {
+		false
+	}
+
+	fn is_revert_layer(&self) -> bool {
+		false
+	}
+
+	fn needs_computing(&self) -> bool {
+		false
+	}
+
+	fn valid_declaration_name<I>(p: &Parser<'a, I>, c: Cursor) -> bool
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		if c != Kind::Ident {
+			return false;
+		}
+		let atom = p.to_atom::<CsskitAtomSet>(c);
+		matches!(atom, CsskitAtomSet::Type)
+	}
+
+	fn parse_specified_declaration_value<I>(p: &mut Parser<'a, I>, name: Cursor) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		let atom = p.to_atom::<CsskitAtomSet>(name);
+		match atom {
+			CsskitAtomSet::Type => Ok(Self::Type(p.parse::<StatTypeValue>()?)),
+			_ => Err(css_parse::Diagnostic::new(name, css_parse::Diagnostic::unexpected))?,
+		}
+	}
+}
+
+impl<'a> Peek<'a> for StatDeclarationValue {
+	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Ident]);
+}
+
+/// The value for a `type:` declaration in a `@stat` rule.
+#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StatTypeValue {
+	/// `type: counter` - counts matching nodes
+	#[atom(CsskitAtomSet::Counter)]
+	Counter(T![Ident]),
+	/// `type: bytes` - sums byte sizes of matching nodes
+	#[atom(CsskitAtomSet::Bytes)]
+	Bytes(T![Ident]),
+	/// `type: lines` - counts lines in matching nodes
+	#[atom(CsskitAtomSet::Lines)]
+	Lines(T![Ident]),
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use css_parse::assert_parse;
+
+	#[test]
+	fn test_counter_type() {
+		assert_parse!(CsskitAtomSet::ATOMS, StatRule, "@stat --total-selectors{type:counter}");
+	}
+
+	#[test]
+	fn test_bytes_type() {
+		assert_parse!(CsskitAtomSet::ATOMS, StatRule, "@stat --stylesheet-bytes{type:bytes}");
+	}
+
+	#[test]
+	fn test_lines_type() {
+		assert_parse!(CsskitAtomSet::ATOMS, StatRule, "@stat --source-lines{type:lines}");
+	}
+}

--- a/crates/csskit_ast/src/when_rule.rs
+++ b/crates/csskit_ast/src/when_rule.rs
@@ -1,0 +1,146 @@
+use crate::{CsskitAtomSet, rule_block::RuleBlock};
+use bumpalo::collections::Vec;
+use css_lexer::{Cursor, Kind, KindSet};
+use css_parse::{FeatureConditionList, Parse, Parser, Peek, Result as ParserResult, T};
+use csskit_derives::*;
+
+/// An `@when` rule for conditional validation.
+///
+/// # Syntax
+///
+/// ```css
+/// @when (--stat > threshold) {
+///   diagnostic: "message";
+///   level: error;
+///
+///   selector {
+///     collect: --another-stat;
+///   }
+/// }
+/// ```
+#[derive(Peek, Parse, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct WhenRule<'a> {
+	#[atom(CsskitAtomSet::When)]
+	pub at_keyword: T![AtKeyword],
+	pub condition: WhenCondition<'a>,
+	pub block: RuleBlock<'a>,
+}
+
+/// The condition of an @when rule.
+#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum WhenCondition<'a> {
+	Is(WhenFeature),
+	Not(T![Ident], WhenFeature),
+	And(Vec<'a, (WhenFeature, Option<T![Ident]>)>),
+	Or(Vec<'a, (WhenFeature, Option<T![Ident]>)>),
+}
+
+impl<'a> WhenCondition<'a> {
+	pub fn is_empty(&self) -> bool {
+		match self {
+			Self::Is(_) => false,
+			Self::Not(_, _) => false,
+			Self::And(xs) => xs.is_empty(),
+			Self::Or(xs) => xs.is_empty(),
+		}
+	}
+
+	/// Check if all features in this condition have valid threshold values.
+	pub fn is_valid(&self, source: &str) -> bool {
+		match self {
+			Self::Is(feature) => feature.is_valid(source),
+			Self::Not(_, feature) => feature.is_valid(source),
+			Self::And(features) => features.iter().all(|(f, _)| f.is_valid(source)),
+			Self::Or(features) => features.iter().all(|(f, _)| f.is_valid(source)),
+		}
+	}
+}
+
+impl<'a> FeatureConditionList<'a> for WhenCondition<'a> {
+	type FeatureCondition = WhenFeature;
+
+	fn keyword_is_not<I>(p: &Parser<'a, I>, c: Cursor) -> bool
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		p.to_atom::<CsskitAtomSet>(c) == CsskitAtomSet::Not
+	}
+
+	fn keyword_is_and<I>(p: &Parser<'a, I>, c: Cursor) -> bool
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		p.to_atom::<CsskitAtomSet>(c) == CsskitAtomSet::And
+	}
+
+	fn keyword_is_or<I>(p: &Parser<'a, I>, c: Cursor) -> bool
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		p.to_atom::<CsskitAtomSet>(c) == CsskitAtomSet::Or
+	}
+
+	fn build_is(feature: WhenFeature) -> Self {
+		Self::Is(feature)
+	}
+
+	fn build_not(keyword: T![Ident], feature: WhenFeature) -> Self {
+		Self::Not(keyword, feature)
+	}
+
+	fn build_and(features: Vec<'a, (WhenFeature, Option<T![Ident]>)>) -> Self {
+		Self::And(features)
+	}
+
+	fn build_or(features: Vec<'a, (WhenFeature, Option<T![Ident]>)>) -> Self {
+		Self::Or(features)
+	}
+}
+
+impl<'a> Parse<'a> for WhenCondition<'a> {
+	fn parse<I>(p: &mut Parser<'a, I>) -> ParserResult<Self>
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		Self::parse_condition(p)
+	}
+}
+
+impl<'a> Peek<'a> for WhenCondition<'a> {
+	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::LeftParen, Kind::Ident]);
+}
+
+/// A single condition feature in an @when rule.
+#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[peek(Kind::LeftParen)]
+pub struct WhenFeature {
+	pub open: T!['('],
+	pub stat: T![DashedIdent],
+	pub operator: ComparisonOperator,
+	pub value: T![Number],
+	pub close: Option<T![')']>,
+}
+
+impl WhenFeature {
+	/// Check if the threshold value is valid (can be parsed as usize).
+	pub fn is_valid(&self, source: &str) -> bool {
+		let threshold_cursor = Cursor::from(self.value);
+		let threshold_str = threshold_cursor.str_slice(source);
+		threshold_str.parse::<usize>().is_ok()
+	}
+}
+
+/// Comparison operator for @when conditions.
+#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ComparisonOperator {
+	/// `>`
+	GreaterThan(T![>]),
+	/// `<`
+	LessThan(T![<]),
+	/// `>=`
+	GreaterThanOrEqual(T![>=]),
+	/// `<=`
+	LessThanOrEqual(T![<=]),
+	/// `=`
+	Equal(T![=]),
+}

--- a/crates/csskit_highlight/src/lib.rs
+++ b/crates/csskit_highlight/src/lib.rs
@@ -21,7 +21,7 @@ pub use ansi_highlight_cursor_stream::AnsiHighlightCursorStream;
 #[cfg(feature = "miette")]
 mod highlight;
 #[cfg(feature = "miette")]
-pub use highlight::{CssHighlighter, highlight_css};
+pub use highlight::CssHighlighter;
 
 #[cfg(test)]
 mod test_helpers;


### PR DESCRIPTION
This gigantic commit adds all the infrastructure for basic parsing of rule sheets for a self-built linter infrastructure.

  - Add `Sheet` type for parsing CSS-style statistics/checking files (.cks)
  - Implement `Collector` for traversing CSS and collecting statistics based on rules
  - Add `StatRule` for defining statistics (counter, unique, etc.)
  - Add `NodeRule` for selector-based stat collection with custom properties
  - Add `WhenRule` for conditional validation and diagnostics
  - Add `RuleBlock` supporting nested rules and diagnostic declarations
  - Integrate collector into `csskit check` command with diagnostic output
  - Add acceptance test suite with .cks file format support