### PR TITLE
csskit_ast: Improve docs for a lot of types

### DIFF
--- a/crates/css_ast/src/functions/attr_function.rs
+++ b/crates/css_ast/src/functions/attr_function.rs
@@ -23,7 +23,9 @@ pub struct AttrFunction<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct AttrFunctionParams<'a>(AttrName, Option<AttrType>, Option<T![,]>, Option<ComponentValues<'a>>);
 
-// <attr-name> = [ <ident-token>? '|' ]? <ident-token>
+/// ```text,ignore
+/// <attr-name> = [ <ident-token>? '|' ]? <ident-token>
+/// ```
 #[derive(ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct AttrName(pub Option<T![Ident]>, pub Option<T![|]>, pub Option<T![Ident]>);
@@ -63,7 +65,9 @@ impl<'a> Parse<'a> for AttrName {
 	}
 }
 
-// <attr-type> = type( <syntax> ) | raw-string | <attr-unit>
+/// ```text,ignore
+/// <attr-type> = type( <syntax> ) | raw-string | <attr-unit>
+/// ```
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum AttrType {

--- a/crates/css_ast/src/functions/color_function.rs
+++ b/crates/css_ast/src/functions/color_function.rs
@@ -409,12 +409,15 @@ impl crate::ToChromashift for HslFunctionParams {
 	}
 }
 
-// https://drafts.csswg.org/css-color/#funcdef-hwb
-// hwb() = hwb(
-//  [<hue> | none]
-//  [<percentage> | <number> | none]
-//  [<percentage> | <number> | none]
-//  [ / [<alpha-value> | none] ]? )
+/// <https://drafts.csswg.org/css-color/#funcdef-hwb>
+///
+/// ```text,ignore
+/// hwb() = hwb(
+///  [<hue> | none]
+///  [<percentage> | <number> | none]
+///  [<percentage> | <number> | none]
+///  [ / [<alpha-value> | none] ]? )
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/functions/counter_functions.rs
+++ b/crates/css_ast/src/functions/counter_functions.rs
@@ -41,8 +41,11 @@ pub struct CountersFunction<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct CountersFunctionParams<'a>(T![Ident], Option<T![,]>, T![String], Option<T![,]>, Option<CounterStyle<'a>>);
 
-// https://drafts.csswg.org/css-lists-3/#counter-functions
-// <counter> = <counter()> | <counters()>
+/// <https://drafts.csswg.org/css-lists-3/#counter-functions>
+///
+/// ```text,ignore
+/// <counter> = <counter()> | <counters()>
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]

--- a/crates/css_ast/src/functions/easing_functions.rs
+++ b/crates/css_ast/src/functions/easing_functions.rs
@@ -1,25 +1,28 @@
 use super::prelude::*;
 use crate::Percentage;
 
-// https://drafts.csswg.org/css-easing-2/#typedef-easing-function
-// <easing-function> = <linear-easing-function>
-//                      | <cubic-bezier-easing-function>
-//                      | <step-easing-function>
-//
-// <linear-easing-function> = linear | <linear()>
-//
-// linear() = linear( [ <number> && <percentage>{0,2} ]# )
-//
-// <cubic-bezier-easing-function> =
-// 	ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>
-//
-// cubic-bezier() = cubic-bezier( [ <number [0,1]>, <number> ]#{2} )
-//
-// <step-easing-function> = step-start | step-end | <steps()>
-//
-// steps() = steps( <integer>, <step-position>?)
-//
-// <step-position> = jump-start | jump-end | jump-none | jump-both | start | end
+/// <https://drafts.csswg.org/css-easing-2/#typedef-easing-function>
+///
+/// ```text,ignore
+/// <easing-function> = <linear-easing-function>
+///                      | <cubic-bezier-easing-function>
+///                      | <step-easing-function>
+///
+/// <linear-easing-function> = linear | <linear()>
+///
+/// linear() = linear( [ <number> && <percentage>{0,2} ]# )
+///
+/// <cubic-bezier-easing-function> = ease | ease-in | ease-out | ease-in-out
+///                                    | <cubic-bezier()>
+///
+/// cubic-bezier() = cubic-bezier( [ <number [0,1]>, <number> ]#{2} )
+///
+/// <step-easing-function> = step-start | step-end | <steps()>
+///
+/// steps() = steps( <integer>, <step-position>?)
+///
+/// <step-position> = jump-start | jump-end | jump-none | jump-both | start | end
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/functions/leader_function.rs
+++ b/crates/css_ast/src/functions/leader_function.rs
@@ -17,8 +17,11 @@ pub struct LeaderFunction {
 	pub close: T![')'],
 }
 
-// https://drafts.csswg.org/css-content-3/#typedef-leader-type
-// <leader-type> = dotted | solid | space | <string>
+/// <https://drafts.csswg.org/css-content-3/#typedef-leader-type>
+///
+/// ```text,ignore
+/// <leader-type> = dotted | solid | space | <string>
+/// ```
 #[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum LeaderType {

--- a/crates/css_ast/src/functions/snap_block_function.rs
+++ b/crates/css_ast/src/functions/snap_block_function.rs
@@ -1,8 +1,11 @@
 use super::prelude::*;
 use crate::units::LengthPercentage;
 
