### PR TITLE
csskit_transform: Add Reduce colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ version = "0.0.13"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
+ "chromashift",
  "criterion",
  "css_ast",
  "css_lexer",

--- a/coverage/basic/colors.css
+++ b/coverage/basic/colors.css
@@ -1,0 +1,19 @@
+body {
+  color: #ffffff;
+}
+
+.named {
+  color: rgb(210, 180, 140);
+}
+
+.noop {
+  color: red;
+}
+
+.short {
+  color: #000000;
+}
+
+.alpha {
+  color: rgba(0, 0, 0, 0);
+}

--- a/coverage/basic/colors.min.css
+++ b/coverage/basic/colors.min.css
@@ -1,0 +1,1 @@
+body{color:#fff}.named{color:tan}.noop{color:red}.short{color:#000}.alpha{color:#0000}

--- a/coverage/basic/media.min.css
+++ b/coverage/basic/media.min.css
@@ -1,1 +1,1 @@
-@media screen{body{color:black}}
+@media screen{body{color:#000}}

--- a/crates/csskit_transform/Cargo.toml
+++ b/crates/csskit_transform/Cargo.toml
@@ -13,11 +13,12 @@ repository.workspace = true
 bench = false
 
 [dependencies]
-css_ast = { workspace = true, features = ["visitable"] }
+css_ast = { workspace = true, features = ["visitable", "chromashift"] }
 css_parse = { workspace = true }
 css_lexer = { workspace = true }
 bumpalo = { workspace = true }
 bitmask-enum = { workspace = true }
+chromashift = { workspace = true }
 
 [dev-dependencies]
 glob = { workspace = true }

--- a/crates/csskit_transform/src/css_minifier.rs
+++ b/crates/csskit_transform/src/css_minifier.rs
@@ -1,10 +1,12 @@
-use crate::{ReduceLengths, transformer};
+use crate::{ReduceColors, ReduceLengths, transformer};
 use bitmask_enum::bitmask;
 use css_ast::{CssMetadata, Visitable};
 
 transformer!(
 	/// Runtime feature flags for the CSS minifier, enabling individual transforms.
 	pub enum CssMinifierFeature[CssMetadata, Visitable] {
+		/// Enables the [ReduceColors] transformer.
+		ReduceColors,
 		/// Enables the [ReduceLengths] transformer.
 		ReduceLengths,
 	}

--- a/crates/csskit_transform/src/lib.rs
+++ b/crates/csskit_transform/src/lib.rs
@@ -13,9 +13,11 @@ pub(crate) mod prelude {
 }
 
 mod css_minifier;
+mod reduce_colors;
 mod reduce_lengths;
 
 pub use css_minifier::*;
+pub use reduce_colors::*;
 pub use reduce_lengths::*;
 
 #[cfg(test)]

--- a/crates/csskit_transform/src/reduce_colors.rs
+++ b/crates/csskit_transform/src/reduce_colors.rs
@@ -1,0 +1,108 @@
+use crate::prelude::*;
+use chromashift::{Hex, Named, Srgb};
+use css_ast::{Color, ToChromashift, Visitable};
+
+pub struct ReduceColors<'a, 'ctx, N: Visitable + NodeWithMetadata<CssMetadata>> {
+	pub transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>,
+}
+
+impl<'a, 'ctx, N> Transform<'a, 'ctx, CssMetadata, N, CssMinifierFeature> for ReduceColors<'a, 'ctx, N>
+where
+	N: Visitable + NodeWithMetadata<CssMetadata>,
+{
+	fn may_change(features: CssMinifierFeature, node: &N) -> bool {
+		features.contains(CssMinifierFeature::ReduceColors) && node.metadata().has_colors()
+	}
+
+	fn new(transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>) -> Self {
+		Self { transformer }
+	}
+}
+
+impl<'a, 'ctx, N> Visit for ReduceColors<'a, 'ctx, N>
+where
+	N: Visitable + NodeWithMetadata<CssMetadata>,
+{
+	fn visit_color(&mut self, color: &Color) {
+		let Some(chroma_color) = color.to_chromashift() else {
+			return;
+		};
+		let len = color.to_span().len() as usize;
+
+		let srgb = Srgb::from(chroma_color);
+		let Some(candidate) = [
+			Some(Hex::from(srgb).to_string()),
+			Named::try_from(chroma_color).ok().map(|named| named.to_string()),
+			Some(srgb.to_string()),
+		]
+		.into_iter()
+		.flatten()
+		.min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b))) else {
+			return;
+		};
+
+		if candidate.len() < len {
+			self.transformer.replace_parsed::<Color>(color.to_span(), &candidate);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::test_helpers::{assert_no_transform, assert_transform};
+	use css_ast::{CssAtomSet, StyleSheet};
+
+	#[test]
+	fn reduces_full_length_hex() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"body { color: #ffffff; }",
+			"body { color: #fff; }"
+		);
+	}
+
+	#[test]
+	fn prefers_shorthand_hex_over_keyword() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"body { color: #000000; }",
+			"body { color: #000; }"
+		);
+	}
+
+	#[test]
+	fn prefers_named_over_rgb() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"body { color: rgb(210, 180, 140); }",
+			"body { color: tan; }"
+		);
+	}
+
+	#[test]
+	fn shortens_alpha_hex() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"body { color: rgba(255, 0, 0, 0.5); }",
+			"body { color: #ff000080; }"
+		);
+	}
+
+	#[test]
+	fn no_transform_when_already_short() {
+		assert_no_transform!(CssMinifierFeature::ReduceColors, CssAtomSet, StyleSheet, "body { color: red; }");
+	}
+
+	#[test]
+	fn no_transform_for_currentcolor() {
+		assert_no_transform!(CssMinifierFeature::ReduceColors, CssAtomSet, StyleSheet, "body { color: currentcolor; }");
+	}
+}


### PR DESCRIPTION
This change introduces the ReduceColors transform which compacts color values to their smallest forms. Closes #775.
