### PR TITLE
Regenerate css_ast/src/values from csswg drafts

### DIFF
--- a/crates/css_feature_data/src/data.rs
+++ b/crates/css_feature_data/src/data.rs
@@ -369,7 +369,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(58u16, 0u16), firefox_android : BrowserVersion(58u16, 0u16), safari :
 	BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-font-rendering-controls"], popularity : 50.541046f32, },
+	["https://caniuse.com/css-font-rendering-controls"], popularity : 52.53514f32, },
 	"css.at-rules.font-face.font-family" => CSSFeature { id :
 	"css.at-rules.font-face.font-family", name : "@font-face", description :
 	"The @font-face CSS at-rule creates a custom font-family value. The at-rule's descriptors set the font's name, source, and various display settings.",
@@ -393,7 +393,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16),
 	firefox : BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/font-feature"], popularity : 29.20101f32, },
+	caniuse : & ["https://caniuse.com/font-feature"], popularity : 28.786188f32, },
 	"css.at-rules.font-face.font-stretch" => CSSFeature { id :
 	"css.at-rules.font-face.font-stretch", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -405,7 +405,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(62u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.at-rules.font-face.font-style" => CSSFeature { id :
 	"css.at-rules.font-face.font-style", name : "font-style", description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -416,8 +416,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), },
-	caniuse : & [], popularity : 79.70414f32, }, "css.at-rules.font-face.font-variant" =>
-	CSSFeature { id : "css.at-rules.font-face.font-variant", name : "font-variant",
+	caniuse : & [], popularity : 78.419395f32, }, "css.at-rules.font-face.font-variant"
+	=> CSSFeature { id : "css.at-rules.font-face.font-variant", name : "font-variant",
 	description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -428,7 +428,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 28.726236f32, }, "css.at-rules.font-face.font-variation-settings" =>
+	[], popularity : 29.119843f32, }, "css.at-rules.font-face.font-variation-settings" =>
 	CSSFeature { id : "css.at-rules.font-face.font-variation-settings", name :
 	"font-variation-settings", description :
 	"The font-variation-settings CSS property sets an \"axis of variability\" on a variable font, such as weight, optical size, or a custom axis defined by the typeface designer. When possible, use other CSS font properties, such as font-weight: bold. Also known as variable fonts.",
@@ -438,7 +438,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/variable-fonts"], popularity : 21.542536f32, },
+	["https://caniuse.com/variable-fonts"], popularity : 20.053652f32, },
 	"css.at-rules.font-face.font-weight" => CSSFeature { id :
 	"css.at-rules.font-face.font-weight", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
@@ -450,7 +450,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 88.12362f32, }, "css.at-rules.font-face.font-width" => CSSFeature {
+	[], popularity : 87.1989f32, }, "css.at-rules.font-face.font-width" => CSSFeature {
 	id : "css.at-rules.font-face.font-width", name : "font-width", description :
 	"The font-width CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-width-prop", groups : & ["fonts"],
@@ -479,7 +479,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(92u16, 0u16), edge : BrowserVersion(92u16, 0u16), firefox :
 	BrowserVersion(92u16, 0u16), firefox_android : BrowserVersion(92u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-size-adjust"], popularity : 2.490007f32, },
+	["https://caniuse.com/font-size-adjust"], popularity : 2.486423f32, },
 	"css.at-rules.font-face.src" => CSSFeature { id : "css.at-rules.font-face.src", name
 	: "@font-face", description :
 	"The @font-face CSS at-rule creates a custom font-family value. The at-rule's descriptors set the font's name, source, and various display settings.",
@@ -560,7 +560,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.at-rules.font-feature-values.annotation" => CSSFeature { id :
 	"css.at-rules.font-feature-values.annotation", name : "font-variant-alternates",
 	description :
@@ -573,7 +573,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.at-rules.font-feature-values.character-variant" => CSSFeature { id :
 	"css.at-rules.font-feature-values.character-variant", name :
 	"font-variant-alternates", description :
@@ -586,7 +586,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.at-rules.font-feature-values.historical-forms" => CSSFeature { id :
 	"css.at-rules.font-feature-values.historical-forms", name :
 	"font-variant-alternates", description :
@@ -599,7 +599,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.at-rules.font-feature-values.ornaments" => CSSFeature { id :
 	"css.at-rules.font-feature-values.ornaments", name : "font-variant-alternates",
 	description :
@@ -612,7 +612,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.at-rules.font-feature-values.styleset" => CSSFeature { id :
 	"css.at-rules.font-feature-values.styleset", name : "font-variant-alternates",
 	description :
@@ -625,7 +625,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.at-rules.font-feature-values.stylistic" => CSSFeature { id :
 	"css.at-rules.font-feature-values.stylistic", name : "font-variant-alternates",
 	description :
@@ -638,7 +638,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.at-rules.font-feature-values.swash" => CSSFeature { id :
 	"css.at-rules.font-feature-values.swash", name : "font-variant-alternates",
 	description :
@@ -651,7 +651,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.at-rules.font-palette-values" => CSSFeature { id :
 	"css.at-rules.font-palette-values", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -663,7 +663,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.256348f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.226743f32, },
 	"css.at-rules.font-palette-values.base-palette" => CSSFeature { id :
 	"css.at-rules.font-palette-values.base-palette", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -675,7 +675,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.256348f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.226743f32, },
 	"css.at-rules.font-palette-values.font-family" => CSSFeature { id :
 	"css.at-rules.font-palette-values.font-family", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -687,7 +687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.256348f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.226743f32, },
 	"css.at-rules.font-palette-values.override-colors" => CSSFeature { id :
 	"css.at-rules.font-palette-values.override-colors", name : "font-palette",
 	description :
@@ -700,7 +700,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.256348f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.226743f32, },
 	"css.at-rules.function" => CSSFeature { id : "css.at-rules.function", name :
 	"@function", description :
 	"The @function CSS at-rule defines a custom function that takes CSS values or custom properties as arguments, and returns a CSS value. It can be based on conditional logic such as by using the @media at-rule.",
@@ -1222,8 +1222,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(113u16, 0u16), edge : BrowserVersion(113u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	[], popularity : 87.027626f32, }, "css.at-rules.media.overflow-inline" => CSSFeature
-	{ id : "css.at-rules.media.overflow-inline", name : "Overflow media queries",
+	[], popularity : 86.32124f32, }, "css.at-rules.media.overflow-inline" => CSSFeature {
+	id : "css.at-rules.media.overflow-inline", name : "Overflow media queries",
 	description :
 	"The overflow-block and overflow-inline CSS media queries set styles based on the way a device displays content that's larger than the viewport or page area. For example, a laptop lets users scroll to reveal content, while a printer displays overflowing content on additional pages.",
 	spec : "https://drafts.csswg.org/mediaqueries-5/#mf-overflow-block", groups : &
@@ -1234,7 +1234,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(113u16, 0u16), edge : BrowserVersion(113u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	[], popularity : 87.027626f32, }, "css.at-rules.media.pointer" => CSSFeature { id :
+	[], popularity : 86.32124f32, }, "css.at-rules.media.pointer" => CSSFeature { id :
 	"css.at-rules.media.pointer", name : "Interaction media queries", description :
 	"The pointer, any-pointer, hover, and any-hover CSS media queries set styles based on the presence of pointing devices and their ability to hover over elements. For example, most smartphones match the (hover: none) and (pointer: coarse) media query.",
 	spec : "https://drafts.csswg.org/mediaqueries-5/#mf-interaction", groups : &
@@ -1492,7 +1492,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(85u16, 0u16), edge : BrowserVersion(85u16, 0u16), firefox :
 	BrowserVersion(122u16, 0u16), firefox_android : BrowserVersion(122u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.583042f32, }, "css.at-rules.page.right-bottom" => CSSFeature { id :
+	popularity : 0.237936f32, }, "css.at-rules.page.right-bottom" => CSSFeature { id :
 	"css.at-rules.page.right-bottom", name : "Page setup", description :
 	"The @page CSS at-rule sets the page-specific dimensions and margins for content such as printed documents, ebooks, or slides.",
 	spec : "https://drafts.csswg.org/css-page-3/#at-page-rule", groups : & ["layout",
@@ -1775,7 +1775,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(93u16, 0u16), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(93u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android :
 	BrowserVersion(92u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.67145f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.53177f32, },
 	"css.properties.accent-color.auto" => CSSFeature { id :
 	"css.properties.accent-color.auto", name : "accent-color", description :
 	"The accent-color CSS property sets a color for checkboxes, radio buttons, and other form controls.",
@@ -1784,7 +1784,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(93u16, 0u16), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(93u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android :
 	BrowserVersion(92u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.67145f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.53177f32, },
 	"css.properties.accent-color.currentColor" => CSSFeature { id :
 	"css.properties.accent-color.currentColor", name : "accent-color", description :
 	"The accent-color CSS property sets a color for checkboxes, radio buttons, and other form controls.",
@@ -1793,7 +1793,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(93u16, 0u16), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(93u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android :
 	BrowserVersion(92u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.67145f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.53177f32, },
 	"css.properties.accent-color.transparent" => CSSFeature { id :
 	"css.properties.accent-color.transparent", name : "accent-color", description :
 	"The accent-color CSS property sets a color for checkboxes, radio buttons, and other form controls.",
@@ -1802,7 +1802,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(93u16, 0u16), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(93u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android :
 	BrowserVersion(92u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.67145f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.53177f32, },
 	"css.properties.align-content" => CSSFeature { id : "css.properties.align-content",
 	name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -1925,7 +1925,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(52u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.align-content.multicol_context" => CSSFeature { id :
 	"css.properties.align-content.multicol_context", name : "Multi-column layout",
 	description :
@@ -2047,7 +2047,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(52u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.align-items.grid_context.start_end" => CSSFeature { id :
 	"css.properties.align-items.grid_context.start_end", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -2058,7 +2058,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.align-self" => CSSFeature { id : "css.properties.align-self", name :
 	"Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -2179,7 +2179,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(52u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.align-self.normal" => CSSFeature { id :
 	"css.properties.align-self.normal", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -2223,7 +2223,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.562718f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.441675f32, },
 	"css.properties.alignment-baseline.alphabetic" => CSSFeature { id :
 	"css.properties.alignment-baseline.alphabetic", name : "alignment-baseline",
 	description :
@@ -2233,7 +2233,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.562718f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.441675f32, },
 	"css.properties.alignment-baseline.baseline" => CSSFeature { id :
 	"css.properties.alignment-baseline.baseline", name : "alignment-baseline",
 	description :
@@ -2244,7 +2244,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.562718f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.441675f32, },
 	"css.properties.alignment-baseline.central" => CSSFeature { id :
 	"css.properties.alignment-baseline.central", name : "alignment-baseline", description
 	:
@@ -2254,7 +2254,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.562718f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.441675f32, },
 	"css.properties.alignment-baseline.ideographic" => CSSFeature { id :
 	"css.properties.alignment-baseline.ideographic", name : "alignment-baseline",
 	description :
@@ -2264,7 +2264,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.562718f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.441675f32, },
 	"css.properties.alignment-baseline.mathematical" => CSSFeature { id :
 	"css.properties.alignment-baseline.mathematical", name : "alignment-baseline",
 	description :
@@ -2274,7 +2274,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.562718f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.441675f32, },
 	"css.properties.alignment-baseline.middle" => CSSFeature { id :
 	"css.properties.alignment-baseline.middle", name : "alignment-baseline", description
 	:
@@ -2285,7 +2285,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.562718f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.441675f32, },
 	"css.properties.alignment-baseline.text-after-edge" => CSSFeature { id :
 	"css.properties.alignment-baseline.text-after-edge", name : "alignment-baseline",
 	description :
@@ -2295,7 +2295,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.562718f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.441675f32, },
 	"css.properties.alignment-baseline.text-before-edge" => CSSFeature { id :
 	"css.properties.alignment-baseline.text-before-edge", name : "alignment-baseline",
 	description :
@@ -2305,7 +2305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.562718f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.441675f32, },
 	"css.properties.all" => CSSFeature { id : "css.properties.all", name : "all",
 	description :
 	"The all CSS property is a shorthand for all CSS properties, except for direction and unicode-bidi. It accepts only the keywords for explicit defaulting (such as initial and inherit), since they are the only values supported on all CSS properties.",
@@ -2316,7 +2316,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(27u16, 0u16), firefox_android : BrowserVersion(27u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-all"], popularity : 16.204855f32, },
+	caniuse : & ["https://caniuse.com/css-all"], popularity : 13.587007f32, },
 	"css.properties.anchor-name" => CSSFeature { id : "css.properties.anchor-name", name
 	: "Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
@@ -2389,7 +2389,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16, 0u16), firefox :
 	BrowserVersion(115u16, 0u16), firefox_android : BrowserVersion(115u16, 0u16), safari
 	: BrowserVersion(16u16, 0u16), safari_ios : BrowserVersion(16u16, 0u16), }, caniuse :
-	& [], popularity : 0.462051f32, }, "css.properties.animation-delay" => CSSFeature {
+	& [], popularity : 0.447049f32, }, "css.properties.animation-delay" => CSSFeature {
 	id : "css.properties.animation-delay", name : "Animations (CSS)", description :
 	"The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.",
 	spec : "https://drafts.csswg.org/css-animations-2/", groups : & ["animation"],
@@ -3009,7 +3009,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.auto" =>
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.auto" =>
 	CSSFeature { id : "css.properties.appearance.auto", name : "appearance", description
 	:
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3020,7 +3020,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.base-select"
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.base-select"
 	=> CSSFeature { id : "css.properties.appearance.base-select", name :
 	"Customizable <select>", description :
 	"The <select> element's appearance, including the button, selected option, picker dropdown, and options, can be customized using CSS.",
@@ -3041,7 +3041,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.checkbox" =>
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.checkbox" =>
 	CSSFeature { id : "css.properties.appearance.checkbox", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3052,7 +3052,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.listbox" =>
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.listbox" =>
 	CSSFeature { id : "css.properties.appearance.listbox", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3063,7 +3063,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.menulist" =>
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.menulist" =>
 	CSSFeature { id : "css.properties.appearance.menulist", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3074,7 +3074,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, },
+	caniuse : & [], popularity : 47.60005f32, },
 	"css.properties.appearance.menulist-button" => CSSFeature { id :
 	"css.properties.appearance.menulist-button", name : "appearance", description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3085,7 +3085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.meter" =>
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.meter" =>
 	CSSFeature { id : "css.properties.appearance.meter", name : "appearance", description
 	:
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3096,7 +3096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.none" =>
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.none" =>
 	CSSFeature { id : "css.properties.appearance.none", name : "appearance", description
 	:
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3107,9 +3107,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, },
-	"css.properties.appearance.progress-bar" => CSSFeature { id :
-	"css.properties.appearance.progress-bar", name : "appearance", description :
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.progress-bar"
+	=> CSSFeature { id : "css.properties.appearance.progress-bar", name : "appearance",
+	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
 	spec : "https://drafts.csswg.org/css-ui-4/#appearance-switching", groups : & [],
 	baseline_status : BaselineStatus::High { since : NaiveDate::from_ymd_opt(2024i32,
@@ -3118,7 +3118,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.radio" =>
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.radio" =>
 	CSSFeature { id : "css.properties.appearance.radio", name : "appearance", description
 	:
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3129,7 +3129,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.searchfield"
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.searchfield"
 	=> CSSFeature { id : "css.properties.appearance.searchfield", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3140,7 +3140,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.textarea" =>
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.textarea" =>
 	CSSFeature { id : "css.properties.appearance.textarea", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3151,8 +3151,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.appearance.textfield"
-	=> CSSFeature { id : "css.properties.appearance.textfield", name : "appearance",
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.appearance.textfield" =>
+	CSSFeature { id : "css.properties.appearance.textfield", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
 	spec : "https://drafts.csswg.org/css-ui-4/#appearance-switching", groups : & [],
@@ -3162,7 +3162,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.304256f32, }, "css.properties.aspect-ratio" =>
+	caniuse : & [], popularity : 47.60005f32, }, "css.properties.aspect-ratio" =>
 	CSSFeature { id : "css.properties.aspect-ratio", name : "aspect-ratio", description :
 	"The aspect-ratio CSS property controls the width-to-height ratio of elements. For <img> and <video> elements, the width and height attributes used together with height: auto control the aspect ratio while the image/video is loading.",
 	spec : "https://drafts.csswg.org/css-sizing-4/#aspect-ratio", groups : & [],
@@ -3172,7 +3172,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(88u16, 0u16), edge : BrowserVersion(88u16, 0u16),
 	firefox : BrowserVersion(89u16, 0u16), firefox_android : BrowserVersion(89u16, 0u16),
 	safari : BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), },
-	caniuse : & [], popularity : 34.860096f32, }, "css.properties.aspect-ratio.auto" =>
+	caniuse : & [], popularity : 36.96884f32, }, "css.properties.aspect-ratio.auto" =>
 	CSSFeature { id : "css.properties.aspect-ratio.auto", name : "aspect-ratio",
 	description :
 	"The aspect-ratio CSS property controls the width-to-height ratio of elements. For <img> and <video> elements, the width and height attributes used together with height: auto control the aspect ratio while the image/video is loading.",
@@ -3183,7 +3183,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(88u16, 0u16), edge : BrowserVersion(88u16, 0u16),
 	firefox : BrowserVersion(89u16, 0u16), firefox_android : BrowserVersion(89u16, 0u16),
 	safari : BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), },
-	caniuse : & [], popularity : 34.860096f32, }, "css.properties.backdrop-filter" =>
+	caniuse : & [], popularity : 36.96884f32, }, "css.properties.backdrop-filter" =>
 	CSSFeature { id : "css.properties.backdrop-filter", name : "backdrop-filter",
 	description :
 	"The backdrop-filter CSS property applies graphical effects such as blurring or color shifting to the area behind an element.",
@@ -3194,7 +3194,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), firefox : BrowserVersion(103u16, 0u16), firefox_android :
 	BrowserVersion(103u16, 0u16), safari : BrowserVersion(18u16, 0u16), safari_ios :
 	BrowserVersion(18u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-backdrop-filter"], popularity : 31.679846f32, },
+	["https://caniuse.com/css-backdrop-filter"], popularity : 33.26709f32, },
 	"css.properties.backface-visibility" => CSSFeature { id :
 	"css.properties.backface-visibility", name : "3D transforms", description :
 	"The transform CSS property and its 3D transform functions allow rotations and other transforms in three dimensions, including perspective transforms.",
@@ -3217,7 +3217,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background-attachment" => CSSFeature { id :
 	"css.properties.background-attachment", name : "background-attachment", description :
 	"The background-attachment CSS property sets whether an element's background image or gradient moves as the element scrolls.",
@@ -3229,7 +3229,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.277818f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.24415f32, },
 	"css.properties.background-attachment.fixed" => CSSFeature { id :
 	"css.properties.background-attachment.fixed", name : "background-attachment",
 	description :
@@ -3240,7 +3240,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(2u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.277818f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.24415f32, },
 	"css.properties.background-attachment.local" => CSSFeature { id :
 	"css.properties.background-attachment.local", name : "background-attachment",
 	description :
@@ -3253,7 +3253,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(25u16, 0u16), firefox_android : BrowserVersion(25u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.277818f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.24415f32, },
 	"css.properties.background-attachment.multiple_backgrounds" => CSSFeature { id :
 	"css.properties.background-attachment.multiple_backgrounds", name :
 	"background-attachment", description :
@@ -3266,7 +3266,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.277818f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.24415f32, },
 	"css.properties.background-attachment.scroll" => CSSFeature { id :
 	"css.properties.background-attachment.scroll", name : "background-attachment",
 	description :
@@ -3279,7 +3279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.277818f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.24415f32, },
 	"css.properties.background-blend-mode" => CSSFeature { id :
 	"css.properties.background-blend-mode", name : "background-blend-mode", description :
 	"The background-blend-mode CSS property blends an element's background image and background color using blend modes like multiply, difference, or color.",
@@ -3291,7 +3291,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(35u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(30u16, 0u16), firefox_android : BrowserVersion(30u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-backgroundblendmode"], popularity : 3.607285f32, },
+	["https://caniuse.com/css-backgroundblendmode"], popularity : 3.507342f32, },
 	"css.properties.background-clip" => CSSFeature { id :
 	"css.properties.background-clip", name : "background-clip", description :
 	"The background-clip CSS property sets the extent of the background: the padding box, the content box, or the default border box.",
@@ -3303,7 +3303,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 68.943245f32, }, "css.properties.background-clip.border-area" =>
+	[], popularity : 66.18604f32, }, "css.properties.background-clip.border-area" =>
 	CSSFeature { id : "css.properties.background-clip.border-area", name :
 	"background-clip: border-area", description :
 	"The background-clip: border-area CSS declaration draws the background underneath only the border of an element.",
@@ -3324,7 +3324,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 68.943245f32, }, "css.properties.background-clip.content-box" =>
+	[], popularity : 66.18604f32, }, "css.properties.background-clip.content-box" =>
 	CSSFeature { id : "css.properties.background-clip.content-box", name :
 	"background-clip", description :
 	"The background-clip CSS property sets the extent of the background: the padding box, the content box, or the default border box.",
@@ -3336,7 +3336,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 68.943245f32, }, "css.properties.background-clip.padding-box" =>
+	[], popularity : 66.18604f32, }, "css.properties.background-clip.padding-box" =>
 	CSSFeature { id : "css.properties.background-clip.padding-box", name :
 	"background-clip", description :
 	"The background-clip CSS property sets the extent of the background: the padding box, the content box, or the default border box.",
@@ -3348,7 +3348,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 68.943245f32, }, "css.properties.background-clip.text" => CSSFeature
+	[], popularity : 66.18604f32, }, "css.properties.background-clip.text" => CSSFeature
 	{ id : "css.properties.background-clip.text", name : "background-clip: text",
 	description :
 	"The background-clip: text CSS declaration draws the background underneath only the text in the element.",
@@ -3369,7 +3369,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 90.127914f32, }, "css.properties.background-color.currentColor" =>
+	[], popularity : 89.48081f32, }, "css.properties.background-color.currentColor" =>
 	CSSFeature { id : "css.properties.background-color.currentColor", name :
 	"currentColor", description :
 	"The currentColor CSS value allows you to reuse an element's computed text color for other properties.",
@@ -3394,8 +3394,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 90.127914f32, }, "css.properties.background-image" => CSSFeature {
-	id : "css.properties.background-image", name : "background-image", description :
+	[], popularity : 89.48081f32, }, "css.properties.background-image" => CSSFeature { id
+	: "css.properties.background-image", name : "background-image", description :
 	"The background-image CSS property sets the graphics to display behind the content of an element and in front of the background color. Graphics may be any combination of images or gradients.",
 	spec : "https://drafts.csswg.org/css-backgrounds-3/#background-image", groups : &
 	["background"], baseline_status : BaselineStatus::High { since :
@@ -3405,7 +3405,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 78.600784f32, }, "css.properties.background-image.element" =>
+	[], popularity : 78.47003f32, }, "css.properties.background-image.element" =>
 	CSSFeature { id : "css.properties.background-image.element", name : "element()",
 	description :
 	"The element() CSS function creates a live-updating image from an HTML element that can be used as an image or background image.",
@@ -3449,9 +3449,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 78.600784f32, }, "css.properties.background-image.none" =>
-	CSSFeature { id : "css.properties.background-image.none", name : "background-image",
-	description :
+	[], popularity : 78.47003f32, }, "css.properties.background-image.none" => CSSFeature
+	{ id : "css.properties.background-image.none", name : "background-image", description
+	:
 	"The background-image CSS property sets the graphics to display behind the content of an element and in front of the background color. Graphics may be any combination of images or gradients.",
 	spec : "https://drafts.csswg.org/css-backgrounds-3/#background-image", groups : &
 	["background"], baseline_status : BaselineStatus::High { since :
@@ -3461,7 +3461,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 78.600784f32, }, "css.properties.background-image.svg_images" =>
+	[], popularity : 78.47003f32, }, "css.properties.background-image.svg_images" =>
 	CSSFeature { id : "css.properties.background-image.svg_images", name : "SVG",
 	description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -3485,7 +3485,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 8.477775f32, }, "css.properties.background-origin.border-box" =>
+	[], popularity : 9.09912f32, }, "css.properties.background-origin.border-box" =>
 	CSSFeature { id : "css.properties.background-origin.border-box", name :
 	"background-origin", description :
 	"The background-origin CSS property sets the background starting position relative to the border and padding of an element.",
@@ -3497,7 +3497,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 8.477775f32, }, "css.properties.background-origin.content-box" =>
+	[], popularity : 9.09912f32, }, "css.properties.background-origin.content-box" =>
 	CSSFeature { id : "css.properties.background-origin.content-box", name :
 	"background-origin", description :
 	"The background-origin CSS property sets the background starting position relative to the border and padding of an element.",
@@ -3509,7 +3509,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 8.477775f32, }, "css.properties.background-origin.padding-box" =>
+	[], popularity : 9.09912f32, }, "css.properties.background-origin.padding-box" =>
 	CSSFeature { id : "css.properties.background-origin.padding-box", name :
 	"background-origin", description :
 	"The background-origin CSS property sets the background starting position relative to the border and padding of an element.",
@@ -3521,7 +3521,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 8.477775f32, }, "css.properties.background-position" => CSSFeature {
+	[], popularity : 9.09912f32, }, "css.properties.background-position" => CSSFeature {
 	id : "css.properties.background-position", name : "background-position", description
 	:
 	"The background-position CSS property offsets the initial position of background images relative to the background origin.",
@@ -3534,7 +3534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position-x" => CSSFeature { id :
 	"css.properties.background-position-x", name : "background-position", description :
 	"The background-position CSS property offsets the initial position of background images relative to the background origin.",
@@ -3547,7 +3547,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position-x.side-relative_values" => CSSFeature { id :
 	"css.properties.background-position-x.side-relative_values", name :
 	"background-position", description :
@@ -3560,7 +3560,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
 	caniuse : & ["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position-y" => CSSFeature { id :
 	"css.properties.background-position-y", name : "background-position", description :
 	"The background-position CSS property offsets the initial position of background images relative to the background origin.",
@@ -3573,7 +3573,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position-y.side-relative_values" => CSSFeature { id :
 	"css.properties.background-position-y.side-relative_values", name :
 	"background-position", description :
@@ -3586,7 +3586,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
 	caniuse : & ["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position.bottom" => CSSFeature { id :
 	"css.properties.background-position.bottom", name : "background-position",
 	description :
@@ -3600,7 +3600,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position.center" => CSSFeature { id :
 	"css.properties.background-position.center", name : "background-position",
 	description :
@@ -3614,7 +3614,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position.left" => CSSFeature { id :
 	"css.properties.background-position.left", name : "background-position", description
 	:
@@ -3628,7 +3628,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position.multiple_backgrounds" => CSSFeature { id :
 	"css.properties.background-position.multiple_backgrounds", name :
 	"background-position", description :
@@ -3642,7 +3642,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position.right" => CSSFeature { id :
 	"css.properties.background-position.right", name : "background-position", description
 	:
@@ -3656,7 +3656,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position.side-relative_values" => CSSFeature { id :
 	"css.properties.background-position.side-relative_values", name :
 	"background-position", description :
@@ -3670,7 +3670,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(13u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-position.top" => CSSFeature { id :
 	"css.properties.background-position.top", name : "background-position", description :
 	"The background-position CSS property offsets the initial position of background images relative to the background origin.",
@@ -3683,7 +3683,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.82723f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.53456f32, },
 	"css.properties.background-repeat" => CSSFeature { id :
 	"css.properties.background-repeat", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3695,7 +3695,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 72.33848f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.183945f32, },
 	"css.properties.background-repeat.2-value" => CSSFeature { id :
 	"css.properties.background-repeat.2-value", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3707,7 +3707,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(13u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 72.33848f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.183945f32, },
 	"css.properties.background-repeat.multiple_backgrounds" => CSSFeature { id :
 	"css.properties.background-repeat.multiple_backgrounds", name : "background-repeat",
 	description :
@@ -3720,7 +3720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 72.33848f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.183945f32, },
 	"css.properties.background-repeat.no-repeat" => CSSFeature { id :
 	"css.properties.background-repeat.no-repeat", name : "background-repeat", description
 	: "The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3732,7 +3732,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 72.33848f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.183945f32, },
 	"css.properties.background-repeat.repeat" => CSSFeature { id :
 	"css.properties.background-repeat.repeat", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3744,7 +3744,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 72.33848f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.183945f32, },
 	"css.properties.background-repeat.repeat-x" => CSSFeature { id :
 	"css.properties.background-repeat.repeat-x", name : "background-repeat", description
 	: "The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3756,7 +3756,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 72.33848f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.183945f32, },
 	"css.properties.background-repeat.repeat-y" => CSSFeature { id :
 	"css.properties.background-repeat.repeat-y", name : "background-repeat", description
 	: "The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3768,7 +3768,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 72.33848f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.183945f32, },
 	"css.properties.background-repeat.round" => CSSFeature { id :
 	"css.properties.background-repeat.round", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3780,7 +3780,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(30u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 72.33848f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.183945f32, },
 	"css.properties.background-repeat.space" => CSSFeature { id :
 	"css.properties.background-repeat.space", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3792,7 +3792,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(30u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 72.33848f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.183945f32, },
 	"css.properties.background-size" => CSSFeature { id :
 	"css.properties.background-size", name : "background-size", description :
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
@@ -3804,7 +3804,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 73.33783f32, }, "css.properties.background-size.auto" => CSSFeature
+	[], popularity : 73.57565f32, }, "css.properties.background-size.auto" => CSSFeature
 	{ id : "css.properties.background-size.auto", name : "background-size", description :
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
 	spec : "https://drafts.csswg.org/css-backgrounds-3/#background-size", groups : &
@@ -3815,7 +3815,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 73.33783f32, }, "css.properties.background-size.contain" =>
+	[], popularity : 73.57565f32, }, "css.properties.background-size.contain" =>
 	CSSFeature { id : "css.properties.background-size.contain", name : "background-size",
 	description :
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
@@ -3827,7 +3827,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 73.33783f32, }, "css.properties.background-size.cover" => CSSFeature
+	[], popularity : 73.57565f32, }, "css.properties.background-size.cover" => CSSFeature
 	{ id : "css.properties.background-size.cover", name : "background-size", description
 	:
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
@@ -3839,7 +3839,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 73.33783f32, }, "css.properties.background.SVG_image_as_background"
+	[], popularity : 73.57565f32, }, "css.properties.background.SVG_image_as_background"
 	=> CSSFeature { id : "css.properties.background.SVG_image_as_background", name :
 	"SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -3863,7 +3863,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(22u16, 0u16), firefox_android : BrowserVersion(22u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(4u16, 0u16), }, caniuse : &
-	[], popularity : 68.943245f32, }, "css.properties.background.background-origin" =>
+	[], popularity : 66.18604f32, }, "css.properties.background.background-origin" =>
 	CSSFeature { id : "css.properties.background.background-origin", name :
 	"background-origin", description :
 	"The background-origin CSS property sets the background starting position relative to the border and padding of an element.",
@@ -3875,7 +3875,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(22u16, 0u16), firefox_android : BrowserVersion(22u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(4u16, 0u16), }, caniuse : &
-	[], popularity : 8.477775f32, }, "css.properties.background.background-size" =>
+	[], popularity : 9.09912f32, }, "css.properties.background.background-size" =>
 	CSSFeature { id : "css.properties.background.background-size", name :
 	"background-size", description :
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
@@ -3887,7 +3887,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(18u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(4u16, 0u16), }, caniuse : &
-	[], popularity : 73.33783f32, }, "css.properties.background.currentColor" =>
+	[], popularity : 73.57565f32, }, "css.properties.background.currentColor" =>
 	CSSFeature { id : "css.properties.background.currentColor", name : "currentColor",
 	description :
 	"The currentColor CSS value allows you to reuse an element's computed text color for other properties.",
@@ -3911,7 +3911,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.multiple_backgrounds" => CSSFeature { id :
 	"css.properties.background.multiple_backgrounds", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3923,7 +3923,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.no-repeat" => CSSFeature { id :
 	"css.properties.background.no-repeat", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3935,7 +3935,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.none" => CSSFeature { id :
 	"css.properties.background.none", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3947,7 +3947,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.repeat" => CSSFeature { id :
 	"css.properties.background.repeat", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3959,7 +3959,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.repeat-x" => CSSFeature { id :
 	"css.properties.background.repeat-x", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3971,7 +3971,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.repeat-y" => CSSFeature { id :
 	"css.properties.background.repeat-y", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3983,7 +3983,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.round" => CSSFeature { id :
 	"css.properties.background.round", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3995,7 +3995,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.scroll" => CSSFeature { id :
 	"css.properties.background.scroll", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -4007,7 +4007,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.space" => CSSFeature { id :
 	"css.properties.background.space", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -4019,7 +4019,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.background.transparent" => CSSFeature { id :
 	"css.properties.background.transparent", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -4031,7 +4031,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 87.188805f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.72821f32, },
 	"css.properties.baseline-shift" => CSSFeature { id : "css.properties.baseline-shift",
 	name : "baseline-shift", description :
 	"The baseline-shift CSS property sets the position of an element relative to its dominant baseline.",
@@ -4041,7 +4041,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(4u16, 0u16), safari_ios :
-	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.474719f32, },
+	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.388076f32, },
 	"css.properties.baseline-shift.baseline" => CSSFeature { id :
 	"css.properties.baseline-shift.baseline", name : "baseline-shift", description :
 	"The baseline-shift CSS property sets the position of an element relative to its dominant baseline.",
@@ -4050,7 +4050,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(4u16, 0u16), safari_ios :
-	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.474719f32, },
+	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.388076f32, },
 	"css.properties.baseline-shift.sub" => CSSFeature { id :
 	"css.properties.baseline-shift.sub", name : "baseline-shift", description :
 	"The baseline-shift CSS property sets the position of an element relative to its dominant baseline.",
@@ -4060,7 +4060,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(4u16, 0u16), safari_ios :
-	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.474719f32, },
+	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.388076f32, },
 	"css.properties.baseline-shift.super" => CSSFeature { id :
 	"css.properties.baseline-shift.super", name : "baseline-shift", description :
 	"The baseline-shift CSS property sets the position of an element relative to its dominant baseline.",
@@ -4070,7 +4070,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(4u16, 0u16), safari_ios :
-	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.474719f32, },
+	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.388076f32, },
 	"css.properties.baseline-source" => CSSFeature { id :
 	"css.properties.baseline-source", name : "baseline-source", description :
 	"The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.",
@@ -4079,7 +4079,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), chrome_android : BrowserVersion(111u16, 0u16), edge :
 	BrowserVersion(111u16, 0u16), firefox : BrowserVersion(115u16, 0u16), firefox_android
 	: BrowserVersion(115u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.078584f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.063801f32, },
 	"css.properties.baseline-source.auto" => CSSFeature { id :
 	"css.properties.baseline-source.auto", name : "baseline-source", description :
 	"The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.",
@@ -4088,7 +4088,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), chrome_android : BrowserVersion(111u16, 0u16), edge :
 	BrowserVersion(111u16, 0u16), firefox : BrowserVersion(115u16, 0u16), firefox_android
 	: BrowserVersion(115u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.078584f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.063801f32, },
 	"css.properties.baseline-source.first" => CSSFeature { id :
 	"css.properties.baseline-source.first", name : "baseline-source", description :
 	"The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.",
@@ -4097,7 +4097,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), chrome_android : BrowserVersion(111u16, 0u16), edge :
 	BrowserVersion(111u16, 0u16), firefox : BrowserVersion(115u16, 0u16), firefox_android
 	: BrowserVersion(115u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.078584f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.063801f32, },
 	"css.properties.baseline-source.last" => CSSFeature { id :
 	"css.properties.baseline-source.last", name : "baseline-source", description :
 	"The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.",
@@ -4106,7 +4106,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), chrome_android : BrowserVersion(111u16, 0u16), edge :
 	BrowserVersion(111u16, 0u16), firefox : BrowserVersion(115u16, 0u16), firefox_android
 	: BrowserVersion(115u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.078584f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.063801f32, },
 	"css.properties.block-size" => CSSFeature { id : "css.properties.block-size", name :
 	"Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -5413,7 +5413,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-bottom-left-radius.elliptical_corners" => CSSFeature { id :
 	"css.properties.border-bottom-left-radius.elliptical_corners", name :
 	"border-radius", description :
@@ -5426,7 +5426,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-bottom-left-radius.percentages" => CSSFeature { id :
 	"css.properties.border-bottom-left-radius.percentages", name : "border-radius",
 	description :
@@ -5439,7 +5439,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-bottom-right-radius" => CSSFeature { id :
 	"css.properties.border-bottom-right-radius", name : "border-radius", description :
 	"The border-radius CSS property rounds the corners of the border drawn around an element.",
@@ -5451,7 +5451,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-bottom-right-radius.elliptical_corners" => CSSFeature { id :
 	"css.properties.border-bottom-right-radius.elliptical_corners", name :
 	"border-radius", description :
@@ -5464,7 +5464,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-bottom-right-radius.percentages" => CSSFeature { id :
 	"css.properties.border-bottom-right-radius.percentages", name : "border-radius",
 	description :
@@ -5477,7 +5477,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-bottom-style" => CSSFeature { id :
 	"css.properties.border-bottom-style", name : "Borders", description :
 	"The border CSS property sets the color, style, and width of the line around an element.",
@@ -5910,7 +5910,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-outset" => CSSFeature { id :
 	"css.properties.border-image-outset", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5922,7 +5922,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-repeat" => CSSFeature { id :
 	"css.properties.border-image-repeat", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5934,7 +5934,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-repeat.repeat" => CSSFeature { id :
 	"css.properties.border-image-repeat.repeat", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5946,7 +5946,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-repeat.round" => CSSFeature { id :
 	"css.properties.border-image-repeat.round", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5958,7 +5958,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(30u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-repeat.space" => CSSFeature { id :
 	"css.properties.border-image-repeat.space", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5970,7 +5970,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(50u16, 0u16), firefox_android : BrowserVersion(50u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-repeat.stretch" => CSSFeature { id :
 	"css.properties.border-image-repeat.stretch", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5982,7 +5982,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-slice" => CSSFeature { id :
 	"css.properties.border-image-slice", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5994,7 +5994,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-source" => CSSFeature { id :
 	"css.properties.border-image-source", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6006,7 +6006,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-width" => CSSFeature { id :
 	"css.properties.border-image-width", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6018,7 +6018,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(13u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image-width.auto" => CSSFeature { id :
 	"css.properties.border-image-width.auto", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6030,7 +6030,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image.fill" => CSSFeature { id :
 	"css.properties.border-image.fill", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6042,7 +6042,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image.gradient" => CSSFeature { id :
 	"css.properties.border-image.gradient", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6054,7 +6054,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image.none" => CSSFeature { id :
 	"css.properties.border-image.none", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6066,7 +6066,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image.optional_border_image_slice" => CSSFeature { id :
 	"css.properties.border-image.optional_border_image_slice", name : "Border images",
 	description : "The border-image CSS property draws an image around an element.", spec
@@ -6078,7 +6078,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image.repeat" => CSSFeature { id :
 	"css.properties.border-image.repeat", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6090,7 +6090,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image.round" => CSSFeature { id :
 	"css.properties.border-image.round", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6102,7 +6102,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image.space" => CSSFeature { id :
 	"css.properties.border-image.space", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6114,7 +6114,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-image.stretch" => CSSFeature { id :
 	"css.properties.border-image.stretch", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6126,7 +6126,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 5.96933f32, },
+	["https://caniuse.com/border-image"], popularity : 6.029069f32, },
 	"css.properties.border-inline" => CSSFeature { id : "css.properties.border-inline",
 	name : "Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -7700,7 +7700,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-radius.4_values_for_4_corners" => CSSFeature { id :
 	"css.properties.border-radius.4_values_for_4_corners", name : "border-radius",
 	description :
@@ -7713,7 +7713,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-radius.elliptical_borders" => CSSFeature { id :
 	"css.properties.border-radius.elliptical_borders", name : "border-radius",
 	description :
@@ -7726,7 +7726,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-radius.percentages" => CSSFeature { id :
 	"css.properties.border-radius.percentages", name : "border-radius", description :
 	"The border-radius CSS property rounds the corners of the border drawn around an element.",
@@ -7738,7 +7738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-right" => CSSFeature { id : "css.properties.border-right",
 	name : "Borders", description :
 	"The border CSS property sets the color, style, and width of the line around an element.",
@@ -8124,7 +8124,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(147u16, 0u16), chrome_android : BrowserVersion(147u16, 0u16), edge :
 	BrowserVersion(147u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.160209f32, },
+	0), }, caniuse : & [], popularity : 0.161292f32, },
 	"css.properties.border-shape.none" => CSSFeature { id :
 	"css.properties.border-shape.none", name : "border-shape", description :
 	"The border-shape CSS property sets the geometry of the border box, changing the shape of any applicable border, border image, focus outline, or shadow.",
@@ -8133,7 +8133,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(147u16, 0u16), chrome_android : BrowserVersion(147u16, 0u16), edge :
 	BrowserVersion(147u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.160209f32, }, "css.properties.border-spacing"
+	0), }, caniuse : & [], popularity : 0.161292f32, }, "css.properties.border-spacing"
 	=> CSSFeature { id : "css.properties.border-spacing", name : "Tables", description :
 	"The <table> HTML element, with several related elements, represents tabular data in rows and columns of cells.",
 	spec : "https://html.spec.whatwg.org/multipage/tables.html", groups : &
@@ -8346,7 +8346,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-top-left-radius.elliptical_corners" => CSSFeature { id :
 	"css.properties.border-top-left-radius.elliptical_corners", name : "border-radius",
 	description :
@@ -8359,7 +8359,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-top-left-radius.percentages" => CSSFeature { id :
 	"css.properties.border-top-left-radius.percentages", name : "border-radius",
 	description :
@@ -8372,7 +8372,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-top-right-radius" => CSSFeature { id :
 	"css.properties.border-top-right-radius", name : "border-radius", description :
 	"The border-radius CSS property rounds the corners of the border drawn around an element.",
@@ -8384,7 +8384,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-top-right-radius.elliptical_corners" => CSSFeature { id :
 	"css.properties.border-top-right-radius.elliptical_corners", name : "border-radius",
 	description :
@@ -8397,7 +8397,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-top-right-radius.percentages" => CSSFeature { id :
 	"css.properties.border-top-right-radius.percentages", name : "border-radius",
 	description :
@@ -8410,7 +8410,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 86.14773f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.88f32, },
 	"css.properties.border-top-style" => CSSFeature { id :
 	"css.properties.border-top-style", name : "Borders", description :
 	"The border CSS property sets the color, style, and width of the line around an element.",
@@ -9002,9 +9002,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(32u16, 0u16), firefox_android
 	: BrowserVersion(32u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-boxdecorationbreak"],
-	popularity : 2.78414f32, }, "css.properties.box-decoration-break.clone" => CSSFeature
-	{ id : "css.properties.box-decoration-break.clone", name : "box-decoration-break",
-	description :
+	popularity : 2.429616f32, }, "css.properties.box-decoration-break.clone" =>
+	CSSFeature { id : "css.properties.box-decoration-break.clone", name :
+	"box-decoration-break", description :
 	"The box-decoration-break CSS property sets whether box decorations, such as borders or backgrounds, of an element divided across a page, column, or region wraps each fragment or splits across the break.",
 	spec : "https://drafts.csswg.org/css-break-4/#break-decoration", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -9012,9 +9012,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(32u16, 0u16), firefox_android
 	: BrowserVersion(32u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-boxdecorationbreak"],
-	popularity : 2.78414f32, }, "css.properties.box-decoration-break.slice" => CSSFeature
-	{ id : "css.properties.box-decoration-break.slice", name : "box-decoration-break",
-	description :
+	popularity : 2.429616f32, }, "css.properties.box-decoration-break.slice" =>
+	CSSFeature { id : "css.properties.box-decoration-break.slice", name :
+	"box-decoration-break", description :
 	"The box-decoration-break CSS property sets whether box decorations, such as borders or backgrounds, of an element divided across a page, column, or region wraps each fragment or splits across the break.",
 	spec : "https://drafts.csswg.org/css-break-4/#break-decoration", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -9022,7 +9022,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(32u16, 0u16), firefox_android
 	: BrowserVersion(32u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-boxdecorationbreak"],
-	popularity : 2.78414f32, }, "css.properties.box-shadow" => CSSFeature { id :
+	popularity : 2.429616f32, }, "css.properties.box-shadow" => CSSFeature { id :
 	"css.properties.box-shadow", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
 	spec : "https://drafts.csswg.org/css-backgrounds-3/#box-shadow", groups : &
@@ -9033,7 +9033,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 82.45644f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.80225f32, },
 	"css.properties.box-shadow.inset" => CSSFeature { id :
 	"css.properties.box-shadow.inset", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
@@ -9045,7 +9045,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 82.45644f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.80225f32, },
 	"css.properties.box-shadow.multiple_shadows" => CSSFeature { id :
 	"css.properties.box-shadow.multiple_shadows", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
@@ -9057,7 +9057,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 82.45644f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.80225f32, },
 	"css.properties.box-shadow.none" => CSSFeature { id :
 	"css.properties.box-shadow.none", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
@@ -9069,7 +9069,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 82.45644f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.80225f32, },
 	"css.properties.box-shadow.spread_radius" => CSSFeature { id :
 	"css.properties.box-shadow.spread_radius", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
@@ -9081,7 +9081,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 82.45644f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.80225f32, },
 	"css.properties.box-sizing" => CSSFeature { id : "css.properties.box-sizing", name :
 	"box-sizing", description :
 	"The box-sizing CSS property sets whether an element's width and height are calculated based on the content-box, which does not count the size of borders or padding, or border-box, which does count them.",
@@ -9093,7 +9093,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css3-boxsizing"], popularity : 85.58736f32, },
+	["https://caniuse.com/css3-boxsizing"], popularity : 84.971634f32, },
 	"css.properties.box-sizing.border-box" => CSSFeature { id :
 	"css.properties.box-sizing.border-box", name : "box-sizing", description :
 	"The box-sizing CSS property sets whether an element's width and height are calculated based on the content-box, which does not count the size of borders or padding, or border-box, which does count them.",
@@ -9105,7 +9105,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css3-boxsizing"], popularity : 85.58736f32, },
+	["https://caniuse.com/css3-boxsizing"], popularity : 84.971634f32, },
 	"css.properties.box-sizing.content-box" => CSSFeature { id :
 	"css.properties.box-sizing.content-box", name : "box-sizing", description :
 	"The box-sizing CSS property sets whether an element's width and height are calculated based on the content-box, which does not count the size of borders or padding, or border-box, which does count them.",
@@ -9117,7 +9117,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css3-boxsizing"], popularity : 85.58736f32, },
+	["https://caniuse.com/css3-boxsizing"], popularity : 84.971634f32, },
 	"css.properties.break-after" => CSSFeature { id : "css.properties.break-after", name
 	: "Page breaks", description :
 	"In printed page layouts, the break-after, break-before, break-inside CSS properties control where printed pages start and end. Also known as pagination or page breaking.",
@@ -9680,7 +9680,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(53u16, 0u16), firefox_android : BrowserVersion(53u16, 0u16),
 	safari : BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 15.777197f32, },
+	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 14.573737f32, },
 	"css.properties.caret-color.currentColor" => CSSFeature { id :
 	"css.properties.caret-color.currentColor", name : "caret-color", description :
 	"The caret-color CSS property sets the color of the text insertion pointer in a text input.",
@@ -9691,7 +9691,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(53u16, 0u16), firefox_android : BrowserVersion(53u16, 0u16),
 	safari : BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 15.777197f32, },
+	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 14.573737f32, },
 	"css.properties.caret-color.transparent" => CSSFeature { id :
 	"css.properties.caret-color.transparent", name : "caret-color", description :
 	"The caret-color CSS property sets the color of the text insertion pointer in a text input.",
@@ -9702,7 +9702,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(53u16, 0u16), firefox_android : BrowserVersion(53u16, 0u16),
 	safari : BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 15.777197f32, },
+	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 14.573737f32, },
 	"css.properties.caret-shape" => CSSFeature { id : "css.properties.caret-shape", name
 	: "caret-shape", description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
@@ -9711,7 +9711,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.15853f32, }, "css.properties.caret-shape.auto"
+	0), }, caniuse : & [], popularity : 0.157995f32, }, "css.properties.caret-shape.auto"
 	=> CSSFeature { id : "css.properties.caret-shape.auto", name : "caret-shape",
 	description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
@@ -9720,7 +9720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.15853f32, }, "css.properties.caret-shape.bar"
+	0), }, caniuse : & [], popularity : 0.157995f32, }, "css.properties.caret-shape.bar"
 	=> CSSFeature { id : "css.properties.caret-shape.bar", name : "caret-shape",
 	description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
@@ -9729,16 +9729,16 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.15853f32, }, "css.properties.caret-shape.block"
-	=> CSSFeature { id : "css.properties.caret-shape.block", name : "caret-shape",
-	description :
+	0), }, caniuse : & [], popularity : 0.157995f32, },
+	"css.properties.caret-shape.block" => CSSFeature { id :
+	"css.properties.caret-shape.block", name : "caret-shape", description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
 	spec : "https://drafts.csswg.org/css-ui-4/#propdef-caret-shape", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.15853f32, },
+	0), }, caniuse : & [], popularity : 0.157995f32, },
 	"css.properties.caret-shape.underscore" => CSSFeature { id :
 	"css.properties.caret-shape.underscore", name : "caret-shape", description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
@@ -9747,7 +9747,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.15853f32, }, "css.properties.clear" =>
+	0), }, caniuse : & [], popularity : 0.157995f32, }, "css.properties.clear" =>
 	CSSFeature { id : "css.properties.clear", name : "float and clear", description :
 	"The float CSS property aligns an element to either side of its container, allowing text and inline elements to flow around it. The clear CSS property sets whether an element is moved below floating elements that proceed it.",
 	spec : "https://drafts.csswg.org/css2/#propdef-float", groups : & [], baseline_status
@@ -9828,7 +9828,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 53.784763f32, }, "css.properties.clip-path" => CSSFeature { id :
+	[], popularity : 51.734997f32, }, "css.properties.clip-path" => CSSFeature { id :
 	"css.properties.clip-path", name : "clip-path", description :
 	"The clip-path CSS property and SVG attribute set the visible area of an element. Everything outside the area will be hidden.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
@@ -9839,9 +9839,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 44.448124f32, }, "css.properties.clip-path.basic_shape" =>
-	CSSFeature { id : "css.properties.clip-path.basic_shape", name : "clip-path",
-	description :
+	[], popularity : 43.33584f32, }, "css.properties.clip-path.basic_shape" => CSSFeature
+	{ id : "css.properties.clip-path.basic_shape", name : "clip-path", description :
 	"The clip-path CSS property and SVG attribute set the visible area of an element. Everything outside the area will be hidden.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
 	["clipping-shapes-masking"], baseline_status : BaselineStatus::High { since :
@@ -9851,7 +9850,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(54u16, 0u16), firefox_android : BrowserVersion(54u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 44.448124f32, }, "css.properties.clip-path.fill-box" => CSSFeature {
+	[], popularity : 43.33584f32, }, "css.properties.clip-path.fill-box" => CSSFeature {
 	id : "css.properties.clip-path.fill-box", name : "Clip path boxes", description :
 	"The fill-box, stroke-box, and view-box values for clip-path set an edge of the element's box to use as the clipping shape.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
@@ -9873,7 +9872,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 44.448124f32, }, "css.properties.clip-path.is_animatable" =>
+	[], popularity : 43.33584f32, }, "css.properties.clip-path.is_animatable" =>
 	CSSFeature { id : "css.properties.clip-path.is_animatable", name :
 	"Animatable clipping paths", description :
 	"The clip-path property can be animated using CSS transitions and animations.", spec
@@ -9896,7 +9895,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(88u16, 0u16), edge : BrowserVersion(88u16, 0u16), firefox :
 	BrowserVersion(71u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	[], popularity : 44.448124f32, }, "css.properties.clip-path.stroke-box" => CSSFeature
+	[], popularity : 43.33584f32, }, "css.properties.clip-path.stroke-box" => CSSFeature
 	{ id : "css.properties.clip-path.stroke-box", name : "Clip path boxes", description :
 	"The fill-box, stroke-box, and view-box values for clip-path set an edge of the element's box to use as the clipping shape.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
@@ -9918,7 +9917,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 44.448124f32, }, "css.properties.clip-path.view-box" => CSSFeature {
+	[], popularity : 43.33584f32, }, "css.properties.clip-path.view-box" => CSSFeature {
 	id : "css.properties.clip-path.view-box", name : "Clip path boxes", description :
 	"The fill-box, stroke-box, and view-box values for clip-path set an edge of the element's box to use as the clipping shape.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
@@ -9971,7 +9970,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 53.784763f32, }, "css.properties.color" => CSSFeature { id :
+	[], popularity : 51.734997f32, }, "css.properties.color" => CSSFeature { id :
 	"css.properties.color", name : "Color", description :
 	"The color CSS property sets the primary foreground color of an element, which is used for text, the default border color, and text decorations.",
 	spec : "https://drafts.csswg.org/css-color-4/#the-color-property", groups : & [],
@@ -9981,7 +9980,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 90.658905f32, }, "css.properties.color-adjust" =>
+	caniuse : & [], popularity : 90.188835f32, }, "css.properties.color-adjust" =>
 	CSSFeature { id : "css.properties.color-adjust", name : "color-adjust", description :
 	"The color-adjust shorthand CSS property allows multiple performance related color adjustments to be set at once. Setting the print-color-adjust CSS property directly is preferred, as it is the only such adjustment so far defined.",
 	spec : "https://drafts.csswg.org/css-color-adjust-1/#color-adjust", groups : &
@@ -10091,7 +10090,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(81u16, 0u16), edge : BrowserVersion(81u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.806759f32, }, "css.properties.color-scheme.dark" =>
+	caniuse : & [], popularity : 20.91399f32, }, "css.properties.color-scheme.dark" =>
 	CSSFeature { id : "css.properties.color-scheme.dark", name : "color-scheme",
 	description :
 	"The color-scheme CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.",
@@ -10102,7 +10101,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(81u16, 0u16), edge : BrowserVersion(81u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.806759f32, }, "css.properties.color-scheme.light" =>
+	caniuse : & [], popularity : 20.91399f32, }, "css.properties.color-scheme.light" =>
 	CSSFeature { id : "css.properties.color-scheme.light", name : "color-scheme",
 	description :
 	"The color-scheme CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.",
@@ -10113,7 +10112,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(81u16, 0u16), edge : BrowserVersion(81u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.806759f32, }, "css.properties.color-scheme.normal" =>
+	caniuse : & [], popularity : 20.91399f32, }, "css.properties.color-scheme.normal" =>
 	CSSFeature { id : "css.properties.color-scheme.normal", name : "color-scheme",
 	description :
 	"The color-scheme CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.",
@@ -10124,7 +10123,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(81u16, 0u16), edge : BrowserVersion(81u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.806759f32, }, "css.properties.color-scheme.only" =>
+	caniuse : & [], popularity : 20.91399f32, }, "css.properties.color-scheme.only" =>
 	CSSFeature { id : "css.properties.color-scheme.only", name : "color-scheme",
 	description :
 	"The color-scheme CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.",
@@ -10135,7 +10134,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.806759f32, }, "css.properties.color.currentColor" =>
+	caniuse : & [], popularity : 20.91399f32, }, "css.properties.color.currentColor" =>
 	CSSFeature { id : "css.properties.color.currentColor", name : "currentColor",
 	description :
 	"The currentColor CSS value allows you to reuse an element's computed text color for other properties.",
@@ -10158,7 +10157,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 90.658905f32, }, "css.properties.column-count" =>
+	caniuse : & [], popularity : 90.188835f32, }, "css.properties.column-count" =>
 	CSSFeature { id : "css.properties.column-count", name : "Multi-column layout",
 	description :
 	"Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.",
@@ -10191,7 +10190,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 1.770044f32, }, "css.properties.column-fill.auto" => CSSFeature { id
+	[], popularity : 1.977578f32, }, "css.properties.column-fill.auto" => CSSFeature { id
 	: "css.properties.column-fill.auto", name : "column-fill", description :
 	"The column-fill CSS property sets the distribution of content across columns in a multi-column layout.",
 	spec : "https://drafts.csswg.org/css-multicol-1/#filling-columns", groups : &
@@ -10202,7 +10201,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 1.770044f32, }, "css.properties.column-fill.balance" => CSSFeature {
+	[], popularity : 1.977578f32, }, "css.properties.column-fill.balance" => CSSFeature {
 	id : "css.properties.column-fill.balance", name : "column-fill", description :
 	"The column-fill CSS property sets the distribution of content across columns in a multi-column layout.",
 	spec : "https://drafts.csswg.org/css-multicol-1/#filling-columns", groups : &
@@ -10213,7 +10212,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 1.770044f32, }, "css.properties.column-gap" => CSSFeature { id :
+	[], popularity : 1.977578f32, }, "css.properties.column-gap" => CSSFeature { id :
 	"css.properties.column-gap", name : "Multi-column layout", description :
 	"Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.",
 	spec : "https://drafts.csswg.org/css-multicol-1/", groups : & ["multi-column"],
@@ -10245,7 +10244,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 0u16), safari_ios : BrowserVersion(12u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.column-gap.multicol_context" => CSSFeature { id :
 	"css.properties.column-gap.multicol_context", name : "Multi-column layout",
 	description :
@@ -10674,7 +10673,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(71u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 0.804039f32, }, "css.properties.column-span.all" => CSSFeature { id
+	[], popularity : 0.842819f32, }, "css.properties.column-span.all" => CSSFeature { id
 	: "css.properties.column-span.all", name : "column-span", description :
 	"The column-span CSS property controls whether a child element extends across all columns of a multi-column parent.",
 	spec : "https://drafts.csswg.org/css-multicol-1/#spanning-columns", groups : &
@@ -10685,7 +10684,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(71u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 0.804039f32, }, "css.properties.column-span.none" => CSSFeature { id
+	[], popularity : 0.842819f32, }, "css.properties.column-span.none" => CSSFeature { id
 	: "css.properties.column-span.none", name : "column-span", description :
 	"The column-span CSS property controls whether a child element extends across all columns of a multi-column parent.",
 	spec : "https://drafts.csswg.org/css-multicol-1/#spanning-columns", groups : &
@@ -10696,7 +10695,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(71u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 0.804039f32, }, "css.properties.column-width" => CSSFeature { id :
+	[], popularity : 0.842819f32, }, "css.properties.column-width" => CSSFeature { id :
 	"css.properties.column-width", name : "Multi-column layout", description :
 	"Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.",
 	spec : "https://drafts.csswg.org/css-multicol-1/", groups : & ["multi-column"],
@@ -10738,7 +10737,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-containment"], popularity : 22.816338f32, },
+	["https://caniuse.com/css-containment"], popularity : 21.349806f32, },
 	"css.properties.contain-intrinsic-block-size" => CSSFeature { id :
 	"css.properties.contain-intrinsic-block-size", name : "contain-intrinsic-size",
 	description :
@@ -10751,7 +10750,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), edge : BrowserVersion(95u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain-intrinsic-block-size.none"
+	& [], popularity : 8.156319f32, }, "css.properties.contain-intrinsic-block-size.none"
 	=> CSSFeature { id : "css.properties.contain-intrinsic-block-size.none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10763,7 +10762,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain-intrinsic-height" =>
+	& [], popularity : 8.156319f32, }, "css.properties.contain-intrinsic-height" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-height", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10775,7 +10774,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), edge : BrowserVersion(95u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain-intrinsic-height.none" =>
+	& [], popularity : 8.156319f32, }, "css.properties.contain-intrinsic-height.none" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-height.none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10787,7 +10786,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain-intrinsic-inline-size" =>
+	& [], popularity : 8.156319f32, }, "css.properties.contain-intrinsic-inline-size" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-inline-size", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10799,7 +10798,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), edge : BrowserVersion(95u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, },
+	& [], popularity : 8.156319f32, },
 	"css.properties.contain-intrinsic-inline-size.none" => CSSFeature { id :
 	"css.properties.contain-intrinsic-inline-size.none", name : "contain-intrinsic-size",
 	description :
@@ -10812,7 +10811,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain-intrinsic-size" =>
+	& [], popularity : 8.156319f32, }, "css.properties.contain-intrinsic-size" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-size", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10824,7 +10823,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(83u16, 0u16), edge : BrowserVersion(83u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain-intrinsic-size.auto_none"
+	& [], popularity : 8.156319f32, }, "css.properties.contain-intrinsic-size.auto_none"
 	=> CSSFeature { id : "css.properties.contain-intrinsic-size.auto_none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10836,7 +10835,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16), firefox :
 	BrowserVersion(117u16, 0u16), firefox_android : BrowserVersion(117u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain-intrinsic-size.none" =>
+	& [], popularity : 8.156319f32, }, "css.properties.contain-intrinsic-size.none" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-size.none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10848,7 +10847,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain-intrinsic-width" =>
+	& [], popularity : 8.156319f32, }, "css.properties.contain-intrinsic-width" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-width", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10860,7 +10859,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), edge : BrowserVersion(95u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain-intrinsic-width.none" =>
+	& [], popularity : 8.156319f32, }, "css.properties.contain-intrinsic-width.none" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-width.none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10872,7 +10871,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 7.363164f32, }, "css.properties.contain.content" => CSSFeature {
+	& [], popularity : 8.156319f32, }, "css.properties.contain.content" => CSSFeature {
 	id : "css.properties.contain.content", name : "contain", description :
 	"The contain CSS property sets limits to the scope of styles, layout, and paint rendering for speed and efficiency. The none keyword value disables containment, strict is equivalent to contain: size layout style paint, and content is equivalent to contain: layout style paint.",
 	spec : "https://drafts.csswg.org/css-contain-2/#contain-property", groups : &
@@ -10883,7 +10882,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-containment"], popularity : 22.816338f32, },
+	["https://caniuse.com/css-containment"], popularity : 21.349806f32, },
 	"css.properties.contain.inline-size" => CSSFeature { id :
 	"css.properties.contain.inline-size", name : "Inline-size containment", description :
 	"The contain: inline-size CSS declaration prevents the element's inline dimension from being set by the element's contents. This permits the browser to avoid slower layout calculations.",
@@ -10917,7 +10916,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-containment"], popularity : 22.816338f32, },
+	["https://caniuse.com/css-containment"], popularity : 21.349806f32, },
 	"css.properties.contain.paint" => CSSFeature { id : "css.properties.contain.paint",
 	name : "Paint containment", description :
 	"The contain: paint CSS declaration prevents an element's descendants from being drawn outside the boundaries of the containing element, with any overflow clipped. This permits the browser to avoid slower painting calculations.",
@@ -10951,7 +10950,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-containment"], popularity : 22.816338f32, },
+	["https://caniuse.com/css-containment"], popularity : 21.349806f32, },
 	"css.properties.contain.style" => CSSFeature { id : "css.properties.contain.style",
 	name : "Style containment", description :
 	"The contain: style CSS declaration permits the browser to avoid slower layout calculations by preventing modification to counter (counter-increment and counter-set) and quotation styles (content property quote values) beyond the element's descendants.",
@@ -11085,7 +11084,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, }, "css.properties.content-visibility" =>
+	caniuse : & [], popularity : 80.992294f32, }, "css.properties.content-visibility" =>
 	CSSFeature { id : "css.properties.content-visibility", name : "content-visibility",
 	description :
 	"The content-visibility CSS property delays rendering an element, including layout and painting, until it is needed.",
@@ -11096,7 +11095,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(18u16, 0u16), safari_ios : BrowserVersion(18u16,
 	0u16), }, caniuse : & ["https://caniuse.com/css-content-visibility"], popularity :
