### PR TITLE
css_lexer/css_parse: Add SourceCursor compacting, ensure CursorCompactWriteSink compacts cursors before write

### DIFF
--- a/crates/css_lexer/src/lib.rs
+++ b/crates/css_lexer/src/lib.rs
@@ -88,6 +88,7 @@ mod kindset;
 mod pairwise;
 mod private;
 mod quote_style;
+mod small_str_buf;
 mod source_cursor;
 mod source_offset;
 mod span;

--- a/crates/css_lexer/src/private.rs
+++ b/crates/css_lexer/src/private.rs
@@ -1,6 +1,7 @@
 use crate::{
 	CommentStyle, DynAtomSet, Feature, Lexer, QuoteStyle, Token, Whitespace,
 	constants::SINGLE_CHAR_TOKENS,
+	small_str_buf::SmallStrBuf,
 	syntax::{
 		CR, EOF, FF, LF, ParseEscape, SPACE, TAB,
 		identifier::{
@@ -14,40 +15,6 @@ use std::{char::REPLACEMENT_CHARACTER, str::Chars};
 
 // 7 makes size_of::<SmallStrBuf<8>>() == size_of::<usize>()
 const MAX_SMALL_IDENT_SIZE: usize = 7;
-
-#[derive(Debug)]
-struct SmallStrBuf<const N: usize>(u8, [u8; N]);
-
-impl<const N: usize> SmallStrBuf<N> {
-	pub const fn new() -> Self {
-		Self(0, [b'-'; N])
-	}
-
-	#[inline]
-	pub fn append(&mut self, c: char) {
-		let n = self.0 as usize;
-		let char_len = c.len_utf8();
-		if n + char_len <= N {
-			c.encode_utf8(&mut self.1[n..]);
-		}
-		self.0 += char_len as u8;
-	}
-
-	#[inline]
-	pub const fn over_capacity(&self) -> bool {
-		self.0 >= N as u8
-	}
-
-	#[inline]
-	pub fn as_str(&self) -> Option<&str> {
-		if self.over_capacity() {
-			None
-		} else {
-			// SAFETY: We only append valid UTF-8 chars, so this is always valid
-			Some(unsafe { str::from_utf8_unchecked(&self.1[0..self.0 as usize]) })
-		}
-	}
-}
 
 trait CharsConsumer {
 	fn is_last(&self) -> bool;

--- a/crates/css_lexer/src/small_str_buf.rs
+++ b/crates/css_lexer/src/small_str_buf.rs
@@ -1,0 +1,48 @@
+use std::fmt::{Error, Result, Write};
+
+#[derive(Debug)]
+pub(crate) struct SmallStrBuf<const N: usize>(u8, [u8; N]);
+
+impl<const N: usize> SmallStrBuf<N> {
+	pub const fn new() -> Self {
+		Self(0, [b'-'; N])
+	}
+
+	#[inline]
+	pub fn append(&mut self, c: char) {
+		let n = self.0 as usize;
+		let char_len = c.len_utf8();
+		if n + char_len <= N {
+			c.encode_utf8(&mut self.1[n..]);
+		}
+		self.0 += char_len as u8;
+	}
+
+	#[inline]
+	pub const fn over_capacity(&self) -> bool {
+		self.0 >= N as u8
+	}
+
+	#[inline]
+	pub fn as_str(&self) -> Option<&str> {
+		if self.over_capacity() {
+			None
+		} else {
+			// SAFETY: We only append valid UTF-8 chars, so this is always valid
+			Some(unsafe { str::from_utf8_unchecked(&self.1[0..self.0 as usize]) })
+		}
+	}
+}
+
+impl<const N: usize> Write for SmallStrBuf<N> {
+	fn write_str(&mut self, s: &str) -> Result {
+		let b = s.as_bytes();
+		let n = b.len() as u8;
+		if (self.0 + n) as usize > N {
+			return Err(Error);
+		}
+		self.1[self.0 as usize..(self.0 + n) as usize].copy_from_slice(b);
+		self.0 += n;
+		Ok(())
+	}
+}


### PR DESCRIPTION
This change fixes #778 by adding a `compact()` function to SourceCursor. This
sets a flag that gives SourceCursor the opportunity to change how it formats a
SourceCursor, relying less on the underlying source data and being able to write
out more compacted tokens. For Numbers (and Dimension number parts) this means
writing out using Rust's number formatting, which generally finds the minimum
viable digits to represent an f32 - so omitting trailing `0`s as well as
omitting the sign when not necessary. This also adds the logic to omit the
leading `0` when not necessary. For idents/hashes/at-keywords/functions this
means converting escape characters (e.g. `\66`) to their equivalent unicode
(.e.g `f`). This change also utilises this new API in the
CursorCompactWriteSink, meaning the `csskit min` command will benefit from this.
