### PR TITLE
css_value_definition_parser: Ensure dash prefixed idents are properly emitted

### DIFF
--- a/crates/css_value_definition_parser/src/lib.rs
+++ b/crates/css_value_definition_parser/src/lib.rs
@@ -203,6 +203,11 @@ impl Parse for Def {
 			} else {
 				Self::Ident(ident)
 			}
+		} else if input.peek(Token![-]) && input.peek2(Ident::peek_any) {
+			input.parse::<Token![-]>()?;
+			let mut ident = input.parse::<DefIdent>()?;
+			ident.0.insert(0, '-');
+			Self::Ident(ident)
 		} else if input.peek(Lit) {
 			let lit = input.parse::<Lit>()?;
 			match lit {

--- a/crates/css_value_definition_parser/src/test.rs
+++ b/crates/css_value_definition_parser/src/test.rs
@@ -86,6 +86,22 @@ fn test_def_builds_dashed_idents() {
 }
 
 #[test]
+fn test_def_builds_vendor_prefixed_keyword() {
+	assert_eq!(to_valuedef!(" -webkit-sticky "), Def::Ident(DefIdent("-webkit-sticky".into())),);
+	assert_eq!(
+		to_valuedef!(" foo | -webkit-sticky | -moz-min-content "),
+		Def::Combinator(
+			vec![
+				Def::Ident(DefIdent("foo".into())),
+				Def::Ident(DefIdent("-webkit-sticky".into())),
+				Def::Ident(DefIdent("-moz-min-content".into())),
+			],
+			DefCombinatorStyle::Alternatives,
+		)
+	);
+}
+
+#[test]
 fn def_builds_group_with_brackets() {
 	assert_eq!(
 		to_valuedef! { [ block || inline ] | foo },


### PR DESCRIPTION
This is causing an issue with values that are vendor prefixed.