-	9.971321f32, }, "css.properties.content-visibility.auto" => CSSFeature { id :
+	9.72924f32, }, "css.properties.content-visibility.auto" => CSSFeature { id :
 	"css.properties.content-visibility.auto", name : "content-visibility", description :
 	"The content-visibility CSS property delays rendering an element, including layout and painting, until it is needed.",
 	spec : "https://drafts.csswg.org/css-contain-2/#content-visibility", groups : & [],
@@ -11106,7 +11105,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(26u16, 0u16), safari_ios : BrowserVersion(26u16,
 	0u16), }, caniuse : & ["https://caniuse.com/css-content-visibility"], popularity :
-	9.971321f32, }, "css.properties.content-visibility.hidden" => CSSFeature { id :
+	9.72924f32, }, "css.properties.content-visibility.hidden" => CSSFeature { id :
 	"css.properties.content-visibility.hidden", name : "content-visibility", description
 	:
 	"The content-visibility CSS property delays rendering an element, including layout and painting, until it is needed.",
@@ -11117,7 +11116,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(18u16, 0u16), safari_ios : BrowserVersion(18u16,
 	0u16), }, caniuse : & ["https://caniuse.com/css-content-visibility"], popularity :
-	9.971321f32, }, "css.properties.content-visibility.is_transitionable" => CSSFeature {
+	9.72924f32, }, "css.properties.content-visibility.is_transitionable" => CSSFeature {
 	id : "css.properties.content-visibility.is_transitionable", name :
 	"display animation", description :
 	"You can animate elements between display: none and any other display value or animate between content-visibility: hidden and any other content-visibility value. This also applies to transitions.",
@@ -11148,7 +11147,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(18u16, 0u16), safari_ios : BrowserVersion(18u16,
 	0u16), }, caniuse : & ["https://caniuse.com/css-content-visibility"], popularity :
