### PR TITLE
feat: supports the format feature in the playground

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/csskit_wasm/Cargo.toml
+++ b/crates/csskit_wasm/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["console_error_panic_hook", "serde", "fancy"]
+console_error_panic_hook = ["dep:console_error_panic_hook", "dep:web-sys"]
 serde = ["css_lexer/serde", "css_ast/serde", "css_parse/serde", "bumpalo/serde"]
 miette = ["css_parse/miette", "css_ast/miette"]
 fancy = ["miette", "miette/fancy-no-syscall"]
@@ -35,6 +36,7 @@ serde-wasm-bindgen = { workspace = true }
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { workspace = true, optional = true }
+web-sys = { version = "0.3", features = ["console"], optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.54"

--- a/crates/csskit_wasm/src/lib.rs
+++ b/crates/csskit_wasm/src/lib.rs
@@ -98,7 +98,7 @@ pub fn format(source_text: String, options: JsValue) -> Result<String, serde_was
 			FormatOptions::default()
 		}
 	};
-	format_with_options(&source_text, options).map_err(|err| serde_wasm_bindgen::Error::new(err))
+	format_with_options(&source_text, options).map_err(serde_wasm_bindgen::Error::new)
 }
 
 fn format_with_options(source_text: &str, options: FormatOptions) -> Result<String, String> {
@@ -197,10 +197,7 @@ mod tests {
 	#[test]
 	fn format_respects_quote_style() {
 		let source = r#".a { content: "foo"; }"#;
-		let options = FormatOptions {
-			quote_style: Some(QuoteStyleOption::Single),
-			..FormatOptions::default()
-		};
+		let options = FormatOptions { quote_style: Some(QuoteStyleOption::Single), ..FormatOptions::default() };
 		let output = format_with_options(source, options).expect("format should succeed");
 		assert!(output.contains("content: 'foo'"));
 	}

--- a/crates/csskit_wasm/src/lib.rs
+++ b/crates/csskit_wasm/src/lib.rs
@@ -2,14 +2,16 @@
 use bumpalo::Bump;
 use core::fmt::Write;
 use css_ast::{CssAtomSet, StyleSheet};
-use css_lexer::{Kind, Lexer};
-use css_parse::{CursorCompactWriteSink, CursorOverlaySink, Diagnostic, DiagnosticMeta, Parser, ToCursors};
+use css_lexer::{Kind, Lexer, QuoteStyle};
+use css_parse::{
+	CursorCompactWriteSink, CursorOverlaySink, CursorPrettyWriteSink, Diagnostic, DiagnosticMeta, Parser, ToCursors,
+};
 use csskit_transform::{CssMinifierFeature, Transformer};
 #[cfg(not(feature = "fancy"))]
 use miette::JSONReportHandler;
 #[cfg(feature = "fancy")]
 use miette::{GraphicalReportHandler, GraphicalTheme};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]
@@ -87,6 +89,45 @@ pub fn minify(source_text: String) -> Result<String, serde_wasm_bindgen::Error> 
 }
 
 #[wasm_bindgen]
