### PR TITLE
Release v0.0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+## [0.0.23] - 2026-05-22
+
+### Other Changes
+- Coverage: update css-minify-tests (#1133) ([#1133](https://github.com/csskit/csskit/pull/1133))
+
+
+### Css_ast
+- fix(css_parse): preserve whitespace around +/- in calc() (#1114) ([#1114](https://github.com/csskit/csskit/pull/1114))
+- coverage: drop bootstrap/foundation .min files (#1117) ([#1117](https://github.com/csskit/csskit/pull/1117))
+- css_ast: Implement relative color syntax (#1119) ([#1119](https://github.com/csskit/csskit/pull/1119))
+- Regenerate css_ast/src/values from csswg drafts (#1120) ([#1120](https://github.com/csskit/csskit/pull/1120))
+- csskit_spec_generator/css_ast: Generate properties from SVG, PointerEvents specs (#1121) ([#1121](https://github.com/csskit/csskit/pull/1121))
+- css_ast: Implement ContentStyleValue (#1122) ([#1122](https://github.com/csskit/csskit/pull/1122))
+- Regenerate css_ast/src/values from csswg drafts (#1123) ([#1123](https://github.com/csskit/csskit/pull/1123))
+- css_ast: add pinch-zoom to touch-action (#1128) ([#1128](https://github.com/csskit/csskit/pull/1128))
+- css_ast/csskit: Finish off ToSpecificity, add `csskit specificity` command (#1129) ([#1129](https://github.com/csskit/csskit/pull/1129))
+- css_ast: Box all Gradient types (#1130) ([#1130](https://github.com/csskit/csskit/pull/1130))
+- css_ast: Implement Background property (#1131) ([#1131](https://github.com/csskit/csskit/pull/1131))
+- css_ast: Implement SpreadShadow, improve Shadow (#1132) ([#1132](https://github.com/csskit/csskit/pull/1132))
+- css_ast: Implement text-overflow (#1134) ([#1134](https://github.com/csskit/csskit/pull/1134))
+- css_ast: Implement more legacy/vendor display values (#1135) ([#1135](https://github.com/csskit/csskit/pull/1135))
+- css_ast: Implement light-dark for color values (#1136) ([#1136](https://github.com/csskit/csskit/pull/1136))
+
+
+### Css_lexer
+- css_parse: refactor CursorCompactWriteSink, preserve comments between idents (#1118) ([#1118](https://github.com/csskit/csskit/pull/1118))
+
+
+### Csskit
+- chore(deps): update dependencies (patch) (#1124) ([#1124](https://github.com/csskit/csskit/pull/1124))
+
+
+### Csskit_spec_generator
+- csskit_spec_generator: Replace non-breaking spaces with whitespace (#1137) ([#1137](https://github.com/csskit/csskit/pull/1137))
+
+
+### Csskit_vscode
+- chore(deps): update dependency oxlint to v1.64.0 (#1127) ([#1127](https://github.com/csskit/csskit/pull/1127))
+- chore(deps): update dependency @types/vscode to v1.120.0 (#1125) ([#1125](https://github.com/csskit/csskit/pull/1125))
+
 ## [0.0.22] - 2026-05-15
 
 ### Other Changes
@@ -42,6 +82,7 @@
 ### Csskit
 - chore(deps): update dependencies (patch) (#1103) ([#1103](https://github.com/csskit/csskit/pull/1103))
 - csskit: Improve messaging for check commands with missing sheets (#1113) ([#1113](https://github.com/csskit/csskit/pull/1113))
+- Release v0.0.22 (#1080) ([#1080](https://github.com/csskit/csskit/pull/1080))
 
 
 ### Csskit-linux-x64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chromashift"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anstyle",
  "owo-colors",
@@ -605,7 +605,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "css_ast"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "css_feature_data"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "browserslist-rs",
  "chrono",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "css_lexer"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "allocator-api2",
  "bitmask-enum",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "css_parse"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "css_value_definition_parser"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "css_lexer",
  "heck",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "csskit"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anstyle",
  "bumpalo",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_ast"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_derives"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "darling",
  "heck",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_highlight"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anstyle",
  "bitmask-enum",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_lsp"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_proc_macro"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "css_lexer",
  "css_value_definition_parser",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_source_finder"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "glob",
  "grep-matcher",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_spec_generator"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "clap",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_transform"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_wasm"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "bumpalo",
  "console_error_panic_hook",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "derive_atom_set"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "heck",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,25 +11,25 @@ homepage = "https://csskit.rs"
 keywords = ["CSS", "parser"]
 license = "MIT"
 repository = "https://github.com/csskit/csskit"
-version = "0.0.22"                                      #@release
+version = "0.0.23"                                      #@release
 
 [workspace.dependencies]
 # Local packages
-csskit = { version = "0.0.22", path = "crates/csskit" }                                           #@release
-csskit_derives = { version = "0.0.22", path = "crates/csskit_derives" }                           #@release
-csskit_proc_macro = { version = "0.0.22", path = "crates/csskit_proc_macro" }                     #@release
-css_value_definition_parser = { version = "0.0.22", path = "crates/css_value_definition_parser" } #@release
-css_parse = { version = "0.0.22", path = "crates/css_parse" }                                     #@release
-css_lexer = { version = "0.0.22", path = "crates/css_lexer" }                                     #@release
-css_ast = { version = "0.0.22", path = "crates/css_ast" }                                         #@release
-derive_atom_set = { version = "0.0.22", path = "crates/derive_atom_set" }                         #@release
-css_feature_data = { version = "0.0.22", path = "crates/css_feature_data" }                       #@release
-csskit_source_finder = { version = "0.0.22", path = "crates/csskit_source_finder" }               #@release
-csskit_transform = { version = "0.0.22", path = "crates/csskit_transform" }                       #@release
-csskit_highlight = { version = "0.0.22", path = "crates/csskit_highlight" }                       #@release
-csskit_lsp = { version = "0.0.22", path = "crates/csskit_lsp" }                                   #@release
-csskit_ast = { version = "0.0.22", path = "crates/csskit_ast" }                                   #@release
-chromashift = { version = "0.0.22", path = "crates/chromashift" }                                 #@release
+csskit = { version = "0.0.23", path = "crates/csskit" }                                           #@release
+csskit_derives = { version = "0.0.23", path = "crates/csskit_derives" }                           #@release
+csskit_proc_macro = { version = "0.0.23", path = "crates/csskit_proc_macro" }                     #@release
+css_value_definition_parser = { version = "0.0.23", path = "crates/css_value_definition_parser" } #@release
+css_parse = { version = "0.0.23", path = "crates/css_parse" }                                     #@release
+css_lexer = { version = "0.0.23", path = "crates/css_lexer" }                                     #@release
+css_ast = { version = "0.0.23", path = "crates/css_ast" }                                         #@release
+derive_atom_set = { version = "0.0.23", path = "crates/derive_atom_set" }                         #@release
+css_feature_data = { version = "0.0.23", path = "crates/css_feature_data" }                       #@release
+csskit_source_finder = { version = "0.0.23", path = "crates/csskit_source_finder" }               #@release
+csskit_transform = { version = "0.0.23", path = "crates/csskit_transform" }                       #@release
+csskit_highlight = { version = "0.0.23", path = "crates/csskit_highlight" }                       #@release
+csskit_lsp = { version = "0.0.23", path = "crates/csskit_lsp" }                                   #@release
+csskit_ast = { version = "0.0.23", path = "crates/csskit_ast" }                                   #@release
+chromashift = { version = "0.0.23", path = "crates/chromashift" }                                 #@release
 csskit_spec_generator = { version = "0.0.0", path = "crates/csskit_spec_generator" }
 
 # Memory

--- a/packages/csskit-darwin-arm64/package.json
+++ b/packages/csskit-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-arm64",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "Refreshing CSS - macOS arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-darwin-x64/package.json
+++ b/packages/csskit-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-x64",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "Refreshing CSS - macOS x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-arm64/package.json
+++ b/packages/csskit-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-arm64",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "Refreshing CSS - Linux arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-x64/package.json
+++ b/packages/csskit-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-x64",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "Refreshing CSS - Linux x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-arm64/package.json
+++ b/packages/csskit-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-arm64",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "Refreshing CSS - Windows arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-x64/package.json
+++ b/packages/csskit-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-x64",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "Refreshing CSS - Windows x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit/package-lock.json
+++ b/packages/csskit/package-lock.json
@@ -1,21 +1,13 @@
 {
     "name": "csskit",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "csskit",
-            "version": "0.0.22",
+            "version": "0.0.23",
             "license": "MIT",
-            "dependencies": {
-                "csskit-darwin-arm64": "^0.0.22",
-                "csskit-darwin-x64": "^0.0.22",
-                "csskit-linux-arm64": "^0.0.22",
-                "csskit-linux-x64": "^0.0.22",
-                "csskit-win32-arm64": "^0.0.22",
-                "csskit-win32-x64": "^0.0.22"
-            },
             "bin": {
                 "csskit": "bin/csskit"
             },

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit",
-    "version": "0.0.22",
+    "version": "0.0.23",
     "description": "Refreshing CSS",
     "keywords": [],
     "license": "MIT",
@@ -11,12 +11,12 @@
         "./bin"
     ],
     "optionalDependencies": {
-        "csskit-linux-x64": "0.0.22",
-        "csskit-linux-arm64": "0.0.22",
-        "csskit-darwin-x64": "0.0.22",
-        "csskit-darwin-arm64": "0.0.22",
-        "csskit-win32-x64": "0.0.22",
-        "csskit-win32-arm64": "0.0.22"
+        "csskit-linux-x64": "0.0.23",
+        "csskit-linux-arm64": "0.0.23",
+        "csskit-darwin-x64": "0.0.23",
+        "csskit-darwin-arm64": "0.0.23",
+        "csskit-win32-x64": "0.0.23",
+        "csskit-win32-arm64": "0.0.23"
     },
     "funding": {
         "url": "https://github.com/sponsors/keithamus"


### PR DESCRIPTION
## [0.0.23] - 2026-05-22

### Other Changes
- Coverage: update css-minify-tests (#1133) ([#1133](https://github.com/csskit/csskit/pull/1133))


### Css_ast
- fix(css_parse): preserve whitespace around +/- in calc() (#1114) ([#1114](https://github.com/csskit/csskit/pull/1114))
- coverage: drop bootstrap/foundation .min files (#1117) ([#1117](https://github.com/csskit/csskit/pull/1117))
- css_ast: Implement relative color syntax (#1119) ([#1119](https://github.com/csskit/csskit/pull/1119))
- Regenerate css_ast/src/values from csswg drafts (#1120) ([#1120](https://github.com/csskit/csskit/pull/1120))
- csskit_spec_generator/css_ast: Generate properties from SVG, PointerEvents specs (#1121) ([#1121](https://github.com/csskit/csskit/pull/1121))
- css_ast: Implement ContentStyleValue (#1122) ([#1122](https://github.com/csskit/csskit/pull/1122))
- Regenerate css_ast/src/values from csswg drafts (#1123) ([#1123](https://github.com/csskit/csskit/pull/1123))
- css_ast: add pinch-zoom to touch-action (#1128) ([#1128](https://github.com/csskit/csskit/pull/1128))
- css_ast/csskit: Finish off ToSpecificity, add `csskit specificity` command (#1129) ([#1129](https://github.com/csskit/csskit/pull/1129))
- css_ast: Box all Gradient types (#1130) ([#1130](https://github.com/csskit/csskit/pull/1130))
- css_ast: Implement Background property (#1131) ([#1131](https://github.com/csskit/csskit/pull/1131))
- css_ast: Implement SpreadShadow, improve Shadow (#1132) ([#1132](https://github.com/csskit/csskit/pull/1132))
- css_ast: Implement text-overflow (#1134) ([#1134](https://github.com/csskit/csskit/pull/1134))
- css_ast: Implement more legacy/vendor display values (#1135) ([#1135](https://github.com/csskit/csskit/pull/1135))
- css_ast: Implement light-dark for color values (#1136) ([#1136](https://github.com/csskit/csskit/pull/1136))


### Css_lexer
- css_parse: refactor CursorCompactWriteSink, preserve comments between idents (#1118) ([#1118](https://github.com/csskit/csskit/pull/1118))


### Csskit
- chore(deps): update dependencies (patch) (#1124) ([#1124](https://github.com/csskit/csskit/pull/1124))


### Csskit_spec_generator
- csskit_spec_generator: Replace non-breaking spaces with whitespace (#1137) ([#1137](https://github.com/csskit/csskit/pull/1137))


### Csskit_vscode
- chore(deps): update dependency oxlint to v1.64.0 (#1127) ([#1127](https://github.com/csskit/csskit/pull/1127))
- chore(deps): update dependency @types/vscode to v1.120.0 (#1125) ([#1125](https://github.com/csskit/csskit/pull/1125))