-	9.971321f32, }, "css.properties.content.alt_text" => CSSFeature { id :
+	9.72924f32, }, "css.properties.content.alt_text" => CSSFeature { id :
 	"css.properties.content.alt_text", name : "Alt text for generated content",
 	description :
 	"The / notation in content CSS property values adds alternative text to generated content. For example, the content: url('upvote-icon.svg') / 'Upvote' declaration adds accessible 'Upvote' text to the SVG icon. Also known as alternate text.",
@@ -11169,7 +11168,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, },
+	caniuse : & [], popularity : 80.992294f32, },
 	"css.properties.content.element_replacement" => CSSFeature { id :
 	"css.properties.content.element_replacement", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
@@ -11180,7 +11179,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(28u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(63u16, 0u16), firefox_android : BrowserVersion(63u16, 0u16),
 	safari : BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, }, "css.properties.content.gradient" =>
+	caniuse : & [], popularity : 80.992294f32, }, "css.properties.content.gradient" =>
 	CSSFeature { id : "css.properties.content.gradient", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
 	spec : "https://drafts.csswg.org/css-content-3/#content-property", groups : & [],
@@ -11188,7 +11187,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(26u16, 0u16), chrome_android : BrowserVersion(26u16, 0u16), edge :
 	BrowserVersion(12u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(7u16, 0u16), safari_ios :
-	BrowserVersion(7u16, 0u16), }, caniuse : & [], popularity : 81.5181f32, },
+	BrowserVersion(7u16, 0u16), }, caniuse : & [], popularity : 80.992294f32, },
 	"css.properties.content.image-set" => CSSFeature { id :
 	"css.properties.content.image-set", name : "image-set()", description :
 	"The image-set() CSS function provides a set of images at different resolutions or pixel densities, which the browser can pick from, depending on the device capabilities.",
@@ -11210,8 +11209,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, }, "css.properties.content.no-open-quote" =>
-	CSSFeature { id : "css.properties.content.no-open-quote", name : "Content",
+	caniuse : & [], popularity : 80.992294f32, }, "css.properties.content.no-open-quote"
+	=> CSSFeature { id : "css.properties.content.no-open-quote", name : "Content",
 	description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
 	spec : "https://drafts.csswg.org/css-content-3/#content-property", groups : & [],
@@ -11221,7 +11220,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, }, "css.properties.content.none" =>
+	caniuse : & [], popularity : 80.992294f32, }, "css.properties.content.none" =>
 	CSSFeature { id : "css.properties.content.none", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
 	spec : "https://drafts.csswg.org/css-content-3/#content-property", groups : & [],
@@ -11231,7 +11230,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, },
+	caniuse : & [], popularity : 80.992294f32, },
 	"css.properties.content.none_applies_to_elements" => CSSFeature { id :
 	"css.properties.content.none_applies_to_elements", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
@@ -11240,7 +11239,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 81.5181f32, }, "css.properties.content.normal" => CSSFeature { id :
+	popularity : 80.992294f32, }, "css.properties.content.normal" => CSSFeature { id :
 	"css.properties.content.normal", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
 	spec : "https://drafts.csswg.org/css-content-3/#content-property", groups : & [],
@@ -11250,7 +11249,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, }, "css.properties.content.open-quote" =>
+	caniuse : & [], popularity : 80.992294f32, }, "css.properties.content.open-quote" =>
 	CSSFeature { id : "css.properties.content.open-quote", name : "Content", description
 	:
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
@@ -11261,7 +11260,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, }, "css.properties.content.url" =>
+	caniuse : & [], popularity : 80.992294f32, }, "css.properties.content.url" =>
 	CSSFeature { id : "css.properties.content.url", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
 	spec : "https://drafts.csswg.org/css-content-3/#content-property", groups : & [],
@@ -11271,7 +11270,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, }, "css.properties.corner-block-end-shape"
+	caniuse : & [], popularity : 80.992294f32, }, "css.properties.corner-block-end-shape"
 	=> CSSFeature { id : "css.properties.corner-block-end-shape", name : "corner-shape",
 	description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11280,7 +11279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-block-start-shape" => CSSFeature { id :
 	"css.properties.corner-block-start-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11289,7 +11288,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-bottom-left-shape" => CSSFeature { id :
 	"css.properties.corner-bottom-left-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11298,7 +11297,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-bottom-right-shape" => CSSFeature { id :
 	"css.properties.corner-bottom-right-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11307,7 +11306,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-bottom-shape" => CSSFeature { id :
 	"css.properties.corner-bottom-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11316,7 +11315,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-end-end-shape" => CSSFeature { id :
 	"css.properties.corner-end-end-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11325,7 +11324,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-end-start-shape" => CSSFeature { id :
 	"css.properties.corner-end-start-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11334,7 +11333,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-inline-end-shape" => CSSFeature { id :
 	"css.properties.corner-inline-end-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11343,7 +11342,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-inline-start-shape" => CSSFeature { id :
 	"css.properties.corner-inline-start-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11352,7 +11351,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-left-shape" => CSSFeature { id :
 	"css.properties.corner-left-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11361,7 +11360,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-right-shape" => CSSFeature { id :
 	"css.properties.corner-right-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11370,7 +11369,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, }, "css.properties.corner-shape" =>
+	0), }, caniuse : & [], popularity : 0.779787f32, }, "css.properties.corner-shape" =>
 	CSSFeature { id : "css.properties.corner-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
 	spec : "https://drafts.csswg.org/css-borders-4/#corner-shaping", groups : & [],
@@ -11378,7 +11377,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-start-end-shape" => CSSFeature { id :
 	"css.properties.corner-start-end-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11387,7 +11386,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-start-start-shape" => CSSFeature { id :
 	"css.properties.corner-start-start-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11396,7 +11395,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-top-left-shape" => CSSFeature { id :
 	"css.properties.corner-top-left-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11405,7 +11404,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.corner-top-right-shape" => CSSFeature { id :
 	"css.properties.corner-top-right-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11414,7 +11413,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, }, "css.properties.corner-top-shape"
+	0), }, caniuse : & [], popularity : 0.779787f32, }, "css.properties.corner-top-shape"
 	=> CSSFeature { id : "css.properties.corner-top-shape", name : "corner-shape",
 	description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11423,7 +11422,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.properties.counter-increment" => CSSFeature { id :
 	"css.properties.counter-increment", name : "Counters (CSS)", description :
 	"The counter-reset and counter-increment CSS properties and the counter() and counters() functions automatically number headings or ordered list items.",
@@ -11524,7 +11523,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(85u16, 0u16), chrome_android : BrowserVersion(85u16, 0u16), edge :
 	BrowserVersion(85u16, 0u16), firefox : BrowserVersion(68u16, 0u16), firefox_android :
 	BrowserVersion(68u16, 0u16), safari : BrowserVersion(17u16, 2u16), safari_ios :
-	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.585337f32, },
+	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.40476f32, },
 	"css.properties.counter-set.list-item" => CSSFeature { id :
 	"css.properties.counter-set.list-item", name : "counter-set", description :
 	"The counter-set CSS property creates (and optionally sets a value for) a counter, the numbers for a series of headings or ordered list items.",
@@ -11534,7 +11533,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(85u16, 0u16), chrome_android : BrowserVersion(85u16, 0u16), edge :
 	BrowserVersion(85u16, 0u16), firefox : BrowserVersion(68u16, 0u16), firefox_android :
 	BrowserVersion(68u16, 0u16), safari : BrowserVersion(17u16, 2u16), safari_ios :
-	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.585337f32, },
+	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.40476f32, },
 	"css.properties.counter-set.none" => CSSFeature { id :
 	"css.properties.counter-set.none", name : "counter-set", description :
 	"The counter-set CSS property creates (and optionally sets a value for) a counter, the numbers for a series of headings or ordered list items.",
@@ -11544,7 +11543,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(85u16, 0u16), chrome_android : BrowserVersion(85u16, 0u16), edge :
 	BrowserVersion(85u16, 0u16), firefox : BrowserVersion(68u16, 0u16), firefox_android :
 	BrowserVersion(68u16, 0u16), safari : BrowserVersion(17u16, 2u16), safari_ios :
-	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.585337f32, },
+	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.40476f32, },
 	"css.properties.cursor" => CSSFeature { id : "css.properties.cursor", name :
 	"Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11556,7 +11555,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(1u16, 2u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 85.043175f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.3638f32, },
 	"css.properties.cursor.alias" => CSSFeature { id : "css.properties.cursor.alias",
 	name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11567,7 +11566,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.all-scroll" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.all-scroll" => CSSFeature { id :
 	"css.properties.cursor.all-scroll", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11577,7 +11576,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.auto" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.auto" => CSSFeature { id :
 	"css.properties.cursor.auto", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11588,7 +11587,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(1u16, 2u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 85.043175f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.3638f32, },
 	"css.properties.cursor.cell" => CSSFeature { id : "css.properties.cursor.cell", name
 	: "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11600,7 +11599,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 85.043175f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.3638f32, },
 	"css.properties.cursor.col-resize" => CSSFeature { id :
 	"css.properties.cursor.col-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11611,8 +11610,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.context-menu" => CSSFeature { id
-	: "css.properties.cursor.context-menu", name : "Cursor styles", description :
+	popularity : 84.3638f32, }, "css.properties.cursor.context-menu" => CSSFeature { id :
+	"css.properties.cursor.context-menu", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -11621,7 +11620,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.copy" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.copy" => CSSFeature { id :
 	"css.properties.cursor.copy", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11631,7 +11630,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.crosshair" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.crosshair" => CSSFeature { id :
 	"css.properties.cursor.crosshair", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11641,7 +11640,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.default" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.default" => CSSFeature { id :
 	"css.properties.cursor.default", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11651,7 +11650,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.e-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.e-resize" => CSSFeature { id :
 	"css.properties.cursor.e-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11661,7 +11660,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.ew-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.ew-resize" => CSSFeature { id :
 	"css.properties.cursor.ew-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11671,7 +11670,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.grab" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.grab" => CSSFeature { id :
 	"css.properties.cursor.grab", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11681,7 +11680,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(11u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.grabbing" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.grabbing" => CSSFeature { id :
 	"css.properties.cursor.grabbing", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11691,7 +11690,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(11u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.help" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.help" => CSSFeature { id :
 	"css.properties.cursor.help", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11701,7 +11700,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.move" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.move" => CSSFeature { id :
 	"css.properties.cursor.move", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11711,7 +11710,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.n-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.n-resize" => CSSFeature { id :
 	"css.properties.cursor.n-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11721,7 +11720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.ne-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.ne-resize" => CSSFeature { id :
 	"css.properties.cursor.ne-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11731,8 +11730,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.nesw-resize" => CSSFeature { id
-	: "css.properties.cursor.nesw-resize", name : "Cursor styles", description :
+	popularity : 84.3638f32, }, "css.properties.cursor.nesw-resize" => CSSFeature { id :
+	"css.properties.cursor.nesw-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -11741,7 +11740,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.no-drop" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.no-drop" => CSSFeature { id :
 	"css.properties.cursor.no-drop", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11751,7 +11750,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.none" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.none" => CSSFeature { id :
 	"css.properties.cursor.none", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11761,8 +11760,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(5u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.not-allowed" => CSSFeature { id
-	: "css.properties.cursor.not-allowed", name : "Cursor styles", description :
+	popularity : 84.3638f32, }, "css.properties.cursor.not-allowed" => CSSFeature { id :
+	"css.properties.cursor.not-allowed", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -11771,7 +11770,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.ns-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.ns-resize" => CSSFeature { id :
 	"css.properties.cursor.ns-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11781,7 +11780,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.nw-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.nw-resize" => CSSFeature { id :
 	"css.properties.cursor.nw-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11791,8 +11790,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.nwse-resize" => CSSFeature { id
-	: "css.properties.cursor.nwse-resize", name : "Cursor styles", description :
+	popularity : 84.3638f32, }, "css.properties.cursor.nwse-resize" => CSSFeature { id :
+	"css.properties.cursor.nwse-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -11801,7 +11800,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.pointer" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.pointer" => CSSFeature { id :
 	"css.properties.cursor.pointer", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11811,7 +11810,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.progress" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.progress" => CSSFeature { id :
 	"css.properties.cursor.progress", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11821,7 +11820,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.row-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.row-resize" => CSSFeature { id :
 	"css.properties.cursor.row-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11831,7 +11830,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.s-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.s-resize" => CSSFeature { id :
 	"css.properties.cursor.s-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11841,7 +11840,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.se-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.se-resize" => CSSFeature { id :
 	"css.properties.cursor.se-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11851,7 +11850,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.sw-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.sw-resize" => CSSFeature { id :
 	"css.properties.cursor.sw-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11861,7 +11860,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.text" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.text" => CSSFeature { id :
 	"css.properties.cursor.text", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11872,7 +11871,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(1u16, 2u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 85.043175f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.3638f32, },
 	"css.properties.cursor.url" => CSSFeature { id : "css.properties.cursor.url", name :
 	"Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11884,7 +11883,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 85.043175f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.3638f32, },
 	"css.properties.cursor.url_positioning_syntax" => CSSFeature { id :
 	"css.properties.cursor.url_positioning_syntax", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11895,8 +11894,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.vertical-text" => CSSFeature {
-	id : "css.properties.cursor.vertical-text", name : "Cursor styles", description :
+	popularity : 84.3638f32, }, "css.properties.cursor.vertical-text" => CSSFeature { id
+	: "css.properties.cursor.vertical-text", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -11905,7 +11904,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.w-resize" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.w-resize" => CSSFeature { id :
 	"css.properties.cursor.w-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11915,7 +11914,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.wait" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.wait" => CSSFeature { id :
 	"css.properties.cursor.wait", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11925,7 +11924,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.zoom-in" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.zoom-in" => CSSFeature { id :
 	"css.properties.cursor.zoom-in", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11935,7 +11934,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(9u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.cursor.zoom-out" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.cursor.zoom-out" => CSSFeature { id :
 	"css.properties.cursor.zoom-out", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11945,7 +11944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(9u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 85.043175f32, }, "css.properties.custom-property" => CSSFeature { id :
+	popularity : 84.3638f32, }, "css.properties.custom-property" => CSSFeature { id :
 	"css.properties.custom-property", name : "Custom properties", description :
 	"Custom properties are CSS properties prefixed with -- that set values you can reuse with the var() function. For example, you can set a --key-color property to reuse as border-color: var(--key-color). Also known as CSS variables.",
 	spec : "https://drafts.csswg.org/css-variables-1/", groups : & [], baseline_status :
@@ -12040,7 +12039,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.28295f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 92.92095f32, },
 	"css.properties.display.block" => CSSFeature { id : "css.properties.display.block",
 	name : "Display", description :
 	"The display CSS property sets the display behavior of an element's box within its layout and sets the layout behavior for its child elements.",
@@ -12051,7 +12050,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.28295f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 92.92095f32, },
 	"css.properties.display.contents" => CSSFeature { id :
 	"css.properties.display.contents", name : "display: contents", description :
 	"The display: contents CSS declaration sets an element to display only its contents, not itself.",
@@ -12115,7 +12114,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.display.inline" => CSSFeature { id : "css.properties.display.inline",
 	name : "Display", description :
 	"The display CSS property sets the display behavior of an element's box within its layout and sets the layout behavior for its child elements.",
@@ -12126,7 +12125,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.28295f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 92.92095f32, },
 	"css.properties.display.inline-block" => CSSFeature { id :
 	"css.properties.display.inline-block", name : "Display", description :
 	"The display CSS property sets the display behavior of an element's box within its layout and sets the layout behavior for its child elements.",
@@ -12137,7 +12136,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.28295f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 92.92095f32, },
 	"css.properties.display.inline-flex" => CSSFeature { id :
 	"css.properties.display.inline-flex", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -12159,7 +12158,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.display.inline-table" => CSSFeature { id :
 	"css.properties.display.inline-table", name : "display: table", description :
 	"The display: table CSS declaration renders an element with the box layout of a <table> HTML element. Child elements may use equivalents to <table> internal elements such as display: table-row for <tr>.",
@@ -12241,7 +12240,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.28295f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 92.92095f32, },
 	"css.properties.display.none.option_is_hidden" => CSSFeature { id :
 	"css.properties.display.none.option_is_hidden", name : "Display", description :
 	"The display CSS property sets the display behavior of an element's box within its layout and sets the layout behavior for its child elements.",
@@ -12251,7 +12250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(1u16, 0u16),
 	firefox_android : BrowserVersion(4u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/inline-block"], popularity : 93.28295f32, },
+	["https://caniuse.com/inline-block"], popularity : 92.92095f32, },
 	"css.properties.display.ruby" => CSSFeature { id : "css.properties.display.ruby",
 	name : "display: ruby", description :
 	"The display: ruby CSS declaration renders an element with the box layout of a <ruby> HTML element. Child elements may use equivalents to <ruby> internal elements such as display: ruby-base for <rb>.",
@@ -12407,7 +12406,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.970462f32, }, "css.properties.dominant-baseline.alphabetic" =>
+	[], popularity : 0.805745f32, }, "css.properties.dominant-baseline.alphabetic" =>
 	CSSFeature { id : "css.properties.dominant-baseline.alphabetic", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12419,7 +12418,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.970462f32, }, "css.properties.dominant-baseline.auto" =>
+	[], popularity : 0.805745f32, }, "css.properties.dominant-baseline.auto" =>
 	CSSFeature { id : "css.properties.dominant-baseline.auto", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12431,7 +12430,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.970462f32, }, "css.properties.dominant-baseline.central" =>
+	[], popularity : 0.805745f32, }, "css.properties.dominant-baseline.central" =>
 	CSSFeature { id : "css.properties.dominant-baseline.central", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12443,7 +12442,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.970462f32, }, "css.properties.dominant-baseline.hanging" =>
+	[], popularity : 0.805745f32, }, "css.properties.dominant-baseline.hanging" =>
 	CSSFeature { id : "css.properties.dominant-baseline.hanging", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12455,7 +12454,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.970462f32, }, "css.properties.dominant-baseline.ideographic" =>
+	[], popularity : 0.805745f32, }, "css.properties.dominant-baseline.ideographic" =>
 	CSSFeature { id : "css.properties.dominant-baseline.ideographic", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12467,7 +12466,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.970462f32, }, "css.properties.dominant-baseline.mathematical" =>
+	[], popularity : 0.805745f32, }, "css.properties.dominant-baseline.mathematical" =>
 	CSSFeature { id : "css.properties.dominant-baseline.mathematical", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12479,7 +12478,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.970462f32, }, "css.properties.dominant-baseline.middle" =>
+	[], popularity : 0.805745f32, }, "css.properties.dominant-baseline.middle" =>
 	CSSFeature { id : "css.properties.dominant-baseline.middle", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12491,7 +12490,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.970462f32, }, "css.properties.dynamic-range-limit" => CSSFeature {
+	[], popularity : 0.805745f32, }, "css.properties.dynamic-range-limit" => CSSFeature {
 	id : "css.properties.dynamic-range-limit", name : "dynamic-range-limit", description
 	:
 	"The dynamic-range-limit CSS property controls the peak luminance of high dynamic range content. You can use this to coordinate the apparent brightness of HDR and SDR content.",
@@ -12500,7 +12499,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(26u16, 0u16), safari_ios :
-	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.436744f32, },
+	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.483296f32, },
 	"css.properties.dynamic-range-limit.constrained" => CSSFeature { id :
 	"css.properties.dynamic-range-limit.constrained", name : "dynamic-range-limit",
 	description :
@@ -12510,7 +12509,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.436744f32, },
+	0), }, caniuse : & [], popularity : 0.483296f32, },
 	"css.properties.dynamic-range-limit.dynamic-range-limit-mix_values" => CSSFeature {
 	id : "css.properties.dynamic-range-limit.dynamic-range-limit-mix_values", name :
 	"dynamic-range-limit", description :
@@ -12520,7 +12519,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.436744f32, },
+	0), }, caniuse : & [], popularity : 0.483296f32, },
 	"css.properties.dynamic-range-limit.no-limit" => CSSFeature { id :
 	"css.properties.dynamic-range-limit.no-limit", name : "dynamic-range-limit",
 	description :
@@ -12530,7 +12529,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(26u16, 0u16), safari_ios :
-	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.436744f32, },
+	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.483296f32, },
 	"css.properties.dynamic-range-limit.standard" => CSSFeature { id :
 	"css.properties.dynamic-range-limit.standard", name : "dynamic-range-limit",
 	description :
@@ -12540,7 +12539,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(26u16, 0u16), safari_ios :
-	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.436744f32, },
+	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.483296f32, },
 	"css.properties.empty-cells" => CSSFeature { id : "css.properties.empty-cells", name
 	: "Tables", description :
 	"The <table> HTML element, with several related elements, represents tabular data in rows and columns of cells.",
@@ -12582,7 +12581,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16), edge :
 	BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.55034f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.263923f32, },
 	"css.properties.field-sizing.content" => CSSFeature { id :
 	"css.properties.field-sizing.content", name : "field-sizing", description :
 	"The field-sizing CSS property allows form controls such as <textarea> to be sized based on their content.",
@@ -12591,7 +12590,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16), edge :
 	BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.55034f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.263923f32, },
 	"css.properties.field-sizing.fixed" => CSSFeature { id :
 	"css.properties.field-sizing.fixed", name : "field-sizing", description :
 	"The field-sizing CSS property allows form controls such as <textarea> to be sized based on their content.",
@@ -12600,7 +12599,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16), edge :
 	BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.55034f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.263923f32, },
 	"css.properties.fill" => CSSFeature { id : "css.properties.fill", name : "SVG",
 	description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -12679,7 +12678,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.blur" => CSSFeature { id : "css.properties.filter.blur", name
 	: "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12690,7 +12689,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.brightness" => CSSFeature { id :
 	"css.properties.filter.brightness", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12701,7 +12700,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.contrast" => CSSFeature { id :
 	"css.properties.filter.contrast", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12712,7 +12711,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.drop-shadow" => CSSFeature { id :
 	"css.properties.filter.drop-shadow", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12723,7 +12722,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.grayscale" => CSSFeature { id :
 	"css.properties.filter.grayscale", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12734,7 +12733,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.hue-rotate" => CSSFeature { id :
 	"css.properties.filter.hue-rotate", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12745,7 +12744,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.invert" => CSSFeature { id : "css.properties.filter.invert",
 	name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12756,7 +12755,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.opacity" => CSSFeature { id : "css.properties.filter.opacity",
 	name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12767,7 +12766,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.saturate" => CSSFeature { id :
 	"css.properties.filter.saturate", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12778,7 +12777,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.sepia" => CSSFeature { id : "css.properties.filter.sepia",
 	name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12789,7 +12788,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.properties.filter.svg_elements" => CSSFeature { id :
 	"css.properties.filter.svg_elements", name : "SVG filters", description :
 	"The <filter> SVG element applies custom effects such as color manipulation, blurring, or morphing to SVG elements.",
@@ -13155,8 +13154,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.594475f32, }, "css.properties.font-family.cursive" => CSSFeature
-	{ id : "css.properties.font-family.cursive", name : "font-family", description :
+	[], popularity : 87.88144f32, }, "css.properties.font-family.cursive" => CSSFeature {
+	id : "css.properties.font-family.cursive", name : "font-family", description :
 	"The font-family CSS property sets the desired font face for text, along with optional fallback font faces.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-family-prop", groups : &
 	["fonts"], baseline_status : BaselineStatus::High { since :
@@ -13166,8 +13165,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.594475f32, }, "css.properties.font-family.fantasy" => CSSFeature
-	{ id : "css.properties.font-family.fantasy", name : "font-family", description :
+	[], popularity : 87.88144f32, }, "css.properties.font-family.fantasy" => CSSFeature {
+	id : "css.properties.font-family.fantasy", name : "font-family", description :
 	"The font-family CSS property sets the desired font face for text, along with optional fallback font faces.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-family-prop", groups : &
 	["fonts"], baseline_status : BaselineStatus::High { since :
@@ -13177,8 +13176,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.594475f32, }, "css.properties.font-family.math" => CSSFeature {
-	id : "css.properties.font-family.math", name : "Math font family", description :
+	[], popularity : 87.88144f32, }, "css.properties.font-family.math" => CSSFeature { id
+	: "css.properties.font-family.math", name : "Math font family", description :
 	"The font-family: math CSS declaration uses the browser default font face for displaying mathematical expressions.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#math-def", groups : & ["mathml"],
 	baseline_status : BaselineStatus::Low(NaiveDate::from_ymd_opt(2026i32, 3u32, 24u32)
@@ -13198,7 +13197,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.594475f32, }, "css.properties.font-family.sans-serif" =>
+	[], popularity : 87.88144f32, }, "css.properties.font-family.sans-serif" =>
 	CSSFeature { id : "css.properties.font-family.sans-serif", name : "font-family",
 	description :
 	"The font-family CSS property sets the desired font face for text, along with optional fallback font faces.",
@@ -13210,7 +13209,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.594475f32, }, "css.properties.font-family.serif" => CSSFeature {
+	[], popularity : 87.88144f32, }, "css.properties.font-family.serif" => CSSFeature {
 	id : "css.properties.font-family.serif", name : "font-family", description :
 	"The font-family CSS property sets the desired font face for text, along with optional fallback font faces.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-family-prop", groups : &
@@ -13221,9 +13220,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.594475f32, }, "css.properties.font-family.system-ui" =>
-	CSSFeature { id : "css.properties.font-family.system-ui", name : "System font",
-	description :
+	[], popularity : 87.88144f32, }, "css.properties.font-family.system-ui" => CSSFeature
+	{ id : "css.properties.font-family.system-ui", name : "System font", description :
 	"The font-family: system-ui CSS declaration uses the operating system default font for text.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#system-ui-def", groups : & [],
 	baseline_status : BaselineStatus::High { since : NaiveDate::from_ymd_opt(2024i32,
@@ -13280,7 +13278,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(15u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-feature"], popularity : 29.20101f32, },
+	["https://caniuse.com/font-feature"], popularity : 28.786188f32, },
 	"css.properties.font-feature-settings.normal" => CSSFeature { id :
 	"css.properties.font-feature-settings.normal", name : "font-feature-settings",
 	description :
@@ -13293,7 +13291,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(15u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-feature"], popularity : 29.20101f32, },
+	["https://caniuse.com/font-feature"], popularity : 28.786188f32, },
 	"css.properties.font-kerning" => CSSFeature { id : "css.properties.font-kerning",
 	name : "font-kerning", description :
 	"The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.",
@@ -13305,7 +13303,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-kerning"], popularity : 2.208862f32, },
+	["https://caniuse.com/font-kerning"], popularity : 2.228145f32, },
 	"css.properties.font-kerning.auto" => CSSFeature { id :
 	"css.properties.font-kerning.auto", name : "font-kerning", description :
 	"The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.",
@@ -13317,7 +13315,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-kerning"], popularity : 2.208862f32, },
+	["https://caniuse.com/font-kerning"], popularity : 2.228145f32, },
 	"css.properties.font-kerning.none" => CSSFeature { id :
 	"css.properties.font-kerning.none", name : "font-kerning", description :
 	"The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.",
@@ -13329,7 +13327,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-kerning"], popularity : 2.208862f32, },
+	["https://caniuse.com/font-kerning"], popularity : 2.228145f32, },
 	"css.properties.font-kerning.normal" => CSSFeature { id :
 	"css.properties.font-kerning.normal", name : "font-kerning", description :
 	"The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.",
@@ -13341,7 +13339,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-kerning"], popularity : 2.208862f32, },
+	["https://caniuse.com/font-kerning"], popularity : 2.228145f32, },
 	"css.properties.font-language-override" => CSSFeature { id :
 	"css.properties.font-language-override", name : "font-language-override", description
 	:
@@ -13352,7 +13350,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(143u16, 0u16), edge : BrowserVersion(143u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 1.07775f32, }, "css.properties.font-optical-sizing" => CSSFeature { id :
+	popularity : 1.22397f32, }, "css.properties.font-optical-sizing" => CSSFeature { id :
 	"css.properties.font-optical-sizing", name : "font-optical-sizing", description :
 	"The font-optical-sizing CSS property sets whether text rendering is optimized for viewing at different sizes.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-optical-sizing-def", groups : &
@@ -13363,7 +13361,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
-	[], popularity : 3.304841f32, }, "css.properties.font-optical-sizing.auto" =>
+	[], popularity : 3.026222f32, }, "css.properties.font-optical-sizing.auto" =>
 	CSSFeature { id : "css.properties.font-optical-sizing.auto", name :
 	"font-optical-sizing", description :
 	"The font-optical-sizing CSS property sets whether text rendering is optimized for viewing at different sizes.",
@@ -13375,7 +13373,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
-	[], popularity : 3.304841f32, }, "css.properties.font-optical-sizing.none" =>
+	[], popularity : 3.026222f32, }, "css.properties.font-optical-sizing.none" =>
 	CSSFeature { id : "css.properties.font-optical-sizing.none", name :
 	"font-optical-sizing", description :
 	"The font-optical-sizing CSS property sets whether text rendering is optimized for viewing at different sizes.",
@@ -13387,7 +13385,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
-	[], popularity : 3.304841f32, }, "css.properties.font-palette" => CSSFeature { id :
+	[], popularity : 3.026222f32, }, "css.properties.font-palette" => CSSFeature { id :
 	"css.properties.font-palette", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-palette-prop", groups : &
@@ -13398,7 +13396,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.256348f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.226743f32, },
 	"css.properties.font-palette.animation_computed" => CSSFeature { id :
 	"css.properties.font-palette.animation_computed", name : "font-palette animation",
 	description : "You can animate color fonts between two font-palette values.", spec :
@@ -13419,7 +13417,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.256348f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.226743f32, },
 	"css.properties.font-palette.light" => CSSFeature { id :
 	"css.properties.font-palette.light", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -13431,7 +13429,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.256348f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.226743f32, },
 	"css.properties.font-palette.normal" => CSSFeature { id :
 	"css.properties.font-palette.normal", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -13443,7 +13441,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.256348f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.226743f32, },
 	"css.properties.font-palette.palette-mix_function" => CSSFeature { id :
 	"css.properties.font-palette.palette-mix_function", name : "font-palette animation",
 	description : "You can animate color fonts between two font-palette values.", spec :
@@ -13462,7 +13460,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 89.74227f32, }, "css.properties.font-size-adjust" =>
+	caniuse : & [], popularity : 89.065544f32, }, "css.properties.font-size-adjust" =>
 	CSSFeature { id : "css.properties.font-size-adjust", name : "font-size-adjust",
 	description :
 	"The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.",
@@ -13473,7 +13471,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(127u16, 0u16), firefox : BrowserVersion(3u16, 0u16), firefox_android :
 	BrowserVersion(4u16, 0u16), safari : BrowserVersion(16u16, 4u16), safari_ios :
 	BrowserVersion(16u16, 4u16), }, caniuse : & ["https://caniuse.com/font-size-adjust"],
-	popularity : 2.490007f32, }, "css.properties.font-size-adjust.from-font" =>
+	popularity : 2.486423f32, }, "css.properties.font-size-adjust.from-font" =>
 	CSSFeature { id : "css.properties.font-size-adjust.from-font", name :
 	"font-size-adjust", description :
 	"The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.",
@@ -13484,7 +13482,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(127u16, 0u16), firefox : BrowserVersion(118u16, 0u16), firefox_android
 	: BrowserVersion(118u16, 0u16), safari : BrowserVersion(17u16, 0u16), safari_ios :
 	BrowserVersion(17u16, 0u16), }, caniuse : & ["https://caniuse.com/font-size-adjust"],
-	popularity : 2.490007f32, }, "css.properties.font-size-adjust.none" => CSSFeature {
+	popularity : 2.486423f32, }, "css.properties.font-size-adjust.none" => CSSFeature {
 	id : "css.properties.font-size-adjust.none", name : "font-size-adjust", description :
 	"The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.",
 	spec : "https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop", groups : &
@@ -13494,7 +13492,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(127u16, 0u16), firefox : BrowserVersion(3u16, 0u16), firefox_android :
 	BrowserVersion(4u16, 0u16), safari : BrowserVersion(16u16, 4u16), safari_ios :
 	BrowserVersion(16u16, 4u16), }, caniuse : & ["https://caniuse.com/font-size-adjust"],
-	popularity : 2.490007f32, }, "css.properties.font-size-adjust.two-values" =>
+	popularity : 2.486423f32, }, "css.properties.font-size-adjust.two-values" =>
 	CSSFeature { id : "css.properties.font-size-adjust.two-values", name :
 	"font-size-adjust", description :
 	"The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.",
@@ -13505,7 +13503,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(127u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android
 	: BrowserVersion(92u16, 0u16), safari : BrowserVersion(17u16, 0u16), safari_ios :
 	BrowserVersion(17u16, 0u16), }, caniuse : & ["https://caniuse.com/font-size-adjust"],
-	popularity : 2.490007f32, }, "css.properties.font-size.math" => CSSFeature { id :
+	popularity : 2.486423f32, }, "css.properties.font-size.math" => CSSFeature { id :
 	"css.properties.font-size.math", name : "MathML", description :
 	"MathML, or the Mathematical Markup Language, describes mathematical notation, such as expressions and formulas. Also known as MathML Core.",
 	spec : "https://w3c.github.io/mathml-core/", groups : & ["mathml"], baseline_status :
@@ -13525,7 +13523,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(42u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(31u16, 0u16), firefox_android : BrowserVersion(31u16, 0u16),
 	safari : BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), },
-	caniuse : & [], popularity : 89.74227f32, }, "css.properties.font-size.xxx-large" =>
+	caniuse : & [], popularity : 89.065544f32, }, "css.properties.font-size.xxx-large" =>
 	CSSFeature { id : "css.properties.font-size.xxx-large", name : "font-size",
 	description : "The font-size CSS property sets the text height.", spec :
 	"https://drafts.csswg.org/css-fonts-4/#font-size-prop", groups : & ["fonts"],
@@ -13535,7 +13533,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(79u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 89.74227f32, }, "css.properties.font-stretch" =>
+	caniuse : & [], popularity : 89.065544f32, }, "css.properties.font-stretch" =>
 	CSSFeature { id : "css.properties.font-stretch", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-stretch-prop", groups : &
@@ -13546,7 +13544,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.condensed" => CSSFeature { id :
 	"css.properties.font-stretch.condensed", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13558,7 +13556,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.expanded" => CSSFeature { id :
 	"css.properties.font-stretch.expanded", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13570,7 +13568,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.extra-condensed" => CSSFeature { id :
 	"css.properties.font-stretch.extra-condensed", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13582,7 +13580,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.extra-expanded" => CSSFeature { id :
 	"css.properties.font-stretch.extra-expanded", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13594,7 +13592,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.normal" => CSSFeature { id :
 	"css.properties.font-stretch.normal", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13606,7 +13604,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.percentage" => CSSFeature { id :
 	"css.properties.font-stretch.percentage", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13618,7 +13616,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(62u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16), safari :
 	BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.semi-condensed" => CSSFeature { id :
 	"css.properties.font-stretch.semi-condensed", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13630,7 +13628,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.semi-expanded" => CSSFeature { id :
 	"css.properties.font-stretch.semi-expanded", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13642,7 +13640,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.ultra-condensed" => CSSFeature { id :
 	"css.properties.font-stretch.ultra-condensed", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13654,7 +13652,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-stretch.ultra-expanded" => CSSFeature { id :
 	"css.properties.font-stretch.ultra-expanded", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13666,7 +13664,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font-style" => CSSFeature { id : "css.properties.font-style", name :
 	"font-style", description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13677,7 +13675,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.70414f32, }, "css.properties.font-style.italic" =>
+	caniuse : & [], popularity : 78.419395f32, }, "css.properties.font-style.italic" =>
 	CSSFeature { id : "css.properties.font-style.italic", name : "font-style",
 	description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13688,7 +13686,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.70414f32, }, "css.properties.font-style.normal" =>
+	caniuse : & [], popularity : 78.419395f32, }, "css.properties.font-style.normal" =>
 	CSSFeature { id : "css.properties.font-style.normal", name : "font-style",
 	description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13699,7 +13697,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.70414f32, }, "css.properties.font-style.oblique" =>
+	caniuse : & [], popularity : 78.419395f32, }, "css.properties.font-style.oblique" =>
 	CSSFeature { id : "css.properties.font-style.oblique", name : "font-style",
 	description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13710,7 +13708,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.70414f32, },
+	caniuse : & [], popularity : 78.419395f32, },
 	"css.properties.font-style.oblique-angle" => CSSFeature { id :
 	"css.properties.font-style.oblique-angle", name : "font-style", description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13719,8 +13717,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& [], popularity : 79.70414f32, }, "css.properties.font-synthesis" => CSSFeature { id
-	: "css.properties.font-synthesis", name : "font-synthesis", description :
+	& [], popularity : 78.419395f32, }, "css.properties.font-synthesis" => CSSFeature {
+	id : "css.properties.font-synthesis", name : "font-synthesis", description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-synthesis", groups : &
 	["font-synthesis"], baseline_status : BaselineStatus::High { since :
@@ -13730,9 +13728,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 1.94917f32, }, "css.properties.font-synthesis-position" =>
-	CSSFeature { id : "css.properties.font-synthesis-position", name :
-	"font-synthesis-position", description :
+	[], popularity : 1.8604f32, }, "css.properties.font-synthesis-position" => CSSFeature
+	{ id : "css.properties.font-synthesis-position", name : "font-synthesis-position",
+	description :
 	"The font-synthesis-position CSS property sets whether or not the browser should synthesize subscript and superscript typefaces when they're missing from the font.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-synthesis-position", groups : &
 	["font-synthesis"], baseline_status : BaselineStatus::False, browser_support :
@@ -13772,7 +13770,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.066482f32, }, "css.properties.font-synthesis-small-caps.auto" =>
+	& [], popularity : 0.052214f32, }, "css.properties.font-synthesis-small-caps.auto" =>
 	CSSFeature { id : "css.properties.font-synthesis-small-caps.auto", name :
 	"font-synthesis-small-caps", description :
 	"The font-synthesis-small-caps CSS property sets whether or not the browser should synthesize small caps typefaces when they're missing from the font.",
@@ -13784,7 +13782,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.066482f32, }, "css.properties.font-synthesis-small-caps.none" =>
+	& [], popularity : 0.052214f32, }, "css.properties.font-synthesis-small-caps.none" =>
 	CSSFeature { id : "css.properties.font-synthesis-small-caps.none", name :
 	"font-synthesis-small-caps", description :
 	"The font-synthesis-small-caps CSS property sets whether or not the browser should synthesize small caps typefaces when they're missing from the font.",
@@ -13796,7 +13794,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.066482f32, }, "css.properties.font-synthesis-style" =>
+	& [], popularity : 0.052214f32, }, "css.properties.font-synthesis-style" =>
 	CSSFeature { id : "css.properties.font-synthesis-style", name :
 	"font-synthesis-style", description :
 	"The font-synthesis-style CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.",
@@ -13808,7 +13806,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.083139f32, }, "css.properties.font-synthesis-style.auto" =>
+	& [], popularity : 0.071634f32, }, "css.properties.font-synthesis-style.auto" =>
 	CSSFeature { id : "css.properties.font-synthesis-style.auto", name :
 	"font-synthesis-style", description :
 	"The font-synthesis-style CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.",
@@ -13820,7 +13818,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.083139f32, }, "css.properties.font-synthesis-style.none" =>
+	& [], popularity : 0.071634f32, }, "css.properties.font-synthesis-style.none" =>
 	CSSFeature { id : "css.properties.font-synthesis-style.none", name :
 	"font-synthesis-style", description :
 	"The font-synthesis-style CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.",
@@ -13832,7 +13830,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.083139f32, }, "css.properties.font-synthesis-weight" =>
+	& [], popularity : 0.071634f32, }, "css.properties.font-synthesis-weight" =>
 	CSSFeature { id : "css.properties.font-synthesis-weight", name :
 	"font-synthesis-weight", description :
 	"The font-synthesis-weight CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.",
@@ -13844,7 +13842,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.202983f32, }, "css.properties.font-synthesis-weight.auto" =>
+	& [], popularity : 0.197691f32, }, "css.properties.font-synthesis-weight.auto" =>
 	CSSFeature { id : "css.properties.font-synthesis-weight.auto", name :
 	"font-synthesis-weight", description :
 	"The font-synthesis-weight CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.",
@@ -13856,7 +13854,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.202983f32, }, "css.properties.font-synthesis-weight.none" =>
+	& [], popularity : 0.197691f32, }, "css.properties.font-synthesis-weight.none" =>
 	CSSFeature { id : "css.properties.font-synthesis-weight.none", name :
 	"font-synthesis-weight", description :
 	"The font-synthesis-weight CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.",
@@ -13868,7 +13866,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.202983f32, }, "css.properties.font-synthesis.position" =>
+	& [], popularity : 0.197691f32, }, "css.properties.font-synthesis.position" =>
 	CSSFeature { id : "css.properties.font-synthesis.position", name : "font-synthesis",
 	description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
@@ -13877,7 +13875,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(118u16, 0u16),
 	firefox_android : BrowserVersion(118u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.94917f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.8604f32, },
 	"css.properties.font-synthesis.small-caps" => CSSFeature { id :
 	"css.properties.font-synthesis.small-caps", name : "font-synthesis", description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
@@ -13889,7 +13887,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(93u16, 0u16), firefox_android : BrowserVersion(93u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 1.94917f32, }, "css.properties.font-synthesis.style" => CSSFeature {
+	[], popularity : 1.8604f32, }, "css.properties.font-synthesis.style" => CSSFeature {
 	id : "css.properties.font-synthesis.style", name : "font-synthesis", description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-synthesis", groups : &
@@ -13900,8 +13898,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 1.94917f32, }, "css.properties.font-synthesis.weight" => CSSFeature
-	{ id : "css.properties.font-synthesis.weight", name : "font-synthesis", description :
+	[], popularity : 1.8604f32, }, "css.properties.font-synthesis.weight" => CSSFeature {
+	id : "css.properties.font-synthesis.weight", name : "font-synthesis", description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-synthesis", groups : &
 	["font-synthesis"], baseline_status : BaselineStatus::High { since :
@@ -13911,7 +13909,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 1.94917f32, }, "css.properties.font-variant" => CSSFeature { id :
+	[], popularity : 1.8604f32, }, "css.properties.font-variant" => CSSFeature { id :
 	"css.properties.font-variant", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -13922,7 +13920,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 28.726236f32, }, "css.properties.font-variant-alternates" =>
+	[], popularity : 29.119843f32, }, "css.properties.font-variant-alternates" =>
 	CSSFeature { id : "css.properties.font-variant-alternates", name :
 	"font-variant-alternates", description :
 	"The font-variant-alternates CSS property, along with the @font-feature-values at-rule, chooses when to use a font's alternate glyphs.",
@@ -13934,7 +13932,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.properties.font-variant-alternates.annotation" => CSSFeature { id :
 	"css.properties.font-variant-alternates.annotation", name :
 	"font-variant-alternates", description :
@@ -13947,7 +13945,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.properties.font-variant-alternates.character_variant" => CSSFeature { id :
 	"css.properties.font-variant-alternates.character_variant", name :
 	"font-variant-alternates", description :
@@ -13960,7 +13958,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.properties.font-variant-alternates.historical-forms" => CSSFeature { id :
 	"css.properties.font-variant-alternates.historical-forms", name :
 	"font-variant-alternates", description :
@@ -13973,7 +13971,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.properties.font-variant-alternates.normal" => CSSFeature { id :
 	"css.properties.font-variant-alternates.normal", name : "font-variant-alternates",
 	description :
@@ -13986,7 +13984,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.properties.font-variant-alternates.ornaments" => CSSFeature { id :
 	"css.properties.font-variant-alternates.ornaments", name : "font-variant-alternates",
 	description :
@@ -13999,7 +13997,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.properties.font-variant-alternates.styleset" => CSSFeature { id :
 	"css.properties.font-variant-alternates.styleset", name : "font-variant-alternates",
 	description :
@@ -14012,7 +14010,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.properties.font-variant-alternates.stylistic" => CSSFeature { id :
 	"css.properties.font-variant-alternates.stylistic", name : "font-variant-alternates",
 	description :
@@ -14025,7 +14023,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.properties.font-variant-alternates.swash" => CSSFeature { id :
 	"css.properties.font-variant-alternates.swash", name : "font-variant-alternates",
 	description :
@@ -14038,7 +14036,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.465925f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.435011f32, },
 	"css.properties.font-variant-caps" => CSSFeature { id :
 	"css.properties.font-variant-caps", name : "font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14050,7 +14048,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.036625f32, }, "css.properties.font-variant-caps.all-petite-caps"
+	[], popularity : 0.949439f32, }, "css.properties.font-variant-caps.all-petite-caps"
 	=> CSSFeature { id : "css.properties.font-variant-caps.all-petite-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14062,7 +14060,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.036625f32, }, "css.properties.font-variant-caps.all-small-caps" =>
+	[], popularity : 0.949439f32, }, "css.properties.font-variant-caps.all-small-caps" =>
 	CSSFeature { id : "css.properties.font-variant-caps.all-small-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14074,7 +14072,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.036625f32, }, "css.properties.font-variant-caps.normal" =>
+	[], popularity : 0.949439f32, }, "css.properties.font-variant-caps.normal" =>
 	CSSFeature { id : "css.properties.font-variant-caps.normal", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14086,7 +14084,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.036625f32, }, "css.properties.font-variant-caps.petite-caps" =>
+	[], popularity : 0.949439f32, }, "css.properties.font-variant-caps.petite-caps" =>
 	CSSFeature { id : "css.properties.font-variant-caps.petite-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14098,7 +14096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.036625f32, }, "css.properties.font-variant-caps.small-caps" =>
+	[], popularity : 0.949439f32, }, "css.properties.font-variant-caps.small-caps" =>
 	CSSFeature { id : "css.properties.font-variant-caps.small-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14110,7 +14108,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.036625f32, }, "css.properties.font-variant-caps.titling-caps" =>
+	[], popularity : 0.949439f32, }, "css.properties.font-variant-caps.titling-caps" =>
 	CSSFeature { id : "css.properties.font-variant-caps.titling-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14122,7 +14120,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.036625f32, }, "css.properties.font-variant-caps.unicase" =>
+	[], popularity : 0.949439f32, }, "css.properties.font-variant-caps.unicase" =>
 	CSSFeature { id : "css.properties.font-variant-caps.unicase", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14134,7 +14132,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.036625f32, }, "css.properties.font-variant-east-asian" =>
+	[], popularity : 0.949439f32, }, "css.properties.font-variant-east-asian" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14146,7 +14144,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-east-asian.full-width"
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-east-asian.full-width"
 	=> CSSFeature { id : "css.properties.font-variant-east-asian.full-width", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14158,7 +14156,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-east-asian.jis04" =>
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-east-asian.jis04" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.jis04", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14170,7 +14168,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-east-asian.jis78" =>
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-east-asian.jis78" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.jis78", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14182,7 +14180,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-east-asian.jis83" =>
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-east-asian.jis83" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.jis83", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14194,7 +14192,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-east-asian.jis90" =>
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-east-asian.jis90" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.jis90", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14206,7 +14204,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-east-asian.normal" =>
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-east-asian.normal" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.normal", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14218,7 +14216,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, },
+	[], popularity : 0.541703f32, },
 	"css.properties.font-variant-east-asian.proportional-width" => CSSFeature { id :
 	"css.properties.font-variant-east-asian.proportional-width", name :
 	"font-variant-east-asian", description :
@@ -14231,7 +14229,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-east-asian.ruby" =>
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-east-asian.ruby" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.ruby", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14243,7 +14241,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-east-asian.simplified"
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-east-asian.simplified"
 	=> CSSFeature { id : "css.properties.font-variant-east-asian.simplified", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14255,7 +14253,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-east-asian.traditional"
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-east-asian.traditional"
 	=> CSSFeature { id : "css.properties.font-variant-east-asian.traditional", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14267,7 +14265,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.588429f32, }, "css.properties.font-variant-emoji" => CSSFeature {
+	[], popularity : 0.541703f32, }, "css.properties.font-variant-emoji" => CSSFeature {
 	id : "css.properties.font-variant-emoji", name : "font-variant-emoji", description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-emoji-prop", groups : &
@@ -14276,7 +14274,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.313493f32, }, "css.properties.font-variant-emoji.emoji" => CSSFeature
+	popularity : 0.306056f32, }, "css.properties.font-variant-emoji.emoji" => CSSFeature
 	{ id : "css.properties.font-variant-emoji.emoji", name : "font-variant-emoji",
 	description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
@@ -14286,7 +14284,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.313493f32, }, "css.properties.font-variant-emoji.normal" => CSSFeature
+	popularity : 0.306056f32, }, "css.properties.font-variant-emoji.normal" => CSSFeature
 	{ id : "css.properties.font-variant-emoji.normal", name : "font-variant-emoji",
 	description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
@@ -14296,7 +14294,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.313493f32, }, "css.properties.font-variant-emoji.text" => CSSFeature {
+	popularity : 0.306056f32, }, "css.properties.font-variant-emoji.text" => CSSFeature {
 	id : "css.properties.font-variant-emoji.text", name : "font-variant-emoji",
 	description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
@@ -14306,7 +14304,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.313493f32, }, "css.properties.font-variant-emoji.unicode" =>
+	popularity : 0.306056f32, }, "css.properties.font-variant-emoji.unicode" =>
 	CSSFeature { id : "css.properties.font-variant-emoji.unicode", name :
 	"font-variant-emoji", description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
@@ -14316,7 +14314,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.313493f32, }, "css.properties.font-variant-ligatures" => CSSFeature {
+	popularity : 0.306056f32, }, "css.properties.font-variant-ligatures" => CSSFeature {
 	id : "css.properties.font-variant-ligatures", name : "font-variant-ligatures",
 	description :
 	"The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.",
@@ -14328,7 +14326,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, },
+	[], popularity : 6.399397f32, },
 	"css.properties.font-variant-ligatures.common-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.common-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14341,8 +14339,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, }, "css.properties.font-variant-ligatures.contextual" =>
-	CSSFeature { id : "css.properties.font-variant-ligatures.contextual", name :
+	[], popularity : 6.399397f32, }, "css.properties.font-variant-ligatures.contextual"
+	=> CSSFeature { id : "css.properties.font-variant-ligatures.contextual", name :
 	"font-variant-ligatures", description :
 	"The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-ligatures-prop", groups :
@@ -14353,7 +14351,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, },
+	[], popularity : 6.399397f32, },
 	"css.properties.font-variant-ligatures.discretionary-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.discretionary-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14366,7 +14364,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, },
+	[], popularity : 6.399397f32, },
 	"css.properties.font-variant-ligatures.historical-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.historical-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14379,7 +14377,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, },
