### PR TITLE
css_parse: refactor CursorCompactWriteSink, preserve comments between idents

### DIFF
--- a/crates/css_lexer/src/source_cursor.rs
+++ b/crates/css_lexer/src/source_cursor.rs
@@ -76,6 +76,8 @@ impl<'a> SourceCursor<'a> {
 	pub const NEWLINE: SourceCursor<'static> = SourceCursor::from(Cursor::new(SourceOffset(0), Token::NEWLINE), "\n");
 	pub const SEMICOLON: SourceCursor<'static> =
 		SourceCursor::from(Cursor::new(SourceOffset(0), Token::SEMICOLON), ";");
+	pub const EMPTY_COMMENT: SourceCursor<'static> =
+		SourceCursor::from(Cursor::new(SourceOffset(0), Token::new_comment(CommentStyle::Block, 4)), "/**/");
 
 	#[inline(always)]
 	pub const fn from(cursor: Cursor, source: &'a str) -> Self {

--- a/crates/css_lexer/src/token.rs
+++ b/crates/css_lexer/src/token.rs
@@ -437,7 +437,7 @@ impl Token {
 
 	/// Creates a [Kind::Comment] token.
 	#[inline]
-	pub(crate) fn new_comment(style: CommentStyle, len: u32) -> Self {
+	pub(crate) const fn new_comment(style: CommentStyle, len: u32) -> Self {
 		let flags: u32 = Kind::Comment as u32 | ((style as u32) << 5);
 		Self((flags << 24) & KIND_MASK, len)
 	}

--- a/crates/css_parse/src/cursor_compact_write_sink.rs
+++ b/crates/css_parse/src/cursor_compact_write_sink.rs
@@ -1,6 +1,4 @@
-use crate::{
-	AssociatedWhitespaceRules, Cursor, CursorSink, Kind, KindSet, QuoteStyle, SourceCursor, SourceCursorSink, Token,
-};
+use crate::{Cursor, CursorSink, Kind, KindSet, QuoteStyle, SourceCursor, SourceCursorSink, Token};
 
 /// This is a [CursorSink] that wraps a sink (`impl SourceCursorSink`) and on each [CursorSink::append()] call, will write
 /// the contents of the cursor [Cursor] given into the given sink - using the given `&'a str` as the original source.
@@ -11,78 +9,99 @@ pub struct CursorCompactWriteSink<'a, T: SourceCursorSink<'a>> {
 	sink: T,
 	last_token: Option<Token>,
 	pending: Option<SourceCursor<'a>>,
+	pending_comment: Option<SourceCursor<'a>>,
 }
 
+// Tokens that get buffered as `pending` rather than emitted immediately.
 const PENDING_KINDSET: KindSet = KindSet::new(&[Kind::Semicolon, Kind::Whitespace]);
+// `;` is redundant immediately before/after these.
 const REDUNDANT_SEMI_KINDSET: KindSet = KindSet::new(&[Kind::Semicolon, Kind::RightCurly]);
-// Tokens where whitespace immediately before them can be removed
+// Whitespace immediately before these tokens can always be removed (overrides any
+// `AssociatedWhitespaceRules::EnforceBefore` annotations carried from the source).
 const NO_WHITESPACE_BEFORE_KINDSET: KindSet =
-	KindSet::new(&[Kind::Whitespace, Kind::Colon, Kind::Delim, Kind::LeftCurly, Kind::RightCurly]);
-// Tokens where whitespace immediately after them can be removed
+	KindSet::new(&[Kind::Whitespace, Kind::Colon, Kind::Delim, Kind::LeftCurly, Kind::RightCurly, Kind::Eof]);
+// Whitespace immediately after these tokens can always be removed.
 const NO_WHITESPACE_AFTER_KINDSET: KindSet =
 	KindSet::new(&[Kind::Comma, Kind::RightParen, Kind::RightCurly, Kind::LeftCurly, Kind::Colon]);
 
 impl<'a, T: SourceCursorSink<'a>> CursorCompactWriteSink<'a, T> {
 	pub fn new(source_text: &'a str, sink: T) -> Self {
-		Self { source_text, sink, last_token: None, pending: None }
+		Self { source_text, sink, last_token: None, pending: None, pending_comment: None }
+	}
+
+	/// Would emitting `next` immediately after `last_token` change tokenisation?
+	fn needs_separator(&self, next: Token) -> bool {
+		self.last_token.is_some_and(|t| t.needs_separator_for(next))
+	}
+
+	/// True when the previously-emitted token never needs a separator after it
+	/// (e.g. `,`, `)`, `{`). Whitespace can be dropped and re-injection skipped.
+	fn last_forbids_ws_after(&self) -> bool {
+		self.last_token.is_some_and(|t| t == NO_WHITESPACE_AFTER_KINDSET)
+	}
+
+	fn emit(&mut self, c: SourceCursor<'a>) {
+		self.last_token = Some(c.token());
+		self.sink.append(c);
 	}
 
 	fn write(&mut self, c: SourceCursor<'a>) {
-		let mut skip_separator_check = false;
-		if let Some(prev) = self.pending {
-			self.pending = None;
-			let is_redundant_semi = prev == Kind::Semicolon
-				&& (c == REDUNDANT_SEMI_KINDSET || self.last_token.is_some_and(|c| c == REDUNDANT_SEMI_KINDSET));
-			let prev_is_whitespace = prev == Kind::Whitespace;
-			let whitespace_required = prev_is_whitespace
-				&& (self.last_token.is_some_and(|t| t == AssociatedWhitespaceRules::EnforceAfter)
-					|| c.token() == AssociatedWhitespaceRules::EnforceBefore);
-			let no_whitespace_after_last = prev_is_whitespace
-				&& !whitespace_required
-				&& self.last_token.is_some_and(|c| c == NO_WHITESPACE_AFTER_KINDSET);
-			let is_redundant_whitespace = self.last_token.is_none()
-				|| prev_is_whitespace
-					&& !whitespace_required
-					&& (c == NO_WHITESPACE_BEFORE_KINDSET || no_whitespace_after_last);
-			if !is_redundant_semi && !is_redundant_whitespace {
-				self.last_token = Some(prev.token());
-				self.sink.append(prev.compact());
-			} else if no_whitespace_after_last {
-				// If we're skipping whitespace because the last token doesn't need whitespace after it,
-				// don't add it back via needs_separator_for
-				skip_separator_check = true;
+		if c == Kind::Comment {
+			let can_separate =
+				self.pending.is_none() && self.pending_comment.is_none() && !self.last_forbids_ws_after();
+			if can_separate {
+				self.pending_comment = Some(c);
+			}
+			return;
+		}
+		if self.pending_comment.take().is_some()
+			&& c != Kind::Whitespace
+			&& c != Kind::Eof
+			&& self.needs_separator(c.token())
+		{
+			self.emit(SourceCursor::EMPTY_COMMENT);
+		}
+
+		if c == Kind::Whitespace && self.pending.is_some_and(|c| c == Kind::Semicolon) {
+			return;
+		}
+
+		let suppress_separator = self.last_forbids_ws_after();
+		if let Some(prev) = self.pending.take() {
+			let keep = match prev.token().kind() {
+				Kind::Semicolon => {
+					c != REDUNDANT_SEMI_KINDSET && self.last_token.is_some_and(|t| t != REDUNDANT_SEMI_KINDSET)
+				}
+				_ => !suppress_separator && c != NO_WHITESPACE_BEFORE_KINDSET && self.needs_separator(c.token()),
+			};
+			if keep {
+				self.emit(prev.compact());
 			}
 		}
+
 		if c == PENDING_KINDSET {
 			self.pending = Some(c);
 			return;
 		}
-		if !skip_separator_check
-			&& let Some(last) = self.last_token
-			&& last.needs_separator_for(c.token())
-		{
+		if c == Kind::Eof {
+			return;
+		}
+
+		if !suppress_separator && self.needs_separator(c.token()) {
 			self.sink.append(SourceCursor::SPACE);
 		}
-		self.last_token = Some(c.token());
-		// Normalize quotes
-		if c == Kind::String {
-			self.sink.append(c.with_quotes(QuoteStyle::Double).compact())
-		} else {
-			self.sink.append(c.compact());
-		}
+
+		let out = if c == Kind::String { c.with_quotes(QuoteStyle::Double).compact() } else { c.compact() };
+		self.emit(out);
 	}
 }
 
 impl<'a, T: SourceCursorSink<'a>> Drop for CursorCompactWriteSink<'a, T> {
 	fn drop(&mut self) {
-		// Flush any pending semicolons at the end of the stream.
-		// Trailing whitespace is genuinely redundant, but trailing semicolons may be
-		// required (e.g. `@import "foo.css";` needs the `;`).
 		if let Some(prev) = self.pending.take()
 			&& prev == Kind::Semicolon
 		{
-			self.last_token = Some(prev.token());
-			self.sink.append(prev.compact());
+			self.emit(prev);
 		}
 	}
 }
@@ -118,7 +137,7 @@ mod test {
 				let mut stream = CursorCompactWriteSink::new(source_text, &mut sink);
 				let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
 				let mut parser = Parser::new(&bump, source_text, lexer);
-				parser.parse_entirely::<$struct>().output.unwrap().to_cursors(&mut stream);
+				parser.parse_entirely::<$struct>().with_trivia().to_cursors(&mut stream);
 			}
 			assert_eq!(sink, $after.trim());
 		};
@@ -174,14 +193,6 @@ mod test {
 	}
 
 	#[test]
-	fn test_preserves_whitespace_around_calc_sum_operators() {
-		assert_format!("calc(var(--col-gap) / 2 + var(--date-col))", "calc(var(--col-gap) / 2 + var(--date-col))");
-		assert_format!("calc((var(--col-gap) / -2) - 5px)", "calc((var(--col-gap) / -2) - 5px)");
-		assert_format!("calc(var(--x) + 1px)", "calc(var(--x) + 1px)");
-		assert_format!("calc(var(--x) - 1px)", "calc(var(--x) - 1px)");
-	}
-
-	#[test]
 	fn test_removes_whitespace_after_right_curly() {
 		assert_format!("@media screen{} .foo{}", "@media screen{}.foo{}");
 	}
@@ -226,8 +237,47 @@ mod test {
 	}
 
 	#[test]
+	fn test_removes_trailing_semis_when_after_curly() {
+		assert_format!("{foo};", "{foo}");
+	}
+
+	#[test]
 	fn test_drops_trailing_whitespace() {
 		assert_format!("foo  ", "foo");
 		assert_format!("foo; ", "foo;");
+	}
+
+	#[test]
+	fn test_preserves_comment_absence_in_custom_properties() {
+		assert_format!("div{--bar:a/**/b}", "div{--bar:a/**/b}");
+		assert_format!("div { --bar: a/**/b }", "div{--bar:a/**/b}");
+		assert_format!("div{--bar:a /* comment */ b}", "div{--bar:a b}");
+		assert_format!("div{--bar:a/**//**/b}", "div{--bar:a/**/b}");
+		assert_format!("div{--bar:a /* x */ /* y */ b}", "div{--bar:a b}");
+		assert_format!("div{/*comment*/--bar:a}", "div{--bar:a}");
+		assert_format!("div{--bar:a/*comment*/}", "div{--bar:a}");
+		assert_format!("div{--bar:a  /**/  b}", "div{--bar:a b}");
+		assert_format!("@container style(--bar:a/**/b){}", "@container style(--bar:a/**/b){}");
+		assert_format!("@container style(--bar:a/**/b){}", "@container style(--bar:a/**/b){}");
+		assert_format!("foo /**/bar", "foo bar");
+		assert_format!("foo{/**/bar}", "foo{bar}");
+		assert_format!("foo:/**/bar", "foo:bar");
+		assert_format!("foo(/**/bar)", "foo(bar)");
+		assert_format!("foo/**/,bar", "foo,bar");
+		assert_format!("/**/foo", "foo");
+		assert_format!("div{--bar:a/*some really long comment text*/b}", "div{--bar:a/**/b}");
+	}
+
+	#[test]
+	fn test_at_rule_no_space_before_paren() {
+		assert_format!(
+			"@media(prefers-reduced-motion:no-preference){:root{}}",
+			"@media(prefers-reduced-motion:no-preference){:root{}}"
+		);
+		assert_format!(
+			"@media (prefers-reduced-motion:no-preference){:root{}}",
+			"@media(prefers-reduced-motion:no-preference){:root{}}"
+		);
+		assert_format!("@media(min-width:576px){}", "@media(min-width:576px){}");
 	}
 }

--- a/crates/csskit/src/commands/build.rs
+++ b/crates/csskit/src/commands/build.rs
@@ -33,7 +33,7 @@ impl Build {
 			let result = parser.parse_entirely::<StyleSheet>();
 			if result.output.is_some() {
 				let mut stream = CursorCompactWriteSink::new(source_text, &mut str);
-				result.to_cursors(&mut stream);
+				result.with_trivia().to_cursors(&mut stream);
 			} else {
 				for compact_err in result.errors {
 					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);

--- a/crates/csskit/src/commands/min.rs
+++ b/crates/csskit/src/commands/min.rs
@@ -41,7 +41,7 @@ impl Min {
 			let source_text = source_string.as_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 			let mut parser = Parser::new(&bump, source_text, lexer);
-			let mut result = parser.parse_entirely::<StyleSheet>();
+			let mut result = parser.parse_entirely::<StyleSheet>().with_trivia();
 			if let Some(ref mut stylesheet) = result.output {
 				let mut transformer =
 					Transformer::new_in(&bump, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, source_text);

--- a/crates/csskit_transform/src/css_minifier.rs
+++ b/crates/csskit_transform/src/css_minifier.rs
@@ -36,7 +36,7 @@ mod tests {
 		let mut transformer = Transformer::new_in(&bump, features, &CssAtomSet::ATOMS, source_text);
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 		let mut parser = Parser::new(&bump, source_text, lexer);
-		let mut result = parser.parse_entirely::<StyleSheet>();
+		let mut result = parser.parse_entirely::<StyleSheet>().with_trivia();
 		let mut output = String::new();
 		if let Some(ref mut node) = result.output {
 			transformer.transform(node);
@@ -48,7 +48,7 @@ mod tests {
 					&*overlays,
 					CursorCompactWriteSink::new(source_text, &mut output),
 				);
-				result.output.to_cursors(&mut overlay_stream);
+				result.to_cursors(&mut overlay_stream);
 			}
 			(output, changed)
 		} else {

--- a/crates/csskit_transform/tests/css-minify-tests.rs
+++ b/crates/csskit_transform/tests/css-minify-tests.rs
@@ -44,7 +44,7 @@ fn minify(source_text: &str) -> String {
 	let mut transformer = Transformer::new_in(&bump, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, source_text);
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 	let mut parser = Parser::new(&bump, source_text, lexer);
-	let mut result = parser.parse_entirely::<StyleSheet>();
+	let mut result = parser.parse_entirely::<StyleSheet>().with_trivia();
 	let mut output = String::new();
 	if let Some(ref mut node) = result.output {
 		transformer.transform(node);
@@ -52,7 +52,7 @@ fn minify(source_text: &str) -> String {
 		{
 			let mut overlay_stream =
 				CursorOverlaySink::new(source_text, &*overlays, CursorCompactWriteSink::new(source_text, &mut output));
-			result.output.to_cursors(&mut overlay_stream);
+			result.to_cursors(&mut overlay_stream);
 		}
 	} else {
 		panic!("Could not parse source");

--- a/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
+++ b/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
@@ -11,22 +11,22 @@ FAIL anchor/0002
 +a{position-area:top}
 
 FAIL anchor/0003
--@position-try --flip{position-area:top}a{position-area:bottom; position-try-fallbacks:--flip}
+-@position-try --flip{position-area:top}a{position-area:bottom;position-try-fallbacks:--flip}
 +a{position-area:bottom;position-try-fallbacks:flip-block}
 
 FAIL anchor/0004
 -@position-try --empty{}
 
 FAIL anchor/0005
--@position-try --top{position-area:top}a{position-area:bottom; position-try-fallbacks:--top,--undefined}
+-@position-try --top{position-area:top}a{position-area:bottom;position-try-fallbacks:--top,--undefined}
 +@position-try --top{position-area:top}a{position-area:bottom;position-try-fallbacks:--top}
 
 FAIL charset/0001
--@charset "UTF-8";a{color:red}
+-@charset"UTF-8";a{color:red}
 +a{color:red}
 
 FAIL charset/0002
--@charset "ISO-8859-1";@charset "ISO-8859-15";a{color:red}
+-@charset"ISO-8859-1";@charset"ISO-8859-15";a{color:red}
 +@charset "ISO-8859-1";a{color:red}
 
 FAIL colors/0020
@@ -65,23 +65,15 @@ FAIL comments/0003
 -a{color:red}
 +/*! important */a{color:red}
 
-FAIL comments/0004
--a{--bar:a b}
-+a{--bar:a/**/b}
-
-FAIL comments/0005
--@container style(--bar:a b){a{color:red}}
-+@container style(--bar:a/**/b){a{color:red}}
-
 FAIL container/0002
--@container (min-width:700px){}
+-@container(min-width:700px){}
 
 FAIL container/0004
--@container (min-width:700px){a{color:red}}
+-@container(min-width:700px){a{color:red}}
 +@container(width>=700px){a{color:red}}
 
 FAIL container/0005
--@container (max-width:500px){a{color:red}}
+-@container(max-width:500px){a{color:red}}
 +@container(width<=500px){a{color:red}}
 
 FAIL container/0006
@@ -172,7 +164,7 @@ FAIL font-face/0003
 +@font-face{font-family:Custom;src:url(font.woff2)}
 
 FAIL font-face/0004
--@font-face{font-family:Custom;src:url(font.woff2) format("woff2")}
+-@font-face{font-family:Custom;src:url(font.woff2)format("woff2")}
 +@font-face{font-family:Custom;src:url(font.woff2)format(woff2)}
 
 FAIL font-face/0006
@@ -326,16 +318,12 @@ FAIL nesting/0019
 FAIL page/0003
 -@page{}
 
-FAIL scope/0001
--@scope (.card){.title{color:red}}
-+@scope(.card){.title{color:red}}
-
 FAIL scope/0002
--@scope (.card)to (.card.content){a{color:red}}
+-@scope(.card)to (.card.content){a{color:red}}
 +@scope(.card)to (.card .content){a{color:red}}
 
 FAIL scope/0003
--@scope (.card){}
+-@scope(.card){}
 
 FAIL selectors-advanced/0001
 -:is(a,b){color:red}
@@ -554,7 +542,7 @@ FAIL shorthands/0033
 +a{border:solid red}
 
 FAIL shorthands/0034
--a{background:red url(bg.png) 0% 0% repeat scroll}
+-a{background:red url(bg.png)0% 0% repeat scroll}
 +a{background:red url(bg.png)}
 
 FAIL shorthands/0035
@@ -578,15 +566,15 @@ FAIL shorthands/0040
 +a{overflow:hidden}
 
 FAIL shorthands/0041
--a{border-image:url(border.png) 30 round;border-width:1px;border-style:solid;border-color:red}
+-a{border-image:url(border.png)30 round;border-width:1px;border-style:solid;border-color:red}
 +a{border:1px solid red;border-image:url(border.png) 30 round}
 
 FAIL shorthands/0042
--a{border-width:1px;border-style:solid;border-color:red;border-image:url(border.png) 30 round}
+-a{border-width:1px;border-style:solid;border-color:red;border-image:url(border.png)30 round}
 +a{border:1px solid red;border-image:url(border.png) 30 round}
 
 FAIL shorthands/0043
--a{border-image:url(border.png) 30 round;border:1px solid red}
+-a{border-image:url(border.png)30 round;border:1px solid red}
 +a{border:1px solid red}
 
 FAIL shorthands/0044
@@ -610,15 +598,15 @@ FAIL shorthands/0048
 +a{font:14px/1.4 Georgia,serif;font-kerning:none}
 
 FAIL shorthands/0049
--a{mask-border:url(mask.png) 25 / 10px round;mask-image:linear-gradient(black,transparent);mask-size:cover;mask-repeat:no-repeat}
+-a{mask-border:url(mask.png)25 / 10px round;mask-image:linear-gradient(black,transparent);mask-size:cover;mask-repeat:no-repeat}
 +a{mask:linear-gradient(#000,transparent) no-repeat/cover;mask-border:url(mask.png) 25/10px round}
 
 FAIL shorthands/0050
--a{mask-image:linear-gradient(black,transparent);mask-repeat:no-repeat;mask-border:url(mask.png) 25 round}
+-a{mask-image:linear-gradient(black,transparent);mask-repeat:no-repeat;mask-border:url(mask.png)25 round}
 +a{mask:linear-gradient(#000,transparent) no-repeat;mask-border:url(mask.png) 25 round}
 
 FAIL shorthands/0051
--a{mask-border:url(mask.png) 25 round;mask:linear-gradient(black,transparent)}
+-a{mask-border:url(mask.png)25 round;mask:linear-gradient(black,transparent)}
 +a{mask:linear-gradient(#000,transparent)}
 
 FAIL shorthands/0052
@@ -761,12 +749,8 @@ FAIL values/0003
 -a{background:url("image.png")}
 +a{background:url(image.png)}
 
-FAIL values/0013
--a{background:linear-gradient( 45deg,#111 ,#999)}
-+a{background:linear-gradient(45deg,#111,#999)}
-
 FAIL values/0014
--a{width:calc(calc(100% - 20px) + 10px)}
+-a{width:calc(calc(100% - 20px)+ 10px)}
 +a{width:calc(100% - 10px)}
 
 FAIL values/0015
@@ -778,7 +762,7 @@ FAIL values/0016
 +a{width:100px}
 
 FAIL values/0017
--a{width:calc(((75.37% - 63.5px) - 900px) + (2 * 100px))}
+-a{width:calc(((75.37% - 63.5px)- 900px)+ (2 * 100px))}
 +a{width:calc(75.37% - 763.5px)}
 
 FAIL values/0019
@@ -870,7 +854,7 @@ FAIL values/0042
 +a{width:50px}
 
 FAIL values/0043
--a{width:calc(calc(10px + 20px) + calc(30px + 40px))}
+-a{width:calc(calc(10px + 20px)+ calc(30px + 40px))}
 +a{width:100px}
 
 FAIL values/0044
@@ -957,17 +941,9 @@ FAIL values/0070
 -@property --brand-color{syntax:"<color>";inherits:false;initial-value:#000}a{--brand-color:rgb(0 0 0)}
 +@property --brand-color{syntax:"<color>";inherits:false;initial-value:#000}a{--brand-color:#000}
 
-FAIL whitespace/0010
--@supports (display:grid)and (gap:10px){a{display:grid; gap:10px}}
-+@supports(display:grid)and (gap:10px){a{display:grid;gap:10px}}
-
 FAIL whitespace/0012
 -a{width:calc(100% * 2)}
 +a{width:calc(100%*2)}
-
-FAIL whitespace/0014
--a{background:url(bg.png) no-repeat}
-+a{background:url(bg.png)no-repeat}
 
 FAIL whitespace/0015
 -a{font:16px / 1.5 sans-serif}


### PR DESCRIPTION
We've had a few changes to CursorCompactWriteSink which fixup stuff, but the
flow is getting a little messy. #1112	now introduces another change which could
make things even less comprehensible.

This change attempts to refactor CursorCompactWriteSink while also incorporating
changes from #1112. Closes #1112, fixes #770.
