### PR TITLE
css_lexer: Keep separator between string and value tokens

### DIFF
--- a/crates/css_ast/src/functions/image_set_function.rs
+++ b/crates/css_ast/src/functions/image_set_function.rs
@@ -45,7 +45,7 @@ mod tests {
 
 	#[test]
 	fn test_writes() {
-		assert_parse!(CssAtomSet::ATOMS, ImageSetFunction, "image-set('image.jpg'1x,'image.jpg'2x)");
+		assert_parse!(CssAtomSet::ATOMS, ImageSetFunction, "image-set('image.jpg' 1x,'image.jpg' 2x)");
 		assert_parse!(
 			CssAtomSet::ATOMS,
 			ImageSetFunction,

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -116,8 +116,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, Attribute, "[attr|='foo']");
 		assert_parse!(CssAtomSet::ATOMS, Attribute, "[attr|=foo i]");
 		assert_parse!(CssAtomSet::ATOMS, Attribute, "[attr|=foo s]");
-		assert_parse!(CssAtomSet::ATOMS, Attribute, "[attr|='foo'i]");
-		assert_parse!(CssAtomSet::ATOMS, Attribute, "[attr|='foo's]");
+		assert_parse!(CssAtomSet::ATOMS, Attribute, "[attr|='foo' i]");
+		assert_parse!(CssAtomSet::ATOMS, Attribute, "[attr|='foo' s]");
 	}
 
 	#[cfg(feature = "css_feature_data")]

--- a/crates/css_ast/src/types/content_list.rs
+++ b/crates/css_ast/src/types/content_list.rs
@@ -79,7 +79,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ContentList, "content(marker)");
 		assert_parse!(CssAtomSet::ATOMS, ContentList, "counter(foo,decimal)");
 		assert_parse!(CssAtomSet::ATOMS, ContentList, "counters(foo,'bar',decimal)");
-		assert_parse!(CssAtomSet::ATOMS, ContentList, "leader('.')'foo'counter(section,decimal)");
+		assert_parse!(CssAtomSet::ATOMS, ContentList, "leader('.')'foo' counter(section,decimal)");
 		assert_parse!(CssAtomSet::ATOMS, ContentList, "attr(foo)");
 	}
 

--- a/crates/css_lexer/src/token.rs
+++ b/crates/css_lexer/src/token.rs
@@ -1080,6 +1080,12 @@ impl Token {
 	/// order to avoid abmiguities with CSS-alike languages that treat two consecutive `/` characters as a single line
 	/// comment.
 	///
+	/// A second exception not in the spec table: a `<string-token>` followed by `<ident>`, `<function>`, `<url>`,
+	/// `<bad-url>`, `<number>`, or `<dimension>` is also separated. Strings are self-delimited by quotes so
+	/// re-tokenization is unambiguous, but value grammars like `font-variation-settings` (`<string> <number>`) and
+	/// `font-feature-settings` (`<string> [ <integer> | on | off ]?`) require juxtaposition, and WebKit rejects
+	/// `"opsz"14` without the space.
+	///
 	/// # Example
 	///
 	/// ```
@@ -1124,6 +1130,10 @@ impl Token {
 				) || matches!(second.char(), Some('%'))
 					|| second.is_cdc()
 			}
+			Kind::String => matches!(
+				second.kind(),
+				Kind::Ident | Kind::Function | Kind::Url | Kind::BadUrl | Kind::Number | Kind::Dimension
+			),
 			_ => match self.char() {
 				Some('#') => {
 					matches!(

--- a/crates/css_parse/src/cursor_compact_write_sink.rs
+++ b/crates/css_parse/src/cursor_compact_write_sink.rs
@@ -213,4 +213,12 @@ mod test {
 		assert_format!("foo  ", "foo");
 		assert_format!("foo; ", "foo;");
 	}
+
+	// WebKit rejects `font-variation-settings: "opsz"14` because the value grammar requires
+	// `<string> <number>` to be juxtaposed. Same for `font-feature-settings`.
+	#[test]
+	fn test_preserves_whitespace_after_string() {
+		assert_format!("font-variation-settings: 'opsz' 14", r#"font-variation-settings:"opsz" 14"#);
+		assert_format!("font-feature-settings: 'liga' on", r#"font-feature-settings:"liga" on"#);
+	}
 }


### PR DESCRIPTION
## Description

The compact serializer dropped whitespace between strings and following ident/number tokens, so

    font-variation-settings: "opsz" 14

was minified to

    font-variation-settings:"opsz"14

WebKit rejects the latter and falls back to `normal`, breaking optical-sizing on variable fonts. font-feature-settings has the same `<string> <ident|integer>` grammar and was affected too. Extend `needs_separator_for` so a string followed by ident, function, url, bad-url, number, or dimension preserves a space.

## Notes

I ran into this bug when trying to use csskit on my project.

This patch was created by Claude Code and verified by me.