+	[], popularity : 6.399397f32, },
 	"css.properties.font-variant-ligatures.no-common-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.no-common-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14392,8 +14390,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, }, "css.properties.font-variant-ligatures.no-contextual"
-	=> CSSFeature { id : "css.properties.font-variant-ligatures.no-contextual", name :
+	[], popularity : 6.399397f32, },
+	"css.properties.font-variant-ligatures.no-contextual" => CSSFeature { id :
+	"css.properties.font-variant-ligatures.no-contextual", name :
 	"font-variant-ligatures", description :
 	"The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-ligatures-prop", groups :
@@ -14404,7 +14403,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, },
+	[], popularity : 6.399397f32, },
 	"css.properties.font-variant-ligatures.no-discretionary-ligatures" => CSSFeature { id
 	: "css.properties.font-variant-ligatures.no-discretionary-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14417,7 +14416,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, },
+	[], popularity : 6.399397f32, },
 	"css.properties.font-variant-ligatures.no-historical-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.no-historical-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14430,7 +14429,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, }, "css.properties.font-variant-ligatures.none" =>
+	[], popularity : 6.399397f32, }, "css.properties.font-variant-ligatures.none" =>
 	CSSFeature { id : "css.properties.font-variant-ligatures.none", name :
 	"font-variant-ligatures", description :
 	"The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.",
@@ -14442,7 +14441,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, }, "css.properties.font-variant-ligatures.normal" =>
+	[], popularity : 6.399397f32, }, "css.properties.font-variant-ligatures.normal" =>
 	CSSFeature { id : "css.properties.font-variant-ligatures.normal", name :
 	"font-variant-ligatures", description :
 	"The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.",
@@ -14454,8 +14453,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 7.71546f32, }, "css.properties.font-variant-numeric" => CSSFeature {
-	id : "css.properties.font-variant-numeric", name : "font-variant-numeric",
+	[], popularity : 6.399397f32, }, "css.properties.font-variant-numeric" => CSSFeature
+	{ id : "css.properties.font-variant-numeric", name : "font-variant-numeric",
 	description :
 	"The font-variant-numeric CSS property sets how numeric characters are displayed. For example, you can align columns of numbers or use zeroes that have a slash.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-numeric-prop", groups : &
@@ -14466,7 +14465,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-numeric.diagonal-fractions" => CSSFeature { id :
 	"css.properties.font-variant-numeric.diagonal-fractions", name :
 	"font-variant-numeric", description :
@@ -14479,7 +14478,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-numeric.lining-nums" => CSSFeature { id :
 	"css.properties.font-variant-numeric.lining-nums", name : "font-variant-numeric",
 	description :
@@ -14492,7 +14491,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-numeric.normal" => CSSFeature { id :
 	"css.properties.font-variant-numeric.normal", name : "font-variant-numeric",
 	description :
@@ -14505,7 +14504,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-numeric.oldstyle-nums" => CSSFeature { id :
 	"css.properties.font-variant-numeric.oldstyle-nums", name : "font-variant-numeric",
 	description :
@@ -14518,7 +14517,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-numeric.ordinal" => CSSFeature { id :
 	"css.properties.font-variant-numeric.ordinal", name : "font-variant-numeric",
 	description :
@@ -14531,7 +14530,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-numeric.proportional-nums" => CSSFeature { id :
 	"css.properties.font-variant-numeric.proportional-nums", name :
 	"font-variant-numeric", description :
@@ -14544,7 +14543,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-numeric.slashed-zero" => CSSFeature { id :
 	"css.properties.font-variant-numeric.slashed-zero", name : "font-variant-numeric",
 	description :
@@ -14557,7 +14556,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-numeric.stacked-fractions" => CSSFeature { id :
 	"css.properties.font-variant-numeric.stacked-fractions", name :
 	"font-variant-numeric", description :
@@ -14570,7 +14569,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-numeric.tabular-nums" => CSSFeature { id :
 	"css.properties.font-variant-numeric.tabular-nums", name : "font-variant-numeric",
 	description :
@@ -14583,7 +14582,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.165043f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.067915f32, },
 	"css.properties.font-variant-position" => CSSFeature { id :
 	"css.properties.font-variant-position", name : "font-variant-position", description :
 	"The font-variant-position CSS property sets whether to use alternate glyphs for subscript and superscript text.",
@@ -14595,7 +14594,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.444521f32, }, "css.properties.font-variant-position.normal" =>
+	[], popularity : 0.427059f32, }, "css.properties.font-variant-position.normal" =>
 	CSSFeature { id : "css.properties.font-variant-position.normal", name :
 	"font-variant-position", description :
 	"The font-variant-position CSS property sets whether to use alternate glyphs for subscript and superscript text.",
@@ -14607,7 +14606,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.444521f32, }, "css.properties.font-variant-position.sub" =>
+	[], popularity : 0.427059f32, }, "css.properties.font-variant-position.sub" =>
 	CSSFeature { id : "css.properties.font-variant-position.sub", name :
 	"font-variant-position", description :
 	"The font-variant-position CSS property sets whether to use alternate glyphs for subscript and superscript text.",
@@ -14616,7 +14615,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(34u16, 0u16),
 	firefox_android : BrowserVersion(34u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.444521f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.427059f32, },
 	"css.properties.font-variant-position.super" => CSSFeature { id :
 	"css.properties.font-variant-position.super", name : "font-variant-position",
 	description :
@@ -14626,7 +14625,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(34u16, 0u16),
 	firefox_android : BrowserVersion(34u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.444521f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.427059f32, },
 	"css.properties.font-variant.css_fonts_shorthand" => CSSFeature { id :
 	"css.properties.font-variant.css_fonts_shorthand", name : "font-variant", description
 	:
@@ -14639,7 +14638,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 28.726236f32, },
+	[], popularity : 29.119843f32, },
 	"css.properties.font-variant.greek_accented_characters" => CSSFeature { id :
 	"css.properties.font-variant.greek_accented_characters", name : "font-variant",
 	description :
@@ -14649,7 +14648,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 28.726236f32, },
+	0), }, caniuse : & [], popularity : 29.119843f32, },
 	"css.properties.font-variant.historical-forms" => CSSFeature { id :
 	"css.properties.font-variant.historical-forms", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
@@ -14661,7 +14660,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 28.726236f32, }, "css.properties.font-variant.none" => CSSFeature {
+	[], popularity : 29.119843f32, }, "css.properties.font-variant.none" => CSSFeature {
 	id : "css.properties.font-variant.none", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -14672,7 +14671,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 28.726236f32, }, "css.properties.font-variant.normal" => CSSFeature