+pub fn format(source_text: String, options: JsValue) -> Result<String, serde_wasm_bindgen::Error> {
+	let options: FormatOptions = match serde_wasm_bindgen::from_value(options) {
+		Ok(opts) => opts,
+		Err(e) => {
+			#[cfg(feature = "console_error_panic_hook")]
+			web_sys::console::warn_1(&format!("Failed to parse format options: {}. Using defaults.", e).into());
+			FormatOptions::default()
+		}
+	};
+	format_with_options(&source_text, options).map_err(|err| serde_wasm_bindgen::Error::new(err))
+}
+
+fn format_with_options(source_text: &str, options: FormatOptions) -> Result<String, String> {
+	let allocator = Bump::default();
+	let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
+	let result = Parser::new(&allocator, source_text, lexer).parse_entirely::<StyleSheet>();
+	if !result.errors.is_empty() {
+		let first_error = &result.errors[0];
+		let DiagnosticMeta { code, message, help, .. } = (first_error.formatter)(first_error, source_text);
+		return Err(format!("Parse error [{}]: {} (Help: {})", code, message, help));
+	}
+	let mut output_string = String::new();
+	if result.output.is_some() {
+		let indent_width = options.indent_width.unwrap_or(2).clamp(1, 8);
+		let expand_tab = match options.indent_style.unwrap_or(IndentStyle::Spaces) {
+			IndentStyle::Spaces => Some(indent_width),
+			IndentStyle::Tabs => None,
+		};
+		let quote_style = match options.quote_style.unwrap_or(QuoteStyleOption::Double) {
+			QuoteStyleOption::Double => QuoteStyle::Double,
+			QuoteStyleOption::Single => QuoteStyle::Single,
+		};
+		let mut stream = CursorPrettyWriteSink::new(source_text, &mut output_string, expand_tab, quote_style);
+		result.to_cursors(&mut stream);
+	}
+	Ok(output_string)
+}
+
+#[wasm_bindgen]
 pub fn parse_error_report(source_text: String) -> String {
 	let allocator = Bump::default();
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text.as_str());
@@ -122,6 +163,47 @@ fn build_error(err: &Diagnostic, source: &str, w: &mut impl Write) {
 pub struct SerializableParserResult {
 	ast: JsValue,
 	diagnostics: Vec<JsValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum IndentStyle {
+	Spaces,
+	Tabs,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum QuoteStyleOption {
+	Double,
+	Single,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default, rename_all = "snake_case")]
+struct FormatOptions {
+	#[serde(alias = "indent-style", alias = "indentStyle")]
+	indent_style: Option<IndentStyle>,
+	#[serde(alias = "indent-width", alias = "indentWidth")]
+	indent_width: Option<u8>,
+	#[serde(alias = "quote-style", alias = "quoteStyle")]
+	quote_style: Option<QuoteStyleOption>,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn format_respects_quote_style() {
+		let source = r#".a { content: "foo"; }"#;
+		let options = FormatOptions {
+			quote_style: Some(QuoteStyleOption::Single),
+			..FormatOptions::default()
+		};
+		let output = format_with_options(source, options).expect("format should succeed");
+		assert!(output.contains("content: 'foo'"));
+	}
 }
 
 #[derive(Default, Clone, Serialize)]

--- a/website/css/playground.css
+++ b/website/css/playground.css
@@ -2,6 +2,18 @@ main {
 	height: 100vh;
 }
 
+.container {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.content-panel {
+	display: grid;
+  grid-template-columns: auto 1fr 1fr;
+	flex: 1;
+}
+
 csskit-editor,
 csskit-viewer {
 	font-family: monospace;
@@ -24,11 +36,11 @@ wasm-loader {
 	font-size: 90px;
 }
 
-wasm-loader + csskit-editor {
+wasm-loader+csskit-editor {
 	display: none;
 }
 
-main > row-stack > :first-child {
+.content-panel > * {
 	border-right: 1px solid var(--surface-2);
 }
 
@@ -51,7 +63,6 @@ csskit-viewer {
 	border-bottom: 1px solid var(--indigo-6);
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
 }
 
 metric-observer {
@@ -62,8 +73,70 @@ metric-observer::part(value) {
 	margin-left: 1em;
 }
 
+.controls {
+	color: #333;
+
+	.example-item {
+		color: #fff;
+	}
+}
+
+radiogroup > * {
+	display: grid;
+	grid-template-columns: repeat(2, max-content);
+	justify-content: space-around;
+}
+
 radiogroup label {
-	margin-inline: 1rem;
+	display: inline-flex;
+	align-items: center;
+	gap: 0 .25rem;
+	cursor: pointer;
+}
+
+.formatter-controls {
+	height: auto;
+	min-height: 0;
+	width: 13rem;
+	align-items: flex-start;
+	padding: .8em .5em;
+	background: #fafafa;
+}
+
+.format-form {
+	display: flex;
+	flex-direction: column;
+	gap: 0.6rem;
+}
+
+.formatter-options-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+	margin-top: 1rem;
+}
+
+.formatter-options-title {
+	font-weight: 600;
+}
+
+.format-options {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	flex-wrap: wrap;
+
+	select, input {
+		color: #fff;
+		padding: .2em .5em;
+	}
+}
+
+.format-options label {
+	margin-inline: 0;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35rem;
 }
 
 error-diagnostic-count {
@@ -82,15 +155,16 @@ error-diagnostic-count[count="0"] {
 	visibility: hidden;
 }
 
-body:has(input[name="format"][value="minify"]:not(:checked))
-	metric-observer[name="minify"] {
-	display: none;
+body:has(input[name="format"][value="minify"]:not(:checked)) metric-observer[name="minify"] {
+	visibility: hidden;
 }
 
-:where(
-		textarea,
-		select,
-		input:not([type="button"], [type="submit"], [type="reset"])
-	) {
+body:has(input[name="format"][value="format"]:not(:checked)) .formatter-options-panel {
+	visibility: hidden;
+}
+
+:where(textarea,
+	select,
+	input:not([type="button"], [type="submit"], [type="reset"])) {
 	background-color: var(--gray-7);
 }

--- a/website/playground/index.html
+++ b/website/playground/index.html
@@ -4,69 +4,49 @@ hide_header: true
 hide_sidebar: true
 hide_footer: true
 css:
-  - "playground"
+- "playground"
 script:
-  - index
+- index
 title: csskit playground
 ---
 
-<row-stack>
-	<col-stack>
-		<row-stack class="controls">
-			<a style="width:125px;margin:1rem 0" href="/"><img width="75" src="/images/logo.svg" /></a>
-			<example-picker>
-				<form>
-					<label>
-						Examples:
-						<select name="example">
-							<option value="">(Blank)</option>
-							<option value="/examples/960.css">960.gs</option>
-							<option value="/examples/animate.4.1.1.css">animate 4.1.1</option>
-							<option value="/examples/blueprint.1.0.1.css">blueprint 1.0.1</option>
-							<option value="/examples/bootstrap.4.6.2.css">bootstrap 4.6.2</option>
-							<option value="/examples/bootstrap.5.3.0.css">bootstrap 5.3.0</option>
-							<option value="/examples/font-awesome-all.5.15.4.css">font-awesome (all) 5.15.4</option>
-							<option value="/examples/foundation.6.7.5.css">foundation 6.7.5</option>
-							<option value="/examples/inuitcss.6.0.0.css">inuit 6.0.0</option>
-							<option value="/examples/mini.css.3.0.1.css">mini.css 3.0.1</option>
-							<option value="/examples/foundation.6.7.5.css">foundation 6.7.5</option>
-							<option value="/examples/open-props.1.5.10.min.css">open-props 1.5.10</option>
-							<option value="/examples/pure.2.0.3.css">pure 2.0.3</option>
-							<option value="/examples/reset.2.0.css">reset 2.0</option>
-							<option value="/examples/tailwind.2.2.19.min.css">tailwind 2.2.19</option>
-							<option value="/examples/primer.21.5.1.css">primer 21.5.1</option>
-						</select>
-					</label>
-				</form>
-			</example-picker>
-		</row-stack>
-		<wasm-loader>Loading Wasm</wasm-loader>
-		<csskit-editor id="editor">
-.card {
-	border-radius: var(--radius-2);
-	padding: var(--size-fluid-3);
-	box-shadow: var(--shadow-2);
+<div class="container">
+	<header class="controls">
+		<a style="width:125px;margin:1rem 0" href="/"><img width="75" src="/images/logo.svg" /></a>
+		<example-picker>
+			<form>
+				<label>
+					Examples:
+					<select class="example-item" name="example">
+						<option value="">(Blank)</option>
+						<option value="/examples/960.css">960.gs</option>
+						<option value="/examples/animate.4.1.1.css">animate 4.1.1</option>
+						<option value="/examples/blueprint.1.0.1.css">blueprint 1.0.1</option>
+						<option value="/examples/bootstrap.4.6.2.css">bootstrap 4.6.2</option>
+						<option value="/examples/bootstrap.5.3.0.css">bootstrap 5.3.0</option>
+						<option value="/examples/font-awesome-all.5.15.4.css">font-awesome (all) 5.15.4</option>
+						<option value="/examples/foundation.6.7.5.css">foundation 6.7.5</option>
+						<option value="/examples/inuitcss.6.0.0.css">inuit 6.0.0</option>
+						<option value="/examples/mini.css.3.0.1.css">mini.css 3.0.1</option>
+						<option value="/examples/foundation.6.7.5.css">foundation 6.7.5</option>
+						<option value="/examples/open-props.1.5.10.min.css">open-props 1.5.10</option>
+						<option value="/examples/pure.2.0.3.css">pure 2.0.3</option>
+						<option value="/examples/reset.2.0.css">reset 2.0</option>
+						<option value="/examples/tailwind.2.2.19.min.css">tailwind 2.2.19</option>
+						<option value="/examples/primer.21.5.1.css">primer 21.5.1</option>
+					</select>
+				</label>
+			</form>
+		</example-picker>
+	</header>
 
-	&:hover {
-		box-shadow: var(--shadow-3);
-	}
-
-	@media (--motionOK) {
-		animation: var(--animation-fade-in);
-	}
-}</csskit-editor>
-		<row-stack class="status">
-			<metric-observer name="minify">Minified to</metric-observer>
-			<metric-observer name="parseend">Parsed in</metric-observer>
-		</row-stack>
-	</col-stack>
-	<col-stack>
-		<row-stack class="controls">
-			<form id="format">
+	<div class="content-panel">
+		<col-stack class="formatter-controls">
+			<form id="format" class="format-form">
 				<radiogroup>
 					<view-options>
 						<label>
-							<input type="radio" name="format" value="ast" checked />
+							<input type="radio" name="format" value="ast" />
 							AST
 						</label>
 						<label>
@@ -74,18 +54,69 @@ title: csskit playground
 							Tokens
 						</label>
 						<label>
+							<input type="radio" name="format" value="format" checked />
+							Format
+						</label>
+						<label>
 							<input type="radio" name="format" value="minify" />
 							Minify
 						</label>
 						<label>
-							<input type="radio" name="format" value="errors" checked />
+							<input type="radio" name="format" value="errors" />
 							Errors
 							<error-diagnostic-count count="0"></error-diagnostic-count>
 						</label>
 					</view-options>
 				</radiogroup>
+				<div class="formatter-options-panel">
+					<span class="formatter-options-title">Formatter options</span>
+					<div class="format-options">
+						<label>
+							Indent Style
+							<select name="indent_style">
+								<option value="spaces" selected>Spaces</option>
+								<option value="tabs">Tabs</option>
+							</select>
+						</label>
+						<label>
+							Indent Width
+							<input type="number" name="indent_width" min="1" max="8" value="2" />
+						</label>
+						<label>
+							Quote Style
+							<select name="quote_style">
+								<option value="double" selected>Double</option>
+								<option value="single">Single</option>
+							</select>
+						</label>
+					</div>
+				</div>
 			</form>
-		</row-stack>
-		<csskit-viewer id="viewer" for-editor="editor" for-format="format"></csskit-viewer>
-	</col-stack>
-</row-stack>
+		</col-stack>
+		<col-stack class="input">
+			<wasm-loader>Loading Wasm</wasm-loader>
+			<csskit-editor id="editor">
+				.card {
+					border-radius: var(--radius-2);
+					padding: var(--size-fluid-3);
+					box-shadow: var(--shadow-2);
+
+					&:hover {
+						box-shadow: var(--shadow-3);
+					}
+
+					@media (--motionOK) {
+						animation: var(--animation-fade-in);
+					}
+				}
+			</csskit-editor>
+			<row-stack class="console status">
+				<metric-observer name="minify">Minified to</metric-observer>
+				<metric-observer name="parseend">Parsed in</metric-observer>
+			</row-stack>
+		</col-stack>
+		<col-stack class="output">
+			<csskit-viewer id="viewer" for-editor="editor" for-format="format"></csskit-viewer>
+		</col-stack>
+	</div>
+</div>


### PR DESCRIPTION
- Add `format()` function to csskit_wasm with configurable options:
  - `indent_style`: spaces or tabs
  - `indent_width`: 1-8 (default 2)
  - `quote_style`: single or double quotes
- Add `web-sys` dependency for console error logging
- Add unit tests for format options
- Formatter controls are now positioned on the left side of the page, facilitating future enhancements.

Fixes: #838 

----

It seems we still have a lot of work to do regarding the formatter.

<img width="2324" height="1320" alt="image" src="https://github.com/user-attachments/assets/367cb727-5750-4c43-acee-a7f722bb0f3c" />
