### PR TITLE
css_ast: Don't preserve sign for integer An+B selectors.

### DIFF
--- a/coverage/basic/nth.min.css
+++ b/coverage/basic/nth.min.css
@@ -1,1 +1,1 @@
-:nth-child(n+1){}:nth-child(n-1){}:nth-child(+n){}:nth-child(-n){}:nth-child(5){}:nth-child(+5){}:nth-child(-5){}:nth-child(2n){}:nth-child(2n+1){}:nth-child(2n-1){}:nth-child(2n+1){}:nth-child(-2n+1){}:nth-child(odd){}:nth-child(even){}
+:nth-child(n+1){}:nth-child(n-1){}:nth-child(+n){}:nth-child(-n){}:nth-child(5){}:nth-child(5){}:nth-child(-5){}:nth-child(2n){}:nth-child(2n+1){}:nth-child(2n-1){}:nth-child(2n+1){}:nth-child(-2n+1){}:nth-child(odd){}:nth-child(even){}

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -30,7 +30,7 @@ impl<'a> Parse<'a> for Nth {
 		I: Iterator<Item = Cursor> + Clone,
 	{
 		if p.peek::<CSSInt>() {
-			return Ok(Self::Integer(p.parse::<CSSInt>()?.preserve_sign()));
+			return Ok(Self::Integer(p.parse::<CSSInt>()?));
 		} else if p.peek::<T![Ident]>() {
 			let peek_cursor = p.peek_n(1);
 			let atom = p.to_atom::<CssAtomSet>(peek_cursor);


### PR DESCRIPTION
In #828 we introduced sign preservation to ensure An+B syntax was preserved
while still eliding redundant signs during minification. However we were a
little too conservative. An+B integer expressions like `nth-child(+5)` can be
equally represented by `nth-child(5)`.

This change removes the preserve_sign() call on integer expressions, allowing
these to be properly minified.