+	[], popularity : 29.119843f32, }, "css.properties.font-variant.normal" => CSSFeature
 	{ id : "css.properties.font-variant.normal", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -14683,7 +14682,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 28.726236f32, }, "css.properties.font-variant.sub" => CSSFeature {
+	[], popularity : 29.119843f32, }, "css.properties.font-variant.sub" => CSSFeature {
 	id : "css.properties.font-variant.sub", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -14694,7 +14693,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(110u16, 0u16), edge : BrowserVersion(110u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 28.726236f32, }, "css.properties.font-variant.super" => CSSFeature {
+	[], popularity : 29.119843f32, }, "css.properties.font-variant.super" => CSSFeature {
 	id : "css.properties.font-variant.super", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -14705,7 +14704,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(110u16, 0u16), edge : BrowserVersion(110u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 28.726236f32, }, "css.properties.font-variant.turkic_is" =>
+	[], popularity : 29.119843f32, }, "css.properties.font-variant.turkic_is" =>
 	CSSFeature { id : "css.properties.font-variant.turkic_is", name : "font-variant",
 	description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
@@ -14717,7 +14716,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(31u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(14u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	[], popularity : 28.726236f32, }, "css.properties.font-variant.uppercase_eszett" =>
+	[], popularity : 29.119843f32, }, "css.properties.font-variant.uppercase_eszett" =>
 	CSSFeature { id : "css.properties.font-variant.uppercase_eszett", name :
 	"font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
@@ -14726,7 +14725,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 28.726236f32, },
+	0), }, caniuse : & [], popularity : 29.119843f32, },
 	"css.properties.font-variation-settings" => CSSFeature { id :
 	"css.properties.font-variation-settings", name : "font-variation-settings",
 	description :
@@ -14739,7 +14738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(62u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/variable-fonts"], popularity : 21.542536f32, },
+	["https://caniuse.com/variable-fonts"], popularity : 20.053652f32, },
 	"css.properties.font-weight" => CSSFeature { id : "css.properties.font-weight", name
 	: "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
@@ -14751,7 +14750,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.12362f32, }, "css.properties.font-weight.bold" => CSSFeature { id
+	[], popularity : 87.1989f32, }, "css.properties.font-weight.bold" => CSSFeature { id
 	: "css.properties.font-weight.bold", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14762,7 +14761,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.12362f32, }, "css.properties.font-weight.bolder" => CSSFeature {
+	[], popularity : 87.1989f32, }, "css.properties.font-weight.bolder" => CSSFeature {
 	id : "css.properties.font-weight.bolder", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14773,7 +14772,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.12362f32, }, "css.properties.font-weight.lighter" => CSSFeature {
+	[], popularity : 87.1989f32, }, "css.properties.font-weight.lighter" => CSSFeature {
 	id : "css.properties.font-weight.lighter", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14784,7 +14783,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.12362f32, }, "css.properties.font-weight.normal" => CSSFeature {
+	[], popularity : 87.1989f32, }, "css.properties.font-weight.normal" => CSSFeature {
 	id : "css.properties.font-weight.normal", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14795,7 +14794,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.12362f32, }, "css.properties.font-weight.number" => CSSFeature {
+	[], popularity : 87.1989f32, }, "css.properties.font-weight.number" => CSSFeature {
 	id : "css.properties.font-weight.number", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14806,7 +14805,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(62u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 88.12362f32, }, "css.properties.font-width" => CSSFeature { id :
+	[], popularity : 87.1989f32, }, "css.properties.font-width" => CSSFeature { id :
 	"css.properties.font-width", name : "font-width", description :
 	"The font-width CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-width-prop", groups : & ["fonts"],
@@ -14908,7 +14907,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 28.265795f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.039799f32, },
 	"css.properties.font.icon" => CSSFeature { id : "css.properties.font.icon", name :
 	"Font shorthand", description :
 	"The font CSS property shorthand sets multiple font properties, including style, weight, size, and font family.",
@@ -15007,7 +15006,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.gap.flex_context" => CSSFeature { id :
 	"css.properties.gap.flex_context", name : "Flexbox gap", description :
 	"The gap CSS property in a flexbox layout sets the size of the space between items.",
@@ -15029,7 +15028,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 0u16), safari_ios : BrowserVersion(12u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.gap.grid_context.calc_values" => CSSFeature { id :
 	"css.properties.gap.grid_context.calc_values", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15040,7 +15039,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.gap.grid_context.percentage_values" => CSSFeature { id :
 	"css.properties.gap.grid_context.percentage_values", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15051,7 +15050,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 0u16), safari_ios : BrowserVersion(12u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.gap.multicol_context" => CSSFeature { id :
 	"css.properties.gap.multicol_context", name : "Multi-column layout", description :
 	"Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.",
@@ -15072,7 +15071,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.glyph-orientation-vertical" => CSSFeature { id :
 	"css.properties.glyph-orientation-vertical", name : "glyph-orientation-vertical",
 	description :
@@ -15093,7 +15092,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-area" => CSSFeature { id : "css.properties.grid-area", name :
 	"Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15104,7 +15103,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-auto-columns" => CSSFeature { id :
 	"css.properties.grid-auto-columns", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15115,7 +15114,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-auto-flow" => CSSFeature { id : "css.properties.grid-auto-flow",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15126,7 +15125,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-auto-flow.column" => CSSFeature { id :
 	"css.properties.grid-auto-flow.column", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15137,7 +15136,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-auto-flow.dense" => CSSFeature { id :
 	"css.properties.grid-auto-flow.dense", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15148,7 +15147,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-auto-flow.row" => CSSFeature { id :
 	"css.properties.grid-auto-flow.row", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15159,7 +15158,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-auto-rows" => CSSFeature { id : "css.properties.grid-auto-rows",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15170,7 +15169,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-column" => CSSFeature { id : "css.properties.grid-column", name
 	: "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15181,7 +15180,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-column-end" => CSSFeature { id :
 	"css.properties.grid-column-end", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15192,7 +15191,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-column-start" => CSSFeature { id :
 	"css.properties.grid-column-start", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15203,7 +15202,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-row" => CSSFeature { id : "css.properties.grid-row", name :
 	"Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15214,7 +15213,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-row-end" => CSSFeature { id : "css.properties.grid-row-end",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15225,7 +15224,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-row-start" => CSSFeature { id : "css.properties.grid-row-start",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15236,7 +15235,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template" => CSSFeature { id : "css.properties.grid-template",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15247,7 +15246,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-areas" => CSSFeature { id :
 	"css.properties.grid-template-areas", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15258,7 +15257,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-areas.none" => CSSFeature { id :
 	"css.properties.grid-template-areas.none", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15269,7 +15268,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-columns" => CSSFeature { id :
 	"css.properties.grid-template-columns", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15280,7 +15279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-columns.animation" => CSSFeature { id :
 	"css.properties.grid-template-columns.animation", name : "Grid animation",
 	description :
@@ -15303,7 +15302,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-columns.fit-content" => CSSFeature { id :
 	"css.properties.grid-template-columns.fit-content", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15314,7 +15313,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-columns.masonry" => CSSFeature { id :
 	"css.properties.grid-template-columns.masonry", name : "Masonry", description :
 	"The display: grid-lanes or display: inline-grid-lanes CSS declaration creates a layout where items are tightly packed, like brickwork, in parallel lanes. Items are placed one by one in the lane that has the most available space.",
@@ -15334,7 +15333,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-columns.min-content" => CSSFeature { id :
 	"css.properties.grid-template-columns.min-content", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15345,7 +15344,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-columns.minmax" => CSSFeature { id :
 	"css.properties.grid-template-columns.minmax", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15356,7 +15355,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-columns.none" => CSSFeature { id :
 	"css.properties.grid-template-columns.none", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15367,7 +15366,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-columns.repeat" => CSSFeature { id :
 	"css.properties.grid-template-columns.repeat", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15378,7 +15377,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(76u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-columns.subgrid" => CSSFeature { id :
 	"css.properties.grid-template-columns.subgrid", name : "Subgrid", description :
 	"The subgrid value for the grid-template-columns and grid-template-rows properties allows a grid item to inherit the grid definition of its parent grid container.",
@@ -15400,7 +15399,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-rows.animation" => CSSFeature { id :
 	"css.properties.grid-template-rows.animation", name : "Grid animation", description :
 	"Grid animation allows you to animate the grid-template-columns and grid-template-rows CSS properties.",
@@ -15422,7 +15421,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-rows.fit-content" => CSSFeature { id :
 	"css.properties.grid-template-rows.fit-content", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15433,7 +15432,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-rows.masonry" => CSSFeature { id :
 	"css.properties.grid-template-rows.masonry", name : "Masonry", description :
 	"The display: grid-lanes or display: inline-grid-lanes CSS declaration creates a layout where items are tightly packed, like brickwork, in parallel lanes. Items are placed one by one in the lane that has the most available space.",
@@ -15453,7 +15452,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-rows.min-content" => CSSFeature { id :
 	"css.properties.grid-template-rows.min-content", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15464,7 +15463,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-rows.minmax" => CSSFeature { id :
 	"css.properties.grid-template-rows.minmax", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15475,7 +15474,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-rows.none" => CSSFeature { id :
 	"css.properties.grid-template-rows.none", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15486,7 +15485,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-rows.repeat" => CSSFeature { id :
 	"css.properties.grid-template-rows.repeat", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15497,7 +15496,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(76u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.grid-template-rows.subgrid" => CSSFeature { id :
 	"css.properties.grid-template-rows.subgrid", name : "Subgrid", description :
 	"The subgrid value for the grid-template-columns and grid-template-rows properties allows a grid item to inherit the grid definition of its parent grid container.",
@@ -15519,7 +15518,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.hanging-punctuation" => CSSFeature { id :
 	"css.properties.hanging-punctuation", name : "Hanging punctuation", description :
 	"The hanging-punctuation CSS property puts punctuation characters outside of the box to align the text with the rest of the document.",
@@ -15675,7 +15674,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(106u16, 0u16), edge : BrowserVersion(106u16, 0u16), firefox :
 	BrowserVersion(98u16, 0u16), firefox_android : BrowserVersion(98u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	[], popularity : 0.522309f32, }, "css.properties.hyphenate-character.auto" =>
+	[], popularity : 0.459014f32, }, "css.properties.hyphenate-character.auto" =>
 	CSSFeature { id : "css.properties.hyphenate-character.auto", name :
 	"Hyphenate character", description :
 	"The hyphenate-character CSS property sets the character or string to use at the end of a line before a line break.",
@@ -15687,7 +15686,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(106u16, 0u16), edge : BrowserVersion(106u16, 0u16), firefox :
 	BrowserVersion(98u16, 0u16), firefox_android : BrowserVersion(98u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	[], popularity : 0.522309f32, }, "css.properties.hyphenate-limit-chars" => CSSFeature
+	[], popularity : 0.459014f32, }, "css.properties.hyphenate-limit-chars" => CSSFeature
 	{ id : "css.properties.hyphenate-limit-chars", name : "Hyphenate limit chars",
 	description :
 	"The hyphenate-limit-chars CSS property sets the number of characters in a word before it is hyphenated and the minimum number of characters on either side of the hyphen.",
@@ -15697,7 +15696,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(109u16, 0u16), edge : BrowserVersion(109u16, 0u16), firefox :
 	BrowserVersion(137u16, 0u16), firefox_android : BrowserVersion(137u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.237665f32, }, "css.properties.hyphenate-limit-chars.auto" =>
+	popularity : 0.235307f32, }, "css.properties.hyphenate-limit-chars.auto" =>
 	CSSFeature { id : "css.properties.hyphenate-limit-chars.auto", name :
 	"Hyphenate limit chars", description :
 	"The hyphenate-limit-chars CSS property sets the number of characters in a word before it is hyphenated and the minimum number of characters on either side of the hyphen.",
@@ -15707,7 +15706,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(109u16, 0u16), edge : BrowserVersion(109u16, 0u16), firefox :
 	BrowserVersion(137u16, 0u16), firefox_android : BrowserVersion(137u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.237665f32, }, "css.properties.hyphens" => CSSFeature { id :
+	popularity : 0.235307f32, }, "css.properties.hyphens" => CSSFeature { id :
 	"css.properties.hyphens", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -15717,7 +15716,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.auto" => CSSFeature { id : "css.properties.hyphens.auto",
 	name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15728,7 +15727,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(55u16, 0u16), edge : BrowserVersion(88u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_afrikaans" => CSSFeature { id :
 	"css.properties.hyphens.language_afrikaans", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15738,7 +15737,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android
 	: BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_albanian" => CSSFeature { id :
+	: 9.933514f32, }, "css.properties.hyphens.language_albanian" => CSSFeature { id :
 	"css.properties.hyphens.language_albanian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -15746,7 +15745,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_amharic" => CSSFeature { id :
 	"css.properties.hyphens.language_amharic", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15755,7 +15754,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_armenian" => CSSFeature { id :
 	"css.properties.hyphens.language_armenian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15764,7 +15763,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_assamese" => CSSFeature { id :
 	"css.properties.hyphens.language_assamese", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15773,7 +15772,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_basque" => CSSFeature { id :
 	"css.properties.hyphens.language_basque", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15782,7 +15781,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_belarusian" => CSSFeature { id :
 	"css.properties.hyphens.language_belarusian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15791,7 +15790,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_bengali" => CSSFeature { id :
 	"css.properties.hyphens.language_bengali", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15800,7 +15799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_bosnian" => CSSFeature { id :
 	"css.properties.hyphens.language_bosnian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15809,7 +15808,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_bulgarian" => CSSFeature { id :
 	"css.properties.hyphens.language_bulgarian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15819,7 +15818,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_catalan" => CSSFeature { id :
+	: 9.933514f32, }, "css.properties.hyphens.language_catalan" => CSSFeature { id :
 	"css.properties.hyphens.language_catalan", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -15827,7 +15826,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_croatian" => CSSFeature { id :
 	"css.properties.hyphens.language_croatian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15838,7 +15837,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_cyrillic_mongolian" => CSSFeature { id :
 	"css.properties.hyphens.language_cyrillic_mongolian", name : "Hyphenation",
 	description :
@@ -15848,7 +15847,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_czech" => CSSFeature { id :
 	"css.properties.hyphens.language_czech", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15858,7 +15857,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16, 0u16),
 	firefox : BrowserVersion(130u16, 0u16), firefox_android : BrowserVersion(130u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_danish" => CSSFeature { id :
 	"css.properties.hyphens.language_danish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15869,7 +15868,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_dutch" => CSSFeature { id :
 	"css.properties.hyphens.language_dutch", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15880,7 +15879,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_english" => CSSFeature { id :
 	"css.properties.hyphens.language_english", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15891,7 +15890,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_esperanto" => CSSFeature { id :
 	"css.properties.hyphens.language_esperanto", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15900,7 +15899,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_estonian" => CSSFeature { id :
 	"css.properties.hyphens.language_estonian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15910,16 +15909,16 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_ethiopic_script_mul" =>
-	CSSFeature { id : "css.properties.hyphens.language_ethiopic_script_mul", name :
-	"Hyphenation", description :
+	: 9.933514f32, }, "css.properties.hyphens.language_ethiopic_script_mul" => CSSFeature
+	{ id : "css.properties.hyphens.language_ethiopic_script_mul", name : "Hyphenation",
+	description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_ethiopic_script_und" => CSSFeature { id :
 	"css.properties.hyphens.language_ethiopic_script_und", name : "Hyphenation",
 	description :
@@ -15929,7 +15928,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_finnish" => CSSFeature { id :
 	"css.properties.hyphens.language_finnish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15938,7 +15937,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_french" => CSSFeature { id :
 	"css.properties.hyphens.language_french", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15949,7 +15948,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_galician" => CSSFeature { id :
 	"css.properties.hyphens.language_galician", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15959,7 +15958,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android
 	: BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_georgian" => CSSFeature { id :
+	: 9.933514f32, }, "css.properties.hyphens.language_georgian" => CSSFeature { id :
 	"css.properties.hyphens.language_georgian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -15967,7 +15966,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_german_reformed_orthography" => CSSFeature { id :
 	"css.properties.hyphens.language_german_reformed_orthography", name : "Hyphenation",
 	description :
@@ -15979,7 +15978,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_german_swiss_orthography" => CSSFeature { id :
 	"css.properties.hyphens.language_german_swiss_orthography", name : "Hyphenation",
 	description :
@@ -15990,10 +15989,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_german_traditional_orthography"
-	=> CSSFeature { id :
-	"css.properties.hyphens.language_german_traditional_orthography", name :
-	"Hyphenation", description :
+	: 9.933514f32, }, "css.properties.hyphens.language_german_traditional_orthography" =>
+	CSSFeature { id : "css.properties.hyphens.language_german_traditional_orthography",
+	name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -16001,7 +15999,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_gujarati" => CSSFeature { id :
+	: 9.933514f32, }, "css.properties.hyphens.language_gujarati" => CSSFeature { id :
 	"css.properties.hyphens.language_gujarati", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16009,7 +16007,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_hindi" => CSSFeature { id :
 	"css.properties.hyphens.language_hindi", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16018,7 +16016,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_hungarian" => CSSFeature { id :
 	"css.properties.hyphens.language_hungarian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16029,7 +16027,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_icelandic" => CSSFeature { id :
 	"css.properties.hyphens.language_icelandic", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16038,7 +16036,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_interlingua" => CSSFeature { id :
 	"css.properties.hyphens.language_interlingua", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16047,7 +16045,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_irish" => CSSFeature { id :
 	"css.properties.hyphens.language_irish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16056,7 +16054,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_italian" => CSSFeature { id :
 	"css.properties.hyphens.language_italian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16067,7 +16065,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_kannada" => CSSFeature { id :
 	"css.properties.hyphens.language_kannada", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16076,7 +16074,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_kurmanji" => CSSFeature { id :
 	"css.properties.hyphens.language_kurmanji", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16085,7 +16083,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_latin" => CSSFeature { id :
 	"css.properties.hyphens.language_latin", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16095,7 +16093,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_latvian" => CSSFeature { id :
+	: 9.933514f32, }, "css.properties.hyphens.language_latvian" => CSSFeature { id :
 	"css.properties.hyphens.language_latvian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16103,7 +16101,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_lithuanian" => CSSFeature { id :
 	"css.properties.hyphens.language_lithuanian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16113,7 +16111,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android
 	: BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_malayalam" => CSSFeature { id :
+	: 9.933514f32, }, "css.properties.hyphens.language_malayalam" => CSSFeature { id :
 	"css.properties.hyphens.language_malayalam", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16121,7 +16119,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_marathi" => CSSFeature { id :
 	"css.properties.hyphens.language_marathi", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16130,7 +16128,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_modern_greek" => CSSFeature { id :
 	"css.properties.hyphens.language_modern_greek", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16139,7 +16137,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_mongolian" => CSSFeature { id :
 	"css.properties.hyphens.language_mongolian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16148,7 +16146,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_norwegian_nn" => CSSFeature { id :
 	"css.properties.hyphens.language_norwegian_nn", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16158,7 +16156,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(17u16, 0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"],
-	popularity : 10.601362f32, }, "css.properties.hyphens.language_norwegian_no" =>
+	popularity : 9.933514f32, }, "css.properties.hyphens.language_norwegian_no" =>
 	CSSFeature { id : "css.properties.hyphens.language_norwegian_no", name :
 	"Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16169,7 +16167,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_old_slavonic" => CSSFeature { id :
 	"css.properties.hyphens.language_old_slavonic", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16178,7 +16176,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_oriya" => CSSFeature { id :
 	"css.properties.hyphens.language_oriya", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16187,7 +16185,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_polish" => CSSFeature { id :
 	"css.properties.hyphens.language_polish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16196,7 +16194,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_portuguese" => CSSFeature { id :
 	"css.properties.hyphens.language_portuguese", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16207,7 +16205,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_punjabi" => CSSFeature { id :
 	"css.properties.hyphens.language_punjabi", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16216,7 +16214,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_russian" => CSSFeature { id :
 	"css.properties.hyphens.language_russian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16227,7 +16225,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_slovak" => CSSFeature { id :
 	"css.properties.hyphens.language_slovak", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16237,7 +16235,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(130u16, 0u16), firefox_android
 	: BrowserVersion(130u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_slovenian" => CSSFeature { id :
+	: 9.933514f32, }, "css.properties.hyphens.language_slovenian" => CSSFeature { id :
 	"css.properties.hyphens.language_slovenian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16246,7 +16244,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.hyphens.language_spanish" => CSSFeature { id :
+	: 9.933514f32, }, "css.properties.hyphens.language_spanish" => CSSFeature { id :
 	"css.properties.hyphens.language_spanish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16256,7 +16254,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_swedish" => CSSFeature { id :
 	"css.properties.hyphens.language_swedish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16267,7 +16265,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_tamil" => CSSFeature { id :
 	"css.properties.hyphens.language_tamil", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16276,7 +16274,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_telugu" => CSSFeature { id :
 	"css.properties.hyphens.language_telugu", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16285,7 +16283,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_turkish" => CSSFeature { id :
 	"css.properties.hyphens.language_turkish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16294,7 +16292,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_turkmen" => CSSFeature { id :
 	"css.properties.hyphens.language_turkmen", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16303,7 +16301,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_ukrainian" => CSSFeature { id :
 	"css.properties.hyphens.language_ukrainian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16314,7 +16312,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32,
 	}, "css.properties.hyphens.language_upper_sorbian" => CSSFeature { id :
 	"css.properties.hyphens.language_upper_sorbian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16323,7 +16321,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.601362f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 9.933514f32, },
 	"css.properties.hyphens.language_welsh" => CSSFeature { id :
 	"css.properties.hyphens.language_welsh", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16333,7 +16331,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.601362f32, }, "css.properties.image-orientation" => CSSFeature { id :
+	: 9.933514f32, }, "css.properties.image-orientation" => CSSFeature { id :
 	"css.properties.image-orientation", name : "image-orientation", description :
 	"The image-orientation CSS property corrects the rotation of an image using the image's metadata, such as EXIF.",
 	spec : "https://drafts.csswg.org/css-images-3/#the-image-orientation", groups : &
@@ -16381,7 +16379,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-crisp-edges"], popularity : 6.726499f32, },
+	["https://caniuse.com/css-crisp-edges"], popularity : 6.814777f32, },
 	"css.properties.image-rendering.auto" => CSSFeature { id :
 	"css.properties.image-rendering.auto", name : "image-rendering", description :
 	"The image-rendering CSS property sets how images are scaled, retaining smoothness for photos, or hard edges for pixel art and QR codes.",
@@ -16393,7 +16391,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-crisp-edges"], popularity : 6.726499f32, },
+	["https://caniuse.com/css-crisp-edges"], popularity : 6.814777f32, },
 	"css.properties.image-rendering.crisp-edges" => CSSFeature { id :
 	"css.properties.image-rendering.crisp-edges", name : "crisp-edges", description :
 	"The image-rendering: crisp-edges CSS declaration scales images to preserve lines without blurring.",
@@ -16416,7 +16414,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(41u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(93u16, 0u16), firefox_android : BrowserVersion(93u16, 0u16), safari :
 	BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-crisp-edges"], popularity : 6.726499f32, },
+	["https://caniuse.com/css-crisp-edges"], popularity : 6.814777f32, },
 	"css.properties.image-rendering.smooth" => CSSFeature { id :
 	"css.properties.image-rendering.smooth", name : "image-rendering: smooth",
 	description :
@@ -16444,7 +16442,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(110u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-initial-letter"], popularity :
-	0.38035f32, }, "css.properties.initial-letter.normal" => CSSFeature { id :
+	0.445152f32, }, "css.properties.initial-letter.normal" => CSSFeature { id :
 	"css.properties.initial-letter.normal", name : "initial-letter", description :
 	"The initial-letter CSS property sets the number of lines the first letter of an element occupies. You can use the property to make a raised capital or drop cap.",
 	spec : "https://drafts.csswg.org/css-inline-3/#sizing-drop-initials", groups : & [],
@@ -16453,7 +16451,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(110u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-initial-letter"], popularity :
-	0.38035f32, }, "css.properties.inline-size" => CSSFeature { id :
+	0.445152f32, }, "css.properties.inline-size" => CSSFeature { id :
 	"css.properties.inline-size", name : "Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
 	spec : "https://drafts.csswg.org/css-logical-1/", groups : & [], baseline_status :
@@ -16824,7 +16822,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(135u16, 0u16), chrome_android : BrowserVersion(135u16, 0u16), edge :
 	BrowserVersion(135u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.092205f32, },
+	0), }, caniuse : & [], popularity : 0.076928f32, },
 	"css.properties.interactivity.auto" => CSSFeature { id :
 	"css.properties.interactivity.auto", name : "interactivity", description :
 	"The interactivity: inert CSS declaration makes an element and its descendants inert, like when using the inert HTML attribute. Inert elements can't be focused or clicked, their text can't be selected or found using the browser's find-in-page feature.",
@@ -16833,7 +16831,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(135u16, 0u16), chrome_android : BrowserVersion(135u16, 0u16), edge :
 	BrowserVersion(135u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.092205f32, },
+	0), }, caniuse : & [], popularity : 0.076928f32, },
 	"css.properties.interactivity.inert" => CSSFeature { id :
 	"css.properties.interactivity.inert", name : "interactivity", description :
 	"The interactivity: inert CSS declaration makes an element and its descendants inert, like when using the inert HTML attribute. Inert elements can't be focused or clicked, their text can't be selected or found using the browser's find-in-page feature.",
@@ -16842,7 +16840,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(135u16, 0u16), chrome_android : BrowserVersion(135u16, 0u16), edge :
 	BrowserVersion(135u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.092205f32, }, "css.properties.interpolate-size"
+	0), }, caniuse : & [], popularity : 0.076928f32, }, "css.properties.interpolate-size"
 	=> CSSFeature { id : "css.properties.interpolate-size", name : "interpolate-size",
 	description :
 	"The interpolate-size CSS property sets whether animations and transitions interpolate between a numeric value and a keyword value, such as from a fixed length to auto or fit-content.",
@@ -16852,7 +16850,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(129u16, 0u16), edge : BrowserVersion(129u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 4.281699f32, }, "css.properties.interpolate-size.allow-keywords" =>
+	popularity : 3.092858f32, }, "css.properties.interpolate-size.allow-keywords" =>
 	CSSFeature { id : "css.properties.interpolate-size.allow-keywords", name :
 	"interpolate-size", description :
 	"The interpolate-size CSS property sets whether animations and transitions interpolate between a numeric value and a keyword value, such as from a fixed length to auto or fit-content.",
@@ -16862,7 +16860,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(129u16, 0u16), edge : BrowserVersion(129u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 4.281699f32, }, "css.properties.interpolate-size.numeric-only" =>
+	popularity : 3.092858f32, }, "css.properties.interpolate-size.numeric-only" =>
 	CSSFeature { id : "css.properties.interpolate-size.numeric-only", name :
 	"interpolate-size", description :
 	"The interpolate-size CSS property sets whether animations and transitions interpolate between a numeric value and a keyword value, such as from a fixed length to auto or fit-content.",
@@ -16872,7 +16870,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(129u16, 0u16), edge : BrowserVersion(129u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 4.281699f32, }, "css.properties.isolation" => CSSFeature { id :
+	popularity : 3.092858f32, }, "css.properties.isolation" => CSSFeature { id :
 	"css.properties.isolation", name : "isolation", description :
 	"The isolation CSS property creates a new stacking context, which impacts z-index ordering and blend modes.",
 	spec : "https://drafts.csswg.org/compositing-2/#isolation", groups : &
@@ -16883,7 +16881,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(41u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	[], popularity : 17.649683f32, }, "css.properties.justify-content" => CSSFeature { id
+	[], popularity : 16.549467f32, }, "css.properties.justify-content" => CSSFeature { id
 	: "css.properties.justify-content", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
 	spec : "https://drafts.csswg.org/css-flexbox-1/", groups : & ["flexbox"],
@@ -16974,7 +16972,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(52u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.justify-content.left" => CSSFeature { id :
 	"css.properties.justify-content.left", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -17072,7 +17070,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.justify-items.left" => CSSFeature { id :
 	"css.properties.justify-items.left", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -17116,7 +17114,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.justify-self.anchor-center" => CSSFeature { id :
 	"css.properties.justify-self.anchor-center", name : "Anchor positioning", description
 	:
@@ -17138,7 +17136,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.justify-self.block_context" => CSSFeature { id :
 	"css.properties.justify-self.block_context", name : "justify-self in block layouts",
 	description :
@@ -17159,7 +17157,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.justify-self.left" => CSSFeature { id :
 	"css.properties.justify-self.left", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -17170,7 +17168,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.justify-self.normal" => CSSFeature { id :
 	"css.properties.justify-self.normal", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -17181,7 +17179,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.justify-self.position_absolute_context" => CSSFeature { id :
 	"css.properties.justify-self.position_absolute_context", name :
 	"Absolute positioning", description :
@@ -17204,7 +17202,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.justify-self.stretch" => CSSFeature { id :
 	"css.properties.justify-self.stretch", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -17215,7 +17213,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.left" => CSSFeature { id : "css.properties.left", name :
 	"Physical properties", description :
 	"The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.",
@@ -17267,7 +17265,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-letter-spacing"], popularity : 68.47f32, },
+	["https://caniuse.com/css-letter-spacing"], popularity : 67.96497f32, },
 	"css.properties.letter-spacing.normal" => CSSFeature { id :
 	"css.properties.letter-spacing.normal", name : "letter-spacing", description :
 	"The letter-spacing CSS property controls the amount of space between each letter in an element or block of text.",
@@ -17279,7 +17277,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-letter-spacing"], popularity : 68.47f32, },
+	["https://caniuse.com/css-letter-spacing"], popularity : 67.96497f32, },
 	"css.properties.letter-spacing.svg_elements" => CSSFeature { id :
 	"css.properties.letter-spacing.svg_elements", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -17336,7 +17334,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(14u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 5.871085f32, }, "css.properties.line-break.anywhere" => CSSFeature {
+	[], popularity : 5.734573f32, }, "css.properties.line-break.anywhere" => CSSFeature {
 	id : "css.properties.line-break.anywhere", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17347,7 +17345,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(83u16, 0u16), edge : BrowserVersion(83u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	[], popularity : 5.871085f32, }, "css.properties.line-break.auto" => CSSFeature { id
+	[], popularity : 5.734573f32, }, "css.properties.line-break.auto" => CSSFeature { id
 	: "css.properties.line-break.auto", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17358,7 +17356,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 5.871085f32, }, "css.properties.line-break.loose" => CSSFeature { id
+	[], popularity : 5.734573f32, }, "css.properties.line-break.loose" => CSSFeature { id
 	: "css.properties.line-break.loose", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17369,7 +17367,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 5.871085f32, }, "css.properties.line-break.normal" => CSSFeature {
+	[], popularity : 5.734573f32, }, "css.properties.line-break.normal" => CSSFeature {
 	id : "css.properties.line-break.normal", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17380,7 +17378,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 5.871085f32, }, "css.properties.line-break.strict" => CSSFeature {
+	[], popularity : 5.734573f32, }, "css.properties.line-break.strict" => CSSFeature {
 	id : "css.properties.line-break.strict", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17391,7 +17389,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 5.871085f32, }, "css.properties.line-clamp" => CSSFeature { id :
+	[], popularity : 5.734573f32, }, "css.properties.line-clamp" => CSSFeature { id :
 	"css.properties.line-clamp", name : "line-clamp", description :
 	"The line-clamp CSS property limits the text in a block container to a certain number of lines. The prefixed -webkit-line-clamp is widely supported but only works with -webkit-box-orient: vertical in combination with display: -webkit-box or display: -webkit-inline-box.",
 	spec : "https://drafts.csswg.org/css-overflow-4/#line-clamp", groups : & [],
@@ -17399,7 +17397,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-line-clamp"], popularity : 0.003093f32, },
+	["https://caniuse.com/css-line-clamp"], popularity : 0.003045f32, },
 	"css.properties.line-clamp.none" => CSSFeature { id :
 	"css.properties.line-clamp.none", name : "line-clamp", description :
 	"The line-clamp CSS property limits the text in a block container to a certain number of lines. The prefixed -webkit-line-clamp is widely supported but only works with -webkit-box-orient: vertical in combination with display: -webkit-box or display: -webkit-inline-box.",
@@ -17408,7 +17406,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-line-clamp"], popularity : 0.003093f32, },
+	["https://caniuse.com/css-line-clamp"], popularity : 0.003045f32, },
 	"css.properties.line-height" => CSSFeature { id : "css.properties.line-height", name
 	: "line-height", description :
 	"The line-height CSS property sets the spacing between text baselines, oriented to the horizontal or vertical writing mode.",
@@ -17420,7 +17418,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 86.133064f32, }, "css.properties.line-height.normal" => CSSFeature {
+	[], popularity : 85.48801f32, }, "css.properties.line-height.normal" => CSSFeature {
 	id : "css.properties.line-height.normal", name : "line-height", description :
 	"The line-height CSS property sets the spacing between text baselines, oriented to the horizontal or vertical writing mode.",
 	spec : "https://drafts.csswg.org/css-inline-3/#line-height-property", groups : &
@@ -17431,7 +17429,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 86.133064f32, }, "css.properties.list-style" => CSSFeature { id :
+	[], popularity : 85.48801f32, }, "css.properties.list-style" => CSSFeature { id :
 	"css.properties.list-style", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17442,7 +17440,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-image" => CSSFeature { id
+	[], popularity : 66.69261f32, }, "css.properties.list-style-image" => CSSFeature { id
 	: "css.properties.list-style-image", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17453,7 +17451,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-image.none" => CSSFeature
+	[], popularity : 66.69261f32, }, "css.properties.list-style-image.none" => CSSFeature
 	{ id : "css.properties.list-style-image.none", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17464,7 +17462,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-position" => CSSFeature {
+	[], popularity : 66.69261f32, }, "css.properties.list-style-position" => CSSFeature {
 	id : "css.properties.list-style-position", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17475,7 +17473,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-position.inside" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-position.inside" =>
 	CSSFeature { id : "css.properties.list-style-position.inside", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17487,7 +17485,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-position.outside" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-position.outside" =>
 	CSSFeature { id : "css.properties.list-style-position.outside", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17499,7 +17497,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type" => CSSFeature { id
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type" => CSSFeature { id
 	: "css.properties.list-style-type", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17510,7 +17508,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.arabic-indic" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.arabic-indic" =>
 	CSSFeature { id : "css.properties.list-style-type.arabic-indic", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17522,7 +17520,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.armenian" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.armenian" =>
 	CSSFeature { id : "css.properties.list-style-type.armenian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17534,7 +17532,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.bengali" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.bengali" =>
 	CSSFeature { id : "css.properties.list-style-type.bengali", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17546,7 +17544,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.cambodian" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.cambodian" =>
 	CSSFeature { id : "css.properties.list-style-type.cambodian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17558,7 +17556,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.circle" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.circle" =>
 	CSSFeature { id : "css.properties.list-style-type.circle", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17570,7 +17568,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.cjk-decimal" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.cjk-decimal" =>
 	CSSFeature { id : "css.properties.list-style-type.cjk-decimal", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17582,7 +17580,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.cjk-earthly-branch"
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.cjk-earthly-branch"
 	=> CSSFeature { id : "css.properties.list-style-type.cjk-earthly-branch", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17594,7 +17592,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.cjk-heavenly-stem"
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.cjk-heavenly-stem"
 	=> CSSFeature { id : "css.properties.list-style-type.cjk-heavenly-stem", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17606,7 +17604,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.cjk-ideographic" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.cjk-ideographic" =>
 	CSSFeature { id : "css.properties.list-style-type.cjk-ideographic", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17618,7 +17616,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.decimal" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.decimal" =>
 	CSSFeature { id : "css.properties.list-style-type.decimal", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17630,7 +17628,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, },
+	[], popularity : 66.69261f32, },
 	"css.properties.list-style-type.decimal-leading-zero" => CSSFeature { id :
 	"css.properties.list-style-type.decimal-leading-zero", name : "List style",
 	description :
@@ -17643,7 +17641,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.devanagari" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.devanagari" =>
 	CSSFeature { id : "css.properties.list-style-type.devanagari", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17655,7 +17653,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.disc" => CSSFeature
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.disc" => CSSFeature
 	{ id : "css.properties.list-style-type.disc", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17666,7 +17664,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.disclosure-closed"
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.disclosure-closed"
 	=> CSSFeature { id : "css.properties.list-style-type.disclosure-closed", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17678,7 +17676,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.disclosure-open" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.disclosure-open" =>
 	CSSFeature { id : "css.properties.list-style-type.disclosure-open", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17690,7 +17688,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.ethiopic-numeric" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.ethiopic-numeric" =>
 	CSSFeature { id : "css.properties.list-style-type.ethiopic-numeric", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17702,7 +17700,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.georgian" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.georgian" =>
 	CSSFeature { id : "css.properties.list-style-type.georgian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17714,7 +17712,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.gujarati" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.gujarati" =>
 	CSSFeature { id : "css.properties.list-style-type.gujarati", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17726,7 +17724,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.gurmukhi" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.gurmukhi" =>
 	CSSFeature { id : "css.properties.list-style-type.gurmukhi", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17738,7 +17736,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.hebrew" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.hebrew" =>
 	CSSFeature { id : "css.properties.list-style-type.hebrew", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17750,7 +17748,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.hiragana" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.hiragana" =>
 	CSSFeature { id : "css.properties.list-style-type.hiragana", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17762,7 +17760,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.hiragana-iroha" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.hiragana-iroha" =>
 	CSSFeature { id : "css.properties.list-style-type.hiragana-iroha", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17774,7 +17772,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.japanese-formal" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.japanese-formal" =>
 	CSSFeature { id : "css.properties.list-style-type.japanese-formal", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17786,7 +17784,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.japanese-informal"
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.japanese-informal"
 	=> CSSFeature { id : "css.properties.list-style-type.japanese-informal", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17798,7 +17796,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.kannada" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.kannada" =>
 	CSSFeature { id : "css.properties.list-style-type.kannada", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17810,7 +17808,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.katakana" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.katakana" =>
 	CSSFeature { id : "css.properties.list-style-type.katakana", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17822,7 +17820,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.katakana-iroha" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.katakana-iroha" =>
 	CSSFeature { id : "css.properties.list-style-type.katakana-iroha", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17834,7 +17832,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.khmer" => CSSFeature
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.khmer" => CSSFeature
 	{ id : "css.properties.list-style-type.khmer", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17845,7 +17843,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, },
+	[], popularity : 66.69261f32, },
 	"css.properties.list-style-type.korean-hangul-formal" => CSSFeature { id :
 	"css.properties.list-style-type.korean-hangul-formal", name : "List style",
 	description :
@@ -17858,7 +17856,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.korean-hanja-formal"
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.korean-hanja-formal"
 	=> CSSFeature { id : "css.properties.list-style-type.korean-hanja-formal", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17870,7 +17868,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, },
+	[], popularity : 66.69261f32, },
 	"css.properties.list-style-type.korean-hanja-informal" => CSSFeature { id :
 	"css.properties.list-style-type.korean-hanja-informal", name : "List style",
 	description :
@@ -17883,7 +17881,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.lao" => CSSFeature {
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.lao" => CSSFeature {
 	id : "css.properties.list-style-type.lao", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17894,7 +17892,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.lower-alpha" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.lower-alpha" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-alpha", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17906,7 +17904,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.lower-armenian" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.lower-armenian" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-armenian", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17918,7 +17916,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.lower-greek" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.lower-greek" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-greek", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17930,7 +17928,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.lower-latin" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.lower-latin" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-latin", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17942,7 +17940,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.lower-roman" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.lower-roman" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-roman", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17954,7 +17952,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.malayalam" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.malayalam" =>
 	CSSFeature { id : "css.properties.list-style-type.malayalam", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17966,7 +17964,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.mongolian" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.mongolian" =>
 	CSSFeature { id : "css.properties.list-style-type.mongolian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17978,7 +17976,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.myanmar" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.myanmar" =>
 	CSSFeature { id : "css.properties.list-style-type.myanmar", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17990,7 +17988,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.none" => CSSFeature
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.none" => CSSFeature
 	{ id : "css.properties.list-style-type.none", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -18001,7 +17999,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.oriya" => CSSFeature
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.oriya" => CSSFeature
 	{ id : "css.properties.list-style-type.oriya", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -18012,7 +18010,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.persian" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.persian" =>
 	CSSFeature { id : "css.properties.list-style-type.persian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18024,7 +18022,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.simp-chinese-formal"
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.simp-chinese-formal"
 	=> CSSFeature { id : "css.properties.list-style-type.simp-chinese-formal", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18036,7 +18034,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, },
+	[], popularity : 66.69261f32, },
 	"css.properties.list-style-type.simp-chinese-informal" => CSSFeature { id :
 	"css.properties.list-style-type.simp-chinese-informal", name : "List style",
 	description :
@@ -18049,7 +18047,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.square" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.square" =>
 	CSSFeature { id : "css.properties.list-style-type.square", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18061,7 +18059,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.string" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.string" =>
 	CSSFeature { id : "css.properties.list-style-type.string", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18073,7 +18071,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(39u16, 0u16), firefox_android : BrowserVersion(39u16, 0u16), safari :
 	BrowserVersion(14u16, 1u16), safari_ios : BrowserVersion(14u16, 5u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.symbols" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.symbols" =>
 	CSSFeature { id : "css.properties.list-style-type.symbols", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18082,7 +18080,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(35u16, 0u16), firefox_android :
 	BrowserVersion(35u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 66.68952f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 66.69261f32, },
 	"css.properties.list-style-type.tamil" => CSSFeature { id :
 	"css.properties.list-style-type.tamil", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18094,7 +18092,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.telugu" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.telugu" =>
 	CSSFeature { id : "css.properties.list-style-type.telugu", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18106,7 +18104,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.thai" => CSSFeature
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.thai" => CSSFeature
 	{ id : "css.properties.list-style-type.thai", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -18117,7 +18115,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.tibetan" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.tibetan" =>
 	CSSFeature { id : "css.properties.list-style-type.tibetan", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18129,7 +18127,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.trad-chinese-formal"
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.trad-chinese-formal"
 	=> CSSFeature { id : "css.properties.list-style-type.trad-chinese-formal", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18141,7 +18139,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, },
+	[], popularity : 66.69261f32, },
 	"css.properties.list-style-type.trad-chinese-informal" => CSSFeature { id :
 	"css.properties.list-style-type.trad-chinese-informal", name : "List style",
 	description :
@@ -18154,7 +18152,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.upper-alpha" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.upper-alpha" =>
 	CSSFeature { id : "css.properties.list-style-type.upper-alpha", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18166,7 +18164,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.upper-armenian" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.upper-armenian" =>
 	CSSFeature { id : "css.properties.list-style-type.upper-armenian", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18178,7 +18176,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.upper-latin" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.upper-latin" =>
 	CSSFeature { id : "css.properties.list-style-type.upper-latin", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18190,7 +18188,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style-type.upper-roman" =>
+	[], popularity : 66.69261f32, }, "css.properties.list-style-type.upper-roman" =>
 	CSSFeature { id : "css.properties.list-style-type.upper-roman", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18202,7 +18200,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style.inside" => CSSFeature {
+	[], popularity : 66.69261f32, }, "css.properties.list-style.inside" => CSSFeature {
 	id : "css.properties.list-style.inside", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -18213,7 +18211,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style.none" => CSSFeature { id
+	[], popularity : 66.69261f32, }, "css.properties.list-style.none" => CSSFeature { id
 	: "css.properties.list-style.none", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -18224,7 +18222,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style.outside" => CSSFeature {
+	[], popularity : 66.69261f32, }, "css.properties.list-style.outside" => CSSFeature {
 	id : "css.properties.list-style.outside", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -18235,7 +18233,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.68952f32, }, "css.properties.list-style.symbols" => CSSFeature {
+	[], popularity : 66.69261f32, }, "css.properties.list-style.symbols" => CSSFeature {
 	id : "css.properties.list-style.symbols", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -18243,7 +18241,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(35u16, 0u16), firefox_android :
 	BrowserVersion(35u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 66.68952f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 66.69261f32, },
 	"css.properties.margin" => CSSFeature { id : "css.properties.margin", name :
 	"margin", description :
 	"The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.",
@@ -18254,7 +18252,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, }, "css.properties.margin-block" =>
+	caniuse : & [], popularity : 91.01677f32, }, "css.properties.margin-block" =>
 	CSSFeature { id : "css.properties.margin-block", name : "Logical properties",
 	description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -18330,7 +18328,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, },
+	caniuse : & [], popularity : 91.01677f32, },
 	"css.properties.margin-bottom.anchor-size" => CSSFeature { id :
 	"css.properties.margin-bottom.anchor-size", name : "Anchor positioning", description
 	:
@@ -18352,7 +18350,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, }, "css.properties.margin-inline" =>
+	caniuse : & [], popularity : 91.01677f32, }, "css.properties.margin-inline" =>
 	CSSFeature { id : "css.properties.margin-inline", name : "Logical properties",
 	description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -18429,9 +18427,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, },
-	"css.properties.margin-left.anchor-size" => CSSFeature { id :
-	"css.properties.margin-left.anchor-size", name : "Anchor positioning", description :
+	caniuse : & [], popularity : 91.01677f32, }, "css.properties.margin-left.anchor-size"
+	=> CSSFeature { id : "css.properties.margin-left.anchor-size", name :
+	"Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
 	spec : "https://drafts.csswg.org/css-anchor-position-1/#anchoring", groups : & [],
 	baseline_status : BaselineStatus::Low(NaiveDate::from_ymd_opt(2026i32, 1u32, 13u32)
@@ -18450,7 +18448,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, }, "css.properties.margin-right" =>
+	caniuse : & [], popularity : 91.01677f32, }, "css.properties.margin-right" =>
 	CSSFeature { id : "css.properties.margin-right", name : "margin", description :
 	"The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#margins", groups : & ["layout"],
@@ -18460,7 +18458,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, },
+	caniuse : & [], popularity : 91.01677f32, },
 	"css.properties.margin-right.anchor-size" => CSSFeature { id :
 	"css.properties.margin-right.anchor-size", name : "Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
@@ -18481,7 +18479,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, }, "css.properties.margin-top" =>
+	caniuse : & [], popularity : 91.01677f32, }, "css.properties.margin-top" =>
 	CSSFeature { id : "css.properties.margin-top", name : "margin", description :
 	"The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#margins", groups : & ["layout"],
@@ -18491,7 +18489,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, }, "css.properties.margin-top.anchor-size"
+	caniuse : & [], popularity : 91.01677f32, }, "css.properties.margin-top.anchor-size"
 	=> CSSFeature { id : "css.properties.margin-top.anchor-size", name :
 	"Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
@@ -18512,7 +18510,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, }, "css.properties.margin-trim" =>
+	caniuse : & [], popularity : 91.01677f32, }, "css.properties.margin-trim" =>
 	CSSFeature { id : "css.properties.margin-trim", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
@@ -18520,15 +18518,15 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001382f32, }, "css.properties.margin-trim.block" => CSSFeature {
-	id : "css.properties.margin-trim.block", name : "margin-trim", description :
+	[], popularity : 0.00107f32, }, "css.properties.margin-trim.block" => CSSFeature { id
+	: "css.properties.margin-trim.block", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001382f32, }, "css.properties.margin-trim.block-end" => CSSFeature
+	[], popularity : 0.00107f32, }, "css.properties.margin-trim.block-end" => CSSFeature
 	{ id : "css.properties.margin-trim.block-end", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
@@ -18536,7 +18534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001382f32, }, "css.properties.margin-trim.block-start" =>
+	[], popularity : 0.00107f32, }, "css.properties.margin-trim.block-start" =>
 	CSSFeature { id : "css.properties.margin-trim.block-start", name : "margin-trim",
 	description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
@@ -18545,7 +18543,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001382f32, }, "css.properties.margin-trim.inline" => CSSFeature {
+	[], popularity : 0.00107f32, }, "css.properties.margin-trim.inline" => CSSFeature {
 	id : "css.properties.margin-trim.inline", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
@@ -18553,16 +18551,15 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001382f32, }, "css.properties.margin-trim.inline-end" =>
-	CSSFeature { id : "css.properties.margin-trim.inline-end", name : "margin-trim",
-	description :
+	[], popularity : 0.00107f32, }, "css.properties.margin-trim.inline-end" => CSSFeature
+	{ id : "css.properties.margin-trim.inline-end", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001382f32, }, "css.properties.margin-trim.inline-start" =>
+	[], popularity : 0.00107f32, }, "css.properties.margin-trim.inline-start" =>
 	CSSFeature { id : "css.properties.margin-trim.inline-start", name : "margin-trim",
 	description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
@@ -18571,7 +18568,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001382f32, }, "css.properties.margin-trim.none" => CSSFeature { id
+	[], popularity : 0.00107f32, }, "css.properties.margin-trim.none" => CSSFeature { id
 	: "css.properties.margin-trim.none", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
@@ -18579,7 +18576,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001382f32, }, "css.properties.margin.anchor-size" => CSSFeature {
+	[], popularity : 0.00107f32, }, "css.properties.margin.anchor-size" => CSSFeature {
 	id : "css.properties.margin.anchor-size", name : "Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
 	spec : "https://drafts.csswg.org/css-anchor-position-1/#anchoring", groups : & [],
@@ -18599,7 +18596,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.305275f32, }, "css.properties.marker" => CSSFeature {
+	caniuse : & [], popularity : 91.01677f32, }, "css.properties.marker" => CSSFeature {
 	id : "css.properties.marker", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -19043,7 +19040,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	[], popularity : 3.114152f32, }, "css.properties.mask-type.alpha" => CSSFeature { id
+	[], popularity : 2.846512f32, }, "css.properties.mask-type.alpha" => CSSFeature { id
 	: "css.properties.mask-type.alpha", name : "mask-type", description :
 	"The mask-type CSS property on an SVG <mask> element sets whether the mask is a luminance or alpha mask.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-mask-type", groups : &
@@ -19054,7 +19051,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	[], popularity : 3.114152f32, }, "css.properties.mask-type.luminance" => CSSFeature {
+	[], popularity : 2.846512f32, }, "css.properties.mask-type.luminance" => CSSFeature {
 	id : "css.properties.mask-type.luminance", name : "mask-type", description :
 	"The mask-type CSS property on an SVG <mask> element sets whether the mask is a luminance or alpha mask.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-mask-type", groups : &
@@ -19065,7 +19062,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	[], popularity : 3.114152f32, }, "css.properties.math-depth" => CSSFeature { id :
+	[], popularity : 2.846512f32, }, "css.properties.math-depth" => CSSFeature { id :
 	"css.properties.math-depth", name : "MathML", description :
 	"MathML, or the Mathematical Markup Language, describes mathematical notation, such as expressions and formulas. Also known as MathML Core.",
 	spec : "https://w3c.github.io/mathml-core/", groups : & ["mathml"], baseline_status :
@@ -19721,7 +19718,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(41u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-mixblendmode"], popularity : 12.609471f32, },
+	["https://caniuse.com/css-mixblendmode"], popularity : 12.725035f32, },
 	"css.properties.mix-blend-mode.plus-darker" => CSSFeature { id :
 	"css.properties.mix-blend-mode.plus-darker", name : "mix-blend-mode", description :
 	"The mix-blend-mode CSS property blends an element's content with its background or parent elements using blend modes like multiply, difference, or color.",
@@ -19731,7 +19728,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(9u16, 0u16), safari_ios :
 	BrowserVersion(9u16, 0u16), }, caniuse : & ["https://caniuse.com/css-mixblendmode"],
-	popularity : 12.609471f32, }, "css.properties.mix-blend-mode.plus-lighter" =>
+	popularity : 12.725035f32, }, "css.properties.mix-blend-mode.plus-lighter" =>
 	CSSFeature { id : "css.properties.mix-blend-mode.plus-lighter", name :
 	"mix-blend-mode", description :
 	"The mix-blend-mode CSS property blends an element's content with its background or parent elements using blend modes like multiply, difference, or color.",
@@ -19743,7 +19740,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(100u16, 0u16), edge : BrowserVersion(100u16, 0u16), firefox :
 	BrowserVersion(99u16, 0u16), firefox_android : BrowserVersion(99u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-mixblendmode"], popularity : 12.609471f32, },
+	["https://caniuse.com/css-mixblendmode"], popularity : 12.725035f32, },
 	"css.properties.mix-blend-mode.svg_elements" => CSSFeature { id :
 	"css.properties.mix-blend-mode.svg_elements", name : "mix-blend-mode", description :
 	"The mix-blend-mode CSS property blends an element's content with its background or parent elements using blend modes like multiply, difference, or color.",
@@ -19753,7 +19750,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-mixblendmode"], popularity : 12.609471f32, },
+	["https://caniuse.com/css-mixblendmode"], popularity : 12.725035f32, },
 	"css.properties.object-fit" => CSSFeature { id : "css.properties.object-fit", name :
 	"object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19764,7 +19761,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.82769f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.072735f32, },
 	"css.properties.object-fit.contain" => CSSFeature { id :
 	"css.properties.object-fit.contain", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19775,7 +19772,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.82769f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.072735f32, },
 	"css.properties.object-fit.cover" => CSSFeature { id :
 	"css.properties.object-fit.cover", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19786,7 +19783,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.82769f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.072735f32, },
 	"css.properties.object-fit.fill" => CSSFeature { id :
 	"css.properties.object-fit.fill", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19797,7 +19794,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.82769f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.072735f32, },
 	"css.properties.object-fit.none" => CSSFeature { id :
 	"css.properties.object-fit.none", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19808,7 +19805,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.82769f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.072735f32, },
 	"css.properties.object-fit.scale-down" => CSSFeature { id :
 	"css.properties.object-fit.scale-down", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19819,7 +19816,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.82769f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.072735f32, },
 	"css.properties.object-position" => CSSFeature { id :
 	"css.properties.object-position", name : "object-position", description :
 	"The object-position CSS property places images, videos, and other replaced elements within their boxes.",
@@ -19830,7 +19827,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & [], popularity : 20.1575f32, }, "css.properties.object-view-box" =>
+	caniuse : & [], popularity : 21.24113f32, }, "css.properties.object-view-box" =>
 	CSSFeature { id : "css.properties.object-view-box", name : "object-view-box",
 	description :
 	"The object-view-box CSS property crops and zooms to an inset area of an image.",
@@ -19839,7 +19836,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(104u16, 0u16), chrome_android : BrowserVersion(104u16, 0u16), edge :
 	BrowserVersion(104u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.080071f32, },
+	0), }, caniuse : & [], popularity : 0.06436f32, },
 	"css.properties.object-view-box.none" => CSSFeature { id :
 	"css.properties.object-view-box.none", name : "object-view-box", description :
 	"The object-view-box CSS property crops and zooms to an inset area of an image.",
@@ -19848,7 +19845,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(104u16, 0u16), chrome_android : BrowserVersion(104u16, 0u16), edge :
 	BrowserVersion(104u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.080071f32, }, "css.properties.offset" =>
+	0), }, caniuse : & [], popularity : 0.06436f32, }, "css.properties.offset" =>
 	CSSFeature { id : "css.properties.offset", name : "Motion path", description :
 	"The offset CSS property animates an element along a defined motion path.", spec :
 	"https://drafts.csswg.org/motion-1/", groups : & [], baseline_status :
@@ -20201,7 +20198,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(2u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 87.0661f32, },
+	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.52077f32, },
 	"css.properties.opacity.percentages" => CSSFeature { id :
 	"css.properties.opacity.percentages", name : "opacity", description :
 	"The opacity CSS property sets the transparency of an element.", spec :
@@ -20212,7 +20209,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(78u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), },
-	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 87.0661f32, },
+	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.52077f32, },
 	"css.properties.order" => CSSFeature { id : "css.properties.order", name : "Flexbox",
 	description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -20244,7 +20241,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline-color" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline-color" =>
 	CSSFeature { id : "css.properties.outline-color", name : "Outlines", description :
 	"The outline-color, outline-style, and outline-width and outline-offset CSS properties style a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20461,7 +20458,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.dashed" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.dashed" =>
 	CSSFeature { id : "css.properties.outline.dashed", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20471,7 +20468,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.dotted" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.dotted" =>
 	CSSFeature { id : "css.properties.outline.dotted", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20481,7 +20478,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.double" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.double" =>
 	CSSFeature { id : "css.properties.outline.double", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20491,7 +20488,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.groove" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.groove" =>
 	CSSFeature { id : "css.properties.outline.groove", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20501,7 +20498,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.inset" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.inset" =>
 	CSSFeature { id : "css.properties.outline.inset", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20511,7 +20508,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.medium" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.medium" =>
 	CSSFeature { id : "css.properties.outline.medium", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20521,7 +20518,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.none" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.none" =>
 	CSSFeature { id : "css.properties.outline.none", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20531,7 +20528,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.outset" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.outset" =>
 	CSSFeature { id : "css.properties.outline.outset", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20541,7 +20538,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.ridge" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.ridge" =>
 	CSSFeature { id : "css.properties.outline.ridge", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20551,7 +20548,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.solid" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.solid" =>
 	CSSFeature { id : "css.properties.outline.solid", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20561,7 +20558,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.thick" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.thick" =>
 	CSSFeature { id : "css.properties.outline.thick", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20571,7 +20568,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.thin" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.thin" =>
 	CSSFeature { id : "css.properties.outline.thin", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20581,7 +20578,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.outline.transparent" =>
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.outline.transparent" =>
 	CSSFeature { id : "css.properties.outline.transparent", name : "outline", description
 	:
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
@@ -20592,7 +20589,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 77.835495f32, }, "css.properties.overflow" => CSSFeature
+	caniuse : & [], popularity : 76.780785f32, }, "css.properties.overflow" => CSSFeature
 	{ id : "css.properties.overflow", name : "overflow", description :
 	"The overflow CSS property sets the behavior for when content doesn't fit in an element.",
 	spec : "https://drafts.csswg.org/css-overflow-3/#propdef-overflow", groups : & [],
@@ -20612,7 +20609,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-overflow-anchor"], popularity : 9.367037f32, },
+	["https://caniuse.com/css-overflow-anchor"], popularity : 9.070367f32, },
 	"css.properties.overflow-anchor.auto" => CSSFeature { id :
 	"css.properties.overflow-anchor.auto", name : "overflow-anchor", description :
 	"The overflow-anchor CSS property sets an element as a possible scroll anchor, reducing unintended scrolling when document changes occur above the current scrollport. This is enabled by default where supported.",
@@ -20622,7 +20619,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-overflow-anchor"], popularity : 9.367037f32, },
+	["https://caniuse.com/css-overflow-anchor"], popularity : 9.070367f32, },
 	"css.properties.overflow-anchor.none" => CSSFeature { id :
 	"css.properties.overflow-anchor.none", name : "overflow-anchor", description :
 	"The overflow-anchor CSS property sets an element as a possible scroll anchor, reducing unintended scrolling when document changes occur above the current scrollport. This is enabled by default where supported.",
@@ -20632,7 +20629,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-overflow-anchor"], popularity : 9.367037f32, },
+	["https://caniuse.com/css-overflow-anchor"], popularity : 9.070367f32, },
 	"css.properties.overflow-block" => CSSFeature { id : "css.properties.overflow-block",
 	name : "Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -20660,7 +20657,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(102u16, 0u16), firefox_android :
 	BrowserVersion(102u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.778585f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.423092f32, },
 	"css.properties.overflow-clip-margin.border-box" => CSSFeature { id :
 	"css.properties.overflow-clip-margin.border-box", name : "overflow-clip-margin",
 	description :
@@ -20670,7 +20667,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(148u16, 0u16), firefox_android :
 	BrowserVersion(148u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.778585f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.423092f32, },
 	"css.properties.overflow-clip-margin.content-box" => CSSFeature { id :
 	"css.properties.overflow-clip-margin.content-box", name : "overflow-clip-margin",
 	description :
@@ -20680,7 +20677,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(148u16, 0u16), firefox_android :
 	BrowserVersion(148u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.778585f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.423092f32, },
 	"css.properties.overflow-clip-margin.padding-box" => CSSFeature { id :
 	"css.properties.overflow-clip-margin.padding-box", name : "overflow-clip-margin",
 	description :
@@ -20690,7 +20687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(148u16, 0u16), firefox_android :
 	BrowserVersion(148u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.778585f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.423092f32, },
 	"css.properties.overflow-inline" => CSSFeature { id :
 	"css.properties.overflow-inline", name : "Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -20721,7 +20718,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/wordwrap"], popularity : 42.18644f32, },
+	["https://caniuse.com/wordwrap"], popularity : 40.5462f32, },
 	"css.properties.overflow-wrap.anywhere" => CSSFeature { id :
 	"css.properties.overflow-wrap.anywhere", name : "overflow-wrap", description :
 	"The overflow-wrap CSS property breaks a line of text onto multiple lines inside the targeted element in an otherwise unbreakable place to prevent overflow. The legacy property is word-wrap.",
@@ -20733,7 +20730,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(80u16, 0u16), edge : BrowserVersion(80u16, 0u16), firefox :
 	BrowserVersion(65u16, 0u16), firefox_android : BrowserVersion(65u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/wordwrap"], popularity : 42.18644f32, },
+	["https://caniuse.com/wordwrap"], popularity : 40.5462f32, },
 	"css.properties.overflow-wrap.break-word" => CSSFeature { id :
 	"css.properties.overflow-wrap.break-word", name : "overflow-wrap", description :
 	"The overflow-wrap CSS property breaks a line of text onto multiple lines inside the targeted element in an otherwise unbreakable place to prevent overflow. The legacy property is word-wrap.",
@@ -20745,7 +20742,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/wordwrap"], popularity : 42.18644f32, },
+	["https://caniuse.com/wordwrap"], popularity : 40.5462f32, },
 	"css.properties.overflow-wrap.normal" => CSSFeature { id :
 	"css.properties.overflow-wrap.normal", name : "overflow-wrap", description :
 	"The overflow-wrap CSS property breaks a line of text onto multiple lines inside the targeted element in an otherwise unbreakable place to prevent overflow. The legacy property is word-wrap.",
@@ -20757,7 +20754,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/wordwrap"], popularity : 42.18644f32, },
+	["https://caniuse.com/wordwrap"], popularity : 40.5462f32, },
 	"css.properties.overflow-x" => CSSFeature { id : "css.properties.overflow-x", name :
 	"overflow", description :
 	"The overflow CSS property sets the behavior for when content doesn't fit in an element.",
@@ -20963,7 +20960,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), chrome_android : BrowserVersion(117u16, 0u16), edge :
 	BrowserVersion(117u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.10992f32, }, "css.properties.overlay.auto" =>
+	0), }, caniuse : & [], popularity : 0.087034f32, }, "css.properties.overlay.auto" =>
 	CSSFeature { id : "css.properties.overlay.auto", name : "overlay", description :
 	"The overlay CSS property, used as an allow-discrete CSS transition, prevents a top layer element, such as a popover or a <dialog>, from being removed from the top layer before it has finished animating. You can't set the value of the overlay property; only use it as transition property.",
 	spec : "https://drafts.csswg.org/css-position-4/#overlay", groups : & [],
@@ -20971,7 +20968,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), chrome_android : BrowserVersion(117u16, 0u16), edge :
 	BrowserVersion(117u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.10992f32, }, "css.properties.overlay.none" =>
+	0), }, caniuse : & [], popularity : 0.087034f32, }, "css.properties.overlay.none" =>
 	CSSFeature { id : "css.properties.overlay.none", name : "overlay", description :
 	"The overlay CSS property, used as an allow-discrete CSS transition, prevents a top layer element, such as a popover or a <dialog>, from being removed from the top layer before it has finished animating. You can't set the value of the overlay property; only use it as transition property.",
 	spec : "https://drafts.csswg.org/css-position-4/#overlay", groups : & [],
@@ -20979,7 +20976,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), chrome_android : BrowserVersion(117u16, 0u16), edge :
 	BrowserVersion(117u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.10992f32, },
+	0), }, caniuse : & [], popularity : 0.087034f32, },
 	"css.properties.overscroll-behavior" => CSSFeature { id :
 	"css.properties.overscroll-behavior", name : "overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -20989,7 +20986,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-block" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-block" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-block", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -20999,7 +20996,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-block.auto" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-block.auto" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-block.auto", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21009,7 +21006,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-block.contain" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-block.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-block.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21019,7 +21016,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-block.none" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-block.none" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-block.none", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21029,7 +21026,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-inline" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-inline" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-inline", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21039,7 +21036,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-inline.auto" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-inline.auto" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-inline.auto", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21049,7 +21046,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-inline.contain" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-inline.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-inline.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21059,7 +21056,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-inline.none" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-inline.none" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-inline.none", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21069,7 +21066,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-x" => CSSFeature {
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-x" => CSSFeature {
 	id : "css.properties.overscroll-behavior-x", name : "overscroll-behavior",
 	description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21079,7 +21076,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-x.auto" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-x.auto" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-x.auto", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21089,7 +21086,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-x.contain" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-x.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-x.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21099,7 +21096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-x.none" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-x.none" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-x.none", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21109,7 +21106,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-y" => CSSFeature {
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-y" => CSSFeature {
 	id : "css.properties.overscroll-behavior-y", name : "overscroll-behavior",
 	description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21119,7 +21116,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-y.auto" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-y.auto" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-y.auto", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21129,7 +21126,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-y.contain" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-y.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-y.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21139,7 +21136,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior-y.none" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior-y.none" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-y.none", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21149,7 +21146,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior.auto" => CSSFeature
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior.auto" => CSSFeature
 	{ id : "css.properties.overscroll-behavior.auto", name : "overscroll-behavior",
 	description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21159,7 +21156,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior.contain" =>
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21169,7 +21166,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.overscroll-behavior.none" => CSSFeature
+	popularity : 18.881948f32, }, "css.properties.overscroll-behavior.none" => CSSFeature
 	{ id : "css.properties.overscroll-behavior.none", name : "overscroll-behavior",
 	description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21179,7 +21176,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 17.833883f32, }, "css.properties.padding" => CSSFeature { id :
+	popularity : 18.881948f32, }, "css.properties.padding" => CSSFeature { id :
 	"css.properties.padding", name : "padding", description :
 	"The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#paddings", groups : & ["layout"],
@@ -21189,7 +21186,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.18405f32, }, "css.properties.padding-block" =>
+	caniuse : & [], popularity : 90.57307f32, }, "css.properties.padding-block" =>
 	CSSFeature { id : "css.properties.padding-block", name : "Logical properties",
 	description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -21233,7 +21230,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.18405f32, }, "css.properties.padding-inline" =>
+	caniuse : & [], popularity : 90.57307f32, }, "css.properties.padding-inline" =>
 	CSSFeature { id : "css.properties.padding-inline", name : "Logical properties",
 	description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -21277,7 +21274,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.18405f32, }, "css.properties.padding-right" =>
+	caniuse : & [], popularity : 90.57307f32, }, "css.properties.padding-right" =>
 	CSSFeature { id : "css.properties.padding-right", name : "padding", description :
 	"The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#paddings", groups : & ["layout"],
@@ -21287,7 +21284,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.18405f32, }, "css.properties.padding-top" =>
+	caniuse : & [], popularity : 90.57307f32, }, "css.properties.padding-top" =>
 	CSSFeature { id : "css.properties.padding-top", name : "padding", description :
 	"The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#paddings", groups : & ["layout"],
@@ -21297,7 +21294,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.18405f32, }, "css.properties.page" => CSSFeature { id
+	caniuse : & [], popularity : 90.57307f32, }, "css.properties.page" => CSSFeature { id
 	: "css.properties.page", name : "Page setup", description :
 	"The @page CSS at-rule sets the page-specific dimensions and margins for content such as printed documents, ebooks, or slides.",
 	spec : "https://drafts.csswg.org/css-page-3/#at-page-rule", groups : & ["layout",
@@ -21453,7 +21450,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(123u16, 0u16), edge : BrowserVersion(123u16,
 	0u16), firefox : BrowserVersion(60u16, 0u16), firefox_android : BrowserVersion(60u16,
 	0u16), safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16,
-	0u16), }, caniuse : & [], popularity : 1.632476f32, }, "css.properties.perspective"
+	0u16), }, caniuse : & [], popularity : 1.336043f32, }, "css.properties.perspective"
 	=> CSSFeature { id : "css.properties.perspective", name : "3D transforms",
 	description :
 	"The transform CSS property and its 3D transform functions allow rotations and other transforms in three dimensions, including perspective transforms.",
@@ -21574,7 +21571,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(59u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(53u16, 0u16), firefox_android : BrowserVersion(53u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.place-items" => CSSFeature { id : "css.properties.place-items", name
 	: "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -21618,7 +21615,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(59u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.place-self" => CSSFeature { id : "css.properties.place-self", name :
 	"Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -21661,7 +21658,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(59u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.place-self.position_absolute_context" => CSSFeature { id :
 	"css.properties.place-self.position_absolute_context", name : "Absolute positioning",
 	description :
@@ -21684,7 +21681,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), },
-	caniuse : & ["https://caniuse.com/pointer-events"], popularity : 71.75426f32, },
+	caniuse : & ["https://caniuse.com/pointer-events"], popularity : 70.946785f32, },
 	"css.properties.pointer-events.html_elements" => CSSFeature { id :
 	"css.properties.pointer-events.html_elements", name : "pointer-events", description :
 	"The pointer-events CSS property sets whether a user can interact with an element using a mouse, touch, or other pointing input device.",
@@ -21695,7 +21692,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), },
-	caniuse : & ["https://caniuse.com/pointer-events"], popularity : 71.75426f32, },
+	caniuse : & ["https://caniuse.com/pointer-events"], popularity : 70.946785f32, },
 	"css.properties.position" => CSSFeature { id : "css.properties.position", name :
 	"Position", description :
 	"The position CSS property sets the origin position of an element to an element, the element's scrollport, or the viewport.",
@@ -21707,8 +21704,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 91.84935f32, }, "css.properties.position-anchor" => CSSFeature { id
-	: "css.properties.position-anchor", name : "Anchor positioning", description :
+	[], popularity : 91.1839f32, }, "css.properties.position-anchor" => CSSFeature { id :
+	"css.properties.position-anchor", name : "Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
 	spec : "https://drafts.csswg.org/css-anchor-position-1/#anchoring", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -22729,7 +22726,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(136u16, 0u16), edge : BrowserVersion(136u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 3.073287f32, },
+	caniuse : & [], popularity : 2.825934f32, },
 	"css.properties.print-color-adjust.economy" => CSSFeature { id :
 	"css.properties.print-color-adjust.economy", name : "print-color-adjust", description
 	:
@@ -22741,7 +22738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(136u16, 0u16), edge : BrowserVersion(136u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 3.073287f32, },
+	caniuse : & [], popularity : 2.825934f32, },
 	"css.properties.print-color-adjust.exact" => CSSFeature { id :
 	"css.properties.print-color-adjust.exact", name : "print-color-adjust", description :
 	"The print-color-adjust CSS property sets whether styles of printed pages should be adjusted to use less ink, in cases such as light text on a dark background.",
@@ -22752,7 +22749,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(136u16, 0u16), edge : BrowserVersion(136u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 3.073287f32, }, "css.properties.quotes" => CSSFeature {
+	caniuse : & [], popularity : 2.825934f32, }, "css.properties.quotes" => CSSFeature {
 	id : "css.properties.quotes", name : "Quotes", description :
 	"The quotes CSS property sets the quotation marks inserted via the content CSS property or <q> element.",
 	spec : "https://drafts.csswg.org/css-content-3/#quotes", groups : & [],
@@ -22762,7 +22759,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), },
-	caniuse : & [], popularity : 8.225285f32, }, "css.properties.quotes.auto" =>
+	caniuse : & [], popularity : 8.591698f32, }, "css.properties.quotes.auto" =>
 	CSSFeature { id : "css.properties.quotes.auto", name : "Quotes", description :
 	"The quotes CSS property sets the quotation marks inserted via the content CSS property or <q> element.",
 	spec : "https://drafts.csswg.org/css-content-3/#quotes", groups : & [],
@@ -22772,7 +22769,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(14u16, 1u16), safari_ios : BrowserVersion(14u16, 5u16), },
-	caniuse : & [], popularity : 8.225285f32, }, "css.properties.quotes.none" =>
+	caniuse : & [], popularity : 8.591698f32, }, "css.properties.quotes.none" =>
 	CSSFeature { id : "css.properties.quotes.none", name : "Quotes", description :
 	"The quotes CSS property sets the quotation marks inserted via the content CSS property or <q> element.",
 	spec : "https://drafts.csswg.org/css-content-3/#quotes", groups : & [],
@@ -22782,7 +22779,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), },
-	caniuse : & [], popularity : 8.225285f32, }, "css.properties.r" => CSSFeature { id :
+	caniuse : & [], popularity : 8.591698f32, }, "css.properties.r" => CSSFeature { id :
 	"css.properties.r", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -22802,7 +22799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.179532f32, }, "css.properties.reading-flow.flex-flow" => CSSFeature {
+	popularity : 0.180532f32, }, "css.properties.reading-flow.flex-flow" => CSSFeature {
 	id : "css.properties.reading-flow.flex-flow", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22811,7 +22808,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.179532f32, }, "css.properties.reading-flow.flex-visual" => CSSFeature
+	popularity : 0.180532f32, }, "css.properties.reading-flow.flex-visual" => CSSFeature
 	{ id : "css.properties.reading-flow.flex-visual", name : "reading-flow", description
 	:
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
@@ -22821,7 +22818,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.179532f32, }, "css.properties.reading-flow.grid-columns" => CSSFeature
+	popularity : 0.180532f32, }, "css.properties.reading-flow.grid-columns" => CSSFeature
 	{ id : "css.properties.reading-flow.grid-columns", name : "reading-flow", description
 	:
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
@@ -22831,7 +22828,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.179532f32, }, "css.properties.reading-flow.grid-order" => CSSFeature {
+	popularity : 0.180532f32, }, "css.properties.reading-flow.grid-order" => CSSFeature {
 	id : "css.properties.reading-flow.grid-order", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22840,7 +22837,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.179532f32, }, "css.properties.reading-flow.grid-rows" => CSSFeature {
+	popularity : 0.180532f32, }, "css.properties.reading-flow.grid-rows" => CSSFeature {
 	id : "css.properties.reading-flow.grid-rows", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22849,7 +22846,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.179532f32, }, "css.properties.reading-flow.normal" => CSSFeature { id
+	popularity : 0.180532f32, }, "css.properties.reading-flow.normal" => CSSFeature { id
 	: "css.properties.reading-flow.normal", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22858,7 +22855,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.179532f32, }, "css.properties.reading-flow.source-order" => CSSFeature
+	popularity : 0.180532f32, }, "css.properties.reading-flow.source-order" => CSSFeature
 	{ id : "css.properties.reading-flow.source-order", name : "reading-flow", description
 	:
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
@@ -22868,7 +22865,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.179532f32, }, "css.properties.reading-order" => CSSFeature { id :
+	popularity : 0.180532f32, }, "css.properties.reading-order" => CSSFeature { id :
 	"css.properties.reading-order", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22877,7 +22874,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.179532f32, }, "css.properties.resize" => CSSFeature { id :
+	popularity : 0.180532f32, }, "css.properties.resize" => CSSFeature { id :
 	"css.properties.resize", name : "resize (CSS property)", description :
 	"The resize CSS property sets whether an element can be resized by the user, and on which axes.",
 	spec : "https://drafts.csswg.org/css-ui-4/#resize", groups : & [], baseline_status :
@@ -22886,7 +22883,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(4u16, 0u16), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-resize"], popularity :
-	37.290005f32, }, "css.properties.resize.block" => CSSFeature { id :
+	35.307873f32, }, "css.properties.resize.block" => CSSFeature { id :
 	"css.properties.resize.block", name : "resize (CSS property)", description :
 	"The resize CSS property sets whether an element can be resized by the user, and on which axes.",
 	spec : "https://drafts.csswg.org/css-ui-4/#resize", groups : & [], baseline_status :
@@ -22895,7 +22892,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(118u16, 0u16), firefox : BrowserVersion(63u16, 0u16), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(16u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-resize"], popularity :
-	37.290005f32, }, "css.properties.resize.block_level_support" => CSSFeature { id :
+	35.307873f32, }, "css.properties.resize.block_level_support" => CSSFeature { id :
 	"css.properties.resize.block_level_support", name : "resize (CSS property)",
 	description :
 	"The resize CSS property sets whether an element can be resized by the user, and on which axes.",
@@ -22905,7 +22902,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(5u16, 0u16), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(4u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-resize"], popularity :
-	37.290005f32, }, "css.properties.resize.inline" => CSSFeature { id :
+	35.307873f32, }, "css.properties.resize.inline" => CSSFeature { id :
 	"css.properties.resize.inline", name : "resize (CSS property)", description :
 	"The resize CSS property sets whether an element can be resized by the user, and on which axes.",
 	spec : "https://drafts.csswg.org/css-ui-4/#resize", groups : & [], baseline_status :
@@ -22914,7 +22911,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(118u16, 0u16), firefox : BrowserVersion(63u16, 0u16), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(16u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-resize"], popularity :
-	37.290005f32, }, "css.properties.right" => CSSFeature { id : "css.properties.right",
+	35.307873f32, }, "css.properties.right" => CSSFeature { id : "css.properties.right",
 	name : "Physical properties", description :
 	"The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.",
 	spec : "https://drafts.csswg.org/css-position-3/#insets", groups : & [],
@@ -22998,7 +22995,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(47u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.row-gap.flex_context" => CSSFeature { id :
 	"css.properties.row-gap.flex_context", name : "Flexbox gap", description :
 	"The gap CSS property in a flexbox layout sets the size of the space between items.",
@@ -23020,7 +23017,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 0u16), safari_ios : BrowserVersion(12u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.row-gap.normal" => CSSFeature { id : "css.properties.row-gap.normal",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -23031,7 +23028,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(47u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.properties.ruby-align" => CSSFeature { id : "css.properties.ruby-align", name :
 	"ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23041,7 +23038,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.431757f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484998f32, },
 	"css.properties.ruby-align.center" => CSSFeature { id :
 	"css.properties.ruby-align.center", name : "ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23051,7 +23048,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.431757f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484998f32, },
 	"css.properties.ruby-align.space-around" => CSSFeature { id :
 	"css.properties.ruby-align.space-around", name : "ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23061,7 +23058,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.431757f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484998f32, },
 	"css.properties.ruby-align.space-between" => CSSFeature { id :
 	"css.properties.ruby-align.space-between", name : "ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23071,7 +23068,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.431757f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484998f32, },
 	"css.properties.ruby-align.start" => CSSFeature { id :
 	"css.properties.ruby-align.start", name : "ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23081,7 +23078,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.431757f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484998f32, },
 	"css.properties.ruby-overhang" => CSSFeature { id : "css.properties.ruby-overhang",
 	name : "ruby-overhang", description :
 	"The ruby-overhang CSS property sets whether ruby annotations may overlap adjacent text.",
@@ -23090,7 +23087,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), }, caniuse : &
-	[], popularity : 0.000078f32, }, "css.properties.ruby-overhang.auto" => CSSFeature {
+	[], popularity : 0.000044f32, }, "css.properties.ruby-overhang.auto" => CSSFeature {
 	id : "css.properties.ruby-overhang.auto", name : "ruby-overhang", description :
 	"The ruby-overhang CSS property sets whether ruby annotations may overlap adjacent text.",
 	spec : "https://drafts.csswg.org/css-ruby-1/#ruby-overhang", groups : & ["ruby"],
@@ -23098,7 +23095,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), }, caniuse : &
-	[], popularity : 0.000078f32, }, "css.properties.ruby-overhang.none" => CSSFeature {
+	[], popularity : 0.000044f32, }, "css.properties.ruby-overhang.none" => CSSFeature {
 	id : "css.properties.ruby-overhang.none", name : "ruby-overhang", description :
 	"The ruby-overhang CSS property sets whether ruby annotations may overlap adjacent text.",
 	spec : "https://drafts.csswg.org/css-ruby-1/#ruby-overhang", groups : & ["ruby"],
@@ -23106,7 +23103,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), }, caniuse : &
-	[], popularity : 0.000078f32, }, "css.properties.ruby-position" => CSSFeature { id :
+	[], popularity : 0.000044f32, }, "css.properties.ruby-position" => CSSFeature { id :
 	"css.properties.ruby-position", name : "ruby-position", description :
 	"The ruby-position CSS property sets the position of a ruby annotation in relation to its base text. Annotations can display over, under, or interleaved with the base text.",
 	spec : "https://drafts.csswg.org/css-ruby-1/#rubypos", groups : & ["ruby"],
@@ -23115,7 +23112,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(38u16, 0u16), firefox_android : BrowserVersion(38u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 0.237193f32, }, "css.properties.ruby-position.alternate"
+	caniuse : & [], popularity : 0.241407f32, }, "css.properties.ruby-position.alternate"
 	=> CSSFeature { id : "css.properties.ruby-position.alternate", name :
 	"display: ruby", description :
 	"The display: ruby CSS declaration renders an element with the box layout of a <ruby> HTML element. Child elements may use equivalents to <ruby> internal elements such as display: ruby-base for <rb>.",
@@ -23133,7 +23130,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), }, caniuse : &
-	[], popularity : 0.237193f32, }, "css.properties.ruby-position.over" => CSSFeature {
+	[], popularity : 0.241407f32, }, "css.properties.ruby-position.over" => CSSFeature {
 	id : "css.properties.ruby-position.over", name : "ruby-position", description :
 	"The ruby-position CSS property sets the position of a ruby annotation in relation to its base text. Annotations can display over, under, or interleaved with the base text.",
 	spec : "https://drafts.csswg.org/css-ruby-1/#rubypos", groups : & ["ruby"],
@@ -23142,7 +23139,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(38u16, 0u16), firefox_android : BrowserVersion(38u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 0.237193f32, }, "css.properties.ruby-position.under" =>
+	caniuse : & [], popularity : 0.241407f32, }, "css.properties.ruby-position.under" =>
 	CSSFeature { id : "css.properties.ruby-position.under", name : "ruby-position",
 	description :
 	"The ruby-position CSS property sets the position of a ruby annotation in relation to its base text. Annotations can display over, under, or interleaved with the base text.",
@@ -23152,7 +23149,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(38u16, 0u16), firefox_android : BrowserVersion(38u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 0.237193f32, }, "css.properties.rx" => CSSFeature { id :
+	caniuse : & [], popularity : 0.241407f32, }, "css.properties.rx" => CSSFeature { id :
 	"css.properties.rx", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -23206,7 +23203,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(61u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-scroll-behavior"], popularity : 18.82742f32, },
+	["https://caniuse.com/css-scroll-behavior"], popularity : 19.871592f32, },
 	"css.properties.scroll-behavior.auto" => CSSFeature { id :
 	"css.properties.scroll-behavior.auto", name : "scroll-behavior", description :
 	"The scroll-behavior CSS property controls whether scrolling is smooth or snaps, for scroll actions not performed by the user such as those triggered by navigation.",
@@ -23218,7 +23215,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(61u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-scroll-behavior"], popularity : 18.82742f32, },
+	["https://caniuse.com/css-scroll-behavior"], popularity : 19.871592f32, },
 	"css.properties.scroll-behavior.smooth" => CSSFeature { id :
 	"css.properties.scroll-behavior.smooth", name : "scroll-behavior", description :
 	"The scroll-behavior CSS property controls whether scrolling is smooth or snaps, for scroll actions not performed by the user such as those triggered by navigation.",
@@ -23230,7 +23227,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(61u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-scroll-behavior"], popularity : 18.82742f32, },
+	["https://caniuse.com/css-scroll-behavior"], popularity : 19.871592f32, },
 	"css.properties.scroll-initial-target" => CSSFeature { id :
 	"css.properties.scroll-initial-target", name : "scroll-initial-target", description :
 	"The scroll-initial-target: nearest CSS declaration sets the initial scroll position of its scroll container to the top of the element, much like scrolling to a URL fragment.",
@@ -23241,7 +23238,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), edge : BrowserVersion(133u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.072694f32, }, "css.properties.scroll-initial-target.nearest" =>
+	popularity : 0.056957f32, }, "css.properties.scroll-initial-target.nearest" =>
 	CSSFeature { id : "css.properties.scroll-initial-target.nearest", name :
 	"scroll-initial-target", description :
 	"The scroll-initial-target: nearest CSS declaration sets the initial scroll position of its scroll container to the top of the element, much like scrolling to a URL fragment.",
@@ -23252,7 +23249,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), edge : BrowserVersion(133u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.072694f32, }, "css.properties.scroll-initial-target.none" =>
+	popularity : 0.056957f32, }, "css.properties.scroll-initial-target.none" =>
 	CSSFeature { id : "css.properties.scroll-initial-target.none", name :
 	"scroll-initial-target", description :
 	"The scroll-initial-target: nearest CSS declaration sets the initial scroll position of its scroll container to the top of the element, much like scrolling to a URL fragment.",
@@ -23263,7 +23260,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), edge : BrowserVersion(133u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.072694f32, }, "css.properties.scroll-margin" => CSSFeature { id :
+	popularity : 0.056957f32, }, "css.properties.scroll-margin" => CSSFeature { id :
 	"css.properties.scroll-margin", name : "Scroll snap", description :
 	"CSS scroll snap controls the panning and scrolling behavior within a scroll container.",
 	spec : "https://drafts.csswg.org/css-scroll-snap-2/", groups : & ["scrolling"],
@@ -23793,8 +23790,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.233189f32, }, "css.properties.scroll-target-group.auto" => CSSFeature
-	{ id : "css.properties.scroll-target-group.auto", name : "scroll-target-group",
+	popularity : 0.27476f32, }, "css.properties.scroll-target-group.auto" => CSSFeature {
+	id : "css.properties.scroll-target-group.auto", name : "scroll-target-group",
 	description :
 	"The scroll-target-group CSS property sets the container where anchor links act as scroll markers. Using selectors such as :target-current, you can style elements when a target has scrolled into view. It's an alternative to the ::scroll-marker-group pseudo-element, which generates scroll markers.",
 	spec : "https://drafts.csswg.org/css-overflow-5/#scroll-target-group", groups : &
@@ -23803,8 +23800,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.233189f32, }, "css.properties.scroll-target-group.none" => CSSFeature
-	{ id : "css.properties.scroll-target-group.none", name : "scroll-target-group",
+	popularity : 0.27476f32, }, "css.properties.scroll-target-group.none" => CSSFeature {
+	id : "css.properties.scroll-target-group.none", name : "scroll-target-group",
 	description :
 	"The scroll-target-group CSS property sets the container where anchor links act as scroll markers. Using selectors such as :target-current, you can style elements when a target has scrolled into view. It's an alternative to the ::scroll-marker-group pseudo-element, which generates scroll markers.",
 	spec : "https://drafts.csswg.org/css-overflow-5/#scroll-target-group", groups : &
@@ -23813,7 +23810,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.233189f32, }, "css.properties.scroll-timeline" => CSSFeature { id :
+	popularity : 0.27476f32, }, "css.properties.scroll-timeline" => CSSFeature { id :
 	"css.properties.scroll-timeline", name : "Scroll-driven animations", description :
 	"The animation-timeline, scroll-timeline, and view-timeline CSS properties advance animations based on the user's scroll position.",
 	spec : "https://drafts.csswg.org/scroll-animations-1/", groups : & ["scrolling",
@@ -23891,7 +23888,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 18.449986f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 16.134317f32, },
 	"css.properties.scrollbar-color.auto" => CSSFeature { id :
 	"css.properties.scrollbar-color.auto", name : "scrollbar-color", description :
 	"The scrollbar-color CSS property sets the color of the scrollbar track and thumb.",
@@ -23901,7 +23898,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 18.449986f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 16.134317f32, },
 	"css.properties.scrollbar-gutter" => CSSFeature { id :
 	"css.properties.scrollbar-gutter", name : "scrollbar-gutter", description :
 	"The scrollbar-gutter CSS property reserves space for the scrollbar, preventing unwanted layout changes as the scrollbar appears and disappears.",
@@ -23912,7 +23909,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 15.057449f32, }, "css.properties.scrollbar-gutter.auto"
+	caniuse : & [], popularity : 13.508762f32, }, "css.properties.scrollbar-gutter.auto"
 	=> CSSFeature { id : "css.properties.scrollbar-gutter.auto", name :
 	"scrollbar-gutter", description :
 	"The scrollbar-gutter CSS property reserves space for the scrollbar, preventing unwanted layout changes as the scrollbar appears and disappears.",
@@ -23923,7 +23920,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 15.057449f32, },
+	caniuse : & [], popularity : 13.508762f32, },
 	"css.properties.scrollbar-gutter.stable" => CSSFeature { id :
 	"css.properties.scrollbar-gutter.stable", name : "scrollbar-gutter", description :
 	"The scrollbar-gutter CSS property reserves space for the scrollbar, preventing unwanted layout changes as the scrollbar appears and disappears.",
@@ -23934,7 +23931,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 15.057449f32, }, "css.properties.scrollbar-width" =>
+	caniuse : & [], popularity : 13.508762f32, }, "css.properties.scrollbar-width" =>
 	CSSFeature { id : "css.properties.scrollbar-width", name : "scrollbar-width",
 	description : "The scrollbar-width CSS property sets the width of the scrollbar.",
 	spec : "https://drafts.csswg.org/css-scrollbars-1/#scrollbar-width", groups : &
@@ -23943,7 +23940,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 40.21628f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 41.301636f32, },
 	"css.properties.scrollbar-width.auto" => CSSFeature { id :
 	"css.properties.scrollbar-width.auto", name : "scrollbar-width", description :
 	"The scrollbar-width CSS property sets the width of the scrollbar.", spec :
@@ -23953,7 +23950,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 40.21628f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 41.301636f32, },
 	"css.properties.scrollbar-width.none" => CSSFeature { id :
 	"css.properties.scrollbar-width.none", name : "scrollbar-width", description :
 	"The scrollbar-width CSS property sets the width of the scrollbar.", spec :
@@ -23963,7 +23960,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 40.21628f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 41.301636f32, },
 	"css.properties.scrollbar-width.thin" => CSSFeature { id :
 	"css.properties.scrollbar-width.thin", name : "scrollbar-width", description :
 	"The scrollbar-width CSS property sets the width of the scrollbar.", spec :
@@ -23973,7 +23970,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 40.21628f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 41.301636f32, },
 	"css.properties.shape-image-threshold" => CSSFeature { id :
 	"css.properties.shape-image-threshold", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
@@ -23985,7 +23982,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.594324f32, }, "css.properties.shape-image-threshold.percentages"
+	[], popularity : 0.498155f32, }, "css.properties.shape-image-threshold.percentages"
 	=> CSSFeature { id : "css.properties.shape-image-threshold.percentages", name :
 	"shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
@@ -23995,7 +23992,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(78u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.594324f32, }, "css.properties.shape-margin" => CSSFeature { id :
+	popularity : 0.498155f32, }, "css.properties.shape-margin" => CSSFeature { id :
 	"css.properties.shape-margin", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24006,7 +24003,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.594324f32, }, "css.properties.shape-outside" => CSSFeature { id :
+	[], popularity : 0.498155f32, }, "css.properties.shape-outside" => CSSFeature { id :
 	"css.properties.shape-outside", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24017,7 +24014,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.594324f32, }, "css.properties.shape-outside.circle" => CSSFeature
+	[], popularity : 0.498155f32, }, "css.properties.shape-outside.circle" => CSSFeature
 	{ id : "css.properties.shape-outside.circle", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24028,7 +24025,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.594324f32, }, "css.properties.shape-outside.gradient" =>
+	[], popularity : 0.498155f32, }, "css.properties.shape-outside.gradient" =>
 	CSSFeature { id : "css.properties.shape-outside.gradient", name : "shape-outside",
 	description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
@@ -24040,7 +24037,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.594324f32, }, "css.properties.shape-outside.image" => CSSFeature {
+	[], popularity : 0.498155f32, }, "css.properties.shape-outside.image" => CSSFeature {
 	id : "css.properties.shape-outside.image", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24051,7 +24048,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.594324f32, }, "css.properties.shape-outside.inset" => CSSFeature {
+	[], popularity : 0.498155f32, }, "css.properties.shape-outside.inset" => CSSFeature {
 	id : "css.properties.shape-outside.inset", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24062,7 +24059,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.594324f32, }, "css.properties.shape-outside.none" => CSSFeature {
+	[], popularity : 0.498155f32, }, "css.properties.shape-outside.none" => CSSFeature {
 	id : "css.properties.shape-outside.none", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24073,7 +24070,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.594324f32, }, "css.properties.shape-outside.path" => CSSFeature {
+	[], popularity : 0.498155f32, }, "css.properties.shape-outside.path" => CSSFeature {
 	id : "css.properties.shape-outside.path", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24081,7 +24078,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	: BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.594324f32, },
+	0), }, caniuse : & [], popularity : 0.498155f32, },
 	"css.properties.shape-outside.polygon" => CSSFeature { id :
 	"css.properties.shape-outside.polygon", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
@@ -24093,7 +24090,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.594324f32, }, "css.properties.shape-rendering" => CSSFeature { id
+	[], popularity : 0.498155f32, }, "css.properties.shape-rendering" => CSSFeature { id
 	: "css.properties.shape-rendering", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -24124,7 +24121,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 10.466045f32, }, "css.properties.speak-as" => CSSFeature { id :
+	popularity : 10.365858f32, }, "css.properties.speak-as" => CSSFeature { id :
 	"css.properties.speak-as", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
 	spec : "https://drafts.csswg.org/css-speech-1/#speaking-props-speak-as", groups : &
@@ -24132,7 +24129,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.00053f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000479f32, },
 	"css.properties.speak-as.digits" => CSSFeature { id :
 	"css.properties.speak-as.digits", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24141,7 +24138,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.00053f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000479f32, },
 	"css.properties.speak-as.literal-punctuation" => CSSFeature { id :
 	"css.properties.speak-as.literal-punctuation", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24150,7 +24147,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.00053f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000479f32, },
 	"css.properties.speak-as.no-punctuation" => CSSFeature { id :
 	"css.properties.speak-as.no-punctuation", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24159,7 +24156,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.00053f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000479f32, },
 	"css.properties.speak-as.normal" => CSSFeature { id :
 	"css.properties.speak-as.normal", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24168,7 +24165,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.00053f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000479f32, },
 	"css.properties.speak-as.spell-out" => CSSFeature { id :
 	"css.properties.speak-as.spell-out", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24177,7 +24174,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.00053f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000479f32, },
 	"css.properties.stop-color" => CSSFeature { id : "css.properties.stop-color", name :
 	"SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -24446,7 +24443,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(25u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(91u16, 0u16), firefox_android : BrowserVersion(91u16, 0u16),
 	safari : BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css3-tabsize"], popularity : 13.323301f32, },
+	caniuse : & ["https://caniuse.com/css3-tabsize"], popularity : 12.936474f32, },
 	"css.properties.tab-size.length" => CSSFeature { id :
 	"css.properties.tab-size.length", name : "tab-size", description :
 	"The tab-size CSS property sets the width of the tab character.", spec :
@@ -24457,7 +24454,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(42u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(91u16, 0u16), firefox_android : BrowserVersion(91u16, 0u16),
 	safari : BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), },
-	caniuse : & ["https://caniuse.com/css3-tabsize"], popularity : 13.323301f32, },
+	caniuse : & ["https://caniuse.com/css3-tabsize"], popularity : 12.936474f32, },
 	"css.properties.table-layout" => CSSFeature { id : "css.properties.table-layout",
 	name : "Tables", description :
 	"The <table> HTML element, with several related elements, represents tabular data in rows and columns of cells.",
@@ -24502,7 +24499,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 87.65088f32, }, "css.properties.text-align-last" => CSSFeature { id
+	[], popularity : 87.321335f32, }, "css.properties.text-align-last" => CSSFeature { id
 	: "css.properties.text-align-last", name : "text-align-last", description :
 	"The text-align-last CSS property sets the alignment of the last line of text before a forced line break.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-last-property", groups : &
@@ -24513,7 +24510,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(47u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(16u16, 0u16), safari_ios : BrowserVersion(16u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-align-last"], popularity : 2.946808f32, },
+	["https://caniuse.com/css-text-align-last"], popularity : 3.197538f32, },
 	"css.properties.text-align-last.auto" => CSSFeature { id :
 	"css.properties.text-align-last.auto", name : "text-align-last", description :
 	"The text-align-last CSS property sets the alignment of the last line of text before a forced line break.",
@@ -24525,7 +24522,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(47u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(16u16, 0u16), safari_ios : BrowserVersion(16u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-align-last"], popularity : 2.946808f32, },
+	["https://caniuse.com/css-text-align-last"], popularity : 3.197538f32, },
 	"css.properties.text-align.center" => CSSFeature { id :
 	"css.properties.text-align.center", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
@@ -24537,7 +24534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 87.65088f32, }, "css.properties.text-align.end" => CSSFeature { id :
+	popularity : 87.321335f32, }, "css.properties.text-align.end" => CSSFeature { id :
 	"css.properties.text-align.end", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
@@ -24548,7 +24545,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 87.65088f32, }, "css.properties.text-align.justify" => CSSFeature {
+	[], popularity : 87.321335f32, }, "css.properties.text-align.justify" => CSSFeature {
 	id : "css.properties.text-align.justify", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
@@ -24559,7 +24556,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 87.65088f32, }, "css.properties.text-align.left" => CSSFeature { id
+	[], popularity : 87.321335f32, }, "css.properties.text-align.left" => CSSFeature { id
 	: "css.properties.text-align.left", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
@@ -24570,15 +24567,15 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 87.65088f32, }, "css.properties.text-align.match-parent" => CSSFeature {
-	id : "css.properties.text-align.match-parent", name : "text-align", description :
+	popularity : 87.321335f32, }, "css.properties.text-align.match-parent" => CSSFeature
+	{ id : "css.properties.text-align.match-parent", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
 	["text"], baseline_status : BaselineStatus::False, browser_support : BrowserSupport {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(40u16, 0u16), firefox_android :
 	BrowserVersion(40u16, 0u16), safari : BrowserVersion(15u16, 4u16), safari_ios :
-	BrowserVersion(15u16, 4u16), }, caniuse : & [], popularity : 87.65088f32, },
+	BrowserVersion(15u16, 4u16), }, caniuse : & [], popularity : 87.321335f32, },
 	"css.properties.text-align.right" => CSSFeature { id :
 	"css.properties.text-align.right", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
@@ -24590,7 +24587,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 87.65088f32, }, "css.properties.text-align.start" => CSSFeature { id :
+	popularity : 87.321335f32, }, "css.properties.text-align.start" => CSSFeature { id :
 	"css.properties.text-align.start", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
@@ -24601,7 +24598,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 87.65088f32, }, "css.properties.text-anchor" => CSSFeature { id :
+	[], popularity : 87.321335f32, }, "css.properties.text-anchor" => CSSFeature { id :
 	"css.properties.text-anchor", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -24656,7 +24653,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16),
 	firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 0.772835f32, },
+	4u16), }, caniuse : & [], popularity : 0.437065f32, },
 	"css.properties.text-autospace.auto" => CSSFeature { id :
 	"css.properties.text-autospace.auto", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24665,7 +24662,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 0.772835f32, },
+	4u16), }, caniuse : & [], popularity : 0.437065f32, },
 	"css.properties.text-autospace.ideograph-alpha" => CSSFeature { id :
 	"css.properties.text-autospace.ideograph-alpha", name : "text-autospace", description
 	:
@@ -24675,7 +24672,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 0.772835f32, },
+	4u16), }, caniuse : & [], popularity : 0.437065f32, },
 	"css.properties.text-autospace.ideograph-numeric" => CSSFeature { id :
 	"css.properties.text-autospace.ideograph-numeric", name : "text-autospace",
 	description :
@@ -24685,7 +24682,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 0.772835f32, },
+	4u16), }, caniuse : & [], popularity : 0.437065f32, },
 	"css.properties.text-autospace.insert" => CSSFeature { id :
 	"css.properties.text-autospace.insert", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24694,7 +24691,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& [], popularity : 0.772835f32, }, "css.properties.text-autospace.no-autospace" =>
+	& [], popularity : 0.437065f32, }, "css.properties.text-autospace.no-autospace" =>
 	CSSFeature { id : "css.properties.text-autospace.no-autospace", name :
 	"text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24704,7 +24701,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16),
 	firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 0.772835f32, },
+	4u16), }, caniuse : & [], popularity : 0.437065f32, },
 	"css.properties.text-autospace.normal" => CSSFeature { id :
 	"css.properties.text-autospace.normal", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24714,7 +24711,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16),
 	firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 0.772835f32, },
+	4u16), }, caniuse : & [], popularity : 0.437065f32, },
 	"css.properties.text-autospace.punctuation" => CSSFeature { id :
 	"css.properties.text-autospace.punctuation", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24723,7 +24720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.772835f32, }, "css.properties.text-autospace.replace" => CSSFeature {
+	popularity : 0.437065f32, }, "css.properties.text-autospace.replace" => CSSFeature {
 	id : "css.properties.text-autospace.replace", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-autospace-property", groups : & [],
@@ -24731,7 +24728,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.772835f32, }, "css.properties.text-box" => CSSFeature { id :
+	popularity : 0.437065f32, }, "css.properties.text-box" => CSSFeature { id :
 	"css.properties.text-box", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
 	spec : "https://drafts.csswg.org/css-inline-3/#leading-trim", groups : & ["text"],
@@ -24740,7 +24737,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.properties.text-box-edge" => CSSFeature { id : "css.properties.text-box-edge",
 	name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24750,7 +24747,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.properties.text-box-edge.auto" => CSSFeature { id :
 	"css.properties.text-box-edge.auto", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24760,7 +24757,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.properties.text-box-trim" => CSSFeature { id : "css.properties.text-box-trim",
 	name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24770,7 +24767,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.properties.text-box-trim.none" => CSSFeature { id :
 	"css.properties.text-box-trim.none", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24780,7 +24777,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.properties.text-box-trim.trim-both" => CSSFeature { id :
 	"css.properties.text-box-trim.trim-both", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24790,7 +24787,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.properties.text-box-trim.trim-end" => CSSFeature { id :
 	"css.properties.text-box-trim.trim-end", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24800,7 +24797,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.properties.text-box-trim.trim-start" => CSSFeature { id :
 	"css.properties.text-box-trim.trim-start", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24810,7 +24807,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.properties.text-box.normal" => CSSFeature { id :
 	"css.properties.text-box.normal", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24820,7 +24817,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.properties.text-combine-upright" => CSSFeature { id :
 	"css.properties.text-combine-upright", name : "text-combine-upright", description :
 	"The text-combine-upright CSS property displays multiple characters in the space of a single character in vertical text. This is used in East Asian documents to display Latin-based strings such as components of a date or letters of an initialism.",
@@ -24832,7 +24829,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(48u16, 0u16), firefox_android : BrowserVersion(48u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 0.311864f32, }, "css.properties.text-combine-upright.all" =>
+	[], popularity : 0.304581f32, }, "css.properties.text-combine-upright.all" =>
 	CSSFeature { id : "css.properties.text-combine-upright.all", name :
 	"text-combine-upright", description :
 	"The text-combine-upright CSS property displays multiple characters in the space of a single character in vertical text. This is used in East Asian documents to display Latin-based strings such as components of a date or letters of an initialism.",
@@ -24844,7 +24841,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(48u16, 0u16), firefox_android : BrowserVersion(48u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 0.311864f32, }, "css.properties.text-combine-upright.none" =>
+	[], popularity : 0.304581f32, }, "css.properties.text-combine-upright.none" =>
 	CSSFeature { id : "css.properties.text-combine-upright.none", name :
 	"text-combine-upright", description :
 	"The text-combine-upright CSS property displays multiple characters in the space of a single character in vertical text. This is used in East Asian documents to display Latin-based strings such as components of a date or letters of an initialism.",
@@ -24856,7 +24853,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(48u16, 0u16), firefox_android : BrowserVersion(48u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 0.311864f32, }, "css.properties.text-decoration" => CSSFeature { id
+	[], popularity : 0.304581f32, }, "css.properties.text-decoration" => CSSFeature { id
 	: "css.properties.text-decoration", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
 	spec : "https://drafts.csswg.org/css-text-decor-4/#line-decoration", groups : & [],
@@ -24866,7 +24863,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-color" => CSSFeature { id :
 	"css.properties.text-decoration-color", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -24877,7 +24874,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-color.currentColor" => CSSFeature { id :
 	"css.properties.text-decoration-color.currentColor", name : "text-decoration",
 	description :
@@ -24889,7 +24886,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-color.transparent" => CSSFeature { id :
 	"css.properties.text-decoration-color.transparent", name : "text-decoration",
 	description :
@@ -24901,7 +24898,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-line" => CSSFeature { id :
 	"css.properties.text-decoration-line", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -24912,7 +24909,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-line.blink" => CSSFeature { id :
 	"css.properties.text-decoration-line.blink", name : "text-decoration-line: blink",
 	description :
@@ -24947,7 +24944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-line.none" => CSSFeature { id :
 	"css.properties.text-decoration-line.none", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -24958,7 +24955,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-line.overline" => CSSFeature { id :
 	"css.properties.text-decoration-line.overline", name : "text-decoration", description
 	:
@@ -24970,7 +24967,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-line.spelling-error" => CSSFeature { id :
 	"css.properties.text-decoration-line.spelling-error", name :
 	"Spelling and grammar text decorations", description :
@@ -24994,7 +24991,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-skip-ink" => CSSFeature { id :
 	"css.properties.text-decoration-skip-ink", name : "text-decoration-skip-ink",
 	description :
@@ -25008,7 +25005,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 8.242192f32, }, "css.properties.text-decoration-skip-ink.all" =>
+	[], popularity : 7.95011f32, }, "css.properties.text-decoration-skip-ink.all" =>
 	CSSFeature { id : "css.properties.text-decoration-skip-ink.all", name :
 	"text-decoration-skip-ink: all", description :
 	"The text-decoration-skip-ink: all CSS declaration forces interruptions in underlines and overlines where the line would cross a glyph. This contrasts with auto, which does not skip for CJK glyphs.",
@@ -25033,7 +25030,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 8.242192f32, }, "css.properties.text-decoration-skip-ink.none" =>
+	[], popularity : 7.95011f32, }, "css.properties.text-decoration-skip-ink.none" =>
 	CSSFeature { id : "css.properties.text-decoration-skip-ink.none", name :
 	"text-decoration-skip-ink", description :
 	"The text-decoration-skip-ink CSS property sets whether underlines and overlines may be interrupted where the line would cross a glyph.",
@@ -25046,7 +25043,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 8.242192f32, }, "css.properties.text-decoration-style" => CSSFeature
+	[], popularity : 7.95011f32, }, "css.properties.text-decoration-style" => CSSFeature
 	{ id : "css.properties.text-decoration-style", name : "text-decoration", description
 	:
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -25057,7 +25054,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-style.wavy" => CSSFeature { id :
 	"css.properties.text-decoration-style.wavy", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -25068,7 +25065,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-thickness" => CSSFeature { id :
 	"css.properties.text-decoration-thickness", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -25079,7 +25076,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-thickness.auto" => CSSFeature { id :
 	"css.properties.text-decoration-thickness.auto", name : "text-decoration",
 	description :
@@ -25091,7 +25088,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-thickness.from-font" => CSSFeature { id :
 	"css.properties.text-decoration-thickness.from-font", name : "text-decoration",
 	description :
@@ -25103,7 +25100,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration-thickness.percentage" => CSSFeature { id :
 	"css.properties.text-decoration-thickness.percentage", name : "text-decoration",
 	description :
@@ -25114,7 +25111,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16),
 	firefox : BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16, 4u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration.currentColor" => CSSFeature { id :
 	"css.properties.text-decoration.currentColor", name : "text-decoration", description
 	:
@@ -25125,7 +25122,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(26u16, 2u16), safari_ios : BrowserVersion(26u16, 2u16), }, caniuse : &
-	["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration.includes_color-and-style" => CSSFeature { id :
 	"css.properties.text-decoration.includes_color-and-style", name : "text-decoration",
 	description :
@@ -25136,7 +25133,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(6u16, 0u16), firefox_android : BrowserVersion(6u16, 0u16),
 	safari : BrowserVersion(26u16, 2u16), safari_ios : BrowserVersion(26u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration.includes_thickness" => CSSFeature { id :
 	"css.properties.text-decoration.includes_thickness", name : "text-decoration",
 	description :
@@ -25147,7 +25144,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(26u16, 2u16), safari_ios : BrowserVersion(26u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-decoration.transparent" => CSSFeature { id :
 	"css.properties.text-decoration.transparent", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -25157,7 +25154,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(26u16, 2u16), safari_ios : BrowserVersion(26u16, 2u16), }, caniuse : &
-	["https://caniuse.com/text-decoration"], popularity : 83.45231f32, },
+	["https://caniuse.com/text-decoration"], popularity : 82.93222f32, },
 	"css.properties.text-emphasis" => CSSFeature { id : "css.properties.text-emphasis",
 	name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25169,7 +25166,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-color" => CSSFeature { id :
 	"css.properties.text-emphasis-color", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25181,7 +25178,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-color.currentColor" => CSSFeature { id :
 	"css.properties.text-emphasis-color.currentColor", name : "text-emphasis",
 	description :
@@ -25194,7 +25191,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-color.transparent" => CSSFeature { id :
 	"css.properties.text-emphasis-color.transparent", name : "text-emphasis", description
 	:
@@ -25207,7 +25204,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-position" => CSSFeature { id :
 	"css.properties.text-emphasis-position", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25219,7 +25216,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-position.auto" => CSSFeature { id :
 	"css.properties.text-emphasis-position.auto", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25229,7 +25226,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), firefox : BrowserVersion(132u16, 0u16), firefox_android :
 	BrowserVersion(132u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/text-emphasis"],
-	popularity : 0.26526f32, }, "css.properties.text-emphasis-position.left" =>
+	popularity : 0.195772f32, }, "css.properties.text-emphasis-position.left" =>
 	CSSFeature { id : "css.properties.text-emphasis-position.left", name :
 	"text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25241,7 +25238,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-position.over" => CSSFeature { id :
 	"css.properties.text-emphasis-position.over", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25253,7 +25250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(108u16, 0u16), firefox_android : BrowserVersion(108u16, 0u16), safari
 	: BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-position.right" => CSSFeature { id :
 	"css.properties.text-emphasis-position.right", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25265,7 +25262,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-position.under" => CSSFeature { id :
 	"css.properties.text-emphasis-position.under", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25277,7 +25274,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(108u16, 0u16), firefox_android : BrowserVersion(108u16, 0u16), safari
 	: BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-style" => CSSFeature { id :
 	"css.properties.text-emphasis-style", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25289,7 +25286,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-style.circle" => CSSFeature { id :
 	"css.properties.text-emphasis-style.circle", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25301,7 +25298,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-style.dot" => CSSFeature { id :
 	"css.properties.text-emphasis-style.dot", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25313,7 +25310,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-style.double-circle" => CSSFeature { id :
 	"css.properties.text-emphasis-style.double-circle", name : "text-emphasis",
 	description :
@@ -25326,7 +25323,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-style.filled" => CSSFeature { id :
 	"css.properties.text-emphasis-style.filled", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25338,7 +25335,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-style.none" => CSSFeature { id :
 	"css.properties.text-emphasis-style.none", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25350,7 +25347,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-style.sesame" => CSSFeature { id :
 	"css.properties.text-emphasis-style.sesame", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25362,7 +25359,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis-style.triangle" => CSSFeature { id :
 	"css.properties.text-emphasis-style.triangle", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25374,7 +25371,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis.currentColor" => CSSFeature { id :
 	"css.properties.text-emphasis.currentColor", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25386,7 +25383,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-emphasis.transparent" => CSSFeature { id :
 	"css.properties.text-emphasis.transparent", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25398,7 +25395,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.26526f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.195772f32, },
 	"css.properties.text-indent" => CSSFeature { id : "css.properties.text-indent", name
 	: "text-indent", description :
 	"The text-indent CSS property sets the size of the empty space (indentation) at the beginning of lines in a text.",
@@ -25409,7 +25406,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-text-indent"], popularity : 35.198914f32, },
+	caniuse : & ["https://caniuse.com/css-text-indent"], popularity : 34.737267f32, },
 	"css.properties.text-indent.each-line" => CSSFeature { id :
 	"css.properties.text-indent.each-line", name : "text-indent: each-line", description
 	:
@@ -25439,7 +25436,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.018095f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.062508f32, },
 	"css.properties.text-justify.auto" => CSSFeature { id :
 	"css.properties.text-justify.auto", name : "text-justify", description :
 	"The text-justify CSS property sets the justification method of text when text-align: justify is set.",
@@ -25449,7 +25446,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.018095f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.062508f32, },
 	"css.properties.text-justify.inter-character" => CSSFeature { id :
 	"css.properties.text-justify.inter-character", name : "text-justify", description :
 	"The text-justify CSS property sets the justification method of text when text-align: justify is set.",
@@ -25459,7 +25456,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.018095f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.062508f32, },
 	"css.properties.text-justify.inter-word" => CSSFeature { id :
 	"css.properties.text-justify.inter-word", name : "text-justify", description :
 	"The text-justify CSS property sets the justification method of text when text-align: justify is set.",
@@ -25469,7 +25466,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.018095f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.062508f32, },
 	"css.properties.text-justify.none" => CSSFeature { id :
 	"css.properties.text-justify.none", name : "text-justify", description :
 	"The text-justify CSS property sets the justification method of text when text-align: justify is set.",
@@ -25479,7 +25476,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.018095f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.062508f32, },
 	"css.properties.text-orientation" => CSSFeature { id :
 	"css.properties.text-orientation", name : "text-orientation", description :
 	"The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.",
@@ -25491,7 +25488,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(41u16, 0u16), firefox_android : BrowserVersion(41u16, 0u16), safari :
 	BrowserVersion(14u16, 0u16), safari_ios : BrowserVersion(14u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-orientation"], popularity : 1.317427f32, },
+	["https://caniuse.com/css-text-orientation"], popularity : 1.462123f32, },
 	"css.properties.text-orientation.mixed" => CSSFeature { id :
 	"css.properties.text-orientation.mixed", name : "text-orientation", description :
 	"The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.",
@@ -25503,7 +25500,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(41u16, 0u16), firefox_android : BrowserVersion(41u16, 0u16), safari :
 	BrowserVersion(14u16, 0u16), safari_ios : BrowserVersion(14u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-orientation"], popularity : 1.317427f32, },
+	["https://caniuse.com/css-text-orientation"], popularity : 1.462123f32, },
 	"css.properties.text-orientation.sideways" => CSSFeature { id :
 	"css.properties.text-orientation.sideways", name : "text-orientation", description :
 	"The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.",
@@ -25515,7 +25512,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(14u16, 0u16), safari_ios : BrowserVersion(14u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-orientation"], popularity : 1.317427f32, },
+	["https://caniuse.com/css-text-orientation"], popularity : 1.462123f32, },
 	"css.properties.text-orientation.upright" => CSSFeature { id :
 	"css.properties.text-orientation.upright", name : "text-orientation", description :
 	"The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.",
@@ -25527,7 +25524,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(41u16, 0u16), firefox_android : BrowserVersion(41u16, 0u16), safari :
 	BrowserVersion(14u16, 0u16), safari_ios : BrowserVersion(14u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-orientation"], popularity : 1.317427f32, },
+	["https://caniuse.com/css-text-orientation"], popularity : 1.462123f32, },
 	"css.properties.text-overflow" => CSSFeature { id : "css.properties.text-overflow",
 	name : "Text overflow", description :
 	"The text-overflow CSS property sets how hidden overflow content appears to users. The property can clip content, truncate content with an ellipsis (…), or truncate with a custom string.",
@@ -25538,7 +25535,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(7u16, 0u16), firefox_android : BrowserVersion(7u16, 0u16),
 	safari : BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 66.40645f32, },
+	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 66.022156f32, },
 	"css.properties.text-overflow.clip" => CSSFeature { id :
 	"css.properties.text-overflow.clip", name : "Text overflow", description :
 	"The text-overflow CSS property sets how hidden overflow content appears to users. The property can clip content, truncate content with an ellipsis (…), or truncate with a custom string.",
@@ -25549,7 +25546,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(7u16, 0u16), firefox_android : BrowserVersion(7u16, 0u16),
 	safari : BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 66.40645f32, },
+	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 66.022156f32, },
 	"css.properties.text-overflow.ellipsis" => CSSFeature { id :
 	"css.properties.text-overflow.ellipsis", name : "Text overflow", description :
 	"The text-overflow CSS property sets how hidden overflow content appears to users. The property can clip content, truncate content with an ellipsis (…), or truncate with a custom string.",
@@ -25560,7 +25557,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(7u16, 0u16), firefox_android : BrowserVersion(7u16, 0u16),
 	safari : BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 66.40645f32, },
+	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 66.022156f32, },
 	"css.properties.text-overflow.string" => CSSFeature { id :
 	"css.properties.text-overflow.string", name : "Custom ellipses", description :
 	"The text-overflow CSS property with a string value sets the string representing clipped text.",
@@ -25578,7 +25575,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/text-overflow"], popularity : 66.40645f32, },
+	& ["https://caniuse.com/text-overflow"], popularity : 66.022156f32, },
 	"css.properties.text-rendering" => CSSFeature { id : "css.properties.text-rendering",
 	name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -25625,7 +25622,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 1u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-textshadow"], popularity : 43.92993f32, },
+	["https://caniuse.com/css-textshadow"], popularity : 45.011143f32, },
 	"css.properties.text-size-adjust" => CSSFeature { id :
 	"css.properties.text-size-adjust", name : "text-size-adjust", description :
 	"The text-size-adjust CSS property disables or modifies the browser's default text size adjustment for small screen sizes.",
@@ -25635,7 +25632,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/text-size-adjust"], popularity :
-	21.501371f32, }, "css.properties.text-size-adjust.auto" => CSSFeature { id :
+	22.642761f32, }, "css.properties.text-size-adjust.auto" => CSSFeature { id :
 	"css.properties.text-size-adjust.auto", name : "text-size-adjust", description :
 	"The text-size-adjust CSS property disables or modifies the browser's default text size adjustment for small screen sizes.",
 	spec : "https://drafts.csswg.org/css-size-adjust-1/#adjustment-control", groups : &
@@ -25644,7 +25641,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/text-size-adjust"], popularity :
-	21.501371f32, }, "css.properties.text-size-adjust.none" => CSSFeature { id :
+	22.642761f32, }, "css.properties.text-size-adjust.none" => CSSFeature { id :
 	"css.properties.text-size-adjust.none", name : "text-size-adjust", description :
 	"The text-size-adjust CSS property disables or modifies the browser's default text size adjustment for small screen sizes.",
 	spec : "https://drafts.csswg.org/css-size-adjust-1/#adjustment-control", groups : &
@@ -25653,7 +25650,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/text-size-adjust"], popularity :
-	21.501371f32, }, "css.properties.text-size-adjust.percentages" => CSSFeature { id :
+	22.642761f32, }, "css.properties.text-size-adjust.percentages" => CSSFeature { id :
 	"css.properties.text-size-adjust.percentages", name : "text-size-adjust", description
 	:
 	"The text-size-adjust CSS property disables or modifies the browser's default text size adjustment for small screen sizes.",
@@ -25663,7 +25660,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/text-size-adjust"], popularity :
-	21.501371f32, }, "css.properties.text-spacing-trim" => CSSFeature { id :
+	22.642761f32, }, "css.properties.text-spacing-trim" => CSSFeature { id :
 	"css.properties.text-spacing-trim", name : "text-spacing-trim", description :
 	"The text-spacing-trim CSS property controls spacing around CJK characters, avoiding excessive whitespace when using full-width punctuation characters.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-spacing-trim-property", groups : &
@@ -25671,7 +25668,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.967533f32, },
+	0), }, caniuse : & [], popularity : 0.600349f32, },
 	"css.properties.text-spacing-trim.normal" => CSSFeature { id :
 	"css.properties.text-spacing-trim.normal", name : "text-spacing-trim", description :
 	"The text-spacing-trim CSS property controls spacing around CJK characters, avoiding excessive whitespace when using full-width punctuation characters.",
@@ -25680,7 +25677,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.967533f32, },
+	0), }, caniuse : & [], popularity : 0.600349f32, },
 	"css.properties.text-spacing-trim.space-all" => CSSFeature { id :
 	"css.properties.text-spacing-trim.space-all", name : "text-spacing-trim", description
 	:
@@ -25690,7 +25687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.967533f32, },
+	0), }, caniuse : & [], popularity : 0.600349f32, },
 	"css.properties.text-spacing-trim.space-first" => CSSFeature { id :
 	"css.properties.text-spacing-trim.space-first", name : "text-spacing-trim",
 	description :
@@ -25700,7 +25697,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.967533f32, },
+	0), }, caniuse : & [], popularity : 0.600349f32, },
 	"css.properties.text-spacing-trim.trim-start" => CSSFeature { id :
 	"css.properties.text-spacing-trim.trim-start", name : "text-spacing-trim",
 	description :
@@ -25710,7 +25707,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.967533f32, }, "css.properties.text-transform"
+	0), }, caniuse : & [], popularity : 0.600349f32, }, "css.properties.text-transform"
 	=> CSSFeature { id : "css.properties.text-transform", name : "text-transform",
 	description : "The text-transform CSS property sets text case and capitalization.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-transform-property", groups : &
@@ -25721,7 +25718,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 73.413345f32, }, "css.properties.text-transform.capitalize" =>
+	[], popularity : 72.68154f32, }, "css.properties.text-transform.capitalize" =>
 	CSSFeature { id : "css.properties.text-transform.capitalize", name :
 	"text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
@@ -25732,7 +25729,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 73.413345f32, },
+	caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.dutch_ij_digraph" => CSSFeature { id :
 	"css.properties.text-transform.dutch_ij_digraph", name : "text-transform",
 	description : "The text-transform CSS property sets text case and capitalization.",
@@ -25741,7 +25738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(14u16, 0u16), firefox_android :
 	BrowserVersion(14u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 73.413345f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.full-size-kana" => CSSFeature { id :
 	"css.properties.text-transform.full-size-kana", name : "text-transform", description
 	: "The text-transform CSS property sets text case and capitalization.", spec :
@@ -25750,7 +25747,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(64u16, 0u16), firefox_android : BrowserVersion(64u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & [], popularity : 73.413345f32, },
+	0u16), }, caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.full-width" => CSSFeature { id :
 	"css.properties.text-transform.full-width", name : "text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
@@ -25759,7 +25756,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(19u16, 0u16), firefox_android : BrowserVersion(19u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & [], popularity : 73.413345f32, },
+	0u16), }, caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.greek_accented_characters" => CSSFeature { id :
 	"css.properties.text-transform.greek_accented_characters", name : "text-transform",
 	description : "The text-transform CSS property sets text case and capitalization.",
@@ -25768,7 +25765,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(34u16, 0u16), chrome_android : BrowserVersion(34u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(15u16, 0u16),
 	firefox_android : BrowserVersion(15u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 73.413345f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.lowercase" => CSSFeature { id :
 	"css.properties.text-transform.lowercase", name : "text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
@@ -25779,7 +25776,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 73.413345f32, },
+	caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.lowercase_sigma" => CSSFeature { id :
 	"css.properties.text-transform.lowercase_sigma", name : "text-transform", description
 	: "The text-transform CSS property sets text case and capitalization.", spec :
@@ -25790,7 +25787,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(30u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(14u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & [], popularity : 73.413345f32, },
+	caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.math-auto" => CSSFeature { id :
 	"css.properties.text-transform.math-auto", name : "MathML", description :
 	"MathML, or the Mathematical Markup Language, describes mathematical notation, such as expressions and formulas. Also known as MathML Core.",
@@ -25810,7 +25807,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 73.413345f32, },
+	caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.turkic_is" => CSSFeature { id :
 	"css.properties.text-transform.turkic_is", name : "text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
@@ -25821,7 +25818,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(31u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(14u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16),
 	safari : BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), },
-	caniuse : & [], popularity : 73.413345f32, },
+	caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.uppercase" => CSSFeature { id :
 	"css.properties.text-transform.uppercase", name : "text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
@@ -25832,7 +25829,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 73.413345f32, },
+	caniuse : & [], popularity : 72.68154f32, },
 	"css.properties.text-transform.uppercase_eszett" => CSSFeature { id :
 	"css.properties.text-transform.uppercase_eszett", name : "text-transform",
 	description : "The text-transform CSS property sets text case and capitalization.",
@@ -25844,9 +25841,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 73.413345f32, }, "css.properties.text-underline-offset" =>
-	CSSFeature { id : "css.properties.text-underline-offset", name :
-	"text-underline-offset", description :
+	[], popularity : 72.68154f32, }, "css.properties.text-underline-offset" => CSSFeature
+	{ id : "css.properties.text-underline-offset", name : "text-underline-offset",
+	description :
 	"The text-underline-offset CSS property shifts underlines on text from the initial position by a given distance. The initial position is affected by the text-underline-position property.",
 	spec : "https://drafts.csswg.org/css-text-decor-4/#underline-offset", groups : &
 	["text"], baseline_status : BaselineStatus::High { since :
@@ -25856,7 +25853,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 16.515953f32, }, "css.properties.text-underline-offset.auto" =>
+	[], popularity : 16.326185f32, }, "css.properties.text-underline-offset.auto" =>
 	CSSFeature { id : "css.properties.text-underline-offset.auto", name :
 	"text-underline-offset", description :
 	"The text-underline-offset CSS property shifts underlines on text from the initial position by a given distance. The initial position is affected by the text-underline-position property.",
@@ -25868,7 +25865,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 16.515953f32, }, "css.properties.text-underline-offset.percentage"
+	[], popularity : 16.326185f32, }, "css.properties.text-underline-offset.percentage"
 	=> CSSFeature { id : "css.properties.text-underline-offset.percentage", name :
 	"text-underline-offset", description :
 	"The text-underline-offset CSS property shifts underlines on text from the initial position by a given distance. The initial position is affected by the text-underline-position property.",
@@ -25878,7 +25875,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(74u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 16.515953f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 16.326185f32, },
 	"css.properties.text-underline-position" => CSSFeature { id :
 	"css.properties.text-underline-position", name : "text-underline-position",
 	description :
@@ -25891,7 +25888,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 6.95179f32, }, "css.properties.text-underline-position.auto" =>
+	[], popularity : 6.991711f32, }, "css.properties.text-underline-position.auto" =>
 	CSSFeature { id : "css.properties.text-underline-position.auto", name :
 	"text-underline-position", description :
 	"The text-underline-position CSS property sets the position of underlines on text. For example, text-underline-position: under places the underline below the text, avoiding crossing descenders. The underline may be further adjusted by the text-underline-offset property.",
@@ -25903,8 +25900,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 6.95179f32, }, "css.properties.text-underline-position.from-font" =>
-	CSSFeature { id : "css.properties.text-underline-position.from-font", name :
+	[], popularity : 6.991711f32, }, "css.properties.text-underline-position.from-font"
+	=> CSSFeature { id : "css.properties.text-underline-position.from-font", name :
 	"text-underline-position", description :
 	"The text-underline-position CSS property sets the position of underlines on text. For example, text-underline-position: under places the underline below the text, avoiding crossing descenders. The underline may be further adjusted by the text-underline-offset property.",
 	spec : "https://drafts.csswg.org/css-text-decor-4/#text-underline-position-property",
@@ -25915,7 +25912,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16), firefox :
 	BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 6.95179f32, }, "css.properties.text-underline-position.left" =>
+	[], popularity : 6.991711f32, }, "css.properties.text-underline-position.left" =>
 	CSSFeature { id : "css.properties.text-underline-position.left", name :
 	"text-underline-position", description :
 	"The text-underline-position CSS property sets the position of underlines on text. For example, text-underline-position: under places the underline below the text, avoiding crossing descenders. The underline may be further adjusted by the text-underline-offset property.",
@@ -25926,7 +25923,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(71u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 6.95179f32, },
+	caniuse : & [], popularity : 6.991711f32, },
 	"css.properties.text-underline-position.right" => CSSFeature { id :
 	"css.properties.text-underline-position.right", name : "text-underline-position",
 	description :
@@ -25938,7 +25935,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(71u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 6.95179f32, },
+	caniuse : & [], popularity : 6.991711f32, },
 	"css.properties.text-underline-position.under" => CSSFeature { id :
 	"css.properties.text-underline-position.under", name : "text-underline-position",
 	description :
@@ -25951,7 +25948,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 6.95179f32, }, "css.properties.text-wrap" => CSSFeature { id :
+	[], popularity : 6.991711f32, }, "css.properties.text-wrap" => CSSFeature { id :
 	"css.properties.text-wrap", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-wrap-shorthand", groups : &
@@ -25960,7 +25957,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(114u16, 0u16), chrome_android : BrowserVersion(114u16, 0u16), edge :
 	BrowserVersion(114u16, 0u16), firefox : BrowserVersion(121u16, 0u16), firefox_android
 	: BrowserVersion(121u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.text-wrap-mode" => CSSFeature { id : "css.properties.text-wrap-mode",
 	name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -25970,7 +25967,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.text-wrap-mode.nowrap" => CSSFeature { id :
 	"css.properties.text-wrap-mode.nowrap", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -25980,7 +25977,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.text-wrap-mode.wrap" => CSSFeature { id :
 	"css.properties.text-wrap-mode.wrap", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -25990,7 +25987,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.text-wrap-style" => CSSFeature { id :
 	"css.properties.text-wrap-style", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -26000,7 +25997,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 5u16), safari_ios :
-	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.text-wrap-style.auto" => CSSFeature { id :
 	"css.properties.text-wrap-style.auto", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -26010,7 +26007,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 5u16), safari_ios :
-	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.text-wrap-style.balance" => CSSFeature { id :
 	"css.properties.text-wrap-style.balance", name : "text-wrap: balance", description :
 	"The text-wrap: balance CSS declaration balances the length of each line when text is broken into multiple lines. Also known as headline balancing.",
@@ -26040,7 +26037,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 5u16), safari_ios :
-	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.text-wrap.balance" => CSSFeature { id :
 	"css.properties.text-wrap.balance", name : "text-wrap: balance", description :
 	"The text-wrap: balance CSS declaration balances the length of each line when text is broken into multiple lines. Also known as headline balancing.",
@@ -26061,7 +26058,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(114u16, 0u16), chrome_android : BrowserVersion(114u16, 0u16), edge :
 	BrowserVersion(114u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.text-wrap.pretty" => CSSFeature { id :
 	"css.properties.text-wrap.pretty", name : "text-wrap: pretty", description :
 	"The text-wrap: pretty CSS declaration prioritizes better layout over speed when text is broken into multiple lines.",
@@ -26080,7 +26077,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(121u16, 0u16), firefox_android
 	: BrowserVersion(121u16, 0u16), safari : BrowserVersion(17u16, 5u16), safari_ios :
-	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.text-wrap.wrap" => CSSFeature { id : "css.properties.text-wrap.wrap",
 	name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -26090,7 +26087,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(114u16, 0u16), chrome_android : BrowserVersion(114u16, 0u16), edge :
 	BrowserVersion(114u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 23.32548f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.104368f32, },
 	"css.properties.timeline-scope" => CSSFeature { id : "css.properties.timeline-scope",
 	name : "Scroll-driven animations", description :
 	"The animation-timeline, scroll-timeline, and view-timeline CSS properties advance animations based on the user's scroll position.",
@@ -26170,7 +26167,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.334755f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.313953f32, },
 	"css.properties.touch-action.manipulation" => CSSFeature { id :
 	"css.properties.touch-action.manipulation", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26182,7 +26179,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.334755f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.313953f32, },
 	"css.properties.touch-action.none" => CSSFeature { id :
 	"css.properties.touch-action.none", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26194,7 +26191,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.334755f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.313953f32, },
 	"css.properties.touch-action.pan-down" => CSSFeature { id :
 	"css.properties.touch-action.pan-down", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26204,7 +26201,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-touch-action"], popularity :
-	43.334755f32, }, "css.properties.touch-action.pan-left" => CSSFeature { id :
+	44.313953f32, }, "css.properties.touch-action.pan-left" => CSSFeature { id :
 	"css.properties.touch-action.pan-left", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
 	spec : "https://w3c.github.io/pointerevents/#the-touch-action-css-property", groups :
@@ -26213,7 +26210,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-touch-action"], popularity :
-	43.334755f32, }, "css.properties.touch-action.pan-right" => CSSFeature { id :
+	44.313953f32, }, "css.properties.touch-action.pan-right" => CSSFeature { id :
 	"css.properties.touch-action.pan-right", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
 	spec : "https://w3c.github.io/pointerevents/#the-touch-action-css-property", groups :
@@ -26222,7 +26219,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-touch-action"], popularity :
-	43.334755f32, }, "css.properties.touch-action.pan-up" => CSSFeature { id :
+	44.313953f32, }, "css.properties.touch-action.pan-up" => CSSFeature { id :
 	"css.properties.touch-action.pan-up", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
 	spec : "https://w3c.github.io/pointerevents/#the-touch-action-css-property", groups :
@@ -26231,7 +26228,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-touch-action"], popularity :
-	43.334755f32, }, "css.properties.touch-action.pan-x" => CSSFeature { id :
+	44.313953f32, }, "css.properties.touch-action.pan-x" => CSSFeature { id :
 	"css.properties.touch-action.pan-x", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
 	spec : "https://w3c.github.io/pointerevents/#the-touch-action-css-property", groups :
@@ -26242,7 +26239,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.334755f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.313953f32, },
 	"css.properties.touch-action.pan-y" => CSSFeature { id :
 	"css.properties.touch-action.pan-y", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26254,7 +26251,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.334755f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.313953f32, },
 	"css.properties.touch-action.pinch-zoom" => CSSFeature { id :
 	"css.properties.touch-action.pinch-zoom", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26266,7 +26263,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(85u16, 0u16), firefox_android : BrowserVersion(85u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.334755f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.313953f32, },
 	"css.properties.transform" => CSSFeature { id : "css.properties.transform", name :
 	"2D transforms", description :
 	"The transform CSS property and its 2D transform functions allow rotating, scaling, skewing, and translating an element. Arbitrary 2D transforms are also possible using a transformation matrix.",
@@ -26288,7 +26285,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(55u16, 0u16), firefox_android : BrowserVersion(55u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & [], popularity : 5.237149f32, },
+	caniuse : & [], popularity : 4.816831f32, },
 	"css.properties.transform-box.border-box" => CSSFeature { id :
 	"css.properties.transform-box.border-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26299,7 +26296,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(118u16, 0u16), edge : BrowserVersion(118u16,
 	0u16), firefox : BrowserVersion(55u16, 0u16), firefox_android : BrowserVersion(55u16,
 	0u16), safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16,
-	0u16), }, caniuse : & [], popularity : 5.237149f32, },
+	0u16), }, caniuse : & [], popularity : 4.816831f32, },
 	"css.properties.transform-box.content-box" => CSSFeature { id :
 	"css.properties.transform-box.content-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26309,7 +26306,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(118u16, 0u16), edge : BrowserVersion(118u16, 0u16),
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16,
-	4u16), }, caniuse : & [], popularity : 5.237149f32, },
+	4u16), }, caniuse : & [], popularity : 4.816831f32, },
 	"css.properties.transform-box.fill-box" => CSSFeature { id :
 	"css.properties.transform-box.fill-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26320,7 +26317,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(55u16, 0u16), firefox_android : BrowserVersion(55u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & [], popularity : 5.237149f32, },
+	caniuse : & [], popularity : 4.816831f32, },
 	"css.properties.transform-box.stroke-box" => CSSFeature { id :
 	"css.properties.transform-box.stroke-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26330,7 +26327,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(118u16, 0u16), edge : BrowserVersion(118u16, 0u16),
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16,
-	4u16), }, caniuse : & [], popularity : 5.237149f32, },
+	4u16), }, caniuse : & [], popularity : 4.816831f32, },
 	"css.properties.transform-box.view-box" => CSSFeature { id :
 	"css.properties.transform-box.view-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26341,7 +26338,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(55u16, 0u16), firefox_android : BrowserVersion(55u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & [], popularity : 5.237149f32, }, "css.properties.transform-origin" =>
+	caniuse : & [], popularity : 4.816831f32, }, "css.properties.transform-origin" =>
 	CSSFeature { id : "css.properties.transform-origin", name : "2D transforms",
 	description :
 	"The transform CSS property and its 2D transform functions allow rotating, scaling, skewing, and translating an element. Arbitrary 2D transforms are also possible using a transformation matrix.",
@@ -26486,7 +26483,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16),
 	firefox : BrowserVersion(129u16, 0u16), firefox_android : BrowserVersion(129u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 2.039579f32, },
