### PR TITLE
Release csskit vscode extension v1.0.3

### DIFF
--- a/packages/csskit_vscode/package-lock.json
+++ b/packages/csskit_vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "csskit",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "csskit",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-languageclient": "9.0.1"

--- a/packages/csskit_vscode/package.json
+++ b/packages/csskit_vscode/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "csskit",
 	"displayName": "csskit",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Refreshing CSS",
 	"keywords": [],
 	"repository": "https://github.com/csskit/csskit",


### PR DESCRIPTION
Bumps the VS Code extension to v1.0.3 for publishing to the [marketplace](https://marketplace.visualstudio.com/items?itemName=csskit.csskit).