### PR TITLE
css_ast/css_lexer: Preserve sign in an+b, otherwise compact

### DIFF
--- a/coverage/basic/nth.css
+++ b/coverage/basic/nth.css
@@ -1,2 +1,15 @@
-:nth-child(n+1) {
-}
+/* Various nth patterns for testing */
+:nth-child(n+1) {}
+:nth-child(n-1) {}
+:nth-child(+n) {}
+:nth-child(-n) {}
+:nth-child(5) {}
+:nth-child(+5) {}
+:nth-child(-5) {}
+:nth-child(2n) {}
+:nth-child(2n+1) {}
+:nth-child(2n-1) {}
+:nth-child(+2n+1) {}
+:nth-child(-2n+1) {}
+:nth-child(odd) {}
+:nth-child(even) {}

--- a/coverage/basic/nth.find.1.txt
+++ b/coverage/basic/nth.find.1.txt
@@ -1,4 +1,17 @@
 style-rule
 ---
 coverage/basic/nth.css
-1:1::nth-child(n+1) {
+2:1::nth-child(n+1) {}
+3:1::nth-child(n-1) {}
+4:1::nth-child(+n) {}
+5:1::nth-child(-n) {}
+6:1::nth-child(5) {}
+7:1::nth-child(+5) {}
+8:1::nth-child(-5) {}
+9:1::nth-child(2n) {}
+10:1::nth-child(2n+1) {}
+11:1::nth-child(2n-1) {}
+12:1::nth-child(+2n+1) {}
+13:1::nth-child(-2n+1) {}
+14:1::nth-child(odd) {}
+15:1::nth-child(even) {}

--- a/coverage/basic/nth.fmt.css
+++ b/coverage/basic/nth.fmt.css
@@ -1,2 +1,15 @@
 :nth-child(n+1) {}
+:nth-child(n-1) {}
+:nth-child(+ n) {}
+:nth-child(-n) {}
+:nth-child(5) {}
+:nth-child(+5) {}
+:nth-child(-5) {}
+:nth-child(2n) {}
+:nth-child(2n+1) {}
+:nth-child(2n-1) {}
+:nth-child(+2n+1) {}
+:nth-child(-2n+1) {}
+:nth-child(odd) {}
+:nth-child(even) {}
 

--- a/coverage/basic/nth.min.css
+++ b/coverage/basic/nth.min.css
@@ -1,1 +1,1 @@
-:nth-child(n+1){}
+:nth-child(n+1){}:nth-child(n-1){}:nth-child(+n){}:nth-child(-n){}:nth-child(5){}:nth-child(+5){}:nth-child(-5){}:nth-child(2n){}:nth-child(2n+1){}:nth-child(2n-1){}:nth-child(2n+1){}:nth-child(-2n+1){}:nth-child(odd){}:nth-child(even){}

--- a/crates/css_ast/src/units/int.rs
+++ b/crates/css_ast/src/units/int.rs
@@ -9,6 +9,10 @@ pub struct CSSInt(T![Number]);
 impl CSSInt {
 	#[allow(non_upper_case_globals)]
 	pub const Zero: CSSInt = CSSInt(<T![Number]>::ZERO);
+
+	pub fn preserve_sign(self) -> Self {
+		CSSInt(self.0.preserve_sign())
+	}
 }
 
 impl From<CSSInt> for i32 {

--- a/crates/css_ast/tests/snapshots/basic_snapshots__basic_nth.snap
+++ b/crates/css_ast/tests/snapshots/basic_snapshots__basic_nth.snap
@@ -11,26 +11,26 @@ StyleSheet(
             FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
               colon: Colon(Cursor(
                 kind: "Colon",
-                offset: SourceOffset(0),
+                offset: SourceOffset(39),
                 len: 1,
               )),
               function: Function(Cursor(
                 kind: "Function",
-                offset: SourceOffset(1),
+                offset: SourceOffset(40),
                 len: 10,
               )),
               value: Anb(1, 1, (Cursor(
                 kind: "Ident",
-                offset: SourceOffset(11),
+                offset: SourceOffset(50),
                 len: 1,
               ), None, None, Cursor(
                 kind: "Number",
-                offset: SourceOffset(12),
+                offset: SourceOffset(51),
                 len: 2,
               ))),
               close: Some(RightParen(Cursor(
                 kind: "RightParen",
-                offset: SourceOffset(14),
+                offset: SourceOffset(53),
                 len: 1,
               ))),
             ))),
