### PR TITLE
csskit/css_lexer/css_parse: Add super secret hidden `expand` command

### DIFF
--- a/crates/css_lexer/Cargo.toml
+++ b/crates/css_lexer/Cargo.toml
@@ -43,6 +43,8 @@ pprof = { workspace = true, features = ["flamegraph", "criterion"] }
 
 [features]
 default = []
+# Easter egg feature for CSS expansion (opposite of minification)
+egg = []
 # Provides `From<>` implementations for the [SourceSpan] into [miette::SourceSpan] and [Span] into [miette::Span]
 miette = ["dep:miette"]
 # Provides `From<>` implementations for [Vec]

--- a/crates/css_parse/Cargo.toml
+++ b/crates/css_parse/Cargo.toml
@@ -34,6 +34,8 @@ dhat = { workspace = true }
 [features]
 default = []
 testing = []
+# Easter egg feature for CSS expansion (opposite of minification)
+egg = ["css_lexer/egg"]
 miette = ["dep:miette", "dep:thiserror", "css_lexer/miette"]
 serde = ["dep:serde", "dep:serde_json", "css_lexer/serde", "bumpalo/serde"]
 fancy = ["miette", "miette/fancy-no-backtrace"]

--- a/crates/css_parse/src/cursor_expanded_write_sink.rs
+++ b/crates/css_parse/src/cursor_expanded_write_sink.rs
@@ -1,0 +1,139 @@
+use crate::{Cursor, CursorSink, Kind, SourceCursor, SourceCursorSink, Token};
+
+/// This is a [CursorSink] that wraps a sink (`impl SourceCursorSink`) and on each [CursorSink::append()] call, will write
+/// the contents of the cursor [Cursor] given into the given sink - using the given `&'a str` as the original source.
+/// Tokens will be expanded to their most verbose form. It can be used as an "anti-minifier" for ToCursors structs.
+pub struct CursorExpandedWriteSink<'a, T: SourceCursorSink<'a>> {
+	source_text: &'a str,
+	sink: T,
+	last_token: Option<Token>,
+	extra_semicolons: u8,
+	escape_idents: bool,
+}
+
+impl<'a, T: SourceCursorSink<'a>> CursorExpandedWriteSink<'a, T> {
+	pub fn new(source_text: &'a str, sink: T) -> Self {
+		Self { source_text, sink, last_token: None, extra_semicolons: 0, escape_idents: false }
+	}
+
+	/// Set the number of extra semicolons to add after each semicolon.
+	pub fn with_extra_semicolons(mut self, count: u8) -> Self {
+		self.extra_semicolons = count;
+		self
+	}
+
+	/// Disable ident escaping for a milder expansion effect.
+	pub fn with_escape_idents(mut self, escape: bool) -> Self {
+		self.escape_idents = escape;
+		self
+	}
+
+	fn write(&mut self, c: SourceCursor<'a>) {
+		if let Some(last) = self.last_token
+			&& last.needs_separator_for(c.token())
+		{
+			self.sink.append(SourceCursor::SPACE);
+		}
+		self.last_token = Some(c.token());
+		let is_ident_like =
+			matches!(c.token().kind(), Kind::Ident | Kind::Function | Kind::AtKeyword | Kind::Hash | Kind::String);
+		let should_expand = matches!(c.token().kind(), Kind::Whitespace | Kind::Number | Kind::Dimension | Kind::Url)
+			|| (is_ident_like && self.escape_idents);
+		if should_expand {
+			self.sink.append(c.expand());
+		} else {
+			self.sink.append(c);
+		}
+		// Add extra semicolons after each semicolon
+		if c == Kind::Semicolon {
+			for _ in 0..self.extra_semicolons {
+				self.sink.append(SourceCursor::SEMICOLON);
+			}
+		}
+	}
+}
+
+impl<'a, T: SourceCursorSink<'a>> CursorSink for CursorExpandedWriteSink<'a, T> {
+	fn append(&mut self, c: Cursor) {
+		self.write(SourceCursor::from(c, c.str_slice(self.source_text)))
+	}
+}
+
+impl<'a, T: SourceCursorSink<'a>> SourceCursorSink<'a> for CursorExpandedWriteSink<'a, T> {
+	fn append(&mut self, c: SourceCursor<'a>) {
+		self.write(c)
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::{ComponentValues, EmptyAtomSet, Parser, ToCursors};
+	use bumpalo::Bump;
+	use css_lexer::Lexer;
+
+	macro_rules! assert_expand {
+		($before: literal, $after: literal) => {
+			assert_expand!(ComponentValues, $before, $after);
+		};
+		($struct: ident, $before: literal, $after: literal) => {
+			let source_text = $before;
+			let bump = Bump::default();
+			let mut sink = String::new();
+			let mut stream = CursorExpandedWriteSink::new(source_text, &mut sink).with_escape_idents(true);
+			let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
+			let mut parser = Parser::new(&bump, source_text, lexer);
+			parser.parse_entirely::<$struct>().output.unwrap().to_cursors(&mut stream);
+			assert_eq!(sink, $after);
+		};
+	}
+
+	#[test]
+	fn test_basic() {
+		// foo -> \000066 \00006f \00006f (f=0x66, o=0x6f)
+		// bar -> \000062 \000061 \000072 (b=0x62, a=0x61, r=0x72)
+		// baz -> \000062 \000061 \00007a (z=0x7a)
+		assert_expand!(
+			"foo{bar: baz();}",
+			r#"\000066 \00006f \00006f {\000062 \000061 \000072 :    \000062 \000061 \00007a ();}"#
+		);
+	}
+
+	#[test]
+	fn test_expands_numbers() {
+		// opacity -> o=0x6f p=0x70 a=0x61 c=0x63 i=0x69 t=0x74 y=0x79
+		assert_expand!(
+			"opacity: 0.8",
+			r#"\00006f \000070 \000061 \000063 \000069 \000074 \000079 :    +8.00000000000000e-0000000001"#
+		);
+		assert_expand!(
+			"opacity: .5",
+			r#"\00006f \000070 \000061 \000063 \000069 \000074 \000079 :    +5.00000000000000e-0000000001"#
+		);
+		// px -> p=0x70 x=0x78
+		assert_expand!(
+			"width: 1.0px",
+			r#"\000077 \000069 \000064 \000074 \000068 :    +1.00000000000000e+0000000000\000070 \000078 "#
+		);
+	}
+
+	#[test]
+	fn test_expands_whitespace() {
+		// a=0x61, b=0x62
+		assert_expand!("a b", r#"\000061     \000062 "#);
+	}
+
+	#[test]
+	fn test_expands_url() {
+		assert_expand!("url(foo.png)", r#"url(   foo.png   )"#);
+	}
+
+	#[test]
+	fn test_expands_strings() {
+		// h=0x68 e=0x65 l=0x6c o=0x6f
+		assert_expand!(
+			r#"content: "hello""#,
+			r#"\000063 \00006f \00006e \000074 \000065 \00006e \000074 :    '\000068 \000065 \00006c \00006c \00006f '"#
+		);
+	}
+}

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -284,6 +284,8 @@ pub use css_lexer::{
 
 mod comparison;
 mod cursor_compact_write_sink;
+#[cfg(feature = "egg")]
+mod cursor_expanded_write_sink;
 mod cursor_interleave_sink;
 mod cursor_ordered_sink;
 mod cursor_overlay_sink;
@@ -309,6 +311,8 @@ pub type Result<T> = std::result::Result<T, diagnostics::Diagnostic>;
 
 pub use comparison::*;
 pub use cursor_compact_write_sink::*;
+#[cfg(feature = "egg")]
+pub use cursor_expanded_write_sink::*;
 pub use cursor_interleave_sink::*;
 pub use cursor_ordered_sink::*;
 pub use cursor_overlay_sink::*;

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 css_lexer = { workspace = true } # @release
 css_ast = { workspace = true, features = ["chromashift", "visitable", "miette"] } # @release
-css_parse = { workspace = true, features = ["miette"] } # @release
+css_parse = { workspace = true, features = ["miette", "egg"] } # @release
 csskit_ast = { workspace = true, features = ["miette"] } # @release
 csskit_lsp = { workspace = true } # @release
 csskit_highlight = { workspace = true, features = ["miette"] } # @release

--- a/crates/csskit/src/commands/expand.rs
+++ b/crates/csskit/src/commands/expand.rs
@@ -1,0 +1,76 @@
+use crate::{CliError, CliResult, GlobalConfig, InputArgs};
+use bumpalo::Bump;
+use clap::Args;
+use css_ast::{CssAtomSet, StyleSheet};
+use css_lexer::Lexer;
+use css_parse::{CursorExpandedWriteSink, Parser, ToCursors};
+use std::io::Read;
+
+/// Expand CSS files to their most verbose form (the opposite of minify).
+#[derive(Debug, Args)]
+pub struct Expand {
+	/// A list of CSS files to expand. Each input will result in one output file.
+	#[command(flatten)]
+	content: InputArgs,
+
+	/// Where to save files.
+	#[arg(short, long, group = "output_file", value_parser)]
+	output: Option<String>,
+
+	/// Don't write any files, instead report each change that would have been made.
+	/// This will exit with a non-zero status code if any changes need to be made. Useful for CI.
+	#[arg(long, value_parser)]
+	check: bool,
+
+	/// Number of extra semicolons to add after each semicolon (0-255).
+	#[arg(long, default_value = "0", value_parser)]
+	semicolons: u8,
+
+	/// Escape all identifier characters as hex codes (e.g. foo -> \66\6f\6f).
+	#[arg(long, value_parser)]
+	escape_idents: bool,
+}
+
+impl Expand {
+	pub fn run(&self, _config: GlobalConfig) -> CliResult {
+		let Expand { content, output, check, semicolons, escape_idents } = self;
+		let bump = Bump::default();
+		let start = std::time::Instant::now();
+		if *check && output.is_some() {
+			eprintln!("Ignoring output option, because check was passed");
+		}
+		let mut checks = 0;
+		for (file_name, mut source) in content.sources()? {
+			let mut source_string = String::new();
+			source.read_to_string(&mut source_string)?;
+			let source_text = source_string.as_str();
+			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
+			let mut parser = Parser::new(&bump, source_text, lexer);
+			let result = parser.parse_entirely::<StyleSheet>();
+			if let Some(ref _stylesheet) = result.output {
+				let mut str = String::new();
+				let mut stream = CursorExpandedWriteSink::new(source_text, &mut str)
+					.with_extra_semicolons(*semicolons)
+					.with_escape_idents(*escape_idents);
+				result.to_cursors(&mut stream);
+				if *check {
+					if str != source_text {
+						println!("{str}");
+						checks += 1;
+					}
+				} else if let Some(file) = output {
+					std::fs::write(file, str.as_bytes())?;
+				} else {
+					println!("{str}");
+				}
+			} else {
+				for compact_err in result.errors {
+					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
+					println!("{report}");
+				}
+			}
+		}
+		eprintln!("Bloated your CSS in {:?}! Chunky!", start.elapsed());
+		if checks > 0 { Err(CliError::Checks(checks))? } else { Ok(()) }
+	}
+}

--- a/crates/csskit/src/commands/mod.rs
+++ b/crates/csskit/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod check;
 mod colors;
 mod dbg_lex;
 mod dbg_parse;
+mod expand;
 mod find;
 mod fmt;
 mod lsp;
@@ -29,6 +30,10 @@ pub enum Commands {
 
 	/// Minify CSS files to compress them optimized delivery.
 	Min(min::Min),
+
+	/// Expand CSS files to their most verbose form (opposite of minify).
+	#[command(hide = true)]
+	Expand(expand::Expand),
 
 	/// Extract the colours from a CSS file.
 	Colors(colors::ColorCommand),
@@ -60,6 +65,7 @@ impl Commands {
 			Commands::Tree(cmd) => cmd.run(config),
 			Commands::Fmt(cmd) => cmd.run(config),
 			Commands::Min(cmd) => cmd.run(config),
+			Commands::Expand(cmd) => cmd.run(config),
 			Commands::Colors(cmd) => cmd.run(config),
 			Commands::Colours(cmd) => cmd.run(config),
 			Commands::DbgLex(cmd) => cmd.run(config),


### PR DESCRIPTION
This expand command makes unhinged inputs, by turning tokens into a mess of escape codes and unnecessary symbols