+	4u16), }, caniuse : & [], popularity : 2.111392f32, },
 	"css.properties.transition-behavior.transitionable_content-visibility" => CSSFeature
 	{ id : "css.properties.transition-behavior.transitionable_content-visibility", name :
 	"display animation", description :
@@ -26802,7 +26799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16),
 	firefox : BrowserVersion(129u16, 0u16), firefox_android : BrowserVersion(129u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 2.039579f32, }, "css.properties.translate" =>
+	4u16), }, caniuse : & [], popularity : 2.111392f32, }, "css.properties.translate" =>
 	CSSFeature { id : "css.properties.translate", name :
 	"Individual transform properties", description :
 	"The translate, rotate, and scale CSS properties apply single transformations independently, as opposed to applying multiple transformations with the transform CSS property.",
@@ -26911,7 +26908,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 68.5753f32, }, "css.properties.user-select.all" => CSSFeature { id :
+	popularity : 67.60799f32, }, "css.properties.user-select.all" => CSSFeature { id :
 	"css.properties.user-select.all", name : "user-select", description :
 	"The user-select CSS property controls which elements can be selected by the user.",
 	spec : "https://drafts.csswg.org/css-ui-4/#content-selection", groups : & [],
@@ -26920,7 +26917,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 68.5753f32, }, "css.properties.user-select.auto" => CSSFeature { id :
+	popularity : 67.60799f32, }, "css.properties.user-select.auto" => CSSFeature { id :
 	"css.properties.user-select.auto", name : "user-select", description :
 	"The user-select CSS property controls which elements can be selected by the user.",
 	spec : "https://drafts.csswg.org/css-ui-4/#content-selection", groups : & [],
@@ -26929,7 +26926,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 68.5753f32, }, "css.properties.user-select.none" => CSSFeature { id :
+	popularity : 67.60799f32, }, "css.properties.user-select.none" => CSSFeature { id :
 	"css.properties.user-select.none", name : "user-select", description :
 	"The user-select CSS property controls which elements can be selected by the user.",
 	spec : "https://drafts.csswg.org/css-ui-4/#content-selection", groups : & [],
@@ -26938,7 +26935,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 68.5753f32, }, "css.properties.user-select.text" => CSSFeature { id :
+	popularity : 67.60799f32, }, "css.properties.user-select.text" => CSSFeature { id :
 	"css.properties.user-select.text", name : "user-select", description :
 	"The user-select CSS property controls which elements can be selected by the user.",
 	spec : "https://drafts.csswg.org/css-ui-4/#content-selection", groups : & [],
@@ -26947,7 +26944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 68.5753f32, }, "css.properties.vector-effect" => CSSFeature { id :
+	popularity : 67.60799f32, }, "css.properties.vector-effect" => CSSFeature { id :
 	"css.properties.vector-effect", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -26969,7 +26966,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.89733f32, }, "css.properties.vertical-align.baseline"
