### PR TITLE
csskit_ast: Fix up feature flag issues

### DIFF
--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 css_lexer = { workspace = true } # @release
 css_ast = { workspace = true, features = ["chromashift", "visitable", "miette"] } # @release
 css_parse = { workspace = true, features = ["miette"] } # @release
-csskit_ast = { workspace = true, features = ["dynamic-atoms", "miette"] } # @release
+csskit_ast = { workspace = true, features = ["miette"] } # @release
 csskit_lsp = { workspace = true } # @release
 csskit_highlight = { workspace = true, features = ["miette"] } # @release
 chromashift = { workspace = true } # @release

--- a/crates/csskit_ast/Cargo.toml
+++ b/crates/csskit_ast/Cargo.toml
@@ -32,6 +32,4 @@ css_ast = { workspace = true, features = ["visitable"] } # @release
 
 [features]
 default = []
-# Enables dynamic atom interning via CssLexer's DynAtomRegistry
-dynamic-atoms = ["css_lexer/dynamic-atoms"]
 miette = ["dep:miette", "css_lexer/miette"]

--- a/crates/csskit_ast/src/csskit_atom_set.rs
+++ b/crates/csskit_ast/src/csskit_atom_set.rs
@@ -4,7 +4,6 @@ use derive_atom_set::AtomSet;
 
 include!(concat!(env!("OUT_DIR"), "/csskit_atom_set.rs"));
 
-#[cfg(feature = "dynamic-atoms")]
 css_lexer::register_atom_set!(CsskitAtomSet);
 
 impl CsskitAtomSet {


### PR DESCRIPTION
The build failed without `--all-features`, which subsequently failed the
release. This change fixes that.