-// https://drafts.csswg.org/css-page-floats-3/#funcdef-float-snap-block
-// snap-block() = snap-block( <length> , [ start | end | near ]? )
+/// <https://drafts.csswg.org/css-page-floats-3/#funcdef-float-snap-block>
+///
+/// ```text,ignore
+/// snap-block() = snap-block( <length> , [ start | end | near ]? )
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/functions/target_functions.rs
+++ b/crates/css_ast/src/functions/target_functions.rs
@@ -33,14 +33,23 @@ pub enum TargetCounterKind {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum Target<'a> {
-	// https://drafts.csswg.org/css-content-3/#target-counter
-	// target-counter() = target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )
+	/// <https://drafts.csswg.org/css-content-3/#target-counter>
+	///
+	/// ```text,ignore
+	/// target-counter() = target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )
+	/// ```
 	TargetCounter(TargetCounterFunction<'a>),
-	// https://drafts.csswg.org/css-content-3/#target-counters
-	// target-counters() = target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )
+	/// <https://drafts.csswg.org/css-content-3/#target-counters>
+	///
+	/// ```text,ignore
+	/// target-counters() = target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )
+	/// ```
 	TargetCounters(TargetCountersFunction<'a>),
-	// https://drafts.csswg.org/css-content-3/#target-text
-	// target-text() = target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )
+	/// <https://drafts.csswg.org/css-content-3/#target-text>
+	///
+	/// ```text,ignore
+	/// target-text() = target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )
+	/// ```
 	TargetText(TargetTextFunction),
 }
 

--- a/crates/css_ast/src/functions/transform_functions.rs
+++ b/crates/css_ast/src/functions/transform_functions.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 use crate::{AngleOrZero, Length, LengthPercentage, NoneOr, NumberOrPercentage};
 use css_parse::BumpBox;
 
-// https://drafts.csswg.org/css-transforms-1/#two-d-transform-functions
+/// <https://drafts.csswg.org/css-transforms-1/#two-d-transform-functions>
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-syntax-3/#charset-rule
+/// <https://drafts.csswg.org/css-syntax-3/#charset-rule>
 #[derive(ToSpan, ToCursors, SemanticEq, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/rules/color_profile.rs
+++ b/crates/css_ast/src/rules/color_profile.rs
@@ -1,6 +1,6 @@
 use crate::Todo;
 
-// https://drafts.csswg.org/css-color-5/#at-profile
+/// <https://drafts.csswg.org/css-color-5/#at-profile>
 pub type ColorProfileRule = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -6,7 +6,7 @@ use super::prelude::*;
 mod features;
 pub use features::*;
 
-// https://drafts.csswg.org/css-contain-3/#container-rule
+/// <https://drafts.csswg.org/css-contain-3/#container-rule>
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, queryable(skip))]

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-// https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document
+/// <https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document>
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -3,7 +3,7 @@ use css_parse::DeclarationValue;
 use super::prelude::*;
 use crate::{Computed, CssMetadata};
 
-// https://drafts.csswg.org/css-fonts/#font-face-rule
+/// <https://drafts.csswg.org/css-fonts/#font-face-rule>
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/rules/font_feature_values.rs
+++ b/crates/css_ast/src/rules/font_feature_values.rs
@@ -1,6 +1,6 @@
 use crate::Todo;
 
-// https://drafts.csswg.org/css-fonts/#at-ruledef-font-feature-values
+/// <https://drafts.csswg.org/css-fonts/#at-ruledef-font-feature-values>
 pub type FontFeatureValuesRule = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/font_palette_values.rs
+++ b/crates/css_ast/src/rules/font_palette_values.rs
@@ -1,6 +1,6 @@
 use crate::Todo;
 
-// https://drafts.csswg.org/css-fonts/#at-ruledef-font-palette-values
+/// <https://drafts.csswg.org/css-fonts/#at-ruledef-font-palette-values>
 pub type FontPaletteValuesRule = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -4,7 +4,7 @@ use crate::Percentage;
 use crate::visit::{NodeId, QueryableNode};
 use css_parse::NoBlockAllowed;
 
-// https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
+/// <https://drafts.csswg.org/css-animations/#at-ruledef-keyframes>
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, queryable(skip))]

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-cascade-5/#layering
+/// <https://drafts.csswg.org/css-cascade-5/#layering>
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -4,7 +4,7 @@ use crate::{AtRuleId, NodeKinds};
 mod features;
 pub use features::*;
 
