### PR TITLE
Release v0.0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,63 @@
+## [0.0.22] - 2026-05-15
+
+### Other Changes
+- Chore(deps): update rust crate indexmap to v2.13.1 (#1108) ([#1108](https://github.com/csskit/csskit/pull/1108))
+- Chore(deps): update rust crate indexmap to v2.14.0 (#1109) ([#1109](https://github.com/csskit/csskit/pull/1109))
+
+
+### Chromashift
+- chromashift/csskit_transform: Round fractional colour channels to perceptually safe values (#1092) ([#1092](https://github.com/csskit/csskit/pull/1092))
+
+
+### Css_ast
+- css_ast: implement corner-*, whites-pace, text-emphasis(-style), voice-volume (#1084) ([#1084](https://github.com/csskit/csskit/pull/1084))
+- css_ast: Implement FontVariant* properties and sub-types (#1086) ([#1086](https://github.com/csskit/csskit/pull/1086))
+- csskit_proc_macro: use Either<> type for 2-type Alternatives (#1089) ([#1089](https://github.com/csskit/csskit/pull/1089))
+- css_ast: implement BorderColor, BorderImageSlice, BorderImageWidth (#1090) ([#1090](https://github.com/csskit/csskit/pull/1090))
+- css_ast: Implement lots more properties (#1091) ([#1091](https://github.com/csskit/csskit/pull/1091))
+- css_ast: Uncomment BorderShape, OffsetPath, ShapeInside, ShapeOutside (#1093) ([#1093](https://github.com/csskit/csskit/pull/1093))
+- css_parse/css_ast: Use PEEK_KINDSET alot more consistently (#1094) ([#1094](https://github.com/csskit/csskit/pull/1094))
+- css_ast: Implement a bunch of vendor prefixed style values (#1096) ([#1096](https://github.com/csskit/csskit/pull/1096))
+- css_ast: Add vendor prefix display values (#1097) ([#1097](https://github.com/csskit/csskit/pull/1097))
+- css_ast: Implement z-index (#1098) ([#1098](https://github.com/csskit/csskit/pull/1098))
+- css_ast: Add vendor prefixed value keywords (#1101) ([#1101](https://github.com/csskit/csskit/pull/1101))
+- css_ast: Uncomment clip/clip-path/mask/mask-image/mask-mode/mask-border-slice (#1110) ([#1110](https://github.com/csskit/csskit/pull/1110))
+- css_ast: Unlock more properties by stubbing types (#1111) ([#1111](https://github.com/csskit/csskit/pull/1111))
+
+
+### Css_feature_data
+- Regenerate css_ast/src/values from csswg drafts (#1102) ([#1102](https://github.com/csskit/csskit/pull/1102))
+
+
+### Css_lexer
+- css_parse: Add Either<Left, Right> (#1088) ([#1088](https://github.com/csskit/csskit/pull/1088))
+- css_lexer: Add Span.overlaps (#1095) ([#1095](https://github.com/csskit/csskit/pull/1095))
+
+
+### Css_value_definition_parser
+- css_value_definition_parser: Optimize Auto Number/Percentage or LengthPercentage/Number cases (#1087) ([#1087](https://github.com/csskit/csskit/pull/1087))
+- css_value_definition_parser: Ensure dash prefixed idents are properly emitted (#1099) ([#1099](https://github.com/csskit/csskit/pull/1099))
+
+
+### Csskit
+- chore(deps): update dependencies (patch) (#1103) ([#1103](https://github.com/csskit/csskit/pull/1103))
+- csskit: Improve messaging for check commands with missing sheets (#1113) ([#1113](https://github.com/csskit/csskit/pull/1113))
+
+
+### Csskit-linux-x64
+- packages: remove accidentally comitted bin (#1079) ([#1079](https://github.com/csskit/csskit/pull/1079))
+
+
+### Csskit_proc_macro
+- csskit_proc_macro: Auto generate name for Combinator of Alternatives (#1085) ([#1085](https://github.com/csskit/csskit/pull/1085))
+- csskit_proc_macro: Ensure dash prefixed idents are properly emitted (#1100) ([#1100](https://github.com/csskit/csskit/pull/1100))
+
+
+### Csskit_vscode
+- vscode: bump version (#1082) ([#1082](https://github.com/csskit/csskit/pull/1082))
+- Release csskit vscode extension v1.0.7 (#1083) ([#1083](https://github.com/csskit/csskit/pull/1083))
+- chore(deps): update dependency oxlint to v1.63.0 (#1106) ([#1106](https://github.com/csskit/csskit/pull/1106))
+
 ## [0.0.21] - 2026-05-08
 
 ### Other Changes
@@ -68,6 +128,7 @@
 
 ### Csskit
 - chore(deps): update dependencies (patch) (#959) ([#959](https://github.com/csskit/csskit/pull/959))
+- Release v0.0.21 (#952) ([#952](https://github.com/csskit/csskit/pull/952))
 
 
 ### Csskit_derives
@@ -118,6 +179,7 @@
 - chore(deps): update dependency oxlint to v1.61.0 (#1005) ([#1005](https://github.com/csskit/csskit/pull/1005))
 - chore(deps): update dependency oxlint to v1.62.0 (#1049) ([#1049](https://github.com/csskit/csskit/pull/1049))
 - chore(deps): update dependency @types/vscode to v1.118.0 (#1048) ([#1048](https://github.com/csskit/csskit/pull/1048))
+- Release csskit vscode extension v1.0.5 (#1007) ([#1007](https://github.com/csskit/csskit/pull/1007))
 
 
 ### Csskit_wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chromashift"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "anstyle",
  "owo-colors",
@@ -605,7 +605,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "css_ast"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "css_feature_data"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "browserslist-rs",
  "chrono",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "css_lexer"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "allocator-api2",
  "bitmask-enum",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "css_parse"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "css_value_definition_parser"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "css_lexer",
  "heck",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csskit"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "anstyle",
  "bumpalo",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_ast"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_derives"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "darling",
  "heck",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_highlight"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "anstyle",
  "bitmask-enum",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_lsp"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_proc_macro"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "css_lexer",
  "css_value_definition_parser",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_source_finder"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "glob",
  "grep-matcher",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_spec_generator"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_transform"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_wasm"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "bumpalo",
  "console_error_panic_hook",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "derive_atom_set"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "heck",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,25 +11,25 @@ homepage = "https://csskit.rs"
 keywords = ["CSS", "parser"]
 license = "MIT"
 repository = "https://github.com/csskit/csskit"
-version = "0.0.21"                                      #@release
+version = "0.0.22"                                      #@release
 
 [workspace.dependencies]
 # Local packages
-csskit = { version = "0.0.21", path = "crates/csskit" }                                           #@release
-csskit_derives = { version = "0.0.21", path = "crates/csskit_derives" }                           #@release
-csskit_proc_macro = { version = "0.0.21", path = "crates/csskit_proc_macro" }                     #@release
-css_value_definition_parser = { version = "0.0.21", path = "crates/css_value_definition_parser" } #@release
-css_parse = { version = "0.0.21", path = "crates/css_parse" }                                     #@release
-css_lexer = { version = "0.0.21", path = "crates/css_lexer" }                                     #@release
-css_ast = { version = "0.0.21", path = "crates/css_ast" }                                         #@release
-derive_atom_set = { version = "0.0.21", path = "crates/derive_atom_set" }                         #@release
-css_feature_data = { version = "0.0.21", path = "crates/css_feature_data" }                       #@release
-csskit_source_finder = { version = "0.0.21", path = "crates/csskit_source_finder" }               #@release
-csskit_transform = { version = "0.0.21", path = "crates/csskit_transform" }                       #@release
-csskit_highlight = { version = "0.0.21", path = "crates/csskit_highlight" }                       #@release
-csskit_lsp = { version = "0.0.21", path = "crates/csskit_lsp" }                                   #@release
-csskit_ast = { version = "0.0.21", path = "crates/csskit_ast" }                                   #@release
-chromashift = { version = "0.0.21", path = "crates/chromashift" }                                 #@release
+csskit = { version = "0.0.22", path = "crates/csskit" }                                           #@release
+csskit_derives = { version = "0.0.22", path = "crates/csskit_derives" }                           #@release
+csskit_proc_macro = { version = "0.0.22", path = "crates/csskit_proc_macro" }                     #@release
+css_value_definition_parser = { version = "0.0.22", path = "crates/css_value_definition_parser" } #@release
+css_parse = { version = "0.0.22", path = "crates/css_parse" }                                     #@release
+css_lexer = { version = "0.0.22", path = "crates/css_lexer" }                                     #@release
+css_ast = { version = "0.0.22", path = "crates/css_ast" }                                         #@release
+derive_atom_set = { version = "0.0.22", path = "crates/derive_atom_set" }                         #@release
+css_feature_data = { version = "0.0.22", path = "crates/css_feature_data" }                       #@release
+csskit_source_finder = { version = "0.0.22", path = "crates/csskit_source_finder" }               #@release
+csskit_transform = { version = "0.0.22", path = "crates/csskit_transform" }                       #@release
+csskit_highlight = { version = "0.0.22", path = "crates/csskit_highlight" }                       #@release
+csskit_lsp = { version = "0.0.22", path = "crates/csskit_lsp" }                                   #@release
+csskit_ast = { version = "0.0.22", path = "crates/csskit_ast" }                                   #@release
+chromashift = { version = "0.0.22", path = "crates/chromashift" }                                 #@release
 csskit_spec_generator = { version = "0.0.0", path = "crates/csskit_spec_generator" }
 
 # Memory

--- a/packages/csskit-darwin-arm64/package.json
+++ b/packages/csskit-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-arm64",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "Refreshing CSS - macOS arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-darwin-x64/package.json
+++ b/packages/csskit-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-x64",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "Refreshing CSS - macOS x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-arm64/package.json
+++ b/packages/csskit-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-arm64",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "Refreshing CSS - Linux arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-x64/package.json
+++ b/packages/csskit-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-x64",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "Refreshing CSS - Linux x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-arm64/package.json
+++ b/packages/csskit-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-arm64",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "Refreshing CSS - Windows arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-x64/package.json
+++ b/packages/csskit-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-x64",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "Refreshing CSS - Windows x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit/package-lock.json
+++ b/packages/csskit/package-lock.json
@@ -1,21 +1,13 @@
 {
     "name": "csskit",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "csskit",
-            "version": "0.0.21",
+            "version": "0.0.22",
             "license": "MIT",
-            "dependencies": {
-                "csskit-darwin-arm64": "^0.0.21",
-                "csskit-darwin-x64": "^0.0.21",
-                "csskit-linux-arm64": "^0.0.21",
-                "csskit-linux-x64": "^0.0.21",
-                "csskit-win32-arm64": "^0.0.21",
-                "csskit-win32-x64": "^0.0.21"
-            },
             "bin": {
                 "csskit": "bin/csskit"
             },

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "description": "Refreshing CSS",
     "keywords": [],
     "license": "MIT",
@@ -11,12 +11,12 @@
         "./bin"
     ],
     "optionalDependencies": {
-        "csskit-linux-x64": "0.0.21",
-        "csskit-linux-arm64": "0.0.21",
-        "csskit-darwin-x64": "0.0.21",
-        "csskit-darwin-arm64": "0.0.21",
-        "csskit-win32-x64": "0.0.21",
-        "csskit-win32-arm64": "0.0.21"
+        "csskit-linux-x64": "0.0.22",
+        "csskit-linux-arm64": "0.0.22",
+        "csskit-darwin-x64": "0.0.22",
+        "csskit-darwin-arm64": "0.0.22",
+        "csskit-win32-x64": "0.0.22",
+        "csskit-win32-arm64": "0.0.22"
     },
     "funding": {
         "url": "https://github.com/sponsors/keithamus"


### PR DESCRIPTION
## [0.0.22] - 2026-05-15

### Other Changes
- Chore(deps): update rust crate indexmap to v2.13.1 (#1108) ([#1108](https://github.com/csskit/csskit/pull/1108))
- Chore(deps): update rust crate indexmap to v2.14.0 (#1109) ([#1109](https://github.com/csskit/csskit/pull/1109))


### Chromashift
- chromashift/csskit_transform: Round fractional colour channels to perceptually safe values (#1092) ([#1092](https://github.com/csskit/csskit/pull/1092))


### Css_ast
- css_ast: implement corner-*, whites-pace, text-emphasis(-style), voice-volume (#1084) ([#1084](https://github.com/csskit/csskit/pull/1084))
- css_ast: Implement FontVariant* properties and sub-types (#1086) ([#1086](https://github.com/csskit/csskit/pull/1086))
- csskit_proc_macro: use Either<> type for 2-type Alternatives (#1089) ([#1089](https://github.com/csskit/csskit/pull/1089))
- css_ast: implement BorderColor, BorderImageSlice, BorderImageWidth (#1090) ([#1090](https://github.com/csskit/csskit/pull/1090))
- css_ast: Implement lots more properties (#1091) ([#1091](https://github.com/csskit/csskit/pull/1091))
- css_ast: Uncomment BorderShape, OffsetPath, ShapeInside, ShapeOutside (#1093) ([#1093](https://github.com/csskit/csskit/pull/1093))
- css_parse/css_ast: Use PEEK_KINDSET alot more consistently (#1094) ([#1094](https://github.com/csskit/csskit/pull/1094))
- css_ast: Implement a bunch of vendor prefixed style values (#1096) ([#1096](https://github.com/csskit/csskit/pull/1096))
- css_ast: Add vendor prefix display values (#1097) ([#1097](https://github.com/csskit/csskit/pull/1097))
- css_ast: Implement z-index (#1098) ([#1098](https://github.com/csskit/csskit/pull/1098))
- css_ast: Add vendor prefixed value keywords (#1101) ([#1101](https://github.com/csskit/csskit/pull/1101))
- css_ast: Uncomment clip/clip-path/mask/mask-image/mask-mode/mask-border-slice (#1110) ([#1110](https://github.com/csskit/csskit/pull/1110))
- css_ast: Unlock more properties by stubbing types (#1111) ([#1111](https://github.com/csskit/csskit/pull/1111))


### Css_feature_data
- Regenerate css_ast/src/values from csswg drafts (#1102) ([#1102](https://github.com/csskit/csskit/pull/1102))


### Css_lexer
- css_parse: Add Either<Left, Right> (#1088) ([#1088](https://github.com/csskit/csskit/pull/1088))
- css_lexer: Add Span.overlaps (#1095) ([#1095](https://github.com/csskit/csskit/pull/1095))


### Css_value_definition_parser
- css_value_definition_parser: Optimize Auto Number/Percentage or LengthPercentage/Number cases (#1087) ([#1087](https://github.com/csskit/csskit/pull/1087))
- css_value_definition_parser: Ensure dash prefixed idents are properly emitted (#1099) ([#1099](https://github.com/csskit/csskit/pull/1099))


### Csskit
- chore(deps): update dependencies (patch) (#1103) ([#1103](https://github.com/csskit/csskit/pull/1103))
- csskit: Improve messaging for check commands with missing sheets (#1113) ([#1113](https://github.com/csskit/csskit/pull/1113))


### Csskit-linux-x64
- packages: remove accidentally comitted bin (#1079) ([#1079](https://github.com/csskit/csskit/pull/1079))


### Csskit_proc_macro
- csskit_proc_macro: Auto generate name for Combinator of Alternatives (#1085) ([#1085](https://github.com/csskit/csskit/pull/1085))
- csskit_proc_macro: Ensure dash prefixed idents are properly emitted (#1100) ([#1100](https://github.com/csskit/csskit/pull/1100))


### Csskit_vscode
- vscode: bump version (#1082) ([#1082](https://github.com/csskit/csskit/pull/1082))
- Release csskit vscode extension v1.0.7 (#1083) ([#1083](https://github.com/csskit/csskit/pull/1083))
- chore(deps): update dependency oxlint to v1.63.0 (#1106) ([#1106](https://github.com/csskit/csskit/pull/1106))