### PR TITLE
chromashift: Fix lossy alpha conversions

### DIFF
--- a/crates/chromashift/src/hex.rs
+++ b/crates/chromashift/src/hex.rs
@@ -24,7 +24,7 @@ impl Hex {
 		is_shorthand_byte(red)
 			&& is_shorthand_byte(green)
 			&& is_shorthand_byte(blue)
-			&& is_shorthand_byte(((alpha as u32 * 255) / 100) as u8)
+			&& is_shorthand_byte((alpha * 255.0 / 100.0).round() as u8)
 	}
 
 	pub const fn has_alpha(&self) -> bool {
@@ -41,7 +41,7 @@ impl ToAlpha for Hex {
 impl fmt::Display for Hex {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		let Srgb { red, green, blue, alpha } = (*self).into();
-		let alpha = (alpha as u32 * 255) / 100;
+		let alpha = (alpha * 255.0 / 100.0).round() as u32;
 		if self.can_use_3_digit() {
 			write!(f, "#{:x}{:x}{:x}", red & 0xF, green & 0xF, blue & 0xF)
 		} else if self.can_use_4_digit() {
@@ -68,6 +68,11 @@ impl From<Hex> for Srgb {
 impl From<Srgb> for Hex {
 	fn from(value: Srgb) -> Self {
 		let Srgb { red, green, blue, alpha } = value;
-		Hex::new(((red as u32) << 24) | ((green as u32) << 16) | ((blue as u32) << 8) | ((alpha as u32 * 255) / 100))
+		Hex::new(
+			((red as u32) << 24)
+				| ((green as u32) << 16)
+				| ((blue as u32) << 8)
+				| ((alpha * 255.0 / 100.0).round() as u32),
+		)
 	}
 }

--- a/crates/chromashift/src/tests.rs
+++ b/crates/chromashift/src/tests.rs
@@ -202,6 +202,26 @@ fn text_hex_display() {
 }
 
 #[test]
+fn text_hex_alpha_conversion() {
+	assert_eq!(format!("{}", Hex::from(Srgb::new(255, 255, 255, 0.0))), "#fff0");
+	assert_eq!(Hex::from(Srgb::new(255, 255, 255, 0.0)), Hex::new(0xFFFFFF00));
+	assert_eq!(format!("{}", Hex::from(Srgb::new(255, 255, 255, 50.0))), "#ffffff80");
+	assert_eq!(Hex::from(Srgb::new(255, 255, 255, 50.0)), Hex::new(0xFFFFFF80));
+	let original = Srgb::new(255, 255, 255, 50.0);
+	let hex = Hex::from(original);
+	let round_tripped = Srgb::from(hex);
+	assert!(
+		round_tripped.close_to(original, COLOR_EPSILON),
+		"Round-trip failed: original={:?}, round_tripped={:?}",
+		original,
+		round_tripped
+	);
+	assert_eq!(Hex::from(Srgb::new(0, 0, 0, 25.0)), Hex::new(0x00000040));
+	assert_eq!(Hex::from(Srgb::new(0, 0, 0, 75.0)), Hex::new(0x000000BF));
+	assert_eq!(Hex::from(Srgb::new(0, 0, 0, 100.0)), Hex::new(0x000000FF));
+}
+
+#[test]
 fn named_try_from_other_spaces() {
 	let named = Named::Rebeccapurple;
 	let srgb = Srgb::new(102, 51, 153, 100.0);


### PR DESCRIPTION
When converting an Rgb to Hex (or vice versa) Hex colours performed a lossy
conversion of the alpha channel due to floating point issues. This meant an
alpha of 50% would be converted to 127.5 (`(50 * 255) / 100 = 127.50` - floored
due to the conversion to int (u32) from float). This discrepancy would be
exacerbated further when converting back, e.g.

  Rgb 50 -> Hex 127
	Hex 127 -> Rgb 49
	Rgb 49 -> Hex 124

and so on. This change fixes the issue by rounding up before converting to an
int, eliminating this discrepancy.