-// https://drafts.csswg.org/mediaqueries-4/
+/// <https://drafts.csswg.org/mediaqueries-4/>
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.media"))]
@@ -189,7 +189,7 @@ impl<'a> Parse<'a> for MediaCondition<'a> {
 
 macro_rules! media_feature {
 	( $($name: ident($typ: ident): $pat: pat,)+) => {
-		// https://drafts.csswg.org/mediaqueries-5/#media-descriptor-table
+		/// <https://drafts.csswg.org/mediaqueries-5/#media-descriptor-table>
 		#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -2,8 +2,9 @@ use super::prelude::*;
 use crate::specificity::{Specificity, ToSpecificity};
 use css_parse::RuleVariants;
 
-// https://drafts.csswg.org/cssom-1/#csspagerule
-// https://drafts.csswg.org/css-page-3/#at-page-rule
+/// <https://drafts.csswg.org/cssom-1/#csspagerule>
+///
+/// <https://drafts.csswg.org/css-page-3/#at-page-rule>
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
@@ -94,7 +95,7 @@ impl ToSpecificity for PagePseudoClass {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct PageRuleBlock<'a>(#[metadata(delegate)] Block<'a, StyleValue<'a>, MarginRule<'a>, CssMetadata>);
 
-// https://drafts.csswg.org/cssom-1/#cssmarginrule
+/// <https://drafts.csswg.org/cssom-1/#cssmarginrule>
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -3,8 +3,7 @@ use crate::Computed;
 #[cfg(feature = "visitable")]
 use crate::visit::{NodeId, QueryableNode};
 
-// https://drafts.csswg.org/cssom-1/#csspagerule
-// https://drafts.csswg.org/css-page-3/#at-page-rule
+/// <https://drafts.css-houdini.org/css-properties-values-api/#at-property-rule>
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, queryable(skip))]

--- a/crates/css_ast/src/rules/scope.rs
+++ b/crates/css_ast/src/rules/scope.rs
@@ -1,6 +1,6 @@
 use crate::Todo;
 
-// https://drafts.csswg.org/css-cascade-6/#at-ruledef-scope
+/// <https://drafts.csswg.org/css-cascade-6/#at-ruledef-scope>
 pub type ScopeRule = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/rules/starting_style.rs
+++ b/crates/css_ast/src/rules/starting_style.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-transitions-2/#at-ruledef-starting-style
+/// <https://drafts.csswg.org/css-transitions-2/#at-ruledef-starting-style>
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/rules/webkit.rs
+++ b/crates/css_ast/src/rules/webkit.rs
@@ -3,7 +3,9 @@ use super::prelude::*;
 use crate::visit::{NodeId, QueryableNode};
 use crate::{KeyframesName, KeyframesRuleBlock};
 
-// https://drafts.csswg.org/css-animations/#at-ruledef-keyframes
+/// <https://drafts.csswg.org/css-animations/#at-ruledef-keyframes>
+///
+/// Vendor-prefixed variant: `@-webkit-keyframes`
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit, queryable(skip))]

--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -1,7 +1,7 @@
 use css_parse::T;
 use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
 
-// https://drafts.csswg.org/selectors/#combinators
+/// <https://drafts.csswg.org/selectors/#combinators>
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/selector/functional_pseudo_element.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_element.rs
@@ -12,22 +12,22 @@ use super::CompoundSelector;
 #[derive(csskit_derives::NodeWithMetadata)]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.selectors"))]
 pub enum FunctionalPseudoElement<'a> {
-	// https://drafts.csswg.org/css-highlight-api/#custom-highlight-pseudo
+	/// <https://drafts.csswg.org/css-highlight-api/#custom-highlight-pseudo>
 	Highlight(HighlightPseudoElement),
