### PR TITLE
csskit_transform: Reduce more color types

### DIFF
--- a/coverage/basic/colors.css
+++ b/coverage/basic/colors.css
@@ -17,3 +17,11 @@ body {
 .alpha {
   color: rgba(0, 0, 0, 0);
 }
+
+.other-props {
+  background-color: black;
+  outline-color: black;
+  caret-color: black;
+  accent-color: black;
+  border-block-start-color: black;
+}

--- a/coverage/basic/colors.min.css
+++ b/coverage/basic/colors.min.css
@@ -1,1 +1,1 @@
-body{color:#fff}.named{color:tan}.noop{color:red}.short{color:#000}.alpha{color:#0000}
+body{color:#fff}.named{color:tan}.noop{color:red}.short{color:#000}.alpha{color:#0000}.other-props{background-color:#000;outline-color:#000;caret-color:#000;accent-color:#000;border-block-start-color:#000}

--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -217,12 +217,6 @@ impl CssMetadata {
 		!self.box_portions.is_none()
 	}
 
-	/// Returns true if this block contains any color-related properties.
-	#[inline]
-	pub fn has_colors(&self) -> bool {
-		self.property_groups.intersects(PropertyGroup::Color | PropertyGroup::ColorHdr | PropertyGroup::ColorAdjust)
-	}
-
 	/// Returns true if metadata contains important declarations.
 	#[inline]
 	pub fn has_important(&self) -> bool {
@@ -419,7 +413,6 @@ mod tests {
 		assert!(metadata.property_groups.contains(PropertyGroup::Color));
 		assert!(metadata.property_groups.contains(PropertyGroup::Sizing));
 		assert!(metadata.modifies_box());
-		assert!(metadata.has_colors());
 		assert!(metadata.has_longhands());
 	}
 
@@ -462,7 +455,6 @@ mod tests {
 
 		assert!(metadata.property_groups.contains(PropertyGroup::Color));
 		assert!(metadata.used_at_rules.contains(AtRuleId::Media));
-		assert!(metadata.has_colors());
 	}
 
 	#[test]

--- a/crates/csskit_transform/src/reduce_colors.rs
+++ b/crates/csskit_transform/src/reduce_colors.rs
@@ -10,8 +10,8 @@ impl<'a, 'ctx, N> Transform<'a, 'ctx, CssMetadata, N, CssMinifierFeature> for Re
 where
 	N: Visitable + NodeWithMetadata<CssMetadata>,
 {
-	fn may_change(features: CssMinifierFeature, node: &N) -> bool {
-		features.contains(CssMinifierFeature::ReduceColors) && node.metadata().has_colors()
+	fn may_change(features: CssMinifierFeature, _node: &N) -> bool {
+		features.contains(CssMinifierFeature::ReduceColors)
 	}
 
 	fn new(transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>) -> Self {


### PR DESCRIPTION
The `has_colors()` wasn't accurate, as color nodes can be on many properties.
It's far simpler to just visit color nodes and we don't need to check metadata
before that.

This also removes `.has_colors()` as it was not accurate, and could mislead us
later on also.