+	caniuse : & [], popularity : 81.21269f32, }, "css.properties.vertical-align.baseline"
 	=> CSSFeature { id : "css.properties.vertical-align.baseline", name :
 	"vertical-align", description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -26980,7 +26977,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.89733f32, }, "css.properties.vertical-align.bottom"
+	caniuse : & [], popularity : 81.21269f32, }, "css.properties.vertical-align.bottom"
 	=> CSSFeature { id : "css.properties.vertical-align.bottom", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -26991,7 +26988,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.89733f32, }, "css.properties.vertical-align.middle"
+	caniuse : & [], popularity : 81.21269f32, }, "css.properties.vertical-align.middle"
 	=> CSSFeature { id : "css.properties.vertical-align.middle", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -27002,7 +26999,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.89733f32, }, "css.properties.vertical-align.sub" =>
+	caniuse : & [], popularity : 81.21269f32, }, "css.properties.vertical-align.sub" =>
 	CSSFeature { id : "css.properties.vertical-align.sub", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -27013,7 +27010,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.89733f32, }, "css.properties.vertical-align.super" =>
+	caniuse : & [], popularity : 81.21269f32, }, "css.properties.vertical-align.super" =>
 	CSSFeature { id : "css.properties.vertical-align.super", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -27024,7 +27021,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.89733f32, },