-	// https://drafts.csswg.org/css-shadow-parts/#part
+	/// <https://drafts.csswg.org/css-shadow-parts/#part>
 	Part(PartPseudoElement<'a>),
-	// https://drafts.csswg.org/css-forms-1/#picker-pseudo
+	/// <https://drafts.csswg.org/css-forms-1/#picker-pseudo>
 	Picker(PickerPseudoElement),
-	// https://drafts.csswg.org/css-scoping/#slotted-pseudo
+	/// <https://drafts.csswg.org/css-scoping/#slotted-pseudo>
 	Slotted(SlottedPseudoElement<'a>),
-	// https://drafts.csswg.org/css-view-transitions-2/#view-transition-pseudo
-	// https://drafts.csswg.org/css-view-transitions-2/#::view-transition-group
+	/// <https://drafts.csswg.org/css-view-transitions-2/#view-transition-pseudo>
+	/// <https://drafts.csswg.org/css-view-transitions-2/#::view-transition-group>
 	ViewTransitionGroup(ViewTransitionGroupPseudoElement<'a>),
-	// https://drafts.csswg.org/css-view-transitions-2/#::view-transition-image-pair
+	/// <https://drafts.csswg.org/css-view-transitions-2/#::view-transition-image-pair>
 	ViewTransitionImagePair(ViewTransitionImagePairPseudoElement<'a>),
-	// https://drafts.csswg.org/css-view-transitions-2/#::view-transition-new
+	/// <https://drafts.csswg.org/css-view-transitions-2/#::view-transition-new>
 	ViewTransitionNew(ViewTransitionNewPseudoElement<'a>),
-	// https://drafts.csswg.org/css-view-transitions-2/#::view-transition-old
+	/// <https://drafts.csswg.org/css-view-transitions-2/#::view-transition-old>
 	ViewTransitionOld(ViewTransitionOldPseudoElement<'a>),
 }
 

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -3,7 +3,7 @@ use csskit_derives::{IntoCursor, Peek, SemanticEq, ToCursors, ToSpan};
 
 use super::Tag;
 
-// https://drafts.csswg.org/selectors/#combinators
+/// <https://drafts.csswg.org/selectors/#type-nmsp>
 #[derive(Peek, ToSpan, ToCursors, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -53,7 +53,7 @@ macro_rules! nested_group_rule {
     ( $(
         $name: ident($ty: ident$(<$a: lifetime>)?): $str: pat,
     )+ ) => {
-		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
+		/// <https://drafts.csswg.org/cssom-1/#the-cssrule-interface>
 		#[derive(ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -6,7 +6,7 @@ use css_parse::{
 };
 use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
 
-// https://drafts.csswg.org/cssom-1/#the-cssstylesheet-interface
+/// <https://drafts.csswg.org/cssom-1/#the-cssstylesheet-interface>
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
@@ -104,7 +104,7 @@ macro_rules! rule {
     ( $(
         $name: ident($ty: ident$(<$a: lifetime>)?): $str: pat,
     )+ ) => {
-		// https://drafts.csswg.org/cssom-1/#the-cssrule-interface
+		/// <https://drafts.csswg.org/cssom-1/#the-cssrule-interface>
 		#[derive(ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]

--- a/crates/css_ast/src/types/animateable_feature.rs
+++ b/crates/css_ast/src/types/animateable_feature.rs
@@ -1,7 +1,10 @@
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-will-change-1/#typedef-animateable-feature
-// <animateable-feature> = scroll-position | contents | <custom-ident>
+/// <https://drafts.csswg.org/css-will-change-1/#typedef-animateable-feature>
+///
+/// ```text,ignore
+/// <animateable-feature> = scroll-position | contents | <custom-ident>
+/// ```
 #[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/types/auto_line_color_list.rs
+++ b/crates/css_ast/src/types/auto_line_color_list.rs
@@ -3,8 +3,11 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-color-list
-// <auto-line-color-list> = [ <line-color-or-repeat> ]* <auto-repeat-line-color> [ <line-color-or-repeat> ]*
+/// <https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-color-list>
+///
+/// ```text,ignore
+/// <auto-line-color-list> = [ <line-color-or-repeat> ]* <auto-repeat-line-color> [ <line-color-or-repeat> ]*
+/// ```
 pub type AutoLineColorList = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/auto_line_style_list.rs
+++ b/crates/css_ast/src/types/auto_line_style_list.rs
@@ -3,8 +3,11 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-style-list
-// <auto-line-style-list> = [ <line-style-or-repeat> ]* <auto-repeat-line-style> [ <line-style-or-repeat> ]*
+/// <https://drafts.csswg.org/css-gaps-1/#typedef-auto-line-style-list>
+///
+/// ```text,ignore
+/// <auto-line-style-list> = [ <line-style-or-repeat> ]* <auto-repeat-line-style> [ <line-style-or-repeat> ]*
+/// ```
 pub type AutoLineStyleList = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/autospace.rs
+++ b/crates/css_ast/src/types/autospace.rs
@@ -3,8 +3,11 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-text-4/#typedef-autospace
-// <autospace> = no-autospace | [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]
+/// <https://drafts.csswg.org/css-text-4/#typedef-autospace>
+///
+/// ```text,ignore
+/// <autospace> = no-autospace | [ ideograph-alpha || ideograph-numeric || punctuation ] || [ insert | replace ]
+/// ```
 pub type Autospace = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/basic_shape_rect.rs
+++ b/crates/css_ast/src/types/basic_shape_rect.rs
@@ -3,8 +3,11 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape-rect
-// <basic-shape-rect> = <inset()> | <rect()> | <xywh()>
+/// <https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape-rect>
+///
+/// ```text,ignore
+/// <basic-shape-rect> = <inset()> | <rect()> | <xywh()>
+/// ```
 pub type BasicShapeRect = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -30,15 +30,24 @@ pub enum ContentListItem<'a> {
 	Contents(T![Ident]),
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	Quote(Quote),
-	// https://drafts.csswg.org/css-content-3/#leader-function
-	// leader() = leader( <leader-type> )
+	/// <https://drafts.csswg.org/css-content-3/#leader-function>
+	///
+	/// ```text,ignore
+	/// leader() = leader( <leader-type> )
+	/// ```
 	LeaderFunction(LeaderFunction),
 	Target(Target<'a>),
-	// https://drafts.csswg.org/css-content-3/#string-function
-	// string() = string( <custom-ident> , [ first | start | last | first-except ]? )
+	/// <https://drafts.csswg.org/css-content-3/#string-function>
+	///
+	/// ```text,ignore
+	/// string() = string( <custom-ident> , [ first | start | last | first-except ]? )
+	/// ```
 	StringFunction(StringFunction),
-	// https://drafts.csswg.org/css-content-3/#funcdef-content
-	// content() = content( [ text | before | after | first-letter | marker ]? )
+	/// <https://drafts.csswg.org/css-content-3/#funcdef-content>
+	///
+	/// ```text,ignore
+	/// content() = content( [ text | before | after | first-letter | marker ]? )
+	/// ```
 	ContentFunction(ContentFunction),
 	Counter(Counter<'a>),
 }

--- a/crates/css_ast/src/types/counter_style.rs
+++ b/crates/css_ast/src/types/counter_style.rs
@@ -23,7 +23,7 @@ impl<'a> Peek<'a> for CounterStyle<'a> {
 	}
 }
 
-// https://drafts.csswg.org/css-counter-styles-3/#predefined-counters
+/// <https://drafts.csswg.org/css-counter-styles-3/#predefined-counters>
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PredefinedCounter {

--- a/crates/css_ast/src/types/gap_auto_rule_list.rs
+++ b/crates/css_ast/src/types/gap_auto_rule_list.rs
@@ -1,7 +1,10 @@
 use crate::{GapRepeatRule, GapRuleList, GapRuleOrRepeat};
 
-// https://drafts.csswg.org/css-gaps-1/#typedef-gap-auto-rule-list
-// <gap-auto-rule-list> = <gap-rule-or-repeat>#? , <gap-auto-repeat-rule> , <gap-rule-or-repeat>#?
+/// <https://drafts.csswg.org/css-gaps-1/#typedef-gap-auto-rule-list>
+///
+/// ```text,ignore
+/// <gap-auto-rule-list> = <gap-rule-or-repeat>#? , <gap-auto-repeat-rule> , <gap-rule-or-repeat>#?
+/// ```
 // We intentionally flatten this into <gap-rule-list> semantics so higher layers
 // can decide whether stricter auto-repeat placement constraints should apply.
 pub type GapAutoRuleList<'a> = GapRuleList<'a>;

--- a/crates/css_ast/src/types/gap_rule_list.rs
+++ b/crates/css_ast/src/types/gap_rule_list.rs
@@ -4,15 +4,20 @@ use super::prelude::*;
 use crate::{AutoOr, Color, LineStyle, LineWidth, PositiveNonZeroInt};
 use css_parse::{CommaSeparated, Optionals3};
 
-// https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule-list
-// <gap-rule-list> = <gap-rule-or-repeat>#
+/// <https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule-list>
+///
+/// ```text,ignore
+/// <gap-rule-list> = <gap-rule-or-repeat>#
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct GapRuleList<'a>(pub CommaSeparated<'a, GapRuleOrRepeat<'a>>);
 
-// <gap-rule-or-repeat> = <gap-rule> | <gap-repeat-rule>
+/// ```text,ignore
+/// <gap-rule-or-repeat> = <gap-rule> | <gap-repeat-rule>
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
@@ -22,7 +27,9 @@ pub enum GapRuleOrRepeat<'a> {
 	GapRepeatRule(GapRepeatRule<'a>),
 }
 
-// <gap-repeat-rule> = repeat( <integer [1,∞]> , <gap-rule># )
+/// ```text,ignore
+/// <gap-repeat-rule> = repeat( <integer [1,∞]> , <gap-rule># )
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
@@ -40,7 +47,9 @@ pub struct GapRepeatRule<'a> {
 	pub close: T![')'],
 }
 
-// <gap-rule> = <line-width> || <line-style> || <color>
+/// ```text,ignore
+/// <gap-rule> = <line-width> || <line-style> || <color>
+/// ```
 pub type GapRule<'a> = Optionals3<LineWidth, LineStyle, Color<'a>>;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/grid_line.rs
+++ b/crates/css_ast/src/types/grid_line.rs
@@ -2,8 +2,11 @@ use super::prelude::*;
 use crate::{CSSInt, CustomIdent, NonZero, PositiveNonZeroInt};
 use css_parse::parse_optionals;
 
-// https://drafts.csswg.org/css-grid-2/#typedef-grid-row-start-grid-line
-// <grid-line> = auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]
+/// <https://drafts.csswg.org/css-grid-2/#typedef-grid-row-start-grid-line>
+///
+/// ```text,ignore
+/// <grid-line> = auto | <custom-ident> | [ [ <integer [-∞,-1]> | <integer [1,∞]> ] && <custom-ident>? ] | [ span && [ <integer [1,∞]> || <custom-ident> ] ]
+/// ```
 #[derive(Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/types/image_1d.rs
+++ b/crates/css_ast/src/types/image_1d.rs
@@ -2,10 +2,13 @@ use super::prelude::*;
 
 use crate::StripesFunction;
 
-// https://drafts.csswg.org/css-images-4/#typedef-image-1d
-// <image-1D> = <stripes()>
-// <stripes()> = stripes( <color-stripe># )
-// <color-stripe> = <color> && [ <length-percentage> | <flex> ]?
+/// <https://drafts.csswg.org/css-images-4/#typedef-image-1d>
+///
+/// ```text,ignore
+/// <image-1D> = <stripes()>
+/// <stripes()> = stripes( <color-stripe># )
+/// <color-stripe> = <color> && [ <length-percentage> | <flex> ]?
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/types/line_color_list.rs
+++ b/crates/css_ast/src/types/line_color_list.rs
@@ -3,8 +3,11 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-gaps-1/#typedef-line-color-list
-// <line-color-list> = [ <line-color-or-repeat> ]+
+/// <https://drafts.csswg.org/css-gaps-1/#typedef-line-color-list>
+///
+/// ```text,ignore
+/// <line-color-list> = [ <line-color-or-repeat> ]+
+/// ```
 pub type LineColorList = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/line_style_list.rs
+++ b/crates/css_ast/src/types/line_style_list.rs
@@ -3,8 +3,11 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list
-// <line-style-list> = [ <line-style-or-repeat> ]+
+/// <https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list>
+///
+/// ```text,ignore
+/// <line-style-list> = [ <line-style-or-repeat> ]+
+/// ```
 pub type LineStyleList = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/palette_identifier.rs
+++ b/crates/css_ast/src/types/palette_identifier.rs
@@ -1,6 +1,10 @@
 use super::prelude::*;
 
-// https://www.w3.org/TR/css-fonts-4/#typedef-font-palette-palette-identifier
+/// <https://www.w3.org/TR/css-fonts-4/#typedef-font-palette-palette-identifier>
+///
+/// ```text,ignore
+/// <palette-identifier> = <dashed-ident>
+/// ```
 #[derive(Parse, Peek, ToCursors, SemanticEq, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct PaletteIdentifier(T![DashedIdent]);

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -2,18 +2,21 @@ use super::prelude::*;
 use crate::LengthPercentage;
 use css_parse::Token;
 
-// https://drafts.csswg.org/css-values-4/#position
-// <position> = [
-//   [ left | center | right | top | bottom | <length-percentage> ]
-// |
-//   [ left | center | right ] && [ top | center | bottom ]
-// |
-//   [ left | center | right | <length-percentage> ]
-//   [ top | center | bottom | <length-percentage> ]
-// |
-//   [ [ left | right ] <length-percentage> ] &&
-//   [ [ top | bottom ] <length-percentage> ]
-// ]
+/// <https://drafts.csswg.org/css-values-4/#position>
+///
+/// ```text,ignore
+/// <position> = [
+///   [ left | center | right | top | bottom | <length-percentage> ]
+/// |
+///   [ left | center | right ] && [ top | center | bottom ]
+/// |
+///   [ left | center | right | <length-percentage> ]
+///   [ top | center | bottom | <length-percentage> ]
+/// |
+///   [ [ left | right ] <length-percentage> ] &&
+///   [ [ top | bottom ] <length-percentage> ]
+/// ]
+/// ```
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/types/position_area.rs
+++ b/crates/css_ast/src/types/position_area.rs
@@ -1,32 +1,35 @@
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-anchor-position-1/#typedef-position-area
-// <position-area> = [
-//   [ left | center | right | span-left | span-right
-//   | x-start | x-end | span-x-start | span-x-end
-//   | x-self-start | x-self-end | span-x-self-start | span-x-self-end
-//   | span-all ]
-//   ||
-//   [ top | center | bottom | span-top | span-bottom
-//   | y-start | y-end | span-y-start | span-y-end
-//   | y-self-start | y-self-end | span-y-self-start | span-y-self-end
-//   | span-all ]
-// |
-//   [ block-start | center | block-end | span-block-start | span-block-end | span-all ]
-//   ||
-//   [ inline-start | center | inline-end | span-inline-start | span-inline-end
-//   | span-all ]
-// |
-//   [ self-block-start | center | self-block-end | span-self-block-start
-//   | span-self-block-end | span-all ]
-//   ||
-//   [ self-inline-start | center | self-inline-end | span-self-inline-start
-//   | span-self-inline-end | span-all ]
-// |
-//   [ start | center | end | span-start | span-end | span-all ]{1,2}
-// |
-//   [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}
-// ]
+/// <https://drafts.csswg.org/css-anchor-position-1/#typedef-position-area>
+///
+/// ```text,ignore
+/// <position-area> = [
+///   [ left | center | right | span-left | span-right
+///   | x-start | x-end | span-x-start | span-x-end
+///   | x-self-start | x-self-end | span-x-self-start | span-x-self-end
+///   | span-all ]
+///   ||
+///   [ top | center | bottom | span-top | span-bottom
+///   | y-start | y-end | span-y-start | span-y-end
+///   | y-self-start | y-self-end | span-y-self-start | span-y-self-end
+///   | span-all ]
+/// |
+///   [ block-start | center | block-end | span-block-start | span-block-end | span-all ]
+///   ||
+///   [ inline-start | center | inline-end | span-inline-start | span-inline-end
+///   | span-all ]
+/// |
+///   [ self-block-start | center | self-block-end | span-self-block-start
+///   | span-self-block-end | span-all ]
+///   ||
+///   [ self-inline-start | center | self-inline-end | span-self-inline-start
+///   | span-self-inline-end | span-all ]
+/// |
+///   [ start | center | end | span-start | span-end | span-all ]{1,2}
+/// |
+///   [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}
+/// ]
+/// ```
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/types/ratio.rs
+++ b/crates/css_ast/src/types/ratio.rs
@@ -1,7 +1,11 @@
 use super::prelude::*;
 use crate::units::CSSInt;
 
-// https://drafts.csswg.org/css-values-4/#ratios
+/// <https://drafts.csswg.org/css-values-4/#ratios>
+///
+/// ```text,ignore
+/// <ratio> = <number [0,∞]> [ / <number [0,∞]> ]?
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/types/shadow.rs
+++ b/crates/css_ast/src/types/shadow.rs
@@ -1,8 +1,11 @@
 use super::prelude::*;
 use crate::{Color, Length, NonNegative};
 
-// https://drafts.csswg.org/css-backgrounds-3/#typedef-shadow
-// <shadow> = <color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?
+/// <https://drafts.csswg.org/css-backgrounds-3/#typedef-shadow>
+///
+/// ```text,ignore
+/// <shadow> = <color>? && [<length>{2} <length [0,∞]>? <length>?] && inset?
+/// ```
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/types/single_animation_iteration_count.rs
+++ b/crates/css_ast/src/types/single_animation_iteration_count.rs
@@ -1,8 +1,11 @@
 use super::prelude::*;
 use crate::NonNegative;
 
-// https://drafts.csswg.org/css-animations/#typedef-single-animation-iteration-count
-// <single-animation-iteration-count> = infinite | <number [0,∞]>
+/// <https://drafts.csswg.org/css-animations/#typedef-single-animation-iteration-count>
+///
+/// ```text,ignore
+/// <single-animation-iteration-count> = infinite | <number [0,∞]>
+/// ```
 #[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/types/single_animation_trigger.rs
+++ b/crates/css_ast/src/types/single_animation_trigger.rs
@@ -3,8 +3,11 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-animations-2/#typedef-single-animation-trigger
-// <single-animation-trigger> = <single-animation-trigger-behavior> || [ none | auto | [ [ <dashed-ident> | <scroll()> | <view()> ] [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]{0,4} ] ]
+/// <https://drafts.csswg.org/css-animations-2/#typedef-single-animation-trigger>
+///
+/// ```text,ignore
+/// <single-animation-trigger> = <single-animation-trigger-behavior> || [ none | auto | [ [ <dashed-ident> | <scroll()> | <view()> ] [ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]{0,4} ] ]
+/// ```
 pub type SingleAnimationTrigger = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/single_transition.rs
+++ b/crates/css_ast/src/types/single_transition.rs
@@ -2,8 +2,11 @@ use super::prelude::*;
 use crate::{EasingFunction, NoneOr, SingleTransitionProperty, Time, TransitionBehaviorValue};
 use css_parse::parse_optionals;
 
-// https://drafts.csswg.org/css-transitions-2/#single-transition
-// <single-transition> = [ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>
+/// <https://drafts.csswg.org/css-transitions-2/#single-transition>
+///
+/// ```text,ignore
+/// <single-transition> = [ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>
+/// ```
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/types/single_transition_property.rs
+++ b/crates/css_ast/src/types/single_transition_property.rs
@@ -1,7 +1,10 @@
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-transitions-1/#single-transition-property
-// <single-transition-property> = all | <custom-ident>
+/// <https://drafts.csswg.org/css-transitions-1/#single-transition-property>
+///
+/// ```text,ignore
+/// <single-transition-property> = all | <custom-ident>
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/types/spread_shadow.rs
+++ b/crates/css_ast/src/types/spread_shadow.rs
@@ -3,8 +3,11 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-borders-4/#typedef-spread-shadow
-// <spread-shadow> = <'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?
+/// <https://drafts.csswg.org/css-borders-4/#typedef-spread-shadow>
+///
+/// ```text,ignore
+/// <spread-shadow> = <'box-shadow-color'>? && [ <'box-shadow-offset'> [ <'box-shadow-blur'> <'box-shadow-spread'>? ]? ] && <'box-shadow-position'>?
+/// ```
 pub type SpreadShadow = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/syntax.rs
+++ b/crates/css_ast/src/types/syntax.rs
@@ -1,17 +1,20 @@
 #![allow(unused)]
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-values-5/#css-syntax
-// <syntax> = '*' | <syntax-component> [ <syntax-combinator> <syntax-component> ]* | <syntax-string>
-// <syntax-component> = <syntax-single-component> <syntax-multiplier>?
-//                    | '<' transform-list '>'
-// <syntax-single-component> = '<' <syntax-type-name> '>' | <ident>
-// <syntax-type-name> = angle | color | custom-ident | image | integer
-//                    | length | length-percentage | number
-//                    | percentage | resolution | string | time
-//                    | url | transform-function
-// <syntax-combinator> = '|'
-// <syntax-multiplier> = [ '#' | '+' ]
-//
-// <syntax-string> = <string>
+/// <https://drafts.csswg.org/css-values-5/#css-syntax>
+///
+/// ```text,ignore
+/// <syntax> = '*' | <syntax-component> [ <syntax-combinator> <syntax-component> ]* | <syntax-string>
+/// <syntax-component> = <syntax-single-component> <syntax-multiplier>?
+///                    | '<' transform-list '>'
+/// <syntax-single-component> = '<' <syntax-type-name> '>' | <ident>
+/// <syntax-type-name> = angle | color | custom-ident | image | integer
+///                    | length | length-percentage | number
+///                    | percentage | resolution | string | time
+///                    | url | transform-function
+/// <syntax-combinator> = '|'
+/// <syntax-multiplier> = [ '#' | '+' ]
+///
+/// <syntax-string> = <string>
+/// ```
 pub type Syntax = crate::Todo;

--- a/crates/css_ast/src/types/text_edge.rs
+++ b/crates/css_ast/src/types/text_edge.rs
@@ -3,8 +3,11 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-inline-3/#typedef-text-edge
-// <text-edge> = [ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]
+/// <https://drafts.csswg.org/css-inline-3/#typedef-text-edge>
+///
+/// ```text,ignore
+/// <text-edge> = [ text | ideographic | ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex ] [ text | ideographic | ideographic-ink | alphabetic ]
+/// ```
 pub type TextEdge = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/track_size.rs
+++ b/crates/css_ast/src/types/track_size.rs
@@ -3,10 +3,13 @@ use super::prelude::*;
 
 use crate::Todo;
 
-// https://drafts.csswg.org/css-grid-2/#typedef-track-size
-// <track-size> = <track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage [0,∞]> )
-// <track-breadth> = <length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto
-// <inflexible-breadth>  = <length-percentage [0,∞]> | min-content | max-content | auto
+/// <https://drafts.csswg.org/css-grid-2/#typedef-track-size>
+///
+/// ```text,ignore
+/// <track-size> = <track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage [0,∞]> )
+/// <track-breadth> = <length-percentage [0,∞]> | <flex [0,∞]> | min-content | max-content | auto
+/// <inflexible-breadth>  = <length-percentage [0,∞]> | min-content | max-content | auto
+/// ```
 pub type TrackSize = Todo;
 
 #[cfg(test)]

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -2,8 +2,11 @@ use super::prelude::*;
 
 use crate::TransformFunction;
 
-// https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
-// <transform-list> = <transform-function>+
+/// <https://drafts.csswg.org/css-transforms-1/#typedef-transform-list>
+///
+/// ```text,ignore
+/// <transform-list> = <transform-function>+
+/// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -1,6 +1,10 @@
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-values/#angles
+/// <https://drafts.csswg.org/css-values/#angles>
+///
+/// ```text,ignore
+/// <angle> = <dimension-token>
+/// ```
 #[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.types.angle"))]

--- a/crates/css_ast/src/units/flex.rs
+++ b/crates/css_ast/src/units/flex.rs
@@ -1,6 +1,10 @@
 use super::prelude::*;
 
-// https://www.w3.org/TR/css-grid-2/#typedef-flex
+/// <https://www.w3.org/TR/css-grid-2/#typedef-flex>
+///
+/// ```text,ignore
+/// <flex> = <dimension-token>
+/// ```
 #[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_ast/src/units/frequency.rs
+++ b/crates/css_ast/src/units/frequency.rs
@@ -1,6 +1,10 @@
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-values/#resolution
+/// <https://drafts.csswg.org/css-values/#frequency>
+///
+/// ```text,ignore
+/// <frequency> = <dimension-token>
+/// ```
 #[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Frequency {

--- a/crates/css_ast/src/units/resolution.rs
+++ b/crates/css_ast/src/units/resolution.rs
@@ -3,7 +3,11 @@ use super::prelude::*;
 // const DPPX_IN: f32 = 96.0;
 // const DPPX_CM: f32 = DPPX_IN / 2.54;
 
-// https://drafts.csswg.org/css-values/#resolution
+/// <https://drafts.csswg.org/css-values/#resolution>
+///
+/// ```text,ignore
+/// <resolution> = <dimension-token>
+/// ```
 #[derive(ToCursors, Parse, Peek, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Resolution {

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -1,6 +1,10 @@
 use super::prelude::*;
 
-// https://drafts.csswg.org/css-values/#resolution
+/// <https://drafts.csswg.org/css-values/#time>
+///
+/// ```text,ignore
+/// <time> = <dimension-token>
+/// ```
 #[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -3,9 +3,10 @@ use crate::{
 	Result as ParserResult, SemanticEq, SimpleBlock, Span, State, T, ToCursors, ToSpan,
 };
 
-// https://drafts.csswg.org/css-syntax-3/#consume-component-value
-// A compatible "Token" per CSS grammar, subsetted to the tokens possibly
-// rendered by ComponentValue (so no pairwise, function tokens, etc).
+/// <https://drafts.csswg.org/css-syntax-3/#consume-component-value>
+///
+/// A compatible "Token" per CSS grammar, subsetted to the tokens possibly
+/// rendered by ComponentValue (so no pairwise, function tokens, etc).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(untagged))]
 pub enum ComponentValue<'a> {

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -6,7 +6,7 @@ use bumpalo::collections::Vec;
 
 use super::ComponentValue;
 
-// https://drafts.csswg.org/css-syntax-3/#consume-list-of-components
+/// <https://drafts.csswg.org/css-syntax-3/#consume-list-of-components>
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct ComponentValues<'a> {

--- a/crates/css_parse/src/traits/selectors.rs
+++ b/crates/css_parse/src/traits/selectors.rs
@@ -2,11 +2,11 @@ use crate::{Cursor, Diagnostic, Kind, KindSet, Parse, Parser, Peek, Result};
 use bumpalo::collections::Vec;
 
 pub trait CompoundSelector<'a>: Sized + Parse<'a> {
-	// SelectorComponent represents a Selector, or Combinator.
-	// https://drafts.csswg.org/selectors-4/#typedef-combinator
-	// https://drafts.csswg.org/selectors-4/#typedef-type-selector
-	// https://drafts.csswg.org/selectors-4/#typedef-subclass-selector
-	// https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector
+	/// SelectorComponent represents a Selector, or Combinator.
+	/// <https://drafts.csswg.org/selectors-4/#typedef-combinator>
+	/// <https://drafts.csswg.org/selectors-4/#typedef-type-selector>
+	/// <https://drafts.csswg.org/selectors-4/#typedef-subclass-selector>
+	/// <https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector>
 	type SelectorComponent: Parse<'a> + SelectorComponent<'a>;
 
 	/// Parse the next selector component, or return Ok(None) if at a terminator.


### PR DESCRIPTION
Many of these types had the URL as a comment, not a doc comment, also some have
the syntax definition as a comment, these have moved to a fenced markdown block
in a doc comment.