@@ -39,14 +39,602 @@ StyleSheet(
         block: Block(
           open_curly: LeftCurly(Cursor(
             kind: "LeftCurly",
-            offset: SourceOffset(16),
+            offset: SourceOffset(55),
             len: 1,
           )),
           declarations: [],
           rules: [],
           close_curly: Some(RightCurly(Cursor(
             kind: "RightCurly",
-            offset: SourceOffset(18),
+            offset: SourceOffset(56),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(58),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(59),
+                len: 10,
+              )),
+              value: Anb(1, -1, (Cursor(
+                kind: "Ident",
+                offset: SourceOffset(69),
+                len: 3,
+              ), None, None, None)),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(72),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(74),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(75),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(77),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(78),
+                len: 10,
+              )),
+              value: Anb(1, 0, (Cursor(
+                kind: "Delim",
+                offset: SourceOffset(88),
+                len: 1,
+              ), Cursor(
+                kind: "Ident",
+                offset: SourceOffset(89),
+                len: 1,
+              ), None, None)),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(90),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(92),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(93),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(95),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(96),
+                len: 10,
+              )),
+              value: Anb(-1, 0, (Cursor(
+                kind: "Ident",
+                offset: SourceOffset(106),
+                len: 2,
+              ), None, None, None)),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(108),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(110),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(111),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(113),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(114),
+                len: 10,
+              )),
+              value: Integer(Number(Cursor(
+                kind: "Number",
+                offset: SourceOffset(124),
+                len: 1,
+              ))),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(125),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(127),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(128),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(130),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(131),
+                len: 10,
+              )),
+              value: Integer(Number(Cursor(
+                kind: "Number",
+                offset: SourceOffset(141),
+                len: 2,
+              ))),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(143),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(145),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(146),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(148),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(149),
+                len: 10,
+              )),
+              value: Integer(Number(Cursor(
+                kind: "Number",
+                offset: SourceOffset(159),
+                len: 2,
+              ))),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(161),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(163),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(164),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(166),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(167),
+                len: 10,
+              )),
+              value: Anb(2, 0, (Cursor(
+                kind: "Dimension",
+                offset: SourceOffset(177),
+                len: 2,
+              ), None, None, None)),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(179),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(181),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(182),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(184),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(185),
+                len: 10,
+              )),
+              value: Anb(2, 1, (Cursor(
+                kind: "Dimension",
+                offset: SourceOffset(195),
+                len: 2,
+              ), None, None, Cursor(
+                kind: "Number",
+                offset: SourceOffset(197),
+                len: 2,
+              ))),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(199),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(201),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(202),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(204),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(205),
+                len: 10,
+              )),
+              value: Anb(2, -1, (Cursor(
+                kind: "Dimension",
+                offset: SourceOffset(215),
+                len: 4,
+              ), None, None, None)),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(219),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(221),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(222),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(224),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(225),
+                len: 10,
+              )),
+              value: Anb(2, 1, (Cursor(
+                kind: "Dimension",
+                offset: SourceOffset(235),
+                len: 3,
+              ), None, None, Cursor(
+                kind: "Number",
+                offset: SourceOffset(238),
+                len: 2,
+              ))),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(240),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(242),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(243),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(245),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(246),
+                len: 10,
+              )),
+              value: Anb(-2, 1, (Cursor(
+                kind: "Dimension",
+                offset: SourceOffset(256),
+                len: 3,
+              ), None, None, Cursor(
+                kind: "Number",
+                offset: SourceOffset(259),
+                len: 2,
+              ))),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(261),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(263),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(264),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(266),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(267),
+                len: 10,
+              )),
+              value: Odd(Ident(Cursor(
+                kind: "Ident",
+                offset: SourceOffset(277),
+                len: 3,
+              ))),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(280),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(282),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(283),
+            len: 1,
+          ))),
+        ),
+      ),
+    ),
+    StyleRule(
+      rule: QualifiedRule(
+        prelude: SelectorList([
+          (CompoundSelector([
+            FunctionalPseudoClass(NthChild(NthChildPseudoFunction(
+              colon: Colon(Cursor(
+                kind: "Colon",
+                offset: SourceOffset(285),
+                len: 1,
+              )),
+              function: Function(Cursor(
+                kind: "Function",
+                offset: SourceOffset(286),
+                len: 10,
+              )),
+              value: Even(Ident(Cursor(
+                kind: "Ident",
+                offset: SourceOffset(296),
+                len: 4,
+              ))),
+              close: Some(RightParen(Cursor(
+                kind: "RightParen",
+                offset: SourceOffset(300),
+                len: 1,
+              ))),
+            ))),
+          ]), None),
+        ]),
+        block: Block(
+          open_curly: LeftCurly(Cursor(
+            kind: "LeftCurly",
+            offset: SourceOffset(302),
+            len: 1,
+          )),
+          declarations: [],
+          rules: [],
+          close_curly: Some(RightCurly(Cursor(
+            kind: "RightCurly",
+            offset: SourceOffset(303),
             len: 1,
           ))),
         ),

--- a/crates/css_lexer/src/cursor.rs
+++ b/crates/css_lexer/src/cursor.rs
@@ -77,6 +77,15 @@ impl Cursor {
 		Self::new(self.offset(), self.token().with_associated_whitespace(rules))
 	}
 
+	/// Returns a new [Cursor] with the `sign_is_required` flag set on the token.
+	/// This indicates that the `+` sign should be preserved during minification.
+	///
+	/// Asserts: the token `kind()` is [Kind::Number].
+	pub fn with_sign_required(&self) -> Self {
+		debug_assert!(self.1 == Kind::Number);
+		Self::new(self.offset(), self.token().with_sign_required())
+	}
+
 	#[inline]
 	pub fn atom_bits(&self) -> u32 {
 		self.1.atom_bits()

--- a/crates/css_lexer/tests/snapshots/basic_snapshots__basic_nth.snap
+++ b/crates/css_lexer/tests/snapshots/basic_snapshots__basic_nth.snap
@@ -31,4 +31,332 @@ expression: tokens
     kind: "RightCurly",
     len: 1,
   ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Ident",
+    len: 3,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Delim",
+    len: 1,
+  ),
+  Token(
+    kind: "Ident",
+    len: 1,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Ident",
+    len: 2,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Number",
+    len: 1,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Number",
+    len: 2,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Number",
+    len: 2,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Dimension",
+    len: 2,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Dimension",
+    len: 2,
+  ),
+  Token(
+    kind: "Number",
+    len: 2,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Dimension",
+    len: 4,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Dimension",
+    len: 3,
+  ),
+  Token(
+    kind: "Number",
+    len: 2,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Dimension",
+    len: 3,
+  ),
+  Token(
+    kind: "Number",
+    len: 2,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Ident",
+    len: 3,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "Colon",
+    len: 1,
+  ),
+  Token(
+    kind: "Function",
+    len: 10,
+  ),
+  Token(
+    kind: "Ident",
+    len: 4,
+  ),
+  Token(
+    kind: "RightParen",
+    len: 1,
+  ),
+  Token(
+    kind: "LeftCurly",
+    len: 1,
+  ),
+  Token(
+    kind: "RightCurly",
+    len: 1,
+  ),
 ]

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -562,6 +562,10 @@ impl Number {
 	pub fn has_sign(&self) -> bool {
 		self.0.token().has_sign()
 	}
+
+	pub fn preserve_sign(self) -> Self {
+		if self.has_sign() { Self(self.0.with_sign_required()) } else { self }
+	}
 }
 
 impl<'a> Peek<'a> for Number {


### PR DESCRIPTION
Currently the minifier will always preserve the `+` sign, even when it's
redundant. For example `+5s` will be "minified" as `+5s` despite it being
possible to remove the `+` and compact to `5s`. This is largely because the `+`
sign is _sometimes_ required, for example in AN+B syntax where `5n+1` _must_ be
serialised as `5n+1`; `5n1` is invalid.

Luckily, we have a single reserved bit in the Number bitflags. We can leverage
this to store a "preserve sign" flag, which we can set during parse of AN+B
syntax. Then during compaction we can check the "preserve sign" flag to check if
we can safely elide the `+` or render it.