+	caniuse : & [], popularity : 81.21269f32, },
 	"css.properties.vertical-align.text-bottom" => CSSFeature { id :
 	"css.properties.vertical-align.text-bottom", name : "vertical-align", description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -27035,7 +27032,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.89733f32, }, "css.properties.vertical-align.text-top"
+	caniuse : & [], popularity : 81.21269f32, }, "css.properties.vertical-align.text-top"
 	=> CSSFeature { id : "css.properties.vertical-align.text-top", name :
 	"vertical-align", description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -27046,7 +27043,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.89733f32, }, "css.properties.vertical-align.top" =>
+	caniuse : & [], popularity : 81.21269f32, }, "css.properties.vertical-align.top" =>
 	CSSFeature { id : "css.properties.vertical-align.top", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -27057,7 +27054,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.89733f32, }, "css.properties.view-timeline" =>
+	caniuse : & [], popularity : 81.21269f32, }, "css.properties.view-timeline" =>
 	CSSFeature { id : "css.properties.view-timeline", name : "Scroll-driven animations",
 	description :
 	"The animation-timeline, scroll-timeline, and view-timeline CSS properties advance animations based on the user's scroll position.",
@@ -27156,7 +27153,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(125u16, 0u16), edge : BrowserVersion(125u16, 0u16),
 	firefox : BrowserVersion(144u16, 0u16), firefox_android : BrowserVersion(144u16,
 	0u16), safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16,
-	2u16), }, caniuse : & [], popularity : 0.177219f32, },
+	2u16), }, caniuse : & [], popularity : 0.161941f32, },
 	"css.properties.view-transition-class.none" => CSSFeature { id :
 	"css.properties.view-transition-class.none", name : "view-transition-class",
 	description :
@@ -27169,7 +27166,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(125u16, 0u16), edge : BrowserVersion(125u16, 0u16),
 	firefox : BrowserVersion(144u16, 0u16), firefox_android : BrowserVersion(144u16,
 	0u16), safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16,
-	2u16), }, caniuse : & [], popularity : 0.177219f32, },
+	2u16), }, caniuse : & [], popularity : 0.161941f32, },
 	"css.properties.view-transition-name" => CSSFeature { id :
 	"css.properties.view-transition-name", name : "View transitions", description :
 	"View transitions allow you to create animated visual transitions between different states of a document.",
@@ -27244,7 +27241,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.28963f32, }, "css.properties.visibility.collapse" =>
+	caniuse : & [], popularity : 78.671265f32, }, "css.properties.visibility.collapse" =>
 	CSSFeature { id : "css.properties.visibility.collapse", name : "visibility",
 	description :
 	"The visibility CSS property sets whether an element is shown. Invisible elements still affect the document layout.",
@@ -27255,7 +27252,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.28963f32, }, "css.properties.visibility.hidden" =>
+	caniuse : & [], popularity : 78.671265f32, }, "css.properties.visibility.hidden" =>
 	CSSFeature { id : "css.properties.visibility.hidden", name : "visibility",
 	description :
 	"The visibility CSS property sets whether an element is shown. Invisible elements still affect the document layout.",
@@ -27266,7 +27263,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.28963f32, }, "css.properties.visibility.visible" =>
+	caniuse : & [], popularity : 78.671265f32, }, "css.properties.visibility.visible" =>
 	CSSFeature { id : "css.properties.visibility.visible", name : "visibility",
 	description :
 	"The visibility CSS property sets whether an element is shown. Invisible elements still affect the document layout.",
@@ -27277,7 +27274,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.28963f32, }, "css.properties.white-space" =>
+	caniuse : & [], popularity : 78.671265f32, }, "css.properties.white-space" =>
 	CSSFeature { id : "css.properties.white-space", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27288,7 +27285,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 81.439156f32, }, "css.properties.white-space-collapse" => CSSFeature
+	[], popularity : 80.64355f32, }, "css.properties.white-space-collapse" => CSSFeature
 	{ id : "css.properties.white-space-collapse", name : "white-space-collapse",
 	description :
 	"The white-space-collapse CSS property sets whether new line characters are shown as line breaks, and whether multiple consecutive spaces are all displayed or combined.",
@@ -27299,7 +27296,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.978236f32, },
+	4u16), }, caniuse : & [], popularity : 0.873256f32, },
 	"css.properties.white-space-collapse.break-spaces" => CSSFeature { id :
 	"css.properties.white-space-collapse.break-spaces", name : "white-space-collapse",
 	description :
@@ -27311,7 +27308,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.978236f32, },
+	4u16), }, caniuse : & [], popularity : 0.873256f32, },
 	"css.properties.white-space-collapse.collapse" => CSSFeature { id :
 	"css.properties.white-space-collapse.collapse", name : "white-space-collapse",
 	description :
@@ -27323,7 +27320,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.978236f32, },
+	4u16), }, caniuse : & [], popularity : 0.873256f32, },
 	"css.properties.white-space-collapse.preserve" => CSSFeature { id :
 	"css.properties.white-space-collapse.preserve", name : "white-space-collapse",
 	description :
@@ -27335,7 +27332,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.978236f32, },
+	4u16), }, caniuse : & [], popularity : 0.873256f32, },
 	"css.properties.white-space-collapse.preserve-breaks" => CSSFeature { id :
 	"css.properties.white-space-collapse.preserve-breaks", name : "white-space-collapse",
 	description :
@@ -27347,7 +27344,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.978236f32, },
+	4u16), }, caniuse : & [], popularity : 0.873256f32, },
 	"css.properties.white-space-collapse.preserve-spaces" => CSSFeature { id :
 	"css.properties.white-space-collapse.preserve-spaces", name : "white-space-collapse",
 	description :
@@ -27357,7 +27354,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(124u16, 0u16),
 	firefox_android : BrowserVersion(124u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.978236f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.873256f32, },
 	"css.properties.white-space.break-spaces" => CSSFeature { id :
 	"css.properties.white-space.break-spaces", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
@@ -27369,7 +27366,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(76u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
-	[], popularity : 81.439156f32, }, "css.properties.white-space.normal" => CSSFeature {
+	[], popularity : 80.64355f32, }, "css.properties.white-space.normal" => CSSFeature {
 	id : "css.properties.white-space.normal", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27380,7 +27377,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 81.439156f32, }, "css.properties.white-space.nowrap" => CSSFeature {
+	[], popularity : 80.64355f32, }, "css.properties.white-space.nowrap" => CSSFeature {
 	id : "css.properties.white-space.nowrap", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27391,7 +27388,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 81.439156f32, }, "css.properties.white-space.pre" => CSSFeature { id
+	[], popularity : 80.64355f32, }, "css.properties.white-space.pre" => CSSFeature { id
 	: "css.properties.white-space.pre", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27402,7 +27399,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 81.439156f32, }, "css.properties.white-space.pre-line" => CSSFeature
+	[], popularity : 80.64355f32, }, "css.properties.white-space.pre-line" => CSSFeature
 	{ id : "css.properties.white-space.pre-line", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27413,7 +27410,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 81.439156f32, }, "css.properties.white-space.pre-wrap" => CSSFeature
+	[], popularity : 80.64355f32, }, "css.properties.white-space.pre-wrap" => CSSFeature
 	{ id : "css.properties.white-space.pre-wrap", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27424,7 +27421,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 81.439156f32, }, "css.properties.white-space.shorthand_values" =>
+	[], popularity : 80.64355f32, }, "css.properties.white-space.shorthand_values" =>
 	CSSFeature { id : "css.properties.white-space.shorthand_values", name :
 	"white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
@@ -27433,7 +27430,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 81.439156f32, },
+	0), }, caniuse : & [], popularity : 80.64355f32, },
 	"css.properties.white-space.svg_elements" => CSSFeature { id :
 	"css.properties.white-space.svg_elements", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
@@ -27442,7 +27439,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(36u16, 0u16),
 	firefox_android : BrowserVersion(36u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 81.439156f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 80.64355f32, },
 	"css.properties.white-space.textarea_support" => CSSFeature { id :
 	"css.properties.white-space.textarea_support", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
@@ -27454,7 +27451,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 81.439156f32, }, "css.properties.widows" => CSSFeature { id :
+	[], popularity : 80.64355f32, }, "css.properties.widows" => CSSFeature { id :
 	"css.properties.widows", name : "Widows and orphans", description :
 	"The widows and orphans CSS properties set the minimum lines included in a text fragment created by page, column, or region breaks.",
 	spec : "https://drafts.csswg.org/css-break-4/#widows-orphans", groups : & ["layout"],
@@ -27571,7 +27568,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(36u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/will-change"], popularity : 40.26268f32, },
+	caniuse : & ["https://caniuse.com/will-change"], popularity : 40.2851f32, },
 	"css.properties.will-change.auto" => CSSFeature { id :
 	"css.properties.will-change.auto", name : "will-change", description :
 	"The will-change CSS property gives hints to the browser about expected changes to an element's scroll position, contents, or style. These hints allow browsers to optimize for upcoming style changes.",
@@ -27582,7 +27579,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(36u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/will-change"], popularity : 40.26268f32, },
+	caniuse : & ["https://caniuse.com/will-change"], popularity : 40.2851f32, },
 	"css.properties.will-change.contents" => CSSFeature { id :
 	"css.properties.will-change.contents", name : "will-change", description :
 	"The will-change CSS property gives hints to the browser about expected changes to an element's scroll position, contents, or style. These hints allow browsers to optimize for upcoming style changes.",
@@ -27593,7 +27590,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(36u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/will-change"], popularity : 40.26268f32, },
+	caniuse : & ["https://caniuse.com/will-change"], popularity : 40.2851f32, },
 	"css.properties.will-change.scroll-position" => CSSFeature { id :
 	"css.properties.will-change.scroll-position", name : "will-change", description :
 	"The will-change CSS property gives hints to the browser about expected changes to an element's scroll position, contents, or style. These hints allow browsers to optimize for upcoming style changes.",
@@ -27604,7 +27601,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(36u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/will-change"], popularity : 40.26268f32, },
+	caniuse : & ["https://caniuse.com/will-change"], popularity : 40.2851f32, },
 	"css.properties.word-break" => CSSFeature { id : "css.properties.word-break", name :
 	"word-break", description :
 	"The word-break CSS property sets how lines break within words.", spec :
@@ -27615,7 +27612,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16),
 	safari : BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), },
-	caniuse : & ["https://caniuse.com/word-break"], popularity : 57.55077f32, },
+	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.474808f32, },
 	"css.properties.word-break.auto-phrase" => CSSFeature { id :
 	"css.properties.word-break.auto-phrase", name : "word-break: auto-phrase",
 	description :
@@ -27636,7 +27633,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16),
 	safari : BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), },
-	caniuse : & ["https://caniuse.com/word-break"], popularity : 57.55077f32, },
+	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.474808f32, },
 	"css.properties.word-break.break-word" => CSSFeature { id :
 	"css.properties.word-break.break-word", name : "word-break: break-word", description
 	:
@@ -27657,7 +27654,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(44u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16),
 	safari : BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), },
-	caniuse : & ["https://caniuse.com/word-break"], popularity : 57.55077f32, },
+	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.474808f32, },
 	"css.properties.word-break.normal" => CSSFeature { id :
 	"css.properties.word-break.normal", name : "word-break", description :
 	"The word-break CSS property sets how lines break within words.", spec :
@@ -27668,7 +27665,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16),
 	safari : BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), },
-	caniuse : & ["https://caniuse.com/word-break"], popularity : 57.55077f32, },
+	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.474808f32, },
 	"css.properties.word-spacing" => CSSFeature { id : "css.properties.word-spacing",
 	name : "word-spacing", description :
 	"The word-spacing CSS property sets the amount of white space between words.", spec :
@@ -27679,7 +27676,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 14.873061f32, }, "css.properties.word-spacing.normal" =>
+	caniuse : & [], popularity : 12.902373f32, }, "css.properties.word-spacing.normal" =>
 	CSSFeature { id : "css.properties.word-spacing.normal", name : "word-spacing",
 	description :
 	"The word-spacing CSS property sets the amount of white space between words.", spec :
@@ -27690,7 +27687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 14.873061f32, },
+	caniuse : & [], popularity : 12.902373f32, },
 	"css.properties.word-spacing.svg_elements" => CSSFeature { id :
 	"css.properties.word-spacing.svg_elements", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -27712,7 +27709,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(48u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(41u16, 0u16), firefox_android : BrowserVersion(41u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.291639f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.909977f32, },
 	"css.properties.writing-mode.horizontal-tb" => CSSFeature { id :
 	"css.properties.writing-mode.horizontal-tb", name : "writing-mode", description :
 	"The writing-mode CSS property sets whether text is laid out horizontally or vertically, and left to right, or right to left.",
@@ -27723,7 +27720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(48u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.291639f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.909977f32, },
 	"css.properties.writing-mode.lr" => CSSFeature { id :
 	"css.properties.writing-mode.lr", name : "writing-mode SVG 1.1 values", description :
 	"The lr, lr-tb, rl, rl-tb, tb, and tb-rl keyword values for the writing-mode CSS property set the text direction for elements in SVG 1.1 documents.",
@@ -27771,7 +27768,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(132u16, 0u16), edge : BrowserVersion(132u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16, 4u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.291639f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.909977f32, },
 	"css.properties.writing-mode.sideways-rl" => CSSFeature { id :
 	"css.properties.writing-mode.sideways-rl", name : "writing-mode", description :
 	"The writing-mode CSS property sets whether text is laid out horizontally or vertically, and left to right, or right to left.",
@@ -27781,7 +27778,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(132u16, 0u16), edge : BrowserVersion(132u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16, 4u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.291639f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.909977f32, },
 	"css.properties.writing-mode.tb" => CSSFeature { id :
 	"css.properties.writing-mode.tb", name : "writing-mode SVG 1.1 values", description :
 	"The lr, lr-tb, rl, rl-tb, tb, and tb-rl keyword values for the writing-mode CSS property set the text direction for elements in SVG 1.1 documents.",
@@ -27811,7 +27808,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(48u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.291639f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.909977f32, },
 	"css.properties.writing-mode.vertical-rl" => CSSFeature { id :
 	"css.properties.writing-mode.vertical-rl", name : "writing-mode", description :
 	"The writing-mode CSS property sets whether text is laid out horizontally or vertically, and left to right, or right to left.",
@@ -27822,7 +27819,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(48u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.291639f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.909977f32, },
 	"css.properties.writing-mode.vertical_oriented_form_controls" => CSSFeature { id :
 	"css.properties.writing-mode.vertical_oriented_form_controls", name :
 	"Vertical form controls", description :
@@ -27865,7 +27862,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 86.573814f32, }, "css.properties.z-index.auto" =>
+	caniuse : & [], popularity : 86.24538f32, }, "css.properties.z-index.auto" =>
 	CSSFeature { id : "css.properties.z-index.auto", name : "z-index", description :
 	"The z-index CSS property orders overlapping elements, with higher values appearing in front of or on top of lower values.",
 	spec : "https://drafts.csswg.org/css2/#z-index", groups : & [], baseline_status :
@@ -27875,9 +27872,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 86.573814f32, },
-	"css.properties.z-index.negative_values" => CSSFeature { id :
-	"css.properties.z-index.negative_values", name : "z-index", description :
+	caniuse : & [], popularity : 86.24538f32, }, "css.properties.z-index.negative_values"
+	=> CSSFeature { id : "css.properties.z-index.negative_values", name : "z-index",
+	description :
 	"The z-index CSS property orders overlapping elements, with higher values appearing in front of or on top of lower values.",
 	spec : "https://drafts.csswg.org/css2/#z-index", groups : & [], baseline_status :
 	BaselineStatus::High { since : NaiveDate::from_ymd_opt(2018i32, 1u32, 29u32)
@@ -27886,8 +27883,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(3u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 86.573814f32, }, "css.properties.zoom" => CSSFeature {
-	id : "css.properties.zoom", name : "zoom", description :
+	caniuse : & [], popularity : 86.24538f32, }, "css.properties.zoom" => CSSFeature { id
+	: "css.properties.zoom", name : "zoom", description :
 	"The zoom CSS property scales the size of an element. Unlike the transform property, a zoomed element affects page layout.",
 	spec : "https://drafts.csswg.org/css-viewport/#zoom-property", groups : & [],
 	baseline_status : BaselineStatus::Low(NaiveDate::from_ymd_opt(2024i32, 5u32, 14u32)
@@ -27895,7 +27892,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(126u16, 0u16), firefox_android : BrowserVersion(126u16,
 	0u16), safari : BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(3u16, 0u16),
-	}, caniuse : & ["https://caniuse.com/css-zoom"], popularity : 28.895027f32, },
+	}, caniuse : & ["https://caniuse.com/css-zoom"], popularity : 28.140438f32, },
 	"css.selectors.active" => CSSFeature { id : "css.selectors.active", name :
 	"User action pseudo-classes", description :
 	"The :active, :focus, and :hover CSS pseudo-classes match elements based on how users are interacting with them.",
@@ -28822,7 +28819,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(86u16, 0u16), firefox : BrowserVersion(68u16, 0u16), firefox_android :
 	BrowserVersion(68u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-marker-pseudo"],
-	popularity : 0.053187f32, }, "css.selectors.marker.animation_and_transition_support"
+	popularity : 0.048641f32, }, "css.selectors.marker.animation_and_transition_support"
 	=> CSSFeature { id : "css.selectors.marker.animation_and_transition_support", name :
 	"::marker", description :
 	"The ::marker CSS pseudo-element selects list item markers for styling numbers or bullets.",
@@ -28832,7 +28829,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(86u16, 0u16), firefox : BrowserVersion(80u16, 0u16), firefox_android :
 	BrowserVersion(80u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-marker-pseudo"],
-	popularity : 0.053187f32, }, "css.selectors.modal" => CSSFeature { id :
+	popularity : 0.048641f32, }, "css.selectors.modal" => CSSFeature { id :
 	"css.selectors.modal", name : ":modal", description :
 	"The :modal pseudo-class selects elements that put other elements into a non-interactive state, such as a fullscreen element or a <dialog> element used with showModal().",
 	spec : "https://drafts.csswg.org/selectors-4/#modal-state", groups : & ["selectors"],
@@ -30231,7 +30228,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(59u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(30u16, 0u16), firefox_android : BrowserVersion(54u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-backgroundblendmode"], popularity : 3.607285f32, },
+	["https://caniuse.com/css-backgroundblendmode"], popularity : 3.507342f32, },
 	"css.types.calc" => CSSFeature { id : "css.types.calc", name : "calc()", description
 	:
 	"The calc() CSS function computes mathematical expressions such a calc(100%/3 - 1em).",
@@ -30370,7 +30367,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 90.658905f32, }, "css.types.color.color" => CSSFeature {
+	caniuse : & [], popularity : 90.188835f32, }, "css.types.color.color" => CSSFeature {
 	id : "css.types.color.color", name : "color()", description :
 	"The color() function picks a color from a given color space. Wide gamut color spaces like display-p3 allow showing more vibrant and saturated colors than the standard srgb color space.",
 	spec : "https://drafts.csswg.org/css-color-4/#color-function", groups : &
@@ -30846,7 +30843,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 90.658905f32, }, "css.types.corner-shape-value" =>
+	caniuse : & [], popularity : 90.188835f32, }, "css.types.corner-shape-value" =>
 	CSSFeature { id : "css.types.corner-shape-value", name : "corner-shape", description
 	:
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30855,7 +30852,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.types.corner-shape-value.bevel" => CSSFeature { id :
 	"css.types.corner-shape-value.bevel", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30864,7 +30861,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.types.corner-shape-value.notch" => CSSFeature { id :
 	"css.types.corner-shape-value.notch", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30873,7 +30870,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.types.corner-shape-value.round" => CSSFeature { id :
 	"css.types.corner-shape-value.round", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30882,7 +30879,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.types.corner-shape-value.scoop" => CSSFeature { id :
 	"css.types.corner-shape-value.scoop", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30891,7 +30888,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.types.corner-shape-value.square" => CSSFeature { id :
 	"css.types.corner-shape-value.square", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30900,7 +30897,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.types.corner-shape-value.squircle" => CSSFeature { id :
 	"css.types.corner-shape-value.squircle", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30909,7 +30906,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, },
+	0), }, caniuse : & [], popularity : 0.779787f32, },
 	"css.types.corner-shape-value.superellipse" => CSSFeature { id :
 	"css.types.corner-shape-value.superellipse", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30918,7 +30915,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, }, "css.types.cos" => CSSFeature {
+	0), }, caniuse : & [], popularity : 0.779787f32, }, "css.types.cos" => CSSFeature {
 	id : "css.types.cos", name :
 	"sin(), cos(), tan(), asin(), acos(), atan(), and atan2() (CSS)", description :
 	"The sin(), cos(), tan(), asin(), acos(), atan(), and atan2() CSS functions compute various trigonometric functions.",
@@ -30980,7 +30977,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.436744f32, }, "css.types.easing-function" =>
+	0), }, caniuse : & [], popularity : 0.483296f32, }, "css.types.easing-function" =>
 	CSSFeature { id : "css.types.easing-function", name : "cubic-bezier() easing",
 	description :
 	"The cubic-bezier() CSS easing function interpolates along a smooth curve, creating animations and transitions with continuous changes in speed. The ease, ease-in, ease-out, and ease-in-out keyword values are presets for common Bézier curves.",
@@ -31209,7 +31206,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.blur" => CSSFeature { id :
 	"css.types.filter-function.blur", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31220,7 +31217,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.brightness" => CSSFeature { id :
 	"css.types.filter-function.brightness", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31231,7 +31228,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.contrast" => CSSFeature { id :
 	"css.types.filter-function.contrast", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31242,7 +31239,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.drop-shadow" => CSSFeature { id :
 	"css.types.filter-function.drop-shadow", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31253,7 +31250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.grayscale" => CSSFeature { id :
 	"css.types.filter-function.grayscale", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31264,7 +31261,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.hue-rotate" => CSSFeature { id :
 	"css.types.filter-function.hue-rotate", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31275,7 +31272,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.invert" => CSSFeature { id :
 	"css.types.filter-function.invert", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31286,7 +31283,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.opacity" => CSSFeature { id :
 	"css.types.filter-function.opacity", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31297,7 +31294,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.saturate" => CSSFeature { id :
 	"css.types.filter-function.saturate", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31308,7 +31305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.filter-function.sepia" => CSSFeature { id :
 	"css.types.filter-function.sepia", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31319,7 +31316,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 52.725887f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.288868f32, },
 	"css.types.flex" => CSSFeature { id : "css.types.flex", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
 	spec : "https://drafts.csswg.org/css-grid-3/", groups : & ["grid"], baseline_status :
@@ -31329,7 +31326,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(29u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(40u16, 0u16), firefox_android : BrowserVersion(40u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.585192f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.62907f32, },
 	"css.types.global_keywords" => CSSFeature { id : "css.types.global_keywords", name :
 	"inherit", description :
 	"The inherit keyword resets any CSS property to the computed value of that property from the parent element.",
@@ -31363,7 +31360,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(13u16, 0u16), firefox :
 	BrowserVersion(19u16, 0u16), firefox_android : BrowserVersion(19u16, 0u16), safari :
 	BrowserVersion(1u16, 2u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-initial-value"], popularity : 13.411391f32, },
+	["https://caniuse.com/css-initial-value"], popularity : 12.432723f32, },
 	"css.types.global_keywords.revert" => CSSFeature { id :
 	"css.types.global_keywords.revert", name : "revert", description :
 	"The revert CSS keyword resets any property to its previous default, provided by either the user or browser stylesheets. For example, setting display: revert on a <div> will likely result in display: block, the browser default style. This is often confused with initial.",
@@ -31971,7 +31968,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 86.573814f32, }, "css.types.length" => CSSFeature { id :
+	caniuse : & [], popularity : 86.24538f32, }, "css.types.length" => CSSFeature { id :
 	"css.types.length", name : "Width and height", description :
 	"The width and height CSS properties set the preferred physical size of an element.",
 	spec : "https://drafts.csswg.org/css-sizing-3/#preferred-size-properties", groups : &
@@ -32320,7 +32317,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 87.0661f32, },
+	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.52077f32, },
 	"css.types.number.scientific_notation" => CSSFeature { id :
 	"css.types.number.scientific_notation", name : "opacity", description :
 	"The opacity CSS property sets the transparency of an element.", spec :
@@ -32331,7 +32328,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(43u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 87.0661f32, },
+	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.52077f32, },
 	"css.types.overflow" => CSSFeature { id : "css.types.overflow", name : "overflow",
 	description :
 	"The overflow CSS property sets the behavior for when content doesn't fit in an element.",
@@ -32590,7 +32587,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 53.784763f32, }, "css.types.shape.rect" => CSSFeature { id :
+	[], popularity : 51.734997f32, }, "css.types.shape.rect" => CSSFeature { id :
 	"css.types.shape.rect", name : "clip", description :
 	"The clip CSS property sets the visible area of an absolutely positioned element.",
 	spec : "https://drafts.csswg.org/css-masking-1/#clip-property", groups : &
@@ -32599,7 +32596,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 53.784763f32, }, "css.types.sibling-count" => CSSFeature { id :
+	[], popularity : 51.734997f32, }, "css.types.sibling-count" => CSSFeature { id :
 	"css.types.sibling-count", name : "sibling-count() and sibling-index()", description
 	:
 	"The sibling-count() and sibling-index() CSS functions return integers that are useful to style elements based on their positions among siblings or on the number of siblings, for example as part of a calc() expression.",
@@ -32658,7 +32655,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, },
+	caniuse : & [], popularity : 80.992294f32, },
 	"css.types.string.unicode_escaped_characters" => CSSFeature { id :
 	"css.types.string.unicode_escaped_characters", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
@@ -32669,15 +32666,15 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.5181f32, }, "css.types.superellipse" => CSSFeature {
-	id : "css.types.superellipse", name : "corner-shape", description :
+	caniuse : & [], popularity : 80.992294f32, }, "css.types.superellipse" => CSSFeature
+	{ id : "css.types.superellipse", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
 	spec : "https://drafts.csswg.org/css-borders-4/#corner-shaping", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.775705f32, }, "css.types.tan" => CSSFeature {
+	0), }, caniuse : & [], popularity : 0.779787f32, }, "css.types.tan" => CSSFeature {
 	id : "css.types.tan", name :
 	"sin(), cos(), tan(), asin(), acos(), atan(), and atan2() (CSS)", description :
 	"The sin(), cos(), tan(), asin(), acos(), atan(), and atan2() CSS functions compute various trigonometric functions.",
@@ -32698,7 +32695,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.types.text-edge.alphabetic" => CSSFeature { id :
 	"css.types.text-edge.alphabetic", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -32708,7 +32705,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.types.text-edge.cap" => CSSFeature { id : "css.types.text-edge.cap", name :
 	"text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -32718,7 +32715,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.types.text-edge.ex" => CSSFeature { id : "css.types.text-edge.ex", name :
 	"text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -32728,7 +32725,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.types.text-edge.text" => CSSFeature { id : "css.types.text-edge.text", name :
 	"text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -32738,7 +32735,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.577085f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.565718f32, },
 	"css.types.time" => CSSFeature { id : "css.types.time", name : "Animations (CSS)",
 	description :
 	"The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.",


### PR DESCRIPTION
Updates to the latest specs from w3c/csswg-drafts

No changes - csswg-drafts is already at commit [`53d6722`](https://github.com/w3c/csswg-drafts/commit/53d6722b123cba9c9ac37e4ae1a78eb144ecd25f)
