### PR TITLE
Regenerate css_ast/src/values from csswg drafts

### DIFF
--- a/crates/css_ast/src/values/content/mod.rs
+++ b/crates/css_ast/src/values/content/mod.rs
@@ -6,6 +6,7 @@
 
 mod impls;
 use super::prelude::*;
+use impls::*;
 /// Represents the style value for `bookmark-label` as defined in [css-content-3](https://drafts.csswg.org/css-content-3/#bookmark-label).
 ///
 /// The grammar is defined as:

--- a/crates/css_feature_data/src/data.rs
+++ b/crates/css_feature_data/src/data.rs
@@ -369,7 +369,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(58u16, 0u16), firefox_android : BrowserVersion(58u16, 0u16), safari :
 	BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-font-rendering-controls"], popularity : 52.49153f32, },
+	["https://caniuse.com/css-font-rendering-controls"], popularity : 53.99488f32, },
 	"css.at-rules.font-face.font-family" => CSSFeature { id :
 	"css.at-rules.font-face.font-family", name : "@font-face", description :
 	"The @font-face CSS at-rule creates a custom font-family value. The at-rule's descriptors set the font's name, source, and various display settings.",
@@ -393,7 +393,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16),
 	firefox : BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/font-feature"], popularity : 29.656054f32, },
+	caniuse : & ["https://caniuse.com/font-feature"], popularity : 29.541763f32, },
 	"css.at-rules.font-face.font-stretch" => CSSFeature { id :
 	"css.at-rules.font-face.font-stretch", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -405,7 +405,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(62u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.at-rules.font-face.font-style" => CSSFeature { id :
 	"css.at-rules.font-face.font-style", name : "font-style", description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -416,7 +416,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), },
-	caniuse : & [], popularity : 78.53412f32, }, "css.at-rules.font-face.font-variant" =>
+	caniuse : & [], popularity : 78.47664f32, }, "css.at-rules.font-face.font-variant" =>
 	CSSFeature { id : "css.at-rules.font-face.font-variant", name : "font-variant",
 	description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
@@ -428,7 +428,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 29.338179f32, }, "css.at-rules.font-face.font-variation-settings" =>
+	[], popularity : 29.584677f32, }, "css.at-rules.font-face.font-variation-settings" =>
 	CSSFeature { id : "css.at-rules.font-face.font-variation-settings", name :
 	"font-variation-settings", description :
 	"The font-variation-settings CSS property sets an \"axis of variability\" on a variable font, such as weight, optical size, or a custom axis defined by the typeface designer. When possible, use other CSS font properties, such as font-weight: bold. Also known as variable fonts.",
@@ -438,7 +438,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/variable-fonts"], popularity : 20.326927f32, },
+	["https://caniuse.com/variable-fonts"], popularity : 19.899553f32, },
 	"css.at-rules.font-face.font-weight" => CSSFeature { id :
 	"css.at-rules.font-face.font-weight", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
@@ -450,7 +450,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 87.64308f32, }, "css.at-rules.font-face.font-width" => CSSFeature {
+	[], popularity : 87.33229f32, }, "css.at-rules.font-face.font-width" => CSSFeature {
 	id : "css.at-rules.font-face.font-width", name : "font-width", description :
 	"The font-width CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-width-prop", groups : & ["fonts"],
@@ -479,7 +479,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(92u16, 0u16), edge : BrowserVersion(92u16, 0u16), firefox :
 	BrowserVersion(92u16, 0u16), firefox_android : BrowserVersion(92u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-size-adjust"], popularity : 2.404273f32, },
+	["https://caniuse.com/font-size-adjust"], popularity : 2.504975f32, },
 	"css.at-rules.font-face.src" => CSSFeature { id : "css.at-rules.font-face.src", name
 	: "@font-face", description :
 	"The @font-face CSS at-rule creates a custom font-family value. The at-rule's descriptors set the font's name, source, and various display settings.",
@@ -560,7 +560,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.at-rules.font-feature-values.annotation" => CSSFeature { id :
 	"css.at-rules.font-feature-values.annotation", name : "font-variant-alternates",
 	description :
@@ -573,7 +573,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.at-rules.font-feature-values.character-variant" => CSSFeature { id :
 	"css.at-rules.font-feature-values.character-variant", name :
 	"font-variant-alternates", description :
@@ -586,7 +586,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.at-rules.font-feature-values.historical-forms" => CSSFeature { id :
 	"css.at-rules.font-feature-values.historical-forms", name :
 	"font-variant-alternates", description :
@@ -599,7 +599,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.at-rules.font-feature-values.ornaments" => CSSFeature { id :
 	"css.at-rules.font-feature-values.ornaments", name : "font-variant-alternates",
 	description :
@@ -612,7 +612,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.at-rules.font-feature-values.styleset" => CSSFeature { id :
 	"css.at-rules.font-feature-values.styleset", name : "font-variant-alternates",
 	description :
@@ -625,7 +625,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.at-rules.font-feature-values.stylistic" => CSSFeature { id :
 	"css.at-rules.font-feature-values.stylistic", name : "font-variant-alternates",
 	description :
@@ -638,7 +638,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.at-rules.font-feature-values.swash" => CSSFeature { id :
 	"css.at-rules.font-feature-values.swash", name : "font-variant-alternates",
 	description :
@@ -651,7 +651,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.at-rules.font-palette-values" => CSSFeature { id :
 	"css.at-rules.font-palette-values", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -663,7 +663,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.281256f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.235819f32, },
 	"css.at-rules.font-palette-values.base-palette" => CSSFeature { id :
 	"css.at-rules.font-palette-values.base-palette", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -675,7 +675,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.281256f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.235819f32, },
 	"css.at-rules.font-palette-values.font-family" => CSSFeature { id :
 	"css.at-rules.font-palette-values.font-family", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -687,7 +687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.281256f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.235819f32, },
 	"css.at-rules.font-palette-values.override-colors" => CSSFeature { id :
 	"css.at-rules.font-palette-values.override-colors", name : "font-palette",
 	description :
@@ -700,7 +700,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.281256f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.235819f32, },
 	"css.at-rules.function" => CSSFeature { id : "css.at-rules.function", name :
 	"@function", description :
 	"The @function CSS at-rule defines a custom function that takes CSS values or custom properties as arguments, and returns a CSS value. It can be based on conditional logic such as by using the @media at-rule.",
@@ -1222,8 +1222,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(113u16, 0u16), edge : BrowserVersion(113u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	[], popularity : 86.593925f32, }, "css.at-rules.media.overflow-inline" => CSSFeature
-	{ id : "css.at-rules.media.overflow-inline", name : "Overflow media queries",
+	[], popularity : 86.46632f32, }, "css.at-rules.media.overflow-inline" => CSSFeature {
+	id : "css.at-rules.media.overflow-inline", name : "Overflow media queries",
 	description :
 	"The overflow-block and overflow-inline CSS media queries set styles based on the way a device displays content that's larger than the viewport or page area. For example, a laptop lets users scroll to reveal content, while a printer displays overflowing content on additional pages.",
 	spec : "https://drafts.csswg.org/mediaqueries-5/#mf-overflow-block", groups : &
@@ -1234,7 +1234,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(113u16, 0u16), edge : BrowserVersion(113u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	[], popularity : 86.593925f32, }, "css.at-rules.media.pointer" => CSSFeature { id :
+	[], popularity : 86.46632f32, }, "css.at-rules.media.pointer" => CSSFeature { id :
 	"css.at-rules.media.pointer", name : "Interaction media queries", description :
 	"The pointer, any-pointer, hover, and any-hover CSS media queries set styles based on the presence of pointing devices and their ability to hover over elements. For example, most smartphones match the (hover: none) and (pointer: coarse) media query.",
 	spec : "https://drafts.csswg.org/mediaqueries-5/#mf-interaction", groups : &
@@ -1492,7 +1492,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(85u16, 0u16), edge : BrowserVersion(85u16, 0u16), firefox :
 	BrowserVersion(122u16, 0u16), firefox_android : BrowserVersion(122u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 1.070679f32, }, "css.at-rules.page.right-bottom" => CSSFeature { id :
+	popularity : 0.163991f32, }, "css.at-rules.page.right-bottom" => CSSFeature { id :
 	"css.at-rules.page.right-bottom", name : "Page setup", description :
 	"The @page CSS at-rule sets the page-specific dimensions and margins for content such as printed documents, ebooks, or slides.",
 	spec : "https://drafts.csswg.org/css-page-3/#at-page-rule", groups : & ["layout",
@@ -1775,7 +1775,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(93u16, 0u16), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(93u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android :
 	BrowserVersion(92u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.677436f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.566579f32, },
 	"css.properties.accent-color.auto" => CSSFeature { id :
 	"css.properties.accent-color.auto", name : "accent-color", description :
 	"The accent-color CSS property sets a color for checkboxes, radio buttons, and other form controls.",
@@ -1784,7 +1784,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(93u16, 0u16), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(93u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android :
 	BrowserVersion(92u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.677436f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.566579f32, },
 	"css.properties.accent-color.currentColor" => CSSFeature { id :
 	"css.properties.accent-color.currentColor", name : "accent-color", description :
 	"The accent-color CSS property sets a color for checkboxes, radio buttons, and other form controls.",
@@ -1793,7 +1793,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(93u16, 0u16), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(93u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android :
 	BrowserVersion(92u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.677436f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.566579f32, },
 	"css.properties.accent-color.transparent" => CSSFeature { id :
 	"css.properties.accent-color.transparent", name : "accent-color", description :
 	"The accent-color CSS property sets a color for checkboxes, radio buttons, and other form controls.",
@@ -1802,7 +1802,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(93u16, 0u16), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(93u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android :
 	BrowserVersion(92u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.677436f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 2.566579f32, },
 	"css.properties.align-content" => CSSFeature { id : "css.properties.align-content",
 	name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -1925,7 +1925,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(52u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.align-content.multicol_context" => CSSFeature { id :
 	"css.properties.align-content.multicol_context", name : "Multi-column layout",
 	description :
@@ -2047,7 +2047,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(52u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.align-items.grid_context.start_end" => CSSFeature { id :
 	"css.properties.align-items.grid_context.start_end", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -2058,7 +2058,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.align-self" => CSSFeature { id : "css.properties.align-self", name :
 	"Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -2179,7 +2179,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(52u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.align-self.normal" => CSSFeature { id :
 	"css.properties.align-self.normal", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -2223,7 +2223,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.544107f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.438251f32, },
 	"css.properties.alignment-baseline.alphabetic" => CSSFeature { id :
 	"css.properties.alignment-baseline.alphabetic", name : "alignment-baseline",
 	description :
@@ -2233,7 +2233,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.544107f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.438251f32, },
 	"css.properties.alignment-baseline.baseline" => CSSFeature { id :
 	"css.properties.alignment-baseline.baseline", name : "alignment-baseline",
 	description :
@@ -2244,7 +2244,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.544107f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.438251f32, },
 	"css.properties.alignment-baseline.central" => CSSFeature { id :
 	"css.properties.alignment-baseline.central", name : "alignment-baseline", description
 	:
@@ -2254,7 +2254,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.544107f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.438251f32, },
 	"css.properties.alignment-baseline.ideographic" => CSSFeature { id :
 	"css.properties.alignment-baseline.ideographic", name : "alignment-baseline",
 	description :
@@ -2264,7 +2264,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.544107f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.438251f32, },
 	"css.properties.alignment-baseline.mathematical" => CSSFeature { id :
 	"css.properties.alignment-baseline.mathematical", name : "alignment-baseline",
 	description :
@@ -2274,7 +2274,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.544107f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.438251f32, },
 	"css.properties.alignment-baseline.middle" => CSSFeature { id :
 	"css.properties.alignment-baseline.middle", name : "alignment-baseline", description
 	:
@@ -2285,7 +2285,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.544107f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.438251f32, },
 	"css.properties.alignment-baseline.text-after-edge" => CSSFeature { id :
 	"css.properties.alignment-baseline.text-after-edge", name : "alignment-baseline",
 	description :
@@ -2295,7 +2295,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.544107f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.438251f32, },
 	"css.properties.alignment-baseline.text-before-edge" => CSSFeature { id :
 	"css.properties.alignment-baseline.text-before-edge", name : "alignment-baseline",
 	description :
@@ -2305,7 +2305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(5u16, 1u16), safari_ios :
-	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.544107f32, },
+	BrowserVersion(5u16, 0u16), }, caniuse : & [], popularity : 0.438251f32, },
 	"css.properties.all" => CSSFeature { id : "css.properties.all", name : "all",
 	description :
 	"The all CSS property is a shorthand for all CSS properties, except for direction and unicode-bidi. It accepts only the keywords for explicit defaulting (such as initial and inherit), since they are the only values supported on all CSS properties.",
@@ -2316,7 +2316,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(27u16, 0u16), firefox_android : BrowserVersion(27u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-all"], popularity : 13.767732f32, },
+	caniuse : & ["https://caniuse.com/css-all"], popularity : 13.157022f32, },
 	"css.properties.anchor-name" => CSSFeature { id : "css.properties.anchor-name", name
 	: "Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
@@ -2389,7 +2389,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16, 0u16), firefox :
 	BrowserVersion(115u16, 0u16), firefox_android : BrowserVersion(115u16, 0u16), safari
 	: BrowserVersion(16u16, 0u16), safari_ios : BrowserVersion(16u16, 0u16), }, caniuse :
-	& [], popularity : 0.461514f32, }, "css.properties.animation-delay" => CSSFeature {
+	& [], popularity : 0.434875f32, }, "css.properties.animation-delay" => CSSFeature {
 	id : "css.properties.animation-delay", name : "Animations (CSS)", description :
 	"The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.",
 	spec : "https://drafts.csswg.org/css-animations-2/", groups : & ["animation"],
@@ -3009,7 +3009,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.auto" =>
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.auto" =>
 	CSSFeature { id : "css.properties.appearance.auto", name : "appearance", description
 	:
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3020,7 +3020,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.base-select"
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.base-select"
 	=> CSSFeature { id : "css.properties.appearance.base-select", name :
 	"Customizable <select>", description :
 	"The <select> element's appearance, including the button, selected option, picker dropdown, and options, can be customized using CSS.",
@@ -3041,7 +3041,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.checkbox" =>
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.checkbox" =>
 	CSSFeature { id : "css.properties.appearance.checkbox", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3052,7 +3052,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.listbox" =>
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.listbox" =>
 	CSSFeature { id : "css.properties.appearance.listbox", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3063,7 +3063,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.menulist" =>
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.menulist" =>
 	CSSFeature { id : "css.properties.appearance.menulist", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3074,7 +3074,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, },
+	caniuse : & [], popularity : 48.096706f32, },
 	"css.properties.appearance.menulist-button" => CSSFeature { id :
 	"css.properties.appearance.menulist-button", name : "appearance", description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3085,7 +3085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.meter" =>
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.meter" =>
 	CSSFeature { id : "css.properties.appearance.meter", name : "appearance", description
 	:
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3096,7 +3096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.none" =>
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.none" =>
 	CSSFeature { id : "css.properties.appearance.none", name : "appearance", description
 	:
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3107,7 +3107,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, },
+	caniuse : & [], popularity : 48.096706f32, },
 	"css.properties.appearance.progress-bar" => CSSFeature { id :
 	"css.properties.appearance.progress-bar", name : "appearance", description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3118,7 +3118,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.radio" =>
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.radio" =>
 	CSSFeature { id : "css.properties.appearance.radio", name : "appearance", description
 	:
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3129,7 +3129,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.searchfield"
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.searchfield"
 	=> CSSFeature { id : "css.properties.appearance.searchfield", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3140,7 +3140,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.textarea" =>
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.textarea" =>
 	CSSFeature { id : "css.properties.appearance.textarea", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3151,7 +3151,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.appearance.textfield"
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.appearance.textfield"
 	=> CSSFeature { id : "css.properties.appearance.textfield", name : "appearance",
 	description :
 	"The appearance CSS property controls the appearance of form controls. Using appearance: none disables any default native appearance and allows the elements to be styled with CSS.",
@@ -3162,7 +3162,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(80u16, 0u16), firefox_android : BrowserVersion(80u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 48.586834f32, }, "css.properties.aspect-ratio" =>
+	caniuse : & [], popularity : 48.096706f32, }, "css.properties.aspect-ratio" =>
 	CSSFeature { id : "css.properties.aspect-ratio", name : "aspect-ratio", description :
 	"The aspect-ratio CSS property controls the width-to-height ratio of elements. For <img> and <video> elements, the width and height attributes used together with height: auto control the aspect ratio while the image/video is loading.",
 	spec : "https://drafts.csswg.org/css-sizing-4/#aspect-ratio", groups : & [],
@@ -3172,7 +3172,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(88u16, 0u16), edge : BrowserVersion(88u16, 0u16),
 	firefox : BrowserVersion(89u16, 0u16), firefox_android : BrowserVersion(89u16, 0u16),
 	safari : BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), },
-	caniuse : & [], popularity : 35.165146f32, }, "css.properties.aspect-ratio.auto" =>
+	caniuse : & [], popularity : 37.57344f32, }, "css.properties.aspect-ratio.auto" =>
 	CSSFeature { id : "css.properties.aspect-ratio.auto", name : "aspect-ratio",
 	description :
 	"The aspect-ratio CSS property controls the width-to-height ratio of elements. For <img> and <video> elements, the width and height attributes used together with height: auto control the aspect ratio while the image/video is loading.",
@@ -3183,7 +3183,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(88u16, 0u16), edge : BrowserVersion(88u16, 0u16),
 	firefox : BrowserVersion(89u16, 0u16), firefox_android : BrowserVersion(89u16, 0u16),
 	safari : BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), },
-	caniuse : & [], popularity : 35.165146f32, }, "css.properties.backdrop-filter" =>
+	caniuse : & [], popularity : 37.57344f32, }, "css.properties.backdrop-filter" =>
 	CSSFeature { id : "css.properties.backdrop-filter", name : "backdrop-filter",
 	description :
 	"The backdrop-filter CSS property applies graphical effects such as blurring or color shifting to the area behind an element.",
@@ -3194,7 +3194,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), firefox : BrowserVersion(103u16, 0u16), firefox_android :
 	BrowserVersion(103u16, 0u16), safari : BrowserVersion(18u16, 0u16), safari_ios :
 	BrowserVersion(18u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-backdrop-filter"], popularity : 32.388584f32, },
+	["https://caniuse.com/css-backdrop-filter"], popularity : 33.900997f32, },
 	"css.properties.backface-visibility" => CSSFeature { id :
 	"css.properties.backface-visibility", name : "3D transforms", description :
 	"The transform CSS property and its 3D transform functions allow rotations and other transforms in three dimensions, including perspective transforms.",
@@ -3217,7 +3217,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background-attachment" => CSSFeature { id :
 	"css.properties.background-attachment", name : "background-attachment", description :
 	"The background-attachment CSS property sets whether an element's background image or gradient moves as the element scrolls.",
@@ -3229,7 +3229,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.568689f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.714159f32, },
 	"css.properties.background-attachment.fixed" => CSSFeature { id :
 	"css.properties.background-attachment.fixed", name : "background-attachment",
 	description :
@@ -3240,7 +3240,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(2u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.568689f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.714159f32, },
 	"css.properties.background-attachment.local" => CSSFeature { id :
 	"css.properties.background-attachment.local", name : "background-attachment",
 	description :
@@ -3253,7 +3253,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(25u16, 0u16), firefox_android : BrowserVersion(25u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.568689f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.714159f32, },
 	"css.properties.background-attachment.multiple_backgrounds" => CSSFeature { id :
 	"css.properties.background-attachment.multiple_backgrounds", name :
 	"background-attachment", description :
@@ -3266,7 +3266,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.568689f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.714159f32, },
 	"css.properties.background-attachment.scroll" => CSSFeature { id :
 	"css.properties.background-attachment.scroll", name : "background-attachment",
 	description :
@@ -3279,7 +3279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	["https://caniuse.com/background-attachment"], popularity : 9.568689f32, },
+	["https://caniuse.com/background-attachment"], popularity : 9.714159f32, },
 	"css.properties.background-blend-mode" => CSSFeature { id :
 	"css.properties.background-blend-mode", name : "background-blend-mode", description :
 	"The background-blend-mode CSS property blends an element's background image and background color using blend modes like multiply, difference, or color.",
@@ -3291,7 +3291,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(35u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(30u16, 0u16), firefox_android : BrowserVersion(30u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-backgroundblendmode"], popularity : 3.720315f32, },
+	["https://caniuse.com/css-backgroundblendmode"], popularity : 3.632732f32, },
 	"css.properties.background-clip" => CSSFeature { id :
 	"css.properties.background-clip", name : "background-clip", description :
 	"The background-clip CSS property sets the extent of the background: the padding box, the content box, or the default border box.",
@@ -3303,7 +3303,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 68.681305f32, }, "css.properties.background-clip.border-area" =>
+	[], popularity : 66.69213f32, }, "css.properties.background-clip.border-area" =>
 	CSSFeature { id : "css.properties.background-clip.border-area", name :
 	"background-clip: border-area", description :
 	"The background-clip: border-area CSS declaration draws the background underneath only the border of an element.",
@@ -3324,7 +3324,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 68.681305f32, }, "css.properties.background-clip.content-box" =>
+	[], popularity : 66.69213f32, }, "css.properties.background-clip.content-box" =>
 	CSSFeature { id : "css.properties.background-clip.content-box", name :
 	"background-clip", description :
 	"The background-clip CSS property sets the extent of the background: the padding box, the content box, or the default border box.",
@@ -3336,7 +3336,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 68.681305f32, }, "css.properties.background-clip.padding-box" =>
+	[], popularity : 66.69213f32, }, "css.properties.background-clip.padding-box" =>
 	CSSFeature { id : "css.properties.background-clip.padding-box", name :
 	"background-clip", description :
 	"The background-clip CSS property sets the extent of the background: the padding box, the content box, or the default border box.",
@@ -3348,7 +3348,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 68.681305f32, }, "css.properties.background-clip.text" => CSSFeature
+	[], popularity : 66.69213f32, }, "css.properties.background-clip.text" => CSSFeature
 	{ id : "css.properties.background-clip.text", name : "background-clip: text",
 	description :
 	"The background-clip: text CSS declaration draws the background underneath only the text in the element.",
@@ -3369,7 +3369,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 89.826546f32, }, "css.properties.background-color.currentColor" =>
+	[], popularity : 89.60944f32, }, "css.properties.background-color.currentColor" =>
 	CSSFeature { id : "css.properties.background-color.currentColor", name :
 	"currentColor", description :
 	"The currentColor CSS value allows you to reuse an element's computed text color for other properties.",
@@ -3394,8 +3394,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 89.826546f32, }, "css.properties.background-image" => CSSFeature {
-	id : "css.properties.background-image", name : "background-image", description :
+	[], popularity : 89.60944f32, }, "css.properties.background-image" => CSSFeature { id
+	: "css.properties.background-image", name : "background-image", description :
 	"The background-image CSS property sets the graphics to display behind the content of an element and in front of the background color. Graphics may be any combination of images or gradients.",
 	spec : "https://drafts.csswg.org/css-backgrounds-3/#background-image", groups : &
 	["background"], baseline_status : BaselineStatus::High { since :
@@ -3405,7 +3405,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 78.63376f32, }, "css.properties.background-image.element" =>
+	[], popularity : 78.79266f32, }, "css.properties.background-image.element" =>
 	CSSFeature { id : "css.properties.background-image.element", name : "element()",
 	description :
 	"The element() CSS function creates a live-updating image from an HTML element that can be used as an image or background image.",
@@ -3449,7 +3449,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 78.63376f32, }, "css.properties.background-image.none" => CSSFeature
+	[], popularity : 78.79266f32, }, "css.properties.background-image.none" => CSSFeature
 	{ id : "css.properties.background-image.none", name : "background-image", description
 	:
 	"The background-image CSS property sets the graphics to display behind the content of an element and in front of the background color. Graphics may be any combination of images or gradients.",
@@ -3461,7 +3461,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 78.63376f32, }, "css.properties.background-image.svg_images" =>
+	[], popularity : 78.79266f32, }, "css.properties.background-image.svg_images" =>
 	CSSFeature { id : "css.properties.background-image.svg_images", name : "SVG",
 	description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -3485,7 +3485,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 9.218161f32, }, "css.properties.background-origin.border-box" =>
+	[], popularity : 9.677514f32, }, "css.properties.background-origin.border-box" =>
 	CSSFeature { id : "css.properties.background-origin.border-box", name :
 	"background-origin", description :
 	"The background-origin CSS property sets the background starting position relative to the border and padding of an element.",
@@ -3497,7 +3497,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 9.218161f32, }, "css.properties.background-origin.content-box" =>
+	[], popularity : 9.677514f32, }, "css.properties.background-origin.content-box" =>
 	CSSFeature { id : "css.properties.background-origin.content-box", name :
 	"background-origin", description :
 	"The background-origin CSS property sets the background starting position relative to the border and padding of an element.",
@@ -3509,7 +3509,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 9.218161f32, }, "css.properties.background-origin.padding-box" =>
+	[], popularity : 9.677514f32, }, "css.properties.background-origin.padding-box" =>
 	CSSFeature { id : "css.properties.background-origin.padding-box", name :
 	"background-origin", description :
 	"The background-origin CSS property sets the background starting position relative to the border and padding of an element.",
@@ -3521,7 +3521,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 9.218161f32, }, "css.properties.background-position" => CSSFeature {
+	[], popularity : 9.677514f32, }, "css.properties.background-position" => CSSFeature {
 	id : "css.properties.background-position", name : "background-position", description
 	:
 	"The background-position CSS property offsets the initial position of background images relative to the background origin.",
@@ -3534,7 +3534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position-x" => CSSFeature { id :
 	"css.properties.background-position-x", name : "background-position", description :
 	"The background-position CSS property offsets the initial position of background images relative to the background origin.",
@@ -3547,7 +3547,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position-x.side-relative_values" => CSSFeature { id :
 	"css.properties.background-position-x.side-relative_values", name :
 	"background-position", description :
@@ -3560,7 +3560,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
 	caniuse : & ["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position-y" => CSSFeature { id :
 	"css.properties.background-position-y", name : "background-position", description :
 	"The background-position CSS property offsets the initial position of background images relative to the background origin.",
@@ -3573,7 +3573,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position-y.side-relative_values" => CSSFeature { id :
 	"css.properties.background-position-y.side-relative_values", name :
 	"background-position", description :
@@ -3586,7 +3586,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
 	caniuse : & ["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position.bottom" => CSSFeature { id :
 	"css.properties.background-position.bottom", name : "background-position",
 	description :
@@ -3600,7 +3600,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position.center" => CSSFeature { id :
 	"css.properties.background-position.center", name : "background-position",
 	description :
@@ -3614,7 +3614,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position.left" => CSSFeature { id :
 	"css.properties.background-position.left", name : "background-position", description
 	:
@@ -3628,7 +3628,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position.multiple_backgrounds" => CSSFeature { id :
 	"css.properties.background-position.multiple_backgrounds", name :
 	"background-position", description :
@@ -3642,7 +3642,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position.right" => CSSFeature { id :
 	"css.properties.background-position.right", name : "background-position", description
 	:
@@ -3656,7 +3656,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position.side-relative_values" => CSSFeature { id :
 	"css.properties.background-position.side-relative_values", name :
 	"background-position", description :
@@ -3670,7 +3670,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(13u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-position.top" => CSSFeature { id :
 	"css.properties.background-position.top", name : "background-position", description :
 	"The background-position CSS property offsets the initial position of background images relative to the background origin.",
@@ -3683,7 +3683,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
 	["https://caniuse.com/css-background-offsets",
-	"https://caniuse.com/background-position-x-y"], popularity : 74.3413f32, },
+	"https://caniuse.com/background-position-x-y"], popularity : 74.72269f32, },
 	"css.properties.background-repeat" => CSSFeature { id :
 	"css.properties.background-repeat", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3695,7 +3695,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 71.773155f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.39573f32, },
 	"css.properties.background-repeat.2-value" => CSSFeature { id :
 	"css.properties.background-repeat.2-value", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3707,7 +3707,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(13u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 71.773155f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.39573f32, },
 	"css.properties.background-repeat.multiple_backgrounds" => CSSFeature { id :
 	"css.properties.background-repeat.multiple_backgrounds", name : "background-repeat",
 	description :
@@ -3720,7 +3720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 71.773155f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.39573f32, },
 	"css.properties.background-repeat.no-repeat" => CSSFeature { id :
 	"css.properties.background-repeat.no-repeat", name : "background-repeat", description
 	: "The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3732,7 +3732,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 71.773155f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.39573f32, },
 	"css.properties.background-repeat.repeat" => CSSFeature { id :
 	"css.properties.background-repeat.repeat", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3744,7 +3744,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 71.773155f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.39573f32, },
 	"css.properties.background-repeat.repeat-x" => CSSFeature { id :
 	"css.properties.background-repeat.repeat-x", name : "background-repeat", description
 	: "The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3756,7 +3756,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 71.773155f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.39573f32, },
 	"css.properties.background-repeat.repeat-y" => CSSFeature { id :
 	"css.properties.background-repeat.repeat-y", name : "background-repeat", description
 	: "The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3768,7 +3768,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 71.773155f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.39573f32, },
 	"css.properties.background-repeat.round" => CSSFeature { id :
 	"css.properties.background-repeat.round", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3780,7 +3780,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(30u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 71.773155f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.39573f32, },
 	"css.properties.background-repeat.space" => CSSFeature { id :
 	"css.properties.background-repeat.space", name : "background-repeat", description :
 	"The background-repeat CSS property sets how a background image is tiled.", spec :
@@ -3792,7 +3792,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(30u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/background-repeat-round-space"], popularity : 71.773155f32, },
+	["https://caniuse.com/background-repeat-round-space"], popularity : 72.39573f32, },
 	"css.properties.background-size" => CSSFeature { id :
 	"css.properties.background-size", name : "background-size", description :
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
@@ -3804,7 +3804,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 72.39759f32, }, "css.properties.background-size.auto" => CSSFeature
+	[], popularity : 73.64552f32, }, "css.properties.background-size.auto" => CSSFeature
 	{ id : "css.properties.background-size.auto", name : "background-size", description :
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
 	spec : "https://drafts.csswg.org/css-backgrounds-3/#background-size", groups : &
@@ -3815,7 +3815,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 72.39759f32, }, "css.properties.background-size.contain" =>
+	[], popularity : 73.64552f32, }, "css.properties.background-size.contain" =>
 	CSSFeature { id : "css.properties.background-size.contain", name : "background-size",
 	description :
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
@@ -3827,7 +3827,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 72.39759f32, }, "css.properties.background-size.cover" => CSSFeature
+	[], popularity : 73.64552f32, }, "css.properties.background-size.cover" => CSSFeature
 	{ id : "css.properties.background-size.cover", name : "background-size", description
 	:
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
@@ -3839,7 +3839,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 72.39759f32, }, "css.properties.background.SVG_image_as_background"
+	[], popularity : 73.64552f32, }, "css.properties.background.SVG_image_as_background"
 	=> CSSFeature { id : "css.properties.background.SVG_image_as_background", name :
 	"SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -3863,7 +3863,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(22u16, 0u16), firefox_android : BrowserVersion(22u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(4u16, 0u16), }, caniuse : &
-	[], popularity : 68.681305f32, }, "css.properties.background.background-origin" =>
+	[], popularity : 66.69213f32, }, "css.properties.background.background-origin" =>
 	CSSFeature { id : "css.properties.background.background-origin", name :
 	"background-origin", description :
 	"The background-origin CSS property sets the background starting position relative to the border and padding of an element.",
@@ -3875,7 +3875,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(22u16, 0u16), firefox_android : BrowserVersion(22u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(4u16, 0u16), }, caniuse : &
-	[], popularity : 9.218161f32, }, "css.properties.background.background-size" =>
+	[], popularity : 9.677514f32, }, "css.properties.background.background-size" =>
 	CSSFeature { id : "css.properties.background.background-size", name :
 	"background-size", description :
 	"The background-size CSS property scales or stretches a background based on the size of the element (with the contain and cover keywords), a length, or percentage.",
@@ -3887,7 +3887,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(18u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(4u16, 0u16), }, caniuse : &
-	[], popularity : 72.39759f32, }, "css.properties.background.currentColor" =>
+	[], popularity : 73.64552f32, }, "css.properties.background.currentColor" =>
 	CSSFeature { id : "css.properties.background.currentColor", name : "currentColor",
 	description :
 	"The currentColor CSS value allows you to reuse an element's computed text color for other properties.",
@@ -3911,7 +3911,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.multiple_backgrounds" => CSSFeature { id :
 	"css.properties.background.multiple_backgrounds", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3923,7 +3923,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.no-repeat" => CSSFeature { id :
 	"css.properties.background.no-repeat", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3935,7 +3935,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.none" => CSSFeature { id :
 	"css.properties.background.none", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3947,7 +3947,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.repeat" => CSSFeature { id :
 	"css.properties.background.repeat", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3959,7 +3959,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.repeat-x" => CSSFeature { id :
 	"css.properties.background.repeat-x", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3971,7 +3971,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.repeat-y" => CSSFeature { id :
 	"css.properties.background.repeat-y", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3983,7 +3983,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.round" => CSSFeature { id :
 	"css.properties.background.round", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -3995,7 +3995,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.scroll" => CSSFeature { id :
 	"css.properties.background.scroll", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -4007,7 +4007,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.space" => CSSFeature { id :
 	"css.properties.background.space", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -4019,7 +4019,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.background.transparent" => CSSFeature { id :
 	"css.properties.background.transparent", name : "background", description :
 	"The background CSS property is a shorthand that sets several background properties at once.",
@@ -4031,7 +4031,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/multibackgrounds"], popularity : 86.9064f32, },
+	["https://caniuse.com/multibackgrounds"], popularity : 86.859344f32, },
 	"css.properties.baseline-shift" => CSSFeature { id : "css.properties.baseline-shift",
 	name : "baseline-shift", description :
 	"The baseline-shift CSS property sets the position of an element relative to its dominant baseline.",
@@ -4041,7 +4041,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(4u16, 0u16), safari_ios :
-	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.457023f32, },
+	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.38753f32, },
 	"css.properties.baseline-shift.baseline" => CSSFeature { id :
 	"css.properties.baseline-shift.baseline", name : "baseline-shift", description :
 	"The baseline-shift CSS property sets the position of an element relative to its dominant baseline.",
@@ -4050,7 +4050,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(4u16, 0u16), safari_ios :
-	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.457023f32, },
+	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.38753f32, },
 	"css.properties.baseline-shift.sub" => CSSFeature { id :
 	"css.properties.baseline-shift.sub", name : "baseline-shift", description :
 	"The baseline-shift CSS property sets the position of an element relative to its dominant baseline.",
@@ -4060,7 +4060,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(4u16, 0u16), safari_ios :
-	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.457023f32, },
+	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.38753f32, },
 	"css.properties.baseline-shift.super" => CSSFeature { id :
 	"css.properties.baseline-shift.super", name : "baseline-shift", description :
 	"The baseline-shift CSS property sets the position of an element relative to its dominant baseline.",
@@ -4070,7 +4070,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), chrome_android : BrowserVersion(18u16, 0u16), edge :
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(149u16, 0u16), firefox_android
 	: BrowserVersion(149u16, 0u16), safari : BrowserVersion(4u16, 0u16), safari_ios :
-	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.457023f32, },
+	BrowserVersion(3u16, 2u16), }, caniuse : & [], popularity : 0.38753f32, },
 	"css.properties.baseline-source" => CSSFeature { id :
 	"css.properties.baseline-source", name : "baseline-source", description :
 	"The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.",
@@ -4079,7 +4079,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), chrome_android : BrowserVersion(111u16, 0u16), edge :
 	BrowserVersion(111u16, 0u16), firefox : BrowserVersion(115u16, 0u16), firefox_android
 	: BrowserVersion(115u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.070573f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.060928f32, },
 	"css.properties.baseline-source.auto" => CSSFeature { id :
 	"css.properties.baseline-source.auto", name : "baseline-source", description :
 	"The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.",
@@ -4088,7 +4088,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), chrome_android : BrowserVersion(111u16, 0u16), edge :
 	BrowserVersion(111u16, 0u16), firefox : BrowserVersion(115u16, 0u16), firefox_android
 	: BrowserVersion(115u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.070573f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.060928f32, },
 	"css.properties.baseline-source.first" => CSSFeature { id :
 	"css.properties.baseline-source.first", name : "baseline-source", description :
 	"The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.",
@@ -4097,7 +4097,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), chrome_android : BrowserVersion(111u16, 0u16), edge :
 	BrowserVersion(111u16, 0u16), firefox : BrowserVersion(115u16, 0u16), firefox_android
 	: BrowserVersion(115u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.070573f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.060928f32, },
 	"css.properties.baseline-source.last" => CSSFeature { id :
 	"css.properties.baseline-source.last", name : "baseline-source", description :
 	"The baseline-source CSS property controls how inline-level boxes with multiple lines of text are aligned with the surrounding text. By default, which typographic baseline is used depends on the display property value.",
@@ -4106,7 +4106,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), chrome_android : BrowserVersion(111u16, 0u16), edge :
 	BrowserVersion(111u16, 0u16), firefox : BrowserVersion(115u16, 0u16), firefox_android
 	: BrowserVersion(115u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.070573f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.060928f32, },
 	"css.properties.block-size" => CSSFeature { id : "css.properties.block-size", name :
 	"Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -5413,7 +5413,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-bottom-left-radius.elliptical_corners" => CSSFeature { id :
 	"css.properties.border-bottom-left-radius.elliptical_corners", name :
 	"border-radius", description :
@@ -5426,7 +5426,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-bottom-left-radius.percentages" => CSSFeature { id :
 	"css.properties.border-bottom-left-radius.percentages", name : "border-radius",
 	description :
@@ -5439,7 +5439,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-bottom-right-radius" => CSSFeature { id :
 	"css.properties.border-bottom-right-radius", name : "border-radius", description :
 	"The border-radius CSS property rounds the corners of the border drawn around an element.",
@@ -5451,7 +5451,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-bottom-right-radius.elliptical_corners" => CSSFeature { id :
 	"css.properties.border-bottom-right-radius.elliptical_corners", name :
 	"border-radius", description :
@@ -5464,7 +5464,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-bottom-right-radius.percentages" => CSSFeature { id :
 	"css.properties.border-bottom-right-radius.percentages", name : "border-radius",
 	description :
@@ -5477,7 +5477,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-bottom-style" => CSSFeature { id :
 	"css.properties.border-bottom-style", name : "Borders", description :
 	"The border CSS property sets the color, style, and width of the line around an element.",
@@ -5910,7 +5910,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-outset" => CSSFeature { id :
 	"css.properties.border-image-outset", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5922,7 +5922,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-repeat" => CSSFeature { id :
 	"css.properties.border-image-repeat", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5934,7 +5934,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-repeat.repeat" => CSSFeature { id :
 	"css.properties.border-image-repeat.repeat", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5946,7 +5946,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-repeat.round" => CSSFeature { id :
 	"css.properties.border-image-repeat.round", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5958,7 +5958,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(30u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-repeat.space" => CSSFeature { id :
 	"css.properties.border-image-repeat.space", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5970,7 +5970,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(50u16, 0u16), firefox_android : BrowserVersion(50u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-repeat.stretch" => CSSFeature { id :
 	"css.properties.border-image-repeat.stretch", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5982,7 +5982,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-slice" => CSSFeature { id :
 	"css.properties.border-image-slice", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -5994,7 +5994,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-source" => CSSFeature { id :
 	"css.properties.border-image-source", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6006,7 +6006,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-width" => CSSFeature { id :
 	"css.properties.border-image-width", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6018,7 +6018,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(13u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image-width.auto" => CSSFeature { id :
 	"css.properties.border-image-width.auto", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6030,7 +6030,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image.fill" => CSSFeature { id :
 	"css.properties.border-image.fill", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6042,7 +6042,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image.gradient" => CSSFeature { id :
 	"css.properties.border-image.gradient", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6054,7 +6054,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image.none" => CSSFeature { id :
 	"css.properties.border-image.none", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6066,7 +6066,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image.optional_border_image_slice" => CSSFeature { id :
 	"css.properties.border-image.optional_border_image_slice", name : "Border images",
 	description : "The border-image CSS property draws an image around an element.", spec
@@ -6078,7 +6078,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image.repeat" => CSSFeature { id :
 	"css.properties.border-image.repeat", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6090,7 +6090,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image.round" => CSSFeature { id :
 	"css.properties.border-image.round", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6102,7 +6102,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image.space" => CSSFeature { id :
 	"css.properties.border-image.space", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6114,7 +6114,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-image.stretch" => CSSFeature { id :
 	"css.properties.border-image.stretch", name : "Border images", description :
 	"The border-image CSS property draws an image around an element.", spec :
@@ -6126,7 +6126,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-image"], popularity : 6.121996f32, },
+	["https://caniuse.com/border-image"], popularity : 6.057941f32, },
 	"css.properties.border-inline" => CSSFeature { id : "css.properties.border-inline",
 	name : "Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -7700,7 +7700,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-radius.4_values_for_4_corners" => CSSFeature { id :
 	"css.properties.border-radius.4_values_for_4_corners", name : "border-radius",
 	description :
@@ -7713,7 +7713,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-radius.elliptical_borders" => CSSFeature { id :
 	"css.properties.border-radius.elliptical_borders", name : "border-radius",
 	description :
@@ -7726,7 +7726,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-radius.percentages" => CSSFeature { id :
 	"css.properties.border-radius.percentages", name : "border-radius", description :
 	"The border-radius CSS property rounds the corners of the border drawn around an element.",
@@ -7738,7 +7738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-right" => CSSFeature { id : "css.properties.border-right",
 	name : "Borders", description :
 	"The border CSS property sets the color, style, and width of the line around an element.",
@@ -8124,17 +8124,17 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(147u16, 0u16), chrome_android : BrowserVersion(147u16, 0u16), edge :
 	BrowserVersion(147u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.155607f32, },
-	"css.properties.border-shape.none" => CSSFeature { id :
-	"css.properties.border-shape.none", name : "border-shape", description :
+	0), }, caniuse : & [], popularity : 0.15892f32, }, "css.properties.border-shape.none"
+	=> CSSFeature { id : "css.properties.border-shape.none", name : "border-shape",
+	description :
 	"The border-shape CSS property sets the geometry of the border box, changing the shape of any applicable border, border image, focus outline, or shadow.",
 	spec : "https://drafts.csswg.org/css-borders-4/#border-shape", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
 	BrowserVersion(147u16, 0u16), chrome_android : BrowserVersion(147u16, 0u16), edge :
 	BrowserVersion(147u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.155607f32, }, "css.properties.border-spacing"
-	=> CSSFeature { id : "css.properties.border-spacing", name : "Tables", description :
+	0), }, caniuse : & [], popularity : 0.15892f32, }, "css.properties.border-spacing" =>
+	CSSFeature { id : "css.properties.border-spacing", name : "Tables", description :
 	"The <table> HTML element, with several related elements, represents tabular data in rows and columns of cells.",
 	spec : "https://html.spec.whatwg.org/multipage/tables.html", groups : &
 	["html-elements"], baseline_status : BaselineStatus::High { since :
@@ -8346,7 +8346,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-top-left-radius.elliptical_corners" => CSSFeature { id :
 	"css.properties.border-top-left-radius.elliptical_corners", name : "border-radius",
 	description :
@@ -8359,7 +8359,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-top-left-radius.percentages" => CSSFeature { id :
 	"css.properties.border-top-left-radius.percentages", name : "border-radius",
 	description :
@@ -8372,7 +8372,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-top-right-radius" => CSSFeature { id :
 	"css.properties.border-top-right-radius", name : "border-radius", description :
 	"The border-radius CSS property rounds the corners of the border drawn around an element.",
@@ -8384,7 +8384,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-top-right-radius.elliptical_corners" => CSSFeature { id :
 	"css.properties.border-top-right-radius.elliptical_corners", name : "border-radius",
 	description :
@@ -8397,7 +8397,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-top-right-radius.percentages" => CSSFeature { id :
 	"css.properties.border-top-right-radius.percentages", name : "border-radius",
 	description :
@@ -8410,7 +8410,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	["https://caniuse.com/border-radius"], popularity : 85.746765f32, },
+	["https://caniuse.com/border-radius"], popularity : 85.99189f32, },
 	"css.properties.border-top-style" => CSSFeature { id :
 	"css.properties.border-top-style", name : "Borders", description :
 	"The border CSS property sets the color, style, and width of the line around an element.",
@@ -9002,7 +9002,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(32u16, 0u16), firefox_android
 	: BrowserVersion(32u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-boxdecorationbreak"],
-	popularity : 2.969611f32, }, "css.properties.box-decoration-break.clone" =>
+	popularity : 2.654098f32, }, "css.properties.box-decoration-break.clone" =>
 	CSSFeature { id : "css.properties.box-decoration-break.clone", name :
 	"box-decoration-break", description :
 	"The box-decoration-break CSS property sets whether box decorations, such as borders or backgrounds, of an element divided across a page, column, or region wraps each fragment or splits across the break.",
@@ -9012,7 +9012,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(32u16, 0u16), firefox_android
 	: BrowserVersion(32u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-boxdecorationbreak"],
-	popularity : 2.969611f32, }, "css.properties.box-decoration-break.slice" =>
+	popularity : 2.654098f32, }, "css.properties.box-decoration-break.slice" =>
 	CSSFeature { id : "css.properties.box-decoration-break.slice", name :
 	"box-decoration-break", description :
 	"The box-decoration-break CSS property sets whether box decorations, such as borders or backgrounds, of an element divided across a page, column, or region wraps each fragment or splits across the break.",
@@ -9022,7 +9022,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(32u16, 0u16), firefox_android
 	: BrowserVersion(32u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-boxdecorationbreak"],
-	popularity : 2.969611f32, }, "css.properties.box-shadow" => CSSFeature { id :
+	popularity : 2.654098f32, }, "css.properties.box-shadow" => CSSFeature { id :
 	"css.properties.box-shadow", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
 	spec : "https://drafts.csswg.org/css-backgrounds-3/#box-shadow", groups : &
@@ -9033,7 +9033,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 81.72398f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.816734f32, },
 	"css.properties.box-shadow.inset" => CSSFeature { id :
 	"css.properties.box-shadow.inset", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
@@ -9045,7 +9045,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 81.72398f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.816734f32, },
 	"css.properties.box-shadow.multiple_shadows" => CSSFeature { id :
 	"css.properties.box-shadow.multiple_shadows", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
@@ -9057,7 +9057,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 81.72398f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.816734f32, },
 	"css.properties.box-shadow.none" => CSSFeature { id :
 	"css.properties.box-shadow.none", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
@@ -9069,7 +9069,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 81.72398f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.816734f32, },
 	"css.properties.box-shadow.spread_radius" => CSSFeature { id :
 	"css.properties.box-shadow.spread_radius", name : "box-shadow", description :
 	"The box-shadow CSS property applies shadow effects around an element's frame. This can create drop shadow and inner shadow effects.",
@@ -9081,7 +9081,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(4u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-boxshadow"], popularity : 81.72398f32, },
+	["https://caniuse.com/css-boxshadow"], popularity : 81.816734f32, },
 	"css.properties.box-sizing" => CSSFeature { id : "css.properties.box-sizing", name :
 	"box-sizing", description :
 	"The box-sizing CSS property sets whether an element's width and height are calculated based on the content-box, which does not count the size of borders or padding, or border-box, which does count them.",
@@ -9093,7 +9093,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css3-boxsizing"], popularity : 85.22227f32, },
+	["https://caniuse.com/css3-boxsizing"], popularity : 85.24432f32, },
 	"css.properties.box-sizing.border-box" => CSSFeature { id :
 	"css.properties.box-sizing.border-box", name : "box-sizing", description :
 	"The box-sizing CSS property sets whether an element's width and height are calculated based on the content-box, which does not count the size of borders or padding, or border-box, which does count them.",
@@ -9105,7 +9105,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css3-boxsizing"], popularity : 85.22227f32, },
+	["https://caniuse.com/css3-boxsizing"], popularity : 85.24432f32, },
 	"css.properties.box-sizing.content-box" => CSSFeature { id :
 	"css.properties.box-sizing.content-box", name : "box-sizing", description :
 	"The box-sizing CSS property sets whether an element's width and height are calculated based on the content-box, which does not count the size of borders or padding, or border-box, which does count them.",
@@ -9117,7 +9117,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css3-boxsizing"], popularity : 85.22227f32, },
+	["https://caniuse.com/css3-boxsizing"], popularity : 85.24432f32, },
 	"css.properties.break-after" => CSSFeature { id : "css.properties.break-after", name
 	: "Page breaks", description :
 	"In printed page layouts, the break-after, break-before, break-inside CSS properties control where printed pages start and end. Also known as pagination or page breaking.",
@@ -9680,7 +9680,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(53u16, 0u16), firefox_android : BrowserVersion(53u16, 0u16),
 	safari : BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 15.099689f32, },
+	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 14.464512f32, },
 	"css.properties.caret-color.currentColor" => CSSFeature { id :
 	"css.properties.caret-color.currentColor", name : "caret-color", description :
 	"The caret-color CSS property sets the color of the text insertion pointer in a text input.",
@@ -9691,7 +9691,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(53u16, 0u16), firefox_android : BrowserVersion(53u16, 0u16),
 	safari : BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 15.099689f32, },
+	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 14.464512f32, },
 	"css.properties.caret-color.transparent" => CSSFeature { id :
 	"css.properties.caret-color.transparent", name : "caret-color", description :
 	"The caret-color CSS property sets the color of the text insertion pointer in a text input.",
@@ -9702,7 +9702,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(53u16, 0u16), firefox_android : BrowserVersion(53u16, 0u16),
 	safari : BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 15.099689f32, },
+	caniuse : & ["https://caniuse.com/css-caret-color"], popularity : 14.464512f32, },
 	"css.properties.caret-shape" => CSSFeature { id : "css.properties.caret-shape", name
 	: "caret-shape", description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
@@ -9711,7 +9711,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.153082f32, }, "css.properties.caret-shape.auto"
+	0), }, caniuse : & [], popularity : 0.155799f32, }, "css.properties.caret-shape.auto"
 	=> CSSFeature { id : "css.properties.caret-shape.auto", name : "caret-shape",
 	description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
@@ -9720,7 +9720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.153082f32, }, "css.properties.caret-shape.bar"
+	0), }, caniuse : & [], popularity : 0.155799f32, }, "css.properties.caret-shape.bar"
 	=> CSSFeature { id : "css.properties.caret-shape.bar", name : "caret-shape",
 	description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
@@ -9729,7 +9729,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.153082f32, },
+	0), }, caniuse : & [], popularity : 0.155799f32, },
 	"css.properties.caret-shape.block" => CSSFeature { id :
 	"css.properties.caret-shape.block", name : "caret-shape", description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
@@ -9738,7 +9738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.153082f32, },
+	0), }, caniuse : & [], popularity : 0.155799f32, },
 	"css.properties.caret-shape.underscore" => CSSFeature { id :
 	"css.properties.caret-shape.underscore", name : "caret-shape", description :
 	"The caret-shape CSS property sets the shape of the insertion caret, the symbol that shows where the next character is to be inserted or deleted.",
@@ -9747,7 +9747,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), chrome_android : BrowserVersion(144u16, 0u16), edge :
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.153082f32, }, "css.properties.clear" =>
+	0), }, caniuse : & [], popularity : 0.155799f32, }, "css.properties.clear" =>
 	CSSFeature { id : "css.properties.clear", name : "float and clear", description :
 	"The float CSS property aligns an element to either side of its container, allowing text and inline elements to flow around it. The clear CSS property sets whether an element is moved below floating elements that proceed it.",
 	spec : "https://drafts.csswg.org/css2/#propdef-float", groups : & [], baseline_status
@@ -9828,7 +9828,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 52.409042f32, }, "css.properties.clip-path" => CSSFeature { id :
+	[], popularity : 51.87419f32, }, "css.properties.clip-path" => CSSFeature { id :
 	"css.properties.clip-path", name : "clip-path", description :
 	"The clip-path CSS property and SVG attribute set the visible area of an element. Everything outside the area will be hidden.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
@@ -9839,8 +9839,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 42.88221f32, }, "css.properties.clip-path.basic_shape" => CSSFeature
-	{ id : "css.properties.clip-path.basic_shape", name : "clip-path", description :
+	[], popularity : 42.925217f32, }, "css.properties.clip-path.basic_shape" =>
+	CSSFeature { id : "css.properties.clip-path.basic_shape", name : "clip-path",
+	description :
 	"The clip-path CSS property and SVG attribute set the visible area of an element. Everything outside the area will be hidden.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
 	["clipping-shapes-masking"], baseline_status : BaselineStatus::High { since :
@@ -9850,7 +9851,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(54u16, 0u16), firefox_android : BrowserVersion(54u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 42.88221f32, }, "css.properties.clip-path.fill-box" => CSSFeature {
+	[], popularity : 42.925217f32, }, "css.properties.clip-path.fill-box" => CSSFeature {
 	id : "css.properties.clip-path.fill-box", name : "Clip path boxes", description :
 	"The fill-box, stroke-box, and view-box values for clip-path set an edge of the element's box to use as the clipping shape.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
@@ -9872,7 +9873,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 42.88221f32, }, "css.properties.clip-path.is_animatable" =>
+	[], popularity : 42.925217f32, }, "css.properties.clip-path.is_animatable" =>
 	CSSFeature { id : "css.properties.clip-path.is_animatable", name :
 	"Animatable clipping paths", description :
 	"The clip-path property can be animated using CSS transitions and animations.", spec
@@ -9895,7 +9896,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(88u16, 0u16), edge : BrowserVersion(88u16, 0u16), firefox :
 	BrowserVersion(71u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	[], popularity : 42.88221f32, }, "css.properties.clip-path.stroke-box" => CSSFeature
+	[], popularity : 42.925217f32, }, "css.properties.clip-path.stroke-box" => CSSFeature
 	{ id : "css.properties.clip-path.stroke-box", name : "Clip path boxes", description :
 	"The fill-box, stroke-box, and view-box values for clip-path set an edge of the element's box to use as the clipping shape.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
@@ -9917,7 +9918,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 42.88221f32, }, "css.properties.clip-path.view-box" => CSSFeature {
+	[], popularity : 42.925217f32, }, "css.properties.clip-path.view-box" => CSSFeature {
 	id : "css.properties.clip-path.view-box", name : "Clip path boxes", description :
 	"The fill-box, stroke-box, and view-box values for clip-path set an edge of the element's box to use as the clipping shape.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-clip-path", groups : &
@@ -9970,7 +9971,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 52.409042f32, }, "css.properties.color" => CSSFeature { id :
+	[], popularity : 51.87419f32, }, "css.properties.color" => CSSFeature { id :
 	"css.properties.color", name : "Color", description :
 	"The color CSS property sets the primary foreground color of an element, which is used for text, the default border color, and text decorations.",
 	spec : "https://drafts.csswg.org/css-color-4/#the-color-property", groups : & [],
@@ -9980,7 +9981,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 90.34877f32, }, "css.properties.color-adjust" =>
+	caniuse : & [], popularity : 90.24377f32, }, "css.properties.color-adjust" =>
 	CSSFeature { id : "css.properties.color-adjust", name : "color-adjust", description :
 	"The color-adjust shorthand CSS property allows multiple performance related color adjustments to be set at once. Setting the print-color-adjust CSS property directly is preferred, as it is the only such adjustment so far defined.",
 	spec : "https://drafts.csswg.org/css-color-adjust-1/#color-adjust", groups : &
@@ -10090,7 +10091,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(81u16, 0u16), edge : BrowserVersion(81u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.361446f32, }, "css.properties.color-scheme.dark" =>
+	caniuse : & [], popularity : 20.920586f32, }, "css.properties.color-scheme.dark" =>
 	CSSFeature { id : "css.properties.color-scheme.dark", name : "color-scheme",
 	description :
 	"The color-scheme CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.",
@@ -10101,7 +10102,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(81u16, 0u16), edge : BrowserVersion(81u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.361446f32, }, "css.properties.color-scheme.light" =>
+	caniuse : & [], popularity : 20.920586f32, }, "css.properties.color-scheme.light" =>
 	CSSFeature { id : "css.properties.color-scheme.light", name : "color-scheme",
 	description :
 	"The color-scheme CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.",
@@ -10112,7 +10113,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(81u16, 0u16), edge : BrowserVersion(81u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.361446f32, }, "css.properties.color-scheme.normal" =>
+	caniuse : & [], popularity : 20.920586f32, }, "css.properties.color-scheme.normal" =>
 	CSSFeature { id : "css.properties.color-scheme.normal", name : "color-scheme",
 	description :
 	"The color-scheme CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.",
@@ -10123,7 +10124,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(81u16, 0u16), edge : BrowserVersion(81u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.361446f32, }, "css.properties.color-scheme.only" =>
+	caniuse : & [], popularity : 20.920586f32, }, "css.properties.color-scheme.only" =>
 	CSSFeature { id : "css.properties.color-scheme.only", name : "color-scheme",
 	description :
 	"The color-scheme CSS property sets which color schemes (light or dark) an element uses and may prevent automatic dark mode adjustments by the browser.",
@@ -10134,7 +10135,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16),
 	firefox : BrowserVersion(96u16, 0u16), firefox_android : BrowserVersion(96u16, 0u16),
 	safari : BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), },
-	caniuse : & [], popularity : 21.361446f32, }, "css.properties.color.currentColor" =>
+	caniuse : & [], popularity : 20.920586f32, }, "css.properties.color.currentColor" =>
 	CSSFeature { id : "css.properties.color.currentColor", name : "currentColor",
 	description :
 	"The currentColor CSS value allows you to reuse an element's computed text color for other properties.",
@@ -10157,7 +10158,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 90.34877f32, }, "css.properties.column-count" =>
+	caniuse : & [], popularity : 90.24377f32, }, "css.properties.column-count" =>
 	CSSFeature { id : "css.properties.column-count", name : "Multi-column layout",
 	description :
 	"Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.",
@@ -10190,7 +10191,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 1.960711f32, }, "css.properties.column-fill.auto" => CSSFeature { id
+	[], popularity : 2.093662f32, }, "css.properties.column-fill.auto" => CSSFeature { id
 	: "css.properties.column-fill.auto", name : "column-fill", description :
 	"The column-fill CSS property sets the distribution of content across columns in a multi-column layout.",
 	spec : "https://drafts.csswg.org/css-multicol-1/#filling-columns", groups : &
@@ -10201,7 +10202,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 1.960711f32, }, "css.properties.column-fill.balance" => CSSFeature {
+	[], popularity : 2.093662f32, }, "css.properties.column-fill.balance" => CSSFeature {
 	id : "css.properties.column-fill.balance", name : "column-fill", description :
 	"The column-fill CSS property sets the distribution of content across columns in a multi-column layout.",
 	spec : "https://drafts.csswg.org/css-multicol-1/#filling-columns", groups : &
@@ -10212,7 +10213,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 1.960711f32, }, "css.properties.column-gap" => CSSFeature { id :
+	[], popularity : 2.093662f32, }, "css.properties.column-gap" => CSSFeature { id :
 	"css.properties.column-gap", name : "Multi-column layout", description :
 	"Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.",
 	spec : "https://drafts.csswg.org/css-multicol-1/", groups : & ["multi-column"],
@@ -10244,7 +10245,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 0u16), safari_ios : BrowserVersion(12u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.column-gap.multicol_context" => CSSFeature { id :
 	"css.properties.column-gap.multicol_context", name : "Multi-column layout",
 	description :
@@ -10673,7 +10674,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(71u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 0.878335f32, }, "css.properties.column-span.all" => CSSFeature { id
+	[], popularity : 0.936853f32, }, "css.properties.column-span.all" => CSSFeature { id
 	: "css.properties.column-span.all", name : "column-span", description :
 	"The column-span CSS property controls whether a child element extends across all columns of a multi-column parent.",
 	spec : "https://drafts.csswg.org/css-multicol-1/#spanning-columns", groups : &
@@ -10684,7 +10685,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(71u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 0.878335f32, }, "css.properties.column-span.none" => CSSFeature { id
+	[], popularity : 0.936853f32, }, "css.properties.column-span.none" => CSSFeature { id
 	: "css.properties.column-span.none", name : "column-span", description :
 	"The column-span CSS property controls whether a child element extends across all columns of a multi-column parent.",
 	spec : "https://drafts.csswg.org/css-multicol-1/#spanning-columns", groups : &
@@ -10695,7 +10696,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(50u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(71u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 0.878335f32, }, "css.properties.column-width" => CSSFeature { id :
+	[], popularity : 0.936853f32, }, "css.properties.column-width" => CSSFeature { id :
 	"css.properties.column-width", name : "Multi-column layout", description :
 	"Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.",
 	spec : "https://drafts.csswg.org/css-multicol-1/", groups : & ["multi-column"],
@@ -10737,7 +10738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-containment"], popularity : 21.060076f32, },
+	["https://caniuse.com/css-containment"], popularity : 20.761927f32, },
 	"css.properties.contain-intrinsic-block-size" => CSSFeature { id :
 	"css.properties.contain-intrinsic-block-size", name : "contain-intrinsic-size",
 	description :
@@ -10750,7 +10751,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), edge : BrowserVersion(95u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain-intrinsic-block-size.none"
+	& [], popularity : 8.503787f32, }, "css.properties.contain-intrinsic-block-size.none"
 	=> CSSFeature { id : "css.properties.contain-intrinsic-block-size.none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10762,7 +10763,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain-intrinsic-height" =>
+	& [], popularity : 8.503787f32, }, "css.properties.contain-intrinsic-height" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-height", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10774,7 +10775,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), edge : BrowserVersion(95u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain-intrinsic-height.none" =>
+	& [], popularity : 8.503787f32, }, "css.properties.contain-intrinsic-height.none" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-height.none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10786,7 +10787,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain-intrinsic-inline-size" =>
+	& [], popularity : 8.503787f32, }, "css.properties.contain-intrinsic-inline-size" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-inline-size", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10798,7 +10799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), edge : BrowserVersion(95u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, },
+	& [], popularity : 8.503787f32, },
 	"css.properties.contain-intrinsic-inline-size.none" => CSSFeature { id :
 	"css.properties.contain-intrinsic-inline-size.none", name : "contain-intrinsic-size",
 	description :
@@ -10811,7 +10812,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain-intrinsic-size" =>
+	& [], popularity : 8.503787f32, }, "css.properties.contain-intrinsic-size" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-size", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10823,7 +10824,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(83u16, 0u16), edge : BrowserVersion(83u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain-intrinsic-size.auto_none"
+	& [], popularity : 8.503787f32, }, "css.properties.contain-intrinsic-size.auto_none"
 	=> CSSFeature { id : "css.properties.contain-intrinsic-size.auto_none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10835,7 +10836,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16), firefox :
 	BrowserVersion(117u16, 0u16), firefox_android : BrowserVersion(117u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain-intrinsic-size.none" =>
+	& [], popularity : 8.503787f32, }, "css.properties.contain-intrinsic-size.none" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-size.none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10847,7 +10848,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain-intrinsic-width" =>
+	& [], popularity : 8.503787f32, }, "css.properties.contain-intrinsic-width" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-width", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10859,7 +10860,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), edge : BrowserVersion(95u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain-intrinsic-width.none" =>
+	& [], popularity : 8.503787f32, }, "css.properties.contain-intrinsic-width.none" =>
 	CSSFeature { id : "css.properties.contain-intrinsic-width.none", name :
 	"contain-intrinsic-size", description :
 	"The contain-intrinsic-size CSS property sets the intrinsic size of an element. When using size containment, the browser will lay out the element as if it had a single child of this size.",
@@ -10871,7 +10872,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(98u16, 0u16), edge : BrowserVersion(98u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse :
-	& [], popularity : 8.000731f32, }, "css.properties.contain.content" => CSSFeature {
+	& [], popularity : 8.503787f32, }, "css.properties.contain.content" => CSSFeature {
 	id : "css.properties.contain.content", name : "contain", description :
 	"The contain CSS property sets limits to the scope of styles, layout, and paint rendering for speed and efficiency. The none keyword value disables containment, strict is equivalent to contain: size layout style paint, and content is equivalent to contain: layout style paint.",
 	spec : "https://drafts.csswg.org/css-contain-2/#contain-property", groups : &
@@ -10882,7 +10883,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-containment"], popularity : 21.060076f32, },
+	["https://caniuse.com/css-containment"], popularity : 20.761927f32, },
 	"css.properties.contain.inline-size" => CSSFeature { id :
 	"css.properties.contain.inline-size", name : "Inline-size containment", description :
 	"The contain: inline-size CSS declaration prevents the element's inline dimension from being set by the element's contents. This permits the browser to avoid slower layout calculations.",
@@ -10916,7 +10917,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-containment"], popularity : 21.060076f32, },
+	["https://caniuse.com/css-containment"], popularity : 20.761927f32, },
 	"css.properties.contain.paint" => CSSFeature { id : "css.properties.contain.paint",
 	name : "Paint containment", description :
 	"The contain: paint CSS declaration prevents an element's descendants from being drawn outside the boundaries of the containing element, with any overflow clipped. This permits the browser to avoid slower painting calculations.",
@@ -10950,7 +10951,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-containment"], popularity : 21.060076f32, },
+	["https://caniuse.com/css-containment"], popularity : 20.761927f32, },
 	"css.properties.contain.style" => CSSFeature { id : "css.properties.contain.style",
 	name : "Style containment", description :
 	"The contain: style CSS declaration permits the browser to avoid slower layout calculations by preventing modification to counter (counter-increment and counter-set) and quotation styles (content property quote values) beyond the element's descendants.",
@@ -11084,7 +11085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, }, "css.properties.content-visibility" =>
+	caniuse : & [], popularity : 81.013176f32, }, "css.properties.content-visibility" =>
 	CSSFeature { id : "css.properties.content-visibility", name : "content-visibility",
 	description :
 	"The content-visibility CSS property delays rendering an element, including layout and painting, until it is needed.",
@@ -11095,7 +11096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(18u16, 0u16), safari_ios : BrowserVersion(18u16,
 	0u16), }, caniuse : & ["https://caniuse.com/css-content-visibility"], popularity :
-	9.318105f32, }, "css.properties.content-visibility.auto" => CSSFeature { id :
+	9.537761f32, }, "css.properties.content-visibility.auto" => CSSFeature { id :
 	"css.properties.content-visibility.auto", name : "content-visibility", description :
 	"The content-visibility CSS property delays rendering an element, including layout and painting, until it is needed.",
 	spec : "https://drafts.csswg.org/css-contain-2/#content-visibility", groups : & [],
@@ -11105,7 +11106,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(26u16, 0u16), safari_ios : BrowserVersion(26u16,
 	0u16), }, caniuse : & ["https://caniuse.com/css-content-visibility"], popularity :
-	9.318105f32, }, "css.properties.content-visibility.hidden" => CSSFeature { id :
+	9.537761f32, }, "css.properties.content-visibility.hidden" => CSSFeature { id :
 	"css.properties.content-visibility.hidden", name : "content-visibility", description
 	:
 	"The content-visibility CSS property delays rendering an element, including layout and painting, until it is needed.",
@@ -11116,7 +11117,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(18u16, 0u16), safari_ios : BrowserVersion(18u16,
 	0u16), }, caniuse : & ["https://caniuse.com/css-content-visibility"], popularity :
-	9.318105f32, }, "css.properties.content-visibility.is_transitionable" => CSSFeature {
+	9.537761f32, }, "css.properties.content-visibility.is_transitionable" => CSSFeature {
 	id : "css.properties.content-visibility.is_transitionable", name :
 	"display animation", description :
 	"You can animate elements between display: none and any other display value or animate between content-visibility: hidden and any other content-visibility value. This also applies to transitions.",
@@ -11147,7 +11148,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(18u16, 0u16), safari_ios : BrowserVersion(18u16,
 	0u16), }, caniuse : & ["https://caniuse.com/css-content-visibility"], popularity :
-	9.318105f32, }, "css.properties.content.alt_text" => CSSFeature { id :
+	9.537761f32, }, "css.properties.content.alt_text" => CSSFeature { id :
 	"css.properties.content.alt_text", name : "Alt text for generated content",
 	description :
 	"The / notation in content CSS property values adds alternative text to generated content. For example, the content: url('upvote-icon.svg') / 'Upvote' declaration adds accessible 'Upvote' text to the SVG icon. Also known as alternate text.",
@@ -11168,7 +11169,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, },
+	caniuse : & [], popularity : 81.013176f32, },
 	"css.properties.content.element_replacement" => CSSFeature { id :
 	"css.properties.content.element_replacement", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
@@ -11179,7 +11180,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(28u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(63u16, 0u16), firefox_android : BrowserVersion(63u16, 0u16),
 	safari : BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, }, "css.properties.content.gradient" =>
+	caniuse : & [], popularity : 81.013176f32, }, "css.properties.content.gradient" =>
 	CSSFeature { id : "css.properties.content.gradient", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
 	spec : "https://drafts.csswg.org/css-content-3/#content-property", groups : & [],
@@ -11187,7 +11188,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(26u16, 0u16), chrome_android : BrowserVersion(26u16, 0u16), edge :
 	BrowserVersion(12u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(7u16, 0u16), safari_ios :
-	BrowserVersion(7u16, 0u16), }, caniuse : & [], popularity : 80.86071f32, },
+	BrowserVersion(7u16, 0u16), }, caniuse : & [], popularity : 81.013176f32, },
 	"css.properties.content.image-set" => CSSFeature { id :
 	"css.properties.content.image-set", name : "image-set()", description :
 	"The image-set() CSS function provides a set of images at different resolutions or pixel densities, which the browser can pick from, depending on the device capabilities.",
@@ -11209,7 +11210,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, }, "css.properties.content.no-open-quote"
+	caniuse : & [], popularity : 81.013176f32, }, "css.properties.content.no-open-quote"
 	=> CSSFeature { id : "css.properties.content.no-open-quote", name : "Content",
 	description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
@@ -11220,7 +11221,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, }, "css.properties.content.none" =>
+	caniuse : & [], popularity : 81.013176f32, }, "css.properties.content.none" =>
 	CSSFeature { id : "css.properties.content.none", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
 	spec : "https://drafts.csswg.org/css-content-3/#content-property", groups : & [],
@@ -11230,7 +11231,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, },
+	caniuse : & [], popularity : 81.013176f32, },
 	"css.properties.content.none_applies_to_elements" => CSSFeature { id :
 	"css.properties.content.none_applies_to_elements", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
@@ -11239,7 +11240,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 80.86071f32, }, "css.properties.content.normal" => CSSFeature { id :
+	popularity : 81.013176f32, }, "css.properties.content.normal" => CSSFeature { id :
 	"css.properties.content.normal", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
 	spec : "https://drafts.csswg.org/css-content-3/#content-property", groups : & [],
@@ -11249,7 +11250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, }, "css.properties.content.open-quote" =>
+	caniuse : & [], popularity : 81.013176f32, }, "css.properties.content.open-quote" =>
 	CSSFeature { id : "css.properties.content.open-quote", name : "Content", description
 	:
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
@@ -11260,7 +11261,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, }, "css.properties.content.url" =>
+	caniuse : & [], popularity : 81.013176f32, }, "css.properties.content.url" =>
 	CSSFeature { id : "css.properties.content.url", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
 	spec : "https://drafts.csswg.org/css-content-3/#content-property", groups : & [],
@@ -11270,7 +11271,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, }, "css.properties.corner-block-end-shape"
+	caniuse : & [], popularity : 81.013176f32, }, "css.properties.corner-block-end-shape"
 	=> CSSFeature { id : "css.properties.corner-block-end-shape", name : "corner-shape",
 	description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11279,7 +11280,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-block-start-shape" => CSSFeature { id :
 	"css.properties.corner-block-start-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11288,7 +11289,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-bottom-left-shape" => CSSFeature { id :
 	"css.properties.corner-bottom-left-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11297,7 +11298,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-bottom-right-shape" => CSSFeature { id :
 	"css.properties.corner-bottom-right-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11306,7 +11307,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-bottom-shape" => CSSFeature { id :
 	"css.properties.corner-bottom-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11315,7 +11316,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-end-end-shape" => CSSFeature { id :
 	"css.properties.corner-end-end-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11324,7 +11325,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-end-start-shape" => CSSFeature { id :
 	"css.properties.corner-end-start-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11333,7 +11334,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-inline-end-shape" => CSSFeature { id :
 	"css.properties.corner-inline-end-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11342,7 +11343,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-inline-start-shape" => CSSFeature { id :
 	"css.properties.corner-inline-start-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11351,7 +11352,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-left-shape" => CSSFeature { id :
 	"css.properties.corner-left-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11360,7 +11361,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-right-shape" => CSSFeature { id :
 	"css.properties.corner-right-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11369,7 +11370,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, }, "css.properties.corner-shape" =>
+	0), }, caniuse : & [], popularity : 0.713874f32, }, "css.properties.corner-shape" =>
 	CSSFeature { id : "css.properties.corner-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
 	spec : "https://drafts.csswg.org/css-borders-4/#corner-shaping", groups : & [],
@@ -11377,7 +11378,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-start-end-shape" => CSSFeature { id :
 	"css.properties.corner-start-end-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11386,7 +11387,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-start-start-shape" => CSSFeature { id :
 	"css.properties.corner-start-start-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11395,7 +11396,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-top-left-shape" => CSSFeature { id :
 	"css.properties.corner-top-left-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11404,7 +11405,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.corner-top-right-shape" => CSSFeature { id :
 	"css.properties.corner-top-right-shape", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11413,7 +11414,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, }, "css.properties.corner-top-shape"
+	0), }, caniuse : & [], popularity : 0.713874f32, }, "css.properties.corner-top-shape"
 	=> CSSFeature { id : "css.properties.corner-top-shape", name : "corner-shape",
 	description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -11422,7 +11423,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.properties.counter-increment" => CSSFeature { id :
 	"css.properties.counter-increment", name : "Counters (CSS)", description :
 	"The counter-reset and counter-increment CSS properties and the counter() and counters() functions automatically number headings or ordered list items.",
@@ -11523,7 +11524,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(85u16, 0u16), chrome_android : BrowserVersion(85u16, 0u16), edge :
 	BrowserVersion(85u16, 0u16), firefox : BrowserVersion(68u16, 0u16), firefox_android :
 	BrowserVersion(68u16, 0u16), safari : BrowserVersion(17u16, 2u16), safari_ios :
-	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.516568f32, },
+	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.370347f32, },
 	"css.properties.counter-set.list-item" => CSSFeature { id :
 	"css.properties.counter-set.list-item", name : "counter-set", description :
 	"The counter-set CSS property creates (and optionally sets a value for) a counter, the numbers for a series of headings or ordered list items.",
@@ -11533,7 +11534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(85u16, 0u16), chrome_android : BrowserVersion(85u16, 0u16), edge :
 	BrowserVersion(85u16, 0u16), firefox : BrowserVersion(68u16, 0u16), firefox_android :
 	BrowserVersion(68u16, 0u16), safari : BrowserVersion(17u16, 2u16), safari_ios :
-	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.516568f32, },
+	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.370347f32, },
 	"css.properties.counter-set.none" => CSSFeature { id :
 	"css.properties.counter-set.none", name : "counter-set", description :
 	"The counter-set CSS property creates (and optionally sets a value for) a counter, the numbers for a series of headings or ordered list items.",
@@ -11543,7 +11544,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(85u16, 0u16), chrome_android : BrowserVersion(85u16, 0u16), edge :
 	BrowserVersion(85u16, 0u16), firefox : BrowserVersion(68u16, 0u16), firefox_android :
 	BrowserVersion(68u16, 0u16), safari : BrowserVersion(17u16, 2u16), safari_ios :
-	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.516568f32, },
+	BrowserVersion(17u16, 2u16), }, caniuse : & [], popularity : 0.370347f32, },
 	"css.properties.cursor" => CSSFeature { id : "css.properties.cursor", name :
 	"Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11555,7 +11556,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(1u16, 2u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 84.607765f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.40606f32, },
 	"css.properties.cursor.alias" => CSSFeature { id : "css.properties.cursor.alias",
 	name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11566,7 +11567,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.all-scroll" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.all-scroll" => CSSFeature { id :
 	"css.properties.cursor.all-scroll", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11576,7 +11577,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.auto" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.auto" => CSSFeature { id :
 	"css.properties.cursor.auto", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11587,7 +11588,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(1u16, 2u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 84.607765f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.40606f32, },
 	"css.properties.cursor.cell" => CSSFeature { id : "css.properties.cursor.cell", name
 	: "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11599,7 +11600,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 84.607765f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.40606f32, },
 	"css.properties.cursor.col-resize" => CSSFeature { id :
 	"css.properties.cursor.col-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11610,7 +11611,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.context-menu" => CSSFeature { id
+	popularity : 84.40606f32, }, "css.properties.cursor.context-menu" => CSSFeature { id
 	: "css.properties.cursor.context-menu", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11620,7 +11621,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.copy" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.copy" => CSSFeature { id :
 	"css.properties.cursor.copy", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11630,7 +11631,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.crosshair" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.crosshair" => CSSFeature { id :
 	"css.properties.cursor.crosshair", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11640,7 +11641,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.default" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.default" => CSSFeature { id :
 	"css.properties.cursor.default", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11650,7 +11651,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.e-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.e-resize" => CSSFeature { id :
 	"css.properties.cursor.e-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11660,7 +11661,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.ew-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.ew-resize" => CSSFeature { id :
 	"css.properties.cursor.ew-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11670,7 +11671,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.grab" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.grab" => CSSFeature { id :
 	"css.properties.cursor.grab", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11680,7 +11681,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(11u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.grabbing" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.grabbing" => CSSFeature { id :
 	"css.properties.cursor.grabbing", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11690,7 +11691,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(11u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.help" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.help" => CSSFeature { id :
 	"css.properties.cursor.help", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11700,7 +11701,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.move" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.move" => CSSFeature { id :
 	"css.properties.cursor.move", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11710,7 +11711,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.n-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.n-resize" => CSSFeature { id :
 	"css.properties.cursor.n-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11720,7 +11721,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.ne-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.ne-resize" => CSSFeature { id :
 	"css.properties.cursor.ne-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11730,8 +11731,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.nesw-resize" => CSSFeature { id
-	: "css.properties.cursor.nesw-resize", name : "Cursor styles", description :
+	popularity : 84.40606f32, }, "css.properties.cursor.nesw-resize" => CSSFeature { id :
+	"css.properties.cursor.nesw-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -11740,7 +11741,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.no-drop" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.no-drop" => CSSFeature { id :
 	"css.properties.cursor.no-drop", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11750,7 +11751,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.none" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.none" => CSSFeature { id :
 	"css.properties.cursor.none", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11760,8 +11761,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(5u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.not-allowed" => CSSFeature { id
-	: "css.properties.cursor.not-allowed", name : "Cursor styles", description :
+	popularity : 84.40606f32, }, "css.properties.cursor.not-allowed" => CSSFeature { id :
+	"css.properties.cursor.not-allowed", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -11770,7 +11771,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.ns-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.ns-resize" => CSSFeature { id :
 	"css.properties.cursor.ns-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11780,7 +11781,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.nw-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.nw-resize" => CSSFeature { id :
 	"css.properties.cursor.nw-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11790,8 +11791,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.nwse-resize" => CSSFeature { id
-	: "css.properties.cursor.nwse-resize", name : "Cursor styles", description :
+	popularity : 84.40606f32, }, "css.properties.cursor.nwse-resize" => CSSFeature { id :
+	"css.properties.cursor.nwse-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -11800,7 +11801,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.pointer" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.pointer" => CSSFeature { id :
 	"css.properties.cursor.pointer", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11810,7 +11811,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.progress" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.progress" => CSSFeature { id :
 	"css.properties.cursor.progress", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11820,7 +11821,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.row-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.row-resize" => CSSFeature { id :
 	"css.properties.cursor.row-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11830,7 +11831,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.s-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.s-resize" => CSSFeature { id :
 	"css.properties.cursor.s-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11840,7 +11841,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.se-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.se-resize" => CSSFeature { id :
 	"css.properties.cursor.se-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11850,7 +11851,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.sw-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.sw-resize" => CSSFeature { id :
 	"css.properties.cursor.sw-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11860,7 +11861,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.text" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.text" => CSSFeature { id :
 	"css.properties.cursor.text", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11871,7 +11872,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(1u16, 2u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 84.607765f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.40606f32, },
 	"css.properties.cursor.url" => CSSFeature { id : "css.properties.cursor.url", name :
 	"Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11883,7 +11884,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(95u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
 	["https://caniuse.com/css3-cursors", "https://caniuse.com/css3-cursors-grab",
-	"https://caniuse.com/css3-cursors-newer"], popularity : 84.607765f32, },
+	"https://caniuse.com/css3-cursors-newer"], popularity : 84.40606f32, },
 	"css.properties.cursor.url_positioning_syntax" => CSSFeature { id :
 	"css.properties.cursor.url_positioning_syntax", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
@@ -11894,8 +11895,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.vertical-text" => CSSFeature {
-	id : "css.properties.cursor.vertical-text", name : "Cursor styles", description :
+	popularity : 84.40606f32, }, "css.properties.cursor.vertical-text" => CSSFeature { id
+	: "css.properties.cursor.vertical-text", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -11904,7 +11905,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.w-resize" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.w-resize" => CSSFeature { id :
 	"css.properties.cursor.w-resize", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11914,7 +11915,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.wait" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.wait" => CSSFeature { id :
 	"css.properties.cursor.wait", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11924,7 +11925,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(1u16, 2u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.zoom-in" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.zoom-in" => CSSFeature { id :
 	"css.properties.cursor.zoom-in", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11934,7 +11935,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(9u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.cursor.zoom-out" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.cursor.zoom-out" => CSSFeature { id :
 	"css.properties.cursor.zoom-out", name : "Cursor styles", description :
 	"The cursor CSS property styles the pointer, allowing you to provide hints to the user on how to interact with the hovered element.",
 	spec : "https://drafts.csswg.org/css-ui-4/#cursor", groups : & [], baseline_status :
@@ -11944,7 +11945,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(95u16, 0u16), safari : BrowserVersion(9u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css3-cursors",
 	"https://caniuse.com/css3-cursors-grab", "https://caniuse.com/css3-cursors-newer"],
-	popularity : 84.607765f32, }, "css.properties.custom-property" => CSSFeature { id :
+	popularity : 84.40606f32, }, "css.properties.custom-property" => CSSFeature { id :
 	"css.properties.custom-property", name : "Custom properties", description :
 	"Custom properties are CSS properties prefixed with -- that set values you can reuse with the var() function. For example, you can set a --key-color property to reuse as border-color: var(--key-color). Also known as CSS variables.",
 	spec : "https://drafts.csswg.org/css-variables-1/", groups : & [], baseline_status :
@@ -12039,7 +12040,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.066956f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.04305f32, },
 	"css.properties.display.block" => CSSFeature { id : "css.properties.display.block",
 	name : "Display", description :
 	"The display CSS property sets the display behavior of an element's box within its layout and sets the layout behavior for its child elements.",
@@ -12050,7 +12051,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.066956f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.04305f32, },
 	"css.properties.display.contents" => CSSFeature { id :
 	"css.properties.display.contents", name : "display: contents", description :
 	"The display: contents CSS declaration sets an element to display only its contents, not itself.",
@@ -12114,7 +12115,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.display.inline" => CSSFeature { id : "css.properties.display.inline",
 	name : "Display", description :
 	"The display CSS property sets the display behavior of an element's box within its layout and sets the layout behavior for its child elements.",
@@ -12125,7 +12126,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.066956f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.04305f32, },
 	"css.properties.display.inline-block" => CSSFeature { id :
 	"css.properties.display.inline-block", name : "Display", description :
 	"The display CSS property sets the display behavior of an element's box within its layout and sets the layout behavior for its child elements.",
@@ -12136,7 +12137,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.066956f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.04305f32, },
 	"css.properties.display.inline-flex" => CSSFeature { id :
 	"css.properties.display.inline-flex", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -12158,7 +12159,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.display.inline-table" => CSSFeature { id :
 	"css.properties.display.inline-table", name : "display: table", description :
 	"The display: table CSS declaration renders an element with the box layout of a <table> HTML element. Child elements may use equivalents to <table> internal elements such as display: table-row for <tr>.",
@@ -12240,7 +12241,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.066956f32, },
+	caniuse : & ["https://caniuse.com/inline-block"], popularity : 93.04305f32, },
 	"css.properties.display.none.option_is_hidden" => CSSFeature { id :
 	"css.properties.display.none.option_is_hidden", name : "Display", description :
 	"The display CSS property sets the display behavior of an element's box within its layout and sets the layout behavior for its child elements.",
@@ -12250,7 +12251,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(1u16, 0u16),
 	firefox_android : BrowserVersion(4u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/inline-block"], popularity : 93.066956f32, },
+	["https://caniuse.com/inline-block"], popularity : 93.04305f32, },
 	"css.properties.display.ruby" => CSSFeature { id : "css.properties.display.ruby",
 	name : "display: ruby", description :
 	"The display: ruby CSS declaration renders an element with the box layout of a <ruby> HTML element. Child elements may use equivalents to <ruby> internal elements such as display: ruby-base for <rb>.",
@@ -12406,7 +12407,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.949547f32, }, "css.properties.dominant-baseline.alphabetic" =>
+	[], popularity : 0.788287f32, }, "css.properties.dominant-baseline.alphabetic" =>
 	CSSFeature { id : "css.properties.dominant-baseline.alphabetic", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12418,7 +12419,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.949547f32, }, "css.properties.dominant-baseline.auto" =>
+	[], popularity : 0.788287f32, }, "css.properties.dominant-baseline.auto" =>
 	CSSFeature { id : "css.properties.dominant-baseline.auto", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12430,7 +12431,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.949547f32, }, "css.properties.dominant-baseline.central" =>
+	[], popularity : 0.788287f32, }, "css.properties.dominant-baseline.central" =>
 	CSSFeature { id : "css.properties.dominant-baseline.central", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12442,7 +12443,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.949547f32, }, "css.properties.dominant-baseline.hanging" =>
+	[], popularity : 0.788287f32, }, "css.properties.dominant-baseline.hanging" =>
 	CSSFeature { id : "css.properties.dominant-baseline.hanging", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12454,7 +12455,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.949547f32, }, "css.properties.dominant-baseline.ideographic" =>
+	[], popularity : 0.788287f32, }, "css.properties.dominant-baseline.ideographic" =>
 	CSSFeature { id : "css.properties.dominant-baseline.ideographic", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12466,7 +12467,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.949547f32, }, "css.properties.dominant-baseline.mathematical" =>
+	[], popularity : 0.788287f32, }, "css.properties.dominant-baseline.mathematical" =>
 	CSSFeature { id : "css.properties.dominant-baseline.mathematical", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12478,7 +12479,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.949547f32, }, "css.properties.dominant-baseline.middle" =>
+	[], popularity : 0.788287f32, }, "css.properties.dominant-baseline.middle" =>
 	CSSFeature { id : "css.properties.dominant-baseline.middle", name :
 	"dominant-baseline", description :
 	"The dominant-baseline CSS property sets the specific baseline used to align an elements's text and inline-level contents.",
@@ -12490,7 +12491,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), }, caniuse : &
-	[], popularity : 0.949547f32, }, "css.properties.dynamic-range-limit" => CSSFeature {
+	[], popularity : 0.788287f32, }, "css.properties.dynamic-range-limit" => CSSFeature {
 	id : "css.properties.dynamic-range-limit", name : "dynamic-range-limit", description
 	:
 	"The dynamic-range-limit CSS property controls the peak luminance of high dynamic range content. You can use this to coordinate the apparent brightness of HDR and SDR content.",
@@ -12499,7 +12500,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(26u16, 0u16), safari_ios :
-	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.458151f32, },
+	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.497623f32, },
 	"css.properties.dynamic-range-limit.constrained" => CSSFeature { id :
 	"css.properties.dynamic-range-limit.constrained", name : "dynamic-range-limit",
 	description :
@@ -12509,7 +12510,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.458151f32, },
+	0), }, caniuse : & [], popularity : 0.497623f32, },
 	"css.properties.dynamic-range-limit.dynamic-range-limit-mix_values" => CSSFeature {
 	id : "css.properties.dynamic-range-limit.dynamic-range-limit-mix_values", name :
 	"dynamic-range-limit", description :
@@ -12519,7 +12520,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.458151f32, },
+	0), }, caniuse : & [], popularity : 0.497623f32, },
 	"css.properties.dynamic-range-limit.no-limit" => CSSFeature { id :
 	"css.properties.dynamic-range-limit.no-limit", name : "dynamic-range-limit",
 	description :
@@ -12529,7 +12530,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(26u16, 0u16), safari_ios :
-	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.458151f32, },
+	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.497623f32, },
 	"css.properties.dynamic-range-limit.standard" => CSSFeature { id :
 	"css.properties.dynamic-range-limit.standard", name : "dynamic-range-limit",
 	description :
@@ -12539,7 +12540,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(26u16, 0u16), safari_ios :
-	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.458151f32, },
+	BrowserVersion(26u16, 0u16), }, caniuse : & [], popularity : 0.497623f32, },
 	"css.properties.empty-cells" => CSSFeature { id : "css.properties.empty-cells", name
 	: "Tables", description :
 	"The <table> HTML element, with several related elements, represents tabular data in rows and columns of cells.",
@@ -12581,7 +12582,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16), edge :
 	BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.565635f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.226752f32, },
 	"css.properties.field-sizing.content" => CSSFeature { id :
 	"css.properties.field-sizing.content", name : "field-sizing", description :
 	"The field-sizing CSS property allows form controls such as <textarea> to be sized based on their content.",
@@ -12590,7 +12591,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16), edge :
 	BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.565635f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.226752f32, },
 	"css.properties.field-sizing.fixed" => CSSFeature { id :
 	"css.properties.field-sizing.fixed", name : "field-sizing", description :
 	"The field-sizing CSS property allows form controls such as <textarea> to be sized based on their content.",
@@ -12599,7 +12600,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16), edge :
 	BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.565635f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 1.226752f32, },
 	"css.properties.fill" => CSSFeature { id : "css.properties.fill", name : "SVG",
 	description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -12678,7 +12679,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.blur" => CSSFeature { id : "css.properties.filter.blur", name
 	: "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12689,7 +12690,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.brightness" => CSSFeature { id :
 	"css.properties.filter.brightness", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12700,7 +12701,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.contrast" => CSSFeature { id :
 	"css.properties.filter.contrast", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12711,7 +12712,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.drop-shadow" => CSSFeature { id :
 	"css.properties.filter.drop-shadow", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12722,7 +12723,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.grayscale" => CSSFeature { id :
 	"css.properties.filter.grayscale", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12733,7 +12734,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.hue-rotate" => CSSFeature { id :
 	"css.properties.filter.hue-rotate", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12744,7 +12745,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.invert" => CSSFeature { id : "css.properties.filter.invert",
 	name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12755,7 +12756,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.opacity" => CSSFeature { id : "css.properties.filter.opacity",
 	name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12766,7 +12767,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.saturate" => CSSFeature { id :
 	"css.properties.filter.saturate", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12777,7 +12778,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.sepia" => CSSFeature { id : "css.properties.filter.sepia",
 	name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -12788,7 +12789,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.properties.filter.svg_elements" => CSSFeature { id :
 	"css.properties.filter.svg_elements", name : "SVG filters", description :
 	"The <filter> SVG element applies custom effects such as color manipulation, blurring, or morphing to SVG elements.",
@@ -13154,7 +13155,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.06729f32, }, "css.properties.font-family.cursive" => CSSFeature {
+	[], popularity : 87.97503f32, }, "css.properties.font-family.cursive" => CSSFeature {
 	id : "css.properties.font-family.cursive", name : "font-family", description :
 	"The font-family CSS property sets the desired font face for text, along with optional fallback font faces.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-family-prop", groups : &
@@ -13165,7 +13166,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.06729f32, }, "css.properties.font-family.fantasy" => CSSFeature {
+	[], popularity : 87.97503f32, }, "css.properties.font-family.fantasy" => CSSFeature {
 	id : "css.properties.font-family.fantasy", name : "font-family", description :
 	"The font-family CSS property sets the desired font face for text, along with optional fallback font faces.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-family-prop", groups : &
@@ -13176,7 +13177,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.06729f32, }, "css.properties.font-family.math" => CSSFeature { id
+	[], popularity : 87.97503f32, }, "css.properties.font-family.math" => CSSFeature { id
 	: "css.properties.font-family.math", name : "Math font family", description :
 	"The font-family: math CSS declaration uses the browser default font face for displaying mathematical expressions.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#math-def", groups : & ["mathml"],
@@ -13197,7 +13198,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.06729f32, }, "css.properties.font-family.sans-serif" =>
+	[], popularity : 87.97503f32, }, "css.properties.font-family.sans-serif" =>
 	CSSFeature { id : "css.properties.font-family.sans-serif", name : "font-family",
 	description :
 	"The font-family CSS property sets the desired font face for text, along with optional fallback font faces.",
@@ -13209,7 +13210,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.06729f32, }, "css.properties.font-family.serif" => CSSFeature {
+	[], popularity : 87.97503f32, }, "css.properties.font-family.serif" => CSSFeature {
 	id : "css.properties.font-family.serif", name : "font-family", description :
 	"The font-family CSS property sets the desired font face for text, along with optional fallback font faces.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-family-prop", groups : &
@@ -13220,7 +13221,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 88.06729f32, }, "css.properties.font-family.system-ui" => CSSFeature
+	[], popularity : 87.97503f32, }, "css.properties.font-family.system-ui" => CSSFeature
 	{ id : "css.properties.font-family.system-ui", name : "System font", description :
 	"The font-family: system-ui CSS declaration uses the operating system default font for text.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#system-ui-def", groups : & [],
@@ -13278,7 +13279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(15u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-feature"], popularity : 29.656054f32, },
+	["https://caniuse.com/font-feature"], popularity : 29.541763f32, },
 	"css.properties.font-feature-settings.normal" => CSSFeature { id :
 	"css.properties.font-feature-settings.normal", name : "font-feature-settings",
 	description :
@@ -13291,7 +13292,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(15u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-feature"], popularity : 29.656054f32, },
+	["https://caniuse.com/font-feature"], popularity : 29.541763f32, },
 	"css.properties.font-kerning" => CSSFeature { id : "css.properties.font-kerning",
 	name : "font-kerning", description :
 	"The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.",
@@ -13303,7 +13304,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-kerning"], popularity : 2.26315f32, },
+	["https://caniuse.com/font-kerning"], popularity : 2.309195f32, },
 	"css.properties.font-kerning.auto" => CSSFeature { id :
 	"css.properties.font-kerning.auto", name : "font-kerning", description :
 	"The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.",
@@ -13315,7 +13316,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-kerning"], popularity : 2.26315f32, },
+	["https://caniuse.com/font-kerning"], popularity : 2.309195f32, },
 	"css.properties.font-kerning.none" => CSSFeature { id :
 	"css.properties.font-kerning.none", name : "font-kerning", description :
 	"The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.",
@@ -13327,7 +13328,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-kerning"], popularity : 2.26315f32, },
+	["https://caniuse.com/font-kerning"], popularity : 2.309195f32, },
 	"css.properties.font-kerning.normal" => CSSFeature { id :
 	"css.properties.font-kerning.normal", name : "font-kerning", description :
 	"The font-kerning CSS property sets whether kerning data from a font is used to adjust the space between letters.",
@@ -13339,7 +13340,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	["https://caniuse.com/font-kerning"], popularity : 2.26315f32, },
+	["https://caniuse.com/font-kerning"], popularity : 2.309195f32, },
 	"css.properties.font-language-override" => CSSFeature { id :
 	"css.properties.font-language-override", name : "font-language-override", description
 	:
@@ -13350,7 +13351,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(143u16, 0u16), edge : BrowserVersion(143u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 1.137734f32, }, "css.properties.font-optical-sizing" => CSSFeature { id
+	popularity : 1.239514f32, }, "css.properties.font-optical-sizing" => CSSFeature { id
 	: "css.properties.font-optical-sizing", name : "font-optical-sizing", description :
 	"The font-optical-sizing CSS property sets whether text rendering is optimized for viewing at different sizes.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-optical-sizing-def", groups : &
@@ -13361,7 +13362,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
-	[], popularity : 3.306908f32, }, "css.properties.font-optical-sizing.auto" =>
+	[], popularity : 3.032833f32, }, "css.properties.font-optical-sizing.auto" =>
 	CSSFeature { id : "css.properties.font-optical-sizing.auto", name :
 	"font-optical-sizing", description :
 	"The font-optical-sizing CSS property sets whether text rendering is optimized for viewing at different sizes.",
@@ -13373,7 +13374,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
-	[], popularity : 3.306908f32, }, "css.properties.font-optical-sizing.none" =>
+	[], popularity : 3.032833f32, }, "css.properties.font-optical-sizing.none" =>
 	CSSFeature { id : "css.properties.font-optical-sizing.none", name :
 	"font-optical-sizing", description :
 	"The font-optical-sizing CSS property sets whether text rendering is optimized for viewing at different sizes.",
@@ -13385,7 +13386,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
-	[], popularity : 3.306908f32, }, "css.properties.font-palette" => CSSFeature { id :
+	[], popularity : 3.032833f32, }, "css.properties.font-palette" => CSSFeature { id :
 	"css.properties.font-palette", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-palette-prop", groups : &
@@ -13396,7 +13397,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.281256f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.235819f32, },
 	"css.properties.font-palette.animation_computed" => CSSFeature { id :
 	"css.properties.font-palette.animation_computed", name : "font-palette animation",
 	description : "You can animate color fonts between two font-palette values.", spec :
@@ -13417,7 +13418,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.281256f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.235819f32, },
 	"css.properties.font-palette.light" => CSSFeature { id :
 	"css.properties.font-palette.light", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -13429,7 +13430,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.281256f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.235819f32, },
 	"css.properties.font-palette.normal" => CSSFeature { id :
 	"css.properties.font-palette.normal", name : "font-palette", description :
 	"The font-palette CSS property selects a color palette from the font, optionally overriding individual colors in the @font-palette-values at-rule.",
@@ -13441,7 +13442,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(101u16, 0u16), edge : BrowserVersion(101u16, 0u16), firefox :
 	BrowserVersion(107u16, 0u16), firefox_android : BrowserVersion(107u16, 0u16), safari
 	: BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse :
-	& ["https://caniuse.com/css-font-palette"], popularity : 0.281256f32, },
+	& ["https://caniuse.com/css-font-palette"], popularity : 0.235819f32, },
 	"css.properties.font-palette.palette-mix_function" => CSSFeature { id :
 	"css.properties.font-palette.palette-mix_function", name : "font-palette animation",
 	description : "You can animate color fonts between two font-palette values.", spec :
@@ -13460,7 +13461,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 89.481895f32, }, "css.properties.font-size-adjust" =>
+	caniuse : & [], popularity : 89.22966f32, }, "css.properties.font-size-adjust" =>
 	CSSFeature { id : "css.properties.font-size-adjust", name : "font-size-adjust",
 	description :
 	"The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.",
@@ -13471,7 +13472,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(127u16, 0u16), firefox : BrowserVersion(3u16, 0u16), firefox_android :
 	BrowserVersion(4u16, 0u16), safari : BrowserVersion(16u16, 4u16), safari_ios :
 	BrowserVersion(16u16, 4u16), }, caniuse : & ["https://caniuse.com/font-size-adjust"],
-	popularity : 2.404273f32, }, "css.properties.font-size-adjust.from-font" =>
+	popularity : 2.504975f32, }, "css.properties.font-size-adjust.from-font" =>
 	CSSFeature { id : "css.properties.font-size-adjust.from-font", name :
 	"font-size-adjust", description :
 	"The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.",
@@ -13482,7 +13483,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(127u16, 0u16), firefox : BrowserVersion(118u16, 0u16), firefox_android
 	: BrowserVersion(118u16, 0u16), safari : BrowserVersion(17u16, 0u16), safari_ios :
 	BrowserVersion(17u16, 0u16), }, caniuse : & ["https://caniuse.com/font-size-adjust"],
-	popularity : 2.404273f32, }, "css.properties.font-size-adjust.none" => CSSFeature {
+	popularity : 2.504975f32, }, "css.properties.font-size-adjust.none" => CSSFeature {
 	id : "css.properties.font-size-adjust.none", name : "font-size-adjust", description :
 	"The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.",
 	spec : "https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop", groups : &
@@ -13492,7 +13493,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(127u16, 0u16), firefox : BrowserVersion(3u16, 0u16), firefox_android :
 	BrowserVersion(4u16, 0u16), safari : BrowserVersion(16u16, 4u16), safari_ios :
 	BrowserVersion(16u16, 4u16), }, caniuse : & ["https://caniuse.com/font-size-adjust"],
-	popularity : 2.404273f32, }, "css.properties.font-size-adjust.two-values" =>
+	popularity : 2.504975f32, }, "css.properties.font-size-adjust.two-values" =>
 	CSSFeature { id : "css.properties.font-size-adjust.two-values", name :
 	"font-size-adjust", description :
 	"The font-size-adjust CSS property preserves apparent text size, regardless of the font used, by scaling fonts to the same size with respect to a specific metric, such as x-height. This can help make fallback fonts look the same size.",
@@ -13503,7 +13504,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(127u16, 0u16), firefox : BrowserVersion(92u16, 0u16), firefox_android
 	: BrowserVersion(92u16, 0u16), safari : BrowserVersion(17u16, 0u16), safari_ios :
 	BrowserVersion(17u16, 0u16), }, caniuse : & ["https://caniuse.com/font-size-adjust"],
-	popularity : 2.404273f32, }, "css.properties.font-size.math" => CSSFeature { id :
+	popularity : 2.504975f32, }, "css.properties.font-size.math" => CSSFeature { id :
 	"css.properties.font-size.math", name : "MathML", description :
 	"MathML, or the Mathematical Markup Language, describes mathematical notation, such as expressions and formulas. Also known as MathML Core.",
 	spec : "https://w3c.github.io/mathml-core/", groups : & ["mathml"], baseline_status :
@@ -13523,7 +13524,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(42u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(31u16, 0u16), firefox_android : BrowserVersion(31u16, 0u16),
 	safari : BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), },
-	caniuse : & [], popularity : 89.481895f32, }, "css.properties.font-size.xxx-large" =>
+	caniuse : & [], popularity : 89.22966f32, }, "css.properties.font-size.xxx-large" =>
 	CSSFeature { id : "css.properties.font-size.xxx-large", name : "font-size",
 	description : "The font-size CSS property sets the text height.", spec :
 	"https://drafts.csswg.org/css-fonts-4/#font-size-prop", groups : & ["fonts"],
@@ -13533,7 +13534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(79u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 89.481895f32, }, "css.properties.font-stretch" =>
+	caniuse : & [], popularity : 89.22966f32, }, "css.properties.font-stretch" =>
 	CSSFeature { id : "css.properties.font-stretch", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-stretch-prop", groups : &
@@ -13544,7 +13545,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.condensed" => CSSFeature { id :
 	"css.properties.font-stretch.condensed", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13556,7 +13557,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.expanded" => CSSFeature { id :
 	"css.properties.font-stretch.expanded", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13568,7 +13569,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.extra-condensed" => CSSFeature { id :
 	"css.properties.font-stretch.extra-condensed", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13580,7 +13581,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.extra-expanded" => CSSFeature { id :
 	"css.properties.font-stretch.extra-expanded", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13592,7 +13593,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.normal" => CSSFeature { id :
 	"css.properties.font-stretch.normal", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13604,7 +13605,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.percentage" => CSSFeature { id :
 	"css.properties.font-stretch.percentage", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13616,7 +13617,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(62u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16), safari :
 	BrowserVersion(11u16, 1u16), safari_ios : BrowserVersion(11u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.semi-condensed" => CSSFeature { id :
 	"css.properties.font-stretch.semi-condensed", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13628,7 +13629,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.semi-expanded" => CSSFeature { id :
 	"css.properties.font-stretch.semi-expanded", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13640,7 +13641,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.ultra-condensed" => CSSFeature { id :
 	"css.properties.font-stretch.ultra-condensed", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13652,7 +13653,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-stretch.ultra-expanded" => CSSFeature { id :
 	"css.properties.font-stretch.ultra-expanded", name : "font-stretch", description :
 	"The font-stretch CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
@@ -13664,7 +13665,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font-style" => CSSFeature { id : "css.properties.font-style", name :
 	"font-style", description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13675,7 +13676,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 78.53412f32, }, "css.properties.font-style.italic" =>
+	caniuse : & [], popularity : 78.47664f32, }, "css.properties.font-style.italic" =>
 	CSSFeature { id : "css.properties.font-style.italic", name : "font-style",
 	description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13686,7 +13687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 78.53412f32, }, "css.properties.font-style.normal" =>
+	caniuse : & [], popularity : 78.47664f32, }, "css.properties.font-style.normal" =>
 	CSSFeature { id : "css.properties.font-style.normal", name : "font-style",
 	description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13697,7 +13698,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 78.53412f32, }, "css.properties.font-style.oblique" =>
+	caniuse : & [], popularity : 78.47664f32, }, "css.properties.font-style.oblique" =>
 	CSSFeature { id : "css.properties.font-style.oblique", name : "font-style",
 	description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13708,7 +13709,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 78.53412f32, },
+	caniuse : & [], popularity : 78.47664f32, },
 	"css.properties.font-style.oblique-angle" => CSSFeature { id :
 	"css.properties.font-style.oblique-angle", name : "font-style", description :
 	"The font-style CSS property sets the text style, with normal, italic, and oblique options.",
@@ -13717,7 +13718,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& [], popularity : 78.53412f32, }, "css.properties.font-synthesis" => CSSFeature { id
+	& [], popularity : 78.47664f32, }, "css.properties.font-synthesis" => CSSFeature { id
 	: "css.properties.font-synthesis", name : "font-synthesis", description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-synthesis", groups : &
@@ -13728,7 +13729,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 1.814879f32, }, "css.properties.font-synthesis-position" =>
+	[], popularity : 1.816126f32, }, "css.properties.font-synthesis-position" =>
 	CSSFeature { id : "css.properties.font-synthesis-position", name :
 	"font-synthesis-position", description :
 	"The font-synthesis-position CSS property sets whether or not the browser should synthesize subscript and superscript typefaces when they're missing from the font.",
@@ -13770,7 +13771,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.056879f32, }, "css.properties.font-synthesis-small-caps.auto" =>
+	& [], popularity : 0.048026f32, }, "css.properties.font-synthesis-small-caps.auto" =>
 	CSSFeature { id : "css.properties.font-synthesis-small-caps.auto", name :
 	"font-synthesis-small-caps", description :
 	"The font-synthesis-small-caps CSS property sets whether or not the browser should synthesize small caps typefaces when they're missing from the font.",
@@ -13782,7 +13783,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.056879f32, }, "css.properties.font-synthesis-small-caps.none" =>
+	& [], popularity : 0.048026f32, }, "css.properties.font-synthesis-small-caps.none" =>
 	CSSFeature { id : "css.properties.font-synthesis-small-caps.none", name :
 	"font-synthesis-small-caps", description :
 	"The font-synthesis-small-caps CSS property sets whether or not the browser should synthesize small caps typefaces when they're missing from the font.",
@@ -13794,7 +13795,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.056879f32, }, "css.properties.font-synthesis-style" =>
+	& [], popularity : 0.048026f32, }, "css.properties.font-synthesis-style" =>
 	CSSFeature { id : "css.properties.font-synthesis-style", name :
 	"font-synthesis-style", description :
 	"The font-synthesis-style CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.",
@@ -13806,7 +13807,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.075274f32, }, "css.properties.font-synthesis-style.auto" =>
+	& [], popularity : 0.069247f32, }, "css.properties.font-synthesis-style.auto" =>
 	CSSFeature { id : "css.properties.font-synthesis-style.auto", name :
 	"font-synthesis-style", description :
 	"The font-synthesis-style CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.",
@@ -13818,7 +13819,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.075274f32, }, "css.properties.font-synthesis-style.none" =>
+	& [], popularity : 0.069247f32, }, "css.properties.font-synthesis-style.none" =>
 	CSSFeature { id : "css.properties.font-synthesis-style.none", name :
 	"font-synthesis-style", description :
 	"The font-synthesis-style CSS property sets whether or not the browser should synthesize italic and oblique typefaces when they're missing from the font.",
@@ -13830,7 +13831,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.075274f32, }, "css.properties.font-synthesis-weight" =>
+	& [], popularity : 0.069247f32, }, "css.properties.font-synthesis-weight" =>
 	CSSFeature { id : "css.properties.font-synthesis-weight", name :
 	"font-synthesis-weight", description :
 	"The font-synthesis-weight CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.",
@@ -13842,7 +13843,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.20953f32, }, "css.properties.font-synthesis-weight.auto" =>
+	& [], popularity : 0.199587f32, }, "css.properties.font-synthesis-weight.auto" =>
 	CSSFeature { id : "css.properties.font-synthesis-weight.auto", name :
 	"font-synthesis-weight", description :
 	"The font-synthesis-weight CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.",
@@ -13854,7 +13855,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.20953f32, }, "css.properties.font-synthesis-weight.none" =>
+	& [], popularity : 0.199587f32, }, "css.properties.font-synthesis-weight.none" =>
 	CSSFeature { id : "css.properties.font-synthesis-weight.none", name :
 	"font-synthesis-weight", description :
 	"The font-synthesis-weight CSS property sets whether or not the browser should synthesize bold typefaces when they're missing from the font.",
@@ -13866,7 +13867,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(111u16, 0u16), firefox_android : BrowserVersion(111u16, 0u16), safari
 	: BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse :
-	& [], popularity : 0.20953f32, }, "css.properties.font-synthesis.position" =>
+	& [], popularity : 0.199587f32, }, "css.properties.font-synthesis.position" =>
 	CSSFeature { id : "css.properties.font-synthesis.position", name : "font-synthesis",
 	description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
@@ -13875,7 +13876,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(118u16, 0u16),
 	firefox_android : BrowserVersion(118u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.814879f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.816126f32, },
 	"css.properties.font-synthesis.small-caps" => CSSFeature { id :
 	"css.properties.font-synthesis.small-caps", name : "font-synthesis", description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
@@ -13887,7 +13888,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(93u16, 0u16), firefox_android : BrowserVersion(93u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 1.814879f32, }, "css.properties.font-synthesis.style" => CSSFeature
+	[], popularity : 1.816126f32, }, "css.properties.font-synthesis.style" => CSSFeature
 	{ id : "css.properties.font-synthesis.style", name : "font-synthesis", description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-synthesis", groups : &
@@ -13898,7 +13899,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 1.814879f32, }, "css.properties.font-synthesis.weight" => CSSFeature
+	[], popularity : 1.816126f32, }, "css.properties.font-synthesis.weight" => CSSFeature
 	{ id : "css.properties.font-synthesis.weight", name : "font-synthesis", description :
 	"The font-synthesis CSS shorthand property disables all font synthesis except the given kinds. To disable a specific kind of font synthesis, instead use the longhand properties such as font-synthesis-style and font-synthesis-weight.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-synthesis", groups : &
@@ -13909,7 +13910,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(97u16, 0u16), edge : BrowserVersion(97u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 1.814879f32, }, "css.properties.font-variant" => CSSFeature { id :
+	[], popularity : 1.816126f32, }, "css.properties.font-variant" => CSSFeature { id :
 	"css.properties.font-variant", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -13920,7 +13921,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 29.338179f32, }, "css.properties.font-variant-alternates" =>
+	[], popularity : 29.584677f32, }, "css.properties.font-variant-alternates" =>
 	CSSFeature { id : "css.properties.font-variant-alternates", name :
 	"font-variant-alternates", description :
 	"The font-variant-alternates CSS property, along with the @font-feature-values at-rule, chooses when to use a font's alternate glyphs.",
@@ -13932,7 +13933,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.properties.font-variant-alternates.annotation" => CSSFeature { id :
 	"css.properties.font-variant-alternates.annotation", name :
 	"font-variant-alternates", description :
@@ -13945,7 +13946,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.properties.font-variant-alternates.character_variant" => CSSFeature { id :
 	"css.properties.font-variant-alternates.character_variant", name :
 	"font-variant-alternates", description :
@@ -13958,7 +13959,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.properties.font-variant-alternates.historical-forms" => CSSFeature { id :
 	"css.properties.font-variant-alternates.historical-forms", name :
 	"font-variant-alternates", description :
@@ -13971,7 +13972,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.properties.font-variant-alternates.normal" => CSSFeature { id :
 	"css.properties.font-variant-alternates.normal", name : "font-variant-alternates",
 	description :
@@ -13984,7 +13985,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.properties.font-variant-alternates.ornaments" => CSSFeature { id :
 	"css.properties.font-variant-alternates.ornaments", name : "font-variant-alternates",
 	description :
@@ -13997,7 +13998,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.properties.font-variant-alternates.styleset" => CSSFeature { id :
 	"css.properties.font-variant-alternates.styleset", name : "font-variant-alternates",
 	description :
@@ -14010,7 +14011,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.properties.font-variant-alternates.stylistic" => CSSFeature { id :
 	"css.properties.font-variant-alternates.stylistic", name : "font-variant-alternates",
 	description :
@@ -14023,7 +14024,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.properties.font-variant-alternates.swash" => CSSFeature { id :
 	"css.properties.font-variant-alternates.swash", name : "font-variant-alternates",
 	description :
@@ -14036,7 +14037,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(16u16, 2u16), safari_ios : BrowserVersion(16u16, 2u16), }, caniuse : &
-	["https://caniuse.com/font-variant-alternates"], popularity : 0.483742f32, },
+	["https://caniuse.com/font-variant-alternates"], popularity : 0.466816f32, },
 	"css.properties.font-variant-caps" => CSSFeature { id :
 	"css.properties.font-variant-caps", name : "font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14048,8 +14049,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.013374f32, }, "css.properties.font-variant-caps.all-petite-caps"
-	=> CSSFeature { id : "css.properties.font-variant-caps.all-petite-caps", name :
+	[], popularity : 0.9234f32, }, "css.properties.font-variant-caps.all-petite-caps" =>
+	CSSFeature { id : "css.properties.font-variant-caps.all-petite-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-caps-prop", groups : &
@@ -14060,7 +14061,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.013374f32, }, "css.properties.font-variant-caps.all-small-caps" =>
+	[], popularity : 0.9234f32, }, "css.properties.font-variant-caps.all-small-caps" =>
 	CSSFeature { id : "css.properties.font-variant-caps.all-small-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14072,7 +14073,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.013374f32, }, "css.properties.font-variant-caps.normal" =>
+	[], popularity : 0.9234f32, }, "css.properties.font-variant-caps.normal" =>
 	CSSFeature { id : "css.properties.font-variant-caps.normal", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14084,7 +14085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.013374f32, }, "css.properties.font-variant-caps.petite-caps" =>
+	[], popularity : 0.9234f32, }, "css.properties.font-variant-caps.petite-caps" =>
 	CSSFeature { id : "css.properties.font-variant-caps.petite-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14096,7 +14097,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.013374f32, }, "css.properties.font-variant-caps.small-caps" =>
+	[], popularity : 0.9234f32, }, "css.properties.font-variant-caps.small-caps" =>
 	CSSFeature { id : "css.properties.font-variant-caps.small-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14108,7 +14109,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.013374f32, }, "css.properties.font-variant-caps.titling-caps" =>
+	[], popularity : 0.9234f32, }, "css.properties.font-variant-caps.titling-caps" =>
 	CSSFeature { id : "css.properties.font-variant-caps.titling-caps", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14120,7 +14121,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.013374f32, }, "css.properties.font-variant-caps.unicase" =>
+	[], popularity : 0.9234f32, }, "css.properties.font-variant-caps.unicase" =>
 	CSSFeature { id : "css.properties.font-variant-caps.unicase", name :
 	"font-variant-caps", description :
 	"The font-variant-caps CSS property sets whether text should be displayed in small caps, petite caps, or with capital letters designed for titles.",
@@ -14132,9 +14133,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 1.013374f32, }, "css.properties.font-variant-east-asian" =>
-	CSSFeature { id : "css.properties.font-variant-east-asian", name :
-	"font-variant-east-asian", description :
+	[], popularity : 0.9234f32, }, "css.properties.font-variant-east-asian" => CSSFeature
+	{ id : "css.properties.font-variant-east-asian", name : "font-variant-east-asian",
+	description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-east-asian-prop", groups :
 	& ["font-features"], baseline_status : BaselineStatus::High { since :
@@ -14144,7 +14145,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-east-asian.full-width"
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-east-asian.full-width"
 	=> CSSFeature { id : "css.properties.font-variant-east-asian.full-width", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14156,7 +14157,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-east-asian.jis04" =>
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-east-asian.jis04" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.jis04", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14168,7 +14169,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-east-asian.jis78" =>
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-east-asian.jis78" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.jis78", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14180,7 +14181,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-east-asian.jis83" =>
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-east-asian.jis83" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.jis83", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14192,7 +14193,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-east-asian.jis90" =>
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-east-asian.jis90" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.jis90", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14204,7 +14205,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-east-asian.normal" =>
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-east-asian.normal" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.normal", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14216,7 +14217,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, },
+	[], popularity : 0.571104f32, },
 	"css.properties.font-variant-east-asian.proportional-width" => CSSFeature { id :
 	"css.properties.font-variant-east-asian.proportional-width", name :
 	"font-variant-east-asian", description :
@@ -14229,7 +14230,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-east-asian.ruby" =>
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-east-asian.ruby" =>
 	CSSFeature { id : "css.properties.font-variant-east-asian.ruby", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14241,7 +14242,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-east-asian.simplified"
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-east-asian.simplified"
 	=> CSSFeature { id : "css.properties.font-variant-east-asian.simplified", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14253,7 +14254,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-east-asian.traditional"
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-east-asian.traditional"
 	=> CSSFeature { id : "css.properties.font-variant-east-asian.traditional", name :
 	"font-variant-east-asian", description :
 	"The font-variant-east-asian CSS property controls glyph substitution and sizing in East Asian text.",
@@ -14265,7 +14266,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(63u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.603205f32, }, "css.properties.font-variant-emoji" => CSSFeature {
+	[], popularity : 0.571104f32, }, "css.properties.font-variant-emoji" => CSSFeature {
 	id : "css.properties.font-variant-emoji", name : "font-variant-emoji", description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-emoji-prop", groups : &
@@ -14274,7 +14275,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.306222f32, }, "css.properties.font-variant-emoji.emoji" => CSSFeature
+	popularity : 0.315115f32, }, "css.properties.font-variant-emoji.emoji" => CSSFeature
 	{ id : "css.properties.font-variant-emoji.emoji", name : "font-variant-emoji",
 	description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
@@ -14284,7 +14285,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.306222f32, }, "css.properties.font-variant-emoji.normal" => CSSFeature
+	popularity : 0.315115f32, }, "css.properties.font-variant-emoji.normal" => CSSFeature
 	{ id : "css.properties.font-variant-emoji.normal", name : "font-variant-emoji",
 	description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
@@ -14294,7 +14295,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.306222f32, }, "css.properties.font-variant-emoji.text" => CSSFeature {
+	popularity : 0.315115f32, }, "css.properties.font-variant-emoji.text" => CSSFeature {
 	id : "css.properties.font-variant-emoji.text", name : "font-variant-emoji",
 	description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
@@ -14304,7 +14305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.306222f32, }, "css.properties.font-variant-emoji.unicode" =>
+	popularity : 0.315115f32, }, "css.properties.font-variant-emoji.unicode" =>
 	CSSFeature { id : "css.properties.font-variant-emoji.unicode", name :
 	"font-variant-emoji", description :
 	"The font-variant-emoji CSS property sets the default presentation for emoji characters.",
@@ -14314,7 +14315,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(131u16, 0u16), edge : BrowserVersion(131u16, 0u16), firefox :
 	BrowserVersion(141u16, 0u16), firefox_android : BrowserVersion(141u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.306222f32, }, "css.properties.font-variant-ligatures" => CSSFeature {
+	popularity : 0.315115f32, }, "css.properties.font-variant-ligatures" => CSSFeature {
 	id : "css.properties.font-variant-ligatures", name : "font-variant-ligatures",
 	description :
 	"The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.",
@@ -14326,7 +14327,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, },
+	[], popularity : 6.085019f32, },
 	"css.properties.font-variant-ligatures.common-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.common-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14339,7 +14340,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, }, "css.properties.font-variant-ligatures.contextual"
+	[], popularity : 6.085019f32, }, "css.properties.font-variant-ligatures.contextual"
 	=> CSSFeature { id : "css.properties.font-variant-ligatures.contextual", name :
 	"font-variant-ligatures", description :
 	"The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.",
@@ -14351,7 +14352,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, },
+	[], popularity : 6.085019f32, },
 	"css.properties.font-variant-ligatures.discretionary-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.discretionary-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14364,7 +14365,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, },
+	[], popularity : 6.085019f32, },
 	"css.properties.font-variant-ligatures.historical-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.historical-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14377,7 +14378,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, },
+	[], popularity : 6.085019f32, },
 	"css.properties.font-variant-ligatures.no-common-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.no-common-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14390,7 +14391,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, },
+	[], popularity : 6.085019f32, },
 	"css.properties.font-variant-ligatures.no-contextual" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.no-contextual", name :
 	"font-variant-ligatures", description :
@@ -14403,7 +14404,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, },
+	[], popularity : 6.085019f32, },
 	"css.properties.font-variant-ligatures.no-discretionary-ligatures" => CSSFeature { id
 	: "css.properties.font-variant-ligatures.no-discretionary-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14416,7 +14417,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, },
+	[], popularity : 6.085019f32, },
 	"css.properties.font-variant-ligatures.no-historical-ligatures" => CSSFeature { id :
 	"css.properties.font-variant-ligatures.no-historical-ligatures", name :
 	"font-variant-ligatures", description :
@@ -14429,7 +14430,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, }, "css.properties.font-variant-ligatures.none" =>
+	[], popularity : 6.085019f32, }, "css.properties.font-variant-ligatures.none" =>
 	CSSFeature { id : "css.properties.font-variant-ligatures.none", name :
 	"font-variant-ligatures", description :
 	"The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.",
@@ -14441,7 +14442,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, }, "css.properties.font-variant-ligatures.normal" =>
+	[], popularity : 6.085019f32, }, "css.properties.font-variant-ligatures.normal" =>
 	CSSFeature { id : "css.properties.font-variant-ligatures.normal", name :
 	"font-variant-ligatures", description :
 	"The font-variant-ligatures CSS property sets how characters can be visually combined for readability or stylistic reasons.",
@@ -14453,7 +14454,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(34u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 6.915589f32, }, "css.properties.font-variant-numeric" => CSSFeature
+	[], popularity : 6.085019f32, }, "css.properties.font-variant-numeric" => CSSFeature
 	{ id : "css.properties.font-variant-numeric", name : "font-variant-numeric",
 	description :
 	"The font-variant-numeric CSS property sets how numeric characters are displayed. For example, you can align columns of numbers or use zeroes that have a slash.",
@@ -14465,7 +14466,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-numeric.diagonal-fractions" => CSSFeature { id :
 	"css.properties.font-variant-numeric.diagonal-fractions", name :
 	"font-variant-numeric", description :
@@ -14478,7 +14479,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-numeric.lining-nums" => CSSFeature { id :
 	"css.properties.font-variant-numeric.lining-nums", name : "font-variant-numeric",
 	description :
@@ -14491,7 +14492,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-numeric.normal" => CSSFeature { id :
 	"css.properties.font-variant-numeric.normal", name : "font-variant-numeric",
 	description :
@@ -14504,7 +14505,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-numeric.oldstyle-nums" => CSSFeature { id :
 	"css.properties.font-variant-numeric.oldstyle-nums", name : "font-variant-numeric",
 	description :
@@ -14517,7 +14518,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-numeric.ordinal" => CSSFeature { id :
 	"css.properties.font-variant-numeric.ordinal", name : "font-variant-numeric",
 	description :
@@ -14530,7 +14531,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-numeric.proportional-nums" => CSSFeature { id :
 	"css.properties.font-variant-numeric.proportional-nums", name :
 	"font-variant-numeric", description :
@@ -14543,7 +14544,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-numeric.slashed-zero" => CSSFeature { id :
 	"css.properties.font-variant-numeric.slashed-zero", name : "font-variant-numeric",
 	description :
@@ -14556,7 +14557,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-numeric.stacked-fractions" => CSSFeature { id :
 	"css.properties.font-variant-numeric.stacked-fractions", name :
 	"font-variant-numeric", description :
@@ -14569,7 +14570,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-numeric.tabular-nums" => CSSFeature { id :
 	"css.properties.font-variant-numeric.tabular-nums", name : "font-variant-numeric",
 	description :
@@ -14582,7 +14583,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/font-variant-numeric"], popularity : 6.471161f32, },
+	["https://caniuse.com/font-variant-numeric"], popularity : 6.245523f32, },
 	"css.properties.font-variant-position" => CSSFeature { id :
 	"css.properties.font-variant-position", name : "font-variant-position", description :
 	"The font-variant-position CSS property sets whether to use alternate glyphs for subscript and superscript text.",
@@ -14594,7 +14595,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.464985f32, }, "css.properties.font-variant-position.normal" =>
+	[], popularity : 0.460453f32, }, "css.properties.font-variant-position.normal" =>
 	CSSFeature { id : "css.properties.font-variant-position.normal", name :
 	"font-variant-position", description :
 	"The font-variant-position CSS property sets whether to use alternate glyphs for subscript and superscript text.",
@@ -14606,7 +14607,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 0.464985f32, }, "css.properties.font-variant-position.sub" =>
+	[], popularity : 0.460453f32, }, "css.properties.font-variant-position.sub" =>
 	CSSFeature { id : "css.properties.font-variant-position.sub", name :
 	"font-variant-position", description :
 	"The font-variant-position CSS property sets whether to use alternate glyphs for subscript and superscript text.",
@@ -14615,7 +14616,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(34u16, 0u16),
 	firefox_android : BrowserVersion(34u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.464985f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.460453f32, },
 	"css.properties.font-variant-position.super" => CSSFeature { id :
 	"css.properties.font-variant-position.super", name : "font-variant-position",
 	description :
@@ -14625,7 +14626,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(34u16, 0u16),
 	firefox_android : BrowserVersion(34u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.464985f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.460453f32, },
 	"css.properties.font-variant.css_fonts_shorthand" => CSSFeature { id :
 	"css.properties.font-variant.css_fonts_shorthand", name : "font-variant", description
 	:
@@ -14638,7 +14639,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 29.338179f32, },
+	[], popularity : 29.584677f32, },
 	"css.properties.font-variant.greek_accented_characters" => CSSFeature { id :
 	"css.properties.font-variant.greek_accented_characters", name : "font-variant",
 	description :
@@ -14648,7 +14649,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 29.338179f32, },
+	0), }, caniuse : & [], popularity : 29.584677f32, },
 	"css.properties.font-variant.historical-forms" => CSSFeature { id :
 	"css.properties.font-variant.historical-forms", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
@@ -14660,7 +14661,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(111u16, 0u16), edge : BrowserVersion(111u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 29.338179f32, }, "css.properties.font-variant.none" => CSSFeature {
+	[], popularity : 29.584677f32, }, "css.properties.font-variant.none" => CSSFeature {
 	id : "css.properties.font-variant.none", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -14671,7 +14672,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(52u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), }, caniuse : &
-	[], popularity : 29.338179f32, }, "css.properties.font-variant.normal" => CSSFeature
+	[], popularity : 29.584677f32, }, "css.properties.font-variant.normal" => CSSFeature
 	{ id : "css.properties.font-variant.normal", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -14682,7 +14683,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 29.338179f32, }, "css.properties.font-variant.sub" => CSSFeature {
+	[], popularity : 29.584677f32, }, "css.properties.font-variant.sub" => CSSFeature {
 	id : "css.properties.font-variant.sub", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -14693,7 +14694,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(110u16, 0u16), edge : BrowserVersion(110u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 29.338179f32, }, "css.properties.font-variant.super" => CSSFeature {
+	[], popularity : 29.584677f32, }, "css.properties.font-variant.super" => CSSFeature {
 	id : "css.properties.font-variant.super", name : "font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-variant-prop", groups : &
@@ -14704,7 +14705,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(110u16, 0u16), edge : BrowserVersion(110u16, 0u16), firefox :
 	BrowserVersion(34u16, 0u16), firefox_android : BrowserVersion(34u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	[], popularity : 29.338179f32, }, "css.properties.font-variant.turkic_is" =>
+	[], popularity : 29.584677f32, }, "css.properties.font-variant.turkic_is" =>
 	CSSFeature { id : "css.properties.font-variant.turkic_is", name : "font-variant",
 	description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
@@ -14716,7 +14717,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(31u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(14u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	[], popularity : 29.338179f32, }, "css.properties.font-variant.uppercase_eszett" =>
+	[], popularity : 29.584677f32, }, "css.properties.font-variant.uppercase_eszett" =>
 	CSSFeature { id : "css.properties.font-variant.uppercase_eszett", name :
 	"font-variant", description :
 	"The font-variant CSS property is a shorthand for font-variant-alternates, font-variant-caps, font-variant-east-asian, font-variant-emoji, font-variant-ligatures, font-variant-numeric, and font-variant-position.",
@@ -14725,7 +14726,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 29.338179f32, },
+	0), }, caniuse : & [], popularity : 29.584677f32, },
 	"css.properties.font-variation-settings" => CSSFeature { id :
 	"css.properties.font-variation-settings", name : "font-variation-settings",
 	description :
@@ -14738,7 +14739,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(62u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/variable-fonts"], popularity : 20.326927f32, },
+	["https://caniuse.com/variable-fonts"], popularity : 19.899553f32, },
 	"css.properties.font-weight" => CSSFeature { id : "css.properties.font-weight", name
 	: "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
@@ -14750,7 +14751,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 87.64308f32, }, "css.properties.font-weight.bold" => CSSFeature { id
+	[], popularity : 87.33229f32, }, "css.properties.font-weight.bold" => CSSFeature { id
 	: "css.properties.font-weight.bold", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14761,7 +14762,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 87.64308f32, }, "css.properties.font-weight.bolder" => CSSFeature {
+	[], popularity : 87.33229f32, }, "css.properties.font-weight.bolder" => CSSFeature {
 	id : "css.properties.font-weight.bolder", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14772,7 +14773,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 87.64308f32, }, "css.properties.font-weight.lighter" => CSSFeature {
+	[], popularity : 87.33229f32, }, "css.properties.font-weight.lighter" => CSSFeature {
 	id : "css.properties.font-weight.lighter", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14783,7 +14784,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 87.64308f32, }, "css.properties.font-weight.normal" => CSSFeature {
+	[], popularity : 87.33229f32, }, "css.properties.font-weight.normal" => CSSFeature {
 	id : "css.properties.font-weight.normal", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14794,7 +14795,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 87.64308f32, }, "css.properties.font-weight.number" => CSSFeature {
+	[], popularity : 87.33229f32, }, "css.properties.font-weight.number" => CSSFeature {
 	id : "css.properties.font-weight.number", name : "font-weight", description :
 	"The font-weight CSS property controls the thickness of a font. It is set explicitly with the keyword bold or a number, or relative to the inherited thickness with the keywords bolder or lighter.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-weight-prop", groups : &
@@ -14805,7 +14806,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(62u16, 0u16), edge : BrowserVersion(17u16, 0u16), firefox :
 	BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 87.64308f32, }, "css.properties.font-width" => CSSFeature { id :
+	[], popularity : 87.33229f32, }, "css.properties.font-width" => CSSFeature { id :
 	"css.properties.font-width", name : "font-width", description :
 	"The font-width CSS property selects a font face from a font family based on width, either by a keyword such as condensed or a percentage.",
 	spec : "https://drafts.csswg.org/css-fonts-4/#font-width-prop", groups : & ["fonts"],
@@ -14907,7 +14908,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(60u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-font-stretch"], popularity : 27.777647f32, },
+	["https://caniuse.com/css-font-stretch"], popularity : 27.517933f32, },
 	"css.properties.font.icon" => CSSFeature { id : "css.properties.font.icon", name :
 	"Font shorthand", description :
 	"The font CSS property shorthand sets multiple font properties, including style, weight, size, and font family.",
@@ -15006,7 +15007,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.gap.flex_context" => CSSFeature { id :
 	"css.properties.gap.flex_context", name : "Flexbox gap", description :
 	"The gap CSS property in a flexbox layout sets the size of the space between items.",
@@ -15028,7 +15029,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 0u16), safari_ios : BrowserVersion(12u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.gap.grid_context.calc_values" => CSSFeature { id :
 	"css.properties.gap.grid_context.calc_values", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15039,7 +15040,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.gap.grid_context.percentage_values" => CSSFeature { id :
 	"css.properties.gap.grid_context.percentage_values", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15050,7 +15051,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 0u16), safari_ios : BrowserVersion(12u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.gap.multicol_context" => CSSFeature { id :
 	"css.properties.gap.multicol_context", name : "Multi-column layout", description :
 	"Multi-column layout flows an element's content across one or more columns in a single row, without affecting the display property of its children.",
@@ -15071,7 +15072,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.glyph-orientation-vertical" => CSSFeature { id :
 	"css.properties.glyph-orientation-vertical", name : "glyph-orientation-vertical",
 	description :
@@ -15092,7 +15093,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-area" => CSSFeature { id : "css.properties.grid-area", name :
 	"Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15103,7 +15104,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-auto-columns" => CSSFeature { id :
 	"css.properties.grid-auto-columns", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15114,7 +15115,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-auto-flow" => CSSFeature { id : "css.properties.grid-auto-flow",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15125,7 +15126,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-auto-flow.column" => CSSFeature { id :
 	"css.properties.grid-auto-flow.column", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15136,7 +15137,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-auto-flow.dense" => CSSFeature { id :
 	"css.properties.grid-auto-flow.dense", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15147,7 +15148,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-auto-flow.row" => CSSFeature { id :
 	"css.properties.grid-auto-flow.row", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15158,7 +15159,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-auto-rows" => CSSFeature { id : "css.properties.grid-auto-rows",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15169,7 +15170,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-column" => CSSFeature { id : "css.properties.grid-column", name
 	: "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15180,7 +15181,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-column-end" => CSSFeature { id :
 	"css.properties.grid-column-end", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15191,7 +15192,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-column-start" => CSSFeature { id :
 	"css.properties.grid-column-start", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15202,7 +15203,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-row" => CSSFeature { id : "css.properties.grid-row", name :
 	"Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15213,7 +15214,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-row-end" => CSSFeature { id : "css.properties.grid-row-end",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15224,7 +15225,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-row-start" => CSSFeature { id : "css.properties.grid-row-start",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15235,7 +15236,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template" => CSSFeature { id : "css.properties.grid-template",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15246,7 +15247,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-areas" => CSSFeature { id :
 	"css.properties.grid-template-areas", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15257,7 +15258,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-areas.none" => CSSFeature { id :
 	"css.properties.grid-template-areas.none", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15268,7 +15269,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-columns" => CSSFeature { id :
 	"css.properties.grid-template-columns", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15279,7 +15280,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-columns.animation" => CSSFeature { id :
 	"css.properties.grid-template-columns.animation", name : "Grid animation",
 	description :
@@ -15302,7 +15303,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-columns.fit-content" => CSSFeature { id :
 	"css.properties.grid-template-columns.fit-content", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15313,7 +15314,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-columns.masonry" => CSSFeature { id :
 	"css.properties.grid-template-columns.masonry", name : "Masonry", description :
 	"The display: grid-lanes or display: inline-grid-lanes CSS declaration creates a layout where items are tightly packed, like brickwork, in parallel lanes. Items are placed one by one in the lane that has the most available space.",
@@ -15333,7 +15334,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-columns.min-content" => CSSFeature { id :
 	"css.properties.grid-template-columns.min-content", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15344,7 +15345,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-columns.minmax" => CSSFeature { id :
 	"css.properties.grid-template-columns.minmax", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15355,7 +15356,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-columns.none" => CSSFeature { id :
 	"css.properties.grid-template-columns.none", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15366,7 +15367,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-columns.repeat" => CSSFeature { id :
 	"css.properties.grid-template-columns.repeat", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15377,7 +15378,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(76u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-columns.subgrid" => CSSFeature { id :
 	"css.properties.grid-template-columns.subgrid", name : "Subgrid", description :
 	"The subgrid value for the grid-template-columns and grid-template-rows properties allows a grid item to inherit the grid definition of its parent grid container.",
@@ -15399,7 +15400,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-rows.animation" => CSSFeature { id :
 	"css.properties.grid-template-rows.animation", name : "Grid animation", description :
 	"Grid animation allows you to animate the grid-template-columns and grid-template-rows CSS properties.",
@@ -15421,7 +15422,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-rows.fit-content" => CSSFeature { id :
 	"css.properties.grid-template-rows.fit-content", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15432,7 +15433,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-rows.masonry" => CSSFeature { id :
 	"css.properties.grid-template-rows.masonry", name : "Masonry", description :
 	"The display: grid-lanes or display: inline-grid-lanes CSS declaration creates a layout where items are tightly packed, like brickwork, in parallel lanes. Items are placed one by one in the lane that has the most available space.",
@@ -15452,7 +15453,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-rows.min-content" => CSSFeature { id :
 	"css.properties.grid-template-rows.min-content", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15463,7 +15464,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-rows.minmax" => CSSFeature { id :
 	"css.properties.grid-template-rows.minmax", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15474,7 +15475,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-rows.none" => CSSFeature { id :
 	"css.properties.grid-template-rows.none", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15485,7 +15486,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-rows.repeat" => CSSFeature { id :
 	"css.properties.grid-template-rows.repeat", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -15496,7 +15497,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(76u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.grid-template-rows.subgrid" => CSSFeature { id :
 	"css.properties.grid-template-rows.subgrid", name : "Subgrid", description :
 	"The subgrid value for the grid-template-columns and grid-template-rows properties allows a grid item to inherit the grid definition of its parent grid container.",
@@ -15518,7 +15519,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.hanging-punctuation" => CSSFeature { id :
 	"css.properties.hanging-punctuation", name : "Hanging punctuation", description :
 	"The hanging-punctuation CSS property puts punctuation characters outside of the box to align the text with the rest of the document.",
@@ -15674,7 +15675,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(106u16, 0u16), edge : BrowserVersion(106u16, 0u16), firefox :
 	BrowserVersion(98u16, 0u16), firefox_android : BrowserVersion(98u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	[], popularity : 0.518396f32, }, "css.properties.hyphenate-character.auto" =>
+	[], popularity : 0.460875f32, }, "css.properties.hyphenate-character.auto" =>
 	CSSFeature { id : "css.properties.hyphenate-character.auto", name :
 	"Hyphenate character", description :
 	"The hyphenate-character CSS property sets the character or string to use at the end of a line before a line break.",
@@ -15686,7 +15687,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(106u16, 0u16), edge : BrowserVersion(106u16, 0u16), firefox :
 	BrowserVersion(98u16, 0u16), firefox_android : BrowserVersion(98u16, 0u16), safari :
 	BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), }, caniuse : &
-	[], popularity : 0.518396f32, }, "css.properties.hyphenate-limit-chars" => CSSFeature
+	[], popularity : 0.460875f32, }, "css.properties.hyphenate-limit-chars" => CSSFeature
 	{ id : "css.properties.hyphenate-limit-chars", name : "Hyphenate limit chars",
 	description :
 	"The hyphenate-limit-chars CSS property sets the number of characters in a word before it is hyphenated and the minimum number of characters on either side of the hyphen.",
@@ -15696,9 +15697,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(109u16, 0u16), edge : BrowserVersion(109u16, 0u16), firefox :
 	BrowserVersion(137u16, 0u16), firefox_android : BrowserVersion(137u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.244866f32, }, "css.properties.hyphenate-limit-chars.auto" =>
-	CSSFeature { id : "css.properties.hyphenate-limit-chars.auto", name :
-	"Hyphenate limit chars", description :
+	popularity : 0.24738f32, }, "css.properties.hyphenate-limit-chars.auto" => CSSFeature
+	{ id : "css.properties.hyphenate-limit-chars.auto", name : "Hyphenate limit chars",
+	description :
 	"The hyphenate-limit-chars CSS property sets the number of characters in a word before it is hyphenated and the minimum number of characters on either side of the hyphen.",
 	spec : "https://drafts.csswg.org/css-text-4/#hyphenate-char-limits", groups : &
 	["text-wrap"], baseline_status : BaselineStatus::False, browser_support :
@@ -15706,7 +15707,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(109u16, 0u16), edge : BrowserVersion(109u16, 0u16), firefox :
 	BrowserVersion(137u16, 0u16), firefox_android : BrowserVersion(137u16, 0u16), safari
 	: BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.244866f32, }, "css.properties.hyphens" => CSSFeature { id :
+	popularity : 0.24738f32, }, "css.properties.hyphens" => CSSFeature { id :
 	"css.properties.hyphens", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -15716,7 +15717,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.auto" => CSSFeature { id : "css.properties.hyphens.auto",
 	name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15727,7 +15728,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(55u16, 0u16), edge : BrowserVersion(88u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_afrikaans" => CSSFeature { id :
 	"css.properties.hyphens.language_afrikaans", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15737,7 +15738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android
 	: BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_albanian" => CSSFeature { id :
+	: 10.127939f32, }, "css.properties.hyphens.language_albanian" => CSSFeature { id :
 	"css.properties.hyphens.language_albanian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -15745,7 +15746,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_amharic" => CSSFeature { id :
 	"css.properties.hyphens.language_amharic", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15754,7 +15755,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_armenian" => CSSFeature { id :
 	"css.properties.hyphens.language_armenian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15763,7 +15764,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_assamese" => CSSFeature { id :
 	"css.properties.hyphens.language_assamese", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15772,7 +15773,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_basque" => CSSFeature { id :
 	"css.properties.hyphens.language_basque", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15781,7 +15782,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_belarusian" => CSSFeature { id :
 	"css.properties.hyphens.language_belarusian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15790,7 +15791,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_bengali" => CSSFeature { id :
 	"css.properties.hyphens.language_bengali", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15799,7 +15800,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_bosnian" => CSSFeature { id :
 	"css.properties.hyphens.language_bosnian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15808,7 +15809,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_bulgarian" => CSSFeature { id :
 	"css.properties.hyphens.language_bulgarian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15818,7 +15819,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_catalan" => CSSFeature { id :
+	: 10.127939f32, }, "css.properties.hyphens.language_catalan" => CSSFeature { id :
 	"css.properties.hyphens.language_catalan", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -15826,7 +15827,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_croatian" => CSSFeature { id :
 	"css.properties.hyphens.language_croatian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15837,7 +15838,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_cyrillic_mongolian" => CSSFeature { id :
 	"css.properties.hyphens.language_cyrillic_mongolian", name : "Hyphenation",
 	description :
@@ -15847,7 +15848,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_czech" => CSSFeature { id :
 	"css.properties.hyphens.language_czech", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15857,7 +15858,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16, 0u16),
 	firefox : BrowserVersion(130u16, 0u16), firefox_android : BrowserVersion(130u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_danish" => CSSFeature { id :
 	"css.properties.hyphens.language_danish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15868,7 +15869,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_dutch" => CSSFeature { id :
 	"css.properties.hyphens.language_dutch", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15879,7 +15880,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_english" => CSSFeature { id :
 	"css.properties.hyphens.language_english", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15890,7 +15891,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(55u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_esperanto" => CSSFeature { id :
 	"css.properties.hyphens.language_esperanto", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15899,7 +15900,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_estonian" => CSSFeature { id :
 	"css.properties.hyphens.language_estonian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15909,7 +15910,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_ethiopic_script_mul" =>
+	: 10.127939f32, }, "css.properties.hyphens.language_ethiopic_script_mul" =>
 	CSSFeature { id : "css.properties.hyphens.language_ethiopic_script_mul", name :
 	"Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15918,7 +15919,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_ethiopic_script_und" => CSSFeature { id :
 	"css.properties.hyphens.language_ethiopic_script_und", name : "Hyphenation",
 	description :
@@ -15928,7 +15929,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_finnish" => CSSFeature { id :
 	"css.properties.hyphens.language_finnish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15937,7 +15938,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_french" => CSSFeature { id :
 	"css.properties.hyphens.language_french", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15948,7 +15949,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_galician" => CSSFeature { id :
 	"css.properties.hyphens.language_galician", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -15958,7 +15959,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android
 	: BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_georgian" => CSSFeature { id :
+	: 10.127939f32, }, "css.properties.hyphens.language_georgian" => CSSFeature { id :
 	"css.properties.hyphens.language_georgian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -15966,7 +15967,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_german_reformed_orthography" => CSSFeature { id :
 	"css.properties.hyphens.language_german_reformed_orthography", name : "Hyphenation",
 	description :
@@ -15978,7 +15979,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_german_swiss_orthography" => CSSFeature { id :
 	"css.properties.hyphens.language_german_swiss_orthography", name : "Hyphenation",
 	description :
@@ -15989,7 +15990,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_german_traditional_orthography"
+	: 10.127939f32, }, "css.properties.hyphens.language_german_traditional_orthography"
 	=> CSSFeature { id :
 	"css.properties.hyphens.language_german_traditional_orthography", name :
 	"Hyphenation", description :
@@ -16000,7 +16001,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_gujarati" => CSSFeature { id :
+	: 10.127939f32, }, "css.properties.hyphens.language_gujarati" => CSSFeature { id :
 	"css.properties.hyphens.language_gujarati", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16008,7 +16009,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_hindi" => CSSFeature { id :
 	"css.properties.hyphens.language_hindi", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16017,7 +16018,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_hungarian" => CSSFeature { id :
 	"css.properties.hyphens.language_hungarian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16028,7 +16029,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_icelandic" => CSSFeature { id :
 	"css.properties.hyphens.language_icelandic", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16037,7 +16038,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_interlingua" => CSSFeature { id :
 	"css.properties.hyphens.language_interlingua", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16046,7 +16047,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_irish" => CSSFeature { id :
 	"css.properties.hyphens.language_irish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16055,7 +16056,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_italian" => CSSFeature { id :
 	"css.properties.hyphens.language_italian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16066,7 +16067,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_kannada" => CSSFeature { id :
 	"css.properties.hyphens.language_kannada", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16075,7 +16076,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_kurmanji" => CSSFeature { id :
 	"css.properties.hyphens.language_kurmanji", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16084,7 +16085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_latin" => CSSFeature { id :
 	"css.properties.hyphens.language_latin", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16094,7 +16095,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_latvian" => CSSFeature { id :
+	: 10.127939f32, }, "css.properties.hyphens.language_latvian" => CSSFeature { id :
 	"css.properties.hyphens.language_latvian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16102,7 +16103,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_lithuanian" => CSSFeature { id :
 	"css.properties.hyphens.language_lithuanian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16112,7 +16113,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android
 	: BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_malayalam" => CSSFeature { id :
+	: 10.127939f32, }, "css.properties.hyphens.language_malayalam" => CSSFeature { id :
 	"css.properties.hyphens.language_malayalam", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16120,7 +16121,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_marathi" => CSSFeature { id :
 	"css.properties.hyphens.language_marathi", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16129,7 +16130,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_modern_greek" => CSSFeature { id :
 	"css.properties.hyphens.language_modern_greek", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16138,7 +16139,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), chrome_android : BrowserVersion(112u16, 0u16), edge :
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_mongolian" => CSSFeature { id :
 	"css.properties.hyphens.language_mongolian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16147,7 +16148,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_norwegian_nn" => CSSFeature { id :
 	"css.properties.hyphens.language_norwegian_nn", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16157,7 +16158,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(17u16, 0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"],
-	popularity : 10.363075f32, }, "css.properties.hyphens.language_norwegian_no" =>
+	popularity : 10.127939f32, }, "css.properties.hyphens.language_norwegian_no" =>
 	CSSFeature { id : "css.properties.hyphens.language_norwegian_no", name :
 	"Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16168,7 +16169,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_old_slavonic" => CSSFeature { id :
 	"css.properties.hyphens.language_old_slavonic", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16177,7 +16178,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_oriya" => CSSFeature { id :
 	"css.properties.hyphens.language_oriya", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16186,7 +16187,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_polish" => CSSFeature { id :
 	"css.properties.hyphens.language_polish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16195,7 +16196,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_portuguese" => CSSFeature { id :
 	"css.properties.hyphens.language_portuguese", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16206,7 +16207,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_punjabi" => CSSFeature { id :
 	"css.properties.hyphens.language_punjabi", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16215,7 +16216,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_russian" => CSSFeature { id :
 	"css.properties.hyphens.language_russian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16226,7 +16227,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_slovak" => CSSFeature { id :
 	"css.properties.hyphens.language_slovak", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16236,7 +16237,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(112u16, 0u16), firefox : BrowserVersion(130u16, 0u16), firefox_android
 	: BrowserVersion(130u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_slovenian" => CSSFeature { id :
+	: 10.127939f32, }, "css.properties.hyphens.language_slovenian" => CSSFeature { id :
 	"css.properties.hyphens.language_slovenian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16245,7 +16246,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.hyphens.language_spanish" => CSSFeature { id :
+	: 10.127939f32, }, "css.properties.hyphens.language_spanish" => CSSFeature { id :
 	"css.properties.hyphens.language_spanish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
 	spec : "https://drafts.csswg.org/css-text-3/#hyphens-property", groups : & [],
@@ -16255,7 +16256,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_swedish" => CSSFeature { id :
 	"css.properties.hyphens.language_swedish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16266,7 +16267,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_tamil" => CSSFeature { id :
 	"css.properties.hyphens.language_tamil", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16275,7 +16276,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_telugu" => CSSFeature { id :
 	"css.properties.hyphens.language_telugu", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16284,7 +16285,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_turkish" => CSSFeature { id :
 	"css.properties.hyphens.language_turkish", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16293,7 +16294,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_turkmen" => CSSFeature { id :
 	"css.properties.hyphens.language_turkmen", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16302,7 +16303,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_ukrainian" => CSSFeature { id :
 	"css.properties.hyphens.language_ukrainian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16313,7 +16314,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(112u16, 0u16), edge : BrowserVersion(112u16,
 	0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32,
+	0u16), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32,
 	}, "css.properties.hyphens.language_upper_sorbian" => CSSFeature { id :
 	"css.properties.hyphens.language_upper_sorbian", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16322,7 +16323,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/css-hyphens"], popularity : 10.363075f32, },
+	& ["https://caniuse.com/css-hyphens"], popularity : 10.127939f32, },
 	"css.properties.hyphens.language_welsh" => CSSFeature { id :
 	"css.properties.hyphens.language_welsh", name : "Hyphenation", description :
 	"The hyphens CSS property controls when long words are broken by line wrapping. Although called hyphens, the property applies to word-splitting behavior across languages, such as customary spelling changes or the use of other characters. Support for non-English languages varies significantly.",
@@ -16332,7 +16333,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(43u16, 0u16), firefox_android :
 	BrowserVersion(43u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-hyphens"], popularity
-	: 10.363075f32, }, "css.properties.image-orientation" => CSSFeature { id :
+	: 10.127939f32, }, "css.properties.image-orientation" => CSSFeature { id :
 	"css.properties.image-orientation", name : "image-orientation", description :
 	"The image-orientation CSS property corrects the rotation of an image using the image's metadata, such as EXIF.",
 	spec : "https://drafts.csswg.org/css-images-3/#the-image-orientation", groups : &
@@ -16380,7 +16381,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-crisp-edges"], popularity : 7.22023f32, },
+	["https://caniuse.com/css-crisp-edges"], popularity : 7.547593f32, },
 	"css.properties.image-rendering.auto" => CSSFeature { id :
 	"css.properties.image-rendering.auto", name : "image-rendering", description :
 	"The image-rendering CSS property sets how images are scaled, retaining smoothness for photos, or hard edges for pixel art and QR codes.",
@@ -16392,7 +16393,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-crisp-edges"], popularity : 7.22023f32, },
+	["https://caniuse.com/css-crisp-edges"], popularity : 7.547593f32, },
 	"css.properties.image-rendering.crisp-edges" => CSSFeature { id :
 	"css.properties.image-rendering.crisp-edges", name : "crisp-edges", description :
 	"The image-rendering: crisp-edges CSS declaration scales images to preserve lines without blurring.",
@@ -16415,7 +16416,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(41u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(93u16, 0u16), firefox_android : BrowserVersion(93u16, 0u16), safari :
 	BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-crisp-edges"], popularity : 7.22023f32, },
+	["https://caniuse.com/css-crisp-edges"], popularity : 7.547593f32, },
 	"css.properties.image-rendering.smooth" => CSSFeature { id :
 	"css.properties.image-rendering.smooth", name : "image-rendering: smooth",
 	description :
@@ -16443,7 +16444,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(110u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-initial-letter"], popularity :
-	0.358094f32, }, "css.properties.initial-letter.normal" => CSSFeature { id :
+	0.397394f32, }, "css.properties.initial-letter.normal" => CSSFeature { id :
 	"css.properties.initial-letter.normal", name : "initial-letter", description :
 	"The initial-letter CSS property sets the number of lines the first letter of an element occupies. You can use the property to make a raised capital or drop cap.",
 	spec : "https://drafts.csswg.org/css-inline-3/#sizing-drop-initials", groups : & [],
@@ -16452,7 +16453,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(110u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-initial-letter"], popularity :
-	0.358094f32, }, "css.properties.inline-size" => CSSFeature { id :
+	0.397394f32, }, "css.properties.inline-size" => CSSFeature { id :
 	"css.properties.inline-size", name : "Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
 	spec : "https://drafts.csswg.org/css-logical-1/", groups : & [], baseline_status :
@@ -16823,7 +16824,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(135u16, 0u16), chrome_android : BrowserVersion(135u16, 0u16), edge :
 	BrowserVersion(135u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.088891f32, },
+	0), }, caniuse : & [], popularity : 0.078823f32, },
 	"css.properties.interactivity.auto" => CSSFeature { id :
 	"css.properties.interactivity.auto", name : "interactivity", description :
 	"The interactivity: inert CSS declaration makes an element and its descendants inert, like when using the inert HTML attribute. Inert elements can't be focused or clicked, their text can't be selected or found using the browser's find-in-page feature.",
@@ -16832,7 +16833,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(135u16, 0u16), chrome_android : BrowserVersion(135u16, 0u16), edge :
 	BrowserVersion(135u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.088891f32, },
+	0), }, caniuse : & [], popularity : 0.078823f32, },
 	"css.properties.interactivity.inert" => CSSFeature { id :
 	"css.properties.interactivity.inert", name : "interactivity", description :
 	"The interactivity: inert CSS declaration makes an element and its descendants inert, like when using the inert HTML attribute. Inert elements can't be focused or clicked, their text can't be selected or found using the browser's find-in-page feature.",
@@ -16841,7 +16842,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(135u16, 0u16), chrome_android : BrowserVersion(135u16, 0u16), edge :
 	BrowserVersion(135u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.088891f32, }, "css.properties.interpolate-size"
+	0), }, caniuse : & [], popularity : 0.078823f32, }, "css.properties.interpolate-size"
 	=> CSSFeature { id : "css.properties.interpolate-size", name : "interpolate-size",
 	description :
 	"The interpolate-size CSS property sets whether animations and transitions interpolate between a numeric value and a keyword value, such as from a fixed length to auto or fit-content.",
@@ -16851,7 +16852,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(129u16, 0u16), edge : BrowserVersion(129u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 3.612005f32, }, "css.properties.interpolate-size.allow-keywords" =>
+	popularity : 2.87356f32, }, "css.properties.interpolate-size.allow-keywords" =>
 	CSSFeature { id : "css.properties.interpolate-size.allow-keywords", name :
 	"interpolate-size", description :
 	"The interpolate-size CSS property sets whether animations and transitions interpolate between a numeric value and a keyword value, such as from a fixed length to auto or fit-content.",
@@ -16861,7 +16862,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(129u16, 0u16), edge : BrowserVersion(129u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 3.612005f32, }, "css.properties.interpolate-size.numeric-only" =>
+	popularity : 2.87356f32, }, "css.properties.interpolate-size.numeric-only" =>
 	CSSFeature { id : "css.properties.interpolate-size.numeric-only", name :
 	"interpolate-size", description :
 	"The interpolate-size CSS property sets whether animations and transitions interpolate between a numeric value and a keyword value, such as from a fixed length to auto or fit-content.",
@@ -16871,7 +16872,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(129u16, 0u16), edge : BrowserVersion(129u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 3.612005f32, }, "css.properties.isolation" => CSSFeature { id :
+	popularity : 2.87356f32, }, "css.properties.isolation" => CSSFeature { id :
 	"css.properties.isolation", name : "isolation", description :
 	"The isolation CSS property creates a new stacking context, which impacts z-index ordering and blend modes.",
 	spec : "https://drafts.csswg.org/compositing-2/#isolation", groups : &
@@ -16882,7 +16883,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(41u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	[], popularity : 17.069748f32, }, "css.properties.justify-content" => CSSFeature { id
+	[], popularity : 16.547564f32, }, "css.properties.justify-content" => CSSFeature { id
 	: "css.properties.justify-content", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
 	spec : "https://drafts.csswg.org/css-flexbox-1/", groups : & ["flexbox"],
@@ -16973,7 +16974,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(52u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.justify-content.left" => CSSFeature { id :
 	"css.properties.justify-content.left", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -17071,7 +17072,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.justify-items.left" => CSSFeature { id :
 	"css.properties.justify-items.left", name : "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -17115,7 +17116,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.justify-self.anchor-center" => CSSFeature { id :
 	"css.properties.justify-self.anchor-center", name : "Anchor positioning", description
 	:
@@ -17137,7 +17138,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.justify-self.block_context" => CSSFeature { id :
 	"css.properties.justify-self.block_context", name : "justify-self in block layouts",
 	description :
@@ -17158,7 +17159,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.justify-self.left" => CSSFeature { id :
 	"css.properties.justify-self.left", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -17169,7 +17170,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.justify-self.normal" => CSSFeature { id :
 	"css.properties.justify-self.normal", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -17180,7 +17181,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.justify-self.position_absolute_context" => CSSFeature { id :
 	"css.properties.justify-self.position_absolute_context", name :
 	"Absolute positioning", description :
@@ -17203,7 +17204,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.justify-self.stretch" => CSSFeature { id :
 	"css.properties.justify-self.stretch", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -17214,7 +17215,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.left" => CSSFeature { id : "css.properties.left", name :
 	"Physical properties", description :
 	"The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.",
@@ -17266,7 +17267,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-letter-spacing"], popularity : 67.00629f32, },
+	["https://caniuse.com/css-letter-spacing"], popularity : 68.01092f32, },
 	"css.properties.letter-spacing.normal" => CSSFeature { id :
 	"css.properties.letter-spacing.normal", name : "letter-spacing", description :
 	"The letter-spacing CSS property controls the amount of space between each letter in an element or block of text.",
@@ -17278,7 +17279,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-letter-spacing"], popularity : 67.00629f32, },
+	["https://caniuse.com/css-letter-spacing"], popularity : 68.01092f32, },
 	"css.properties.letter-spacing.svg_elements" => CSSFeature { id :
 	"css.properties.letter-spacing.svg_elements", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -17335,7 +17336,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(14u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 6.129375f32, }, "css.properties.line-break.anywhere" => CSSFeature {
+	[], popularity : 5.909169f32, }, "css.properties.line-break.anywhere" => CSSFeature {
 	id : "css.properties.line-break.anywhere", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17346,7 +17347,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(83u16, 0u16), edge : BrowserVersion(83u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	[], popularity : 6.129375f32, }, "css.properties.line-break.auto" => CSSFeature { id
+	[], popularity : 5.909169f32, }, "css.properties.line-break.auto" => CSSFeature { id
 	: "css.properties.line-break.auto", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17357,7 +17358,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 6.129375f32, }, "css.properties.line-break.loose" => CSSFeature { id
+	[], popularity : 5.909169f32, }, "css.properties.line-break.loose" => CSSFeature { id
 	: "css.properties.line-break.loose", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17368,7 +17369,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 6.129375f32, }, "css.properties.line-break.normal" => CSSFeature {
+	[], popularity : 5.909169f32, }, "css.properties.line-break.normal" => CSSFeature {
 	id : "css.properties.line-break.normal", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17379,7 +17380,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 6.129375f32, }, "css.properties.line-break.strict" => CSSFeature {
+	[], popularity : 5.909169f32, }, "css.properties.line-break.strict" => CSSFeature {
 	id : "css.properties.line-break.strict", name : "line-break", description :
 	"The line-break CSS property sets how strictly to apply rules for wrapping text to new lines, especially for symbols and punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#line-break-property", groups : &
@@ -17390,7 +17391,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(58u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), }, caniuse : &
-	[], popularity : 6.129375f32, }, "css.properties.line-clamp" => CSSFeature { id :
+	[], popularity : 5.909169f32, }, "css.properties.line-clamp" => CSSFeature { id :
 	"css.properties.line-clamp", name : "line-clamp", description :
 	"The line-clamp CSS property limits the text in a block container to a certain number of lines. The prefixed -webkit-line-clamp is widely supported but only works with -webkit-box-orient: vertical in combination with display: -webkit-box or display: -webkit-inline-box.",
 	spec : "https://drafts.csswg.org/css-overflow-4/#line-clamp", groups : & [],
@@ -17398,7 +17399,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-line-clamp"], popularity : 0.003394f32, },
+	["https://caniuse.com/css-line-clamp"], popularity : 0.003057f32, },
 	"css.properties.line-clamp.none" => CSSFeature { id :
 	"css.properties.line-clamp.none", name : "line-clamp", description :
 	"The line-clamp CSS property limits the text in a block container to a certain number of lines. The prefixed -webkit-line-clamp is widely supported but only works with -webkit-box-orient: vertical in combination with display: -webkit-box or display: -webkit-inline-box.",
@@ -17407,7 +17408,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-line-clamp"], popularity : 0.003394f32, },
+	["https://caniuse.com/css-line-clamp"], popularity : 0.003057f32, },
 	"css.properties.line-height" => CSSFeature { id : "css.properties.line-height", name
 	: "line-height", description :
 	"The line-height CSS property sets the spacing between text baselines, oriented to the horizontal or vertical writing mode.",
@@ -17419,7 +17420,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 85.54362f32, }, "css.properties.line-height.normal" => CSSFeature {
+	[], popularity : 85.57945f32, }, "css.properties.line-height.normal" => CSSFeature {
 	id : "css.properties.line-height.normal", name : "line-height", description :
 	"The line-height CSS property sets the spacing between text baselines, oriented to the horizontal or vertical writing mode.",
 	spec : "https://drafts.csswg.org/css-inline-3/#line-height-property", groups : &
@@ -17430,7 +17431,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 85.54362f32, }, "css.properties.list-style" => CSSFeature { id :
+	[], popularity : 85.57945f32, }, "css.properties.list-style" => CSSFeature { id :
 	"css.properties.list-style", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17441,8 +17442,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-image" => CSSFeature { id
-	: "css.properties.list-style-image", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-image" => CSSFeature {
+	id : "css.properties.list-style-image", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17452,8 +17453,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-image.none" => CSSFeature
-	{ id : "css.properties.list-style-image.none", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-image.none" =>
+	CSSFeature { id : "css.properties.list-style-image.none", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17463,8 +17465,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-position" => CSSFeature {
-	id : "css.properties.list-style-position", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-position" => CSSFeature
+	{ id : "css.properties.list-style-position", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17474,7 +17476,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-position.inside" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-position.inside" =>
 	CSSFeature { id : "css.properties.list-style-position.inside", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17486,7 +17488,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-position.outside" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-position.outside" =>
 	CSSFeature { id : "css.properties.list-style-position.outside", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17498,8 +17500,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type" => CSSFeature { id :
-	"css.properties.list-style-type", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type" => CSSFeature { id
+	: "css.properties.list-style-type", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17509,7 +17511,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.arabic-indic" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.arabic-indic" =>
 	CSSFeature { id : "css.properties.list-style-type.arabic-indic", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17521,7 +17523,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.armenian" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.armenian" =>
 	CSSFeature { id : "css.properties.list-style-type.armenian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17533,7 +17535,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.bengali" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.bengali" =>
 	CSSFeature { id : "css.properties.list-style-type.bengali", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17545,7 +17547,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.cambodian" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.cambodian" =>
 	CSSFeature { id : "css.properties.list-style-type.cambodian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17557,8 +17559,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.circle" => CSSFeature
-	{ id : "css.properties.list-style-type.circle", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.circle" =>
+	CSSFeature { id : "css.properties.list-style-type.circle", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17568,7 +17571,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.cjk-decimal" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.cjk-decimal" =>
 	CSSFeature { id : "css.properties.list-style-type.cjk-decimal", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17580,7 +17583,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.cjk-earthly-branch"
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.cjk-earthly-branch"
 	=> CSSFeature { id : "css.properties.list-style-type.cjk-earthly-branch", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17592,8 +17595,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.cjk-heavenly-stem" =>
-	CSSFeature { id : "css.properties.list-style-type.cjk-heavenly-stem", name :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.cjk-heavenly-stem"
+	=> CSSFeature { id : "css.properties.list-style-type.cjk-heavenly-stem", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17604,7 +17607,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.cjk-ideographic" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.cjk-ideographic" =>
 	CSSFeature { id : "css.properties.list-style-type.cjk-ideographic", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17616,7 +17619,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.decimal" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.decimal" =>
 	CSSFeature { id : "css.properties.list-style-type.decimal", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17628,9 +17631,10 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.decimal-leading-zero"
-	=> CSSFeature { id : "css.properties.list-style-type.decimal-leading-zero", name :
-	"List style", description :
+	[], popularity : 67.235275f32, },
+	"css.properties.list-style-type.decimal-leading-zero" => CSSFeature { id :
+	"css.properties.list-style-type.decimal-leading-zero", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17640,7 +17644,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.devanagari" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.devanagari" =>
 	CSSFeature { id : "css.properties.list-style-type.devanagari", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17652,8 +17656,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.disc" => CSSFeature {
-	id : "css.properties.list-style-type.disc", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.disc" => CSSFeature
+	{ id : "css.properties.list-style-type.disc", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17663,8 +17667,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.disclosure-closed" =>
-	CSSFeature { id : "css.properties.list-style-type.disclosure-closed", name :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.disclosure-closed"
+	=> CSSFeature { id : "css.properties.list-style-type.disclosure-closed", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17675,7 +17679,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.disclosure-open" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.disclosure-open" =>
 	CSSFeature { id : "css.properties.list-style-type.disclosure-open", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17687,8 +17691,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.ethiopic-numeric" =>
-	CSSFeature { id : "css.properties.list-style-type.ethiopic-numeric", name :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.ethiopic-numeric"
+	=> CSSFeature { id : "css.properties.list-style-type.ethiopic-numeric", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17699,7 +17703,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.georgian" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.georgian" =>
 	CSSFeature { id : "css.properties.list-style-type.georgian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17711,7 +17715,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.gujarati" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.gujarati" =>
 	CSSFeature { id : "css.properties.list-style-type.gujarati", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17723,7 +17727,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.gurmukhi" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.gurmukhi" =>
 	CSSFeature { id : "css.properties.list-style-type.gurmukhi", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17735,8 +17739,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.hebrew" => CSSFeature
-	{ id : "css.properties.list-style-type.hebrew", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.hebrew" =>
+	CSSFeature { id : "css.properties.list-style-type.hebrew", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17746,7 +17751,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.hiragana" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.hiragana" =>
 	CSSFeature { id : "css.properties.list-style-type.hiragana", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17758,7 +17763,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.hiragana-iroha" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.hiragana-iroha" =>
 	CSSFeature { id : "css.properties.list-style-type.hiragana-iroha", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17770,7 +17775,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.japanese-formal" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.japanese-formal" =>
 	CSSFeature { id : "css.properties.list-style-type.japanese-formal", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17782,8 +17787,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.japanese-informal" =>
-	CSSFeature { id : "css.properties.list-style-type.japanese-informal", name :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.japanese-informal"
+	=> CSSFeature { id : "css.properties.list-style-type.japanese-informal", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -17794,7 +17799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.kannada" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.kannada" =>
 	CSSFeature { id : "css.properties.list-style-type.kannada", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17806,7 +17811,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.katakana" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.katakana" =>
 	CSSFeature { id : "css.properties.list-style-type.katakana", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17818,7 +17823,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.katakana-iroha" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.katakana-iroha" =>
 	CSSFeature { id : "css.properties.list-style-type.katakana-iroha", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17830,8 +17835,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.khmer" => CSSFeature
-	{ id : "css.properties.list-style-type.khmer", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.khmer" =>
+	CSSFeature { id : "css.properties.list-style-type.khmer", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17841,9 +17847,10 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.korean-hangul-formal"
-	=> CSSFeature { id : "css.properties.list-style-type.korean-hangul-formal", name :
-	"List style", description :
+	[], popularity : 67.235275f32, },
+	"css.properties.list-style-type.korean-hangul-formal" => CSSFeature { id :
+	"css.properties.list-style-type.korean-hangul-formal", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17853,9 +17860,10 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.korean-hanja-formal"
-	=> CSSFeature { id : "css.properties.list-style-type.korean-hanja-formal", name :
-	"List style", description :
+	[], popularity : 67.235275f32, },
+	"css.properties.list-style-type.korean-hanja-formal" => CSSFeature { id :
+	"css.properties.list-style-type.korean-hanja-formal", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17865,7 +17873,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, },
+	[], popularity : 67.235275f32, },
 	"css.properties.list-style-type.korean-hanja-informal" => CSSFeature { id :
 	"css.properties.list-style-type.korean-hanja-informal", name : "List style",
 	description :
@@ -17878,8 +17886,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.lao" => CSSFeature {
-	id : "css.properties.list-style-type.lao", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.lao" => CSSFeature
+	{ id : "css.properties.list-style-type.lao", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17889,7 +17897,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.lower-alpha" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.lower-alpha" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-alpha", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17901,7 +17909,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.lower-armenian" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.lower-armenian" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-armenian", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17913,7 +17921,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.lower-greek" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.lower-greek" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-greek", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17925,7 +17933,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.lower-latin" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.lower-latin" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-latin", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17937,7 +17945,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.lower-roman" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.lower-roman" =>
 	CSSFeature { id : "css.properties.list-style-type.lower-roman", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17949,7 +17957,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.malayalam" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.malayalam" =>
 	CSSFeature { id : "css.properties.list-style-type.malayalam", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17961,7 +17969,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.mongolian" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.mongolian" =>
 	CSSFeature { id : "css.properties.list-style-type.mongolian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17973,7 +17981,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.myanmar" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.myanmar" =>
 	CSSFeature { id : "css.properties.list-style-type.myanmar", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -17985,8 +17993,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.none" => CSSFeature {
-	id : "css.properties.list-style-type.none", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.none" => CSSFeature
+	{ id : "css.properties.list-style-type.none", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -17996,8 +18004,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.oriya" => CSSFeature
-	{ id : "css.properties.list-style-type.oriya", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.oriya" =>
+	CSSFeature { id : "css.properties.list-style-type.oriya", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -18007,7 +18016,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.persian" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.persian" =>
 	CSSFeature { id : "css.properties.list-style-type.persian", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18019,9 +18028,10 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.simp-chinese-formal"
-	=> CSSFeature { id : "css.properties.list-style-type.simp-chinese-formal", name :
-	"List style", description :
+	[], popularity : 67.235275f32, },
+	"css.properties.list-style-type.simp-chinese-formal" => CSSFeature { id :
+	"css.properties.list-style-type.simp-chinese-formal", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -18031,7 +18041,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, },
+	[], popularity : 67.235275f32, },
 	"css.properties.list-style-type.simp-chinese-informal" => CSSFeature { id :
 	"css.properties.list-style-type.simp-chinese-informal", name : "List style",
 	description :
@@ -18044,8 +18054,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.square" => CSSFeature
-	{ id : "css.properties.list-style-type.square", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.square" =>
+	CSSFeature { id : "css.properties.list-style-type.square", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -18055,8 +18066,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.string" => CSSFeature
-	{ id : "css.properties.list-style-type.string", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.string" =>
+	CSSFeature { id : "css.properties.list-style-type.string", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -18066,7 +18078,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(39u16, 0u16), firefox_android : BrowserVersion(39u16, 0u16), safari :
 	BrowserVersion(14u16, 1u16), safari_ios : BrowserVersion(14u16, 5u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.symbols" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.symbols" =>
 	CSSFeature { id : "css.properties.list-style-type.symbols", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18075,7 +18087,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(35u16, 0u16), firefox_android :
 	BrowserVersion(35u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 66.8365f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 67.235275f32, },
 	"css.properties.list-style-type.tamil" => CSSFeature { id :
 	"css.properties.list-style-type.tamil", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18087,8 +18099,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(91u16, 0u16), edge : BrowserVersion(91u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.telugu" => CSSFeature
-	{ id : "css.properties.list-style-type.telugu", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.telugu" =>
+	CSSFeature { id : "css.properties.list-style-type.telugu", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -18098,8 +18111,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.thai" => CSSFeature {
-	id : "css.properties.list-style-type.thai", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.thai" => CSSFeature
+	{ id : "css.properties.list-style-type.thai", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -18109,7 +18122,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.tibetan" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.tibetan" =>
 	CSSFeature { id : "css.properties.list-style-type.tibetan", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18121,9 +18134,10 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 0u16), safari_ios : BrowserVersion(4u16, 2u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.trad-chinese-formal"
-	=> CSSFeature { id : "css.properties.list-style-type.trad-chinese-formal", name :
-	"List style", description :
+	[], popularity : 67.235275f32, },
+	"css.properties.list-style-type.trad-chinese-formal" => CSSFeature { id :
+	"css.properties.list-style-type.trad-chinese-formal", name : "List style",
+	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -18133,7 +18147,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, },
+	[], popularity : 67.235275f32, },
 	"css.properties.list-style-type.trad-chinese-informal" => CSSFeature { id :
 	"css.properties.list-style-type.trad-chinese-informal", name : "List style",
 	description :
@@ -18146,7 +18160,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(45u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(28u16, 0u16), firefox_android : BrowserVersion(28u16, 0u16), safari :
 	BrowserVersion(15u16, 0u16), safari_ios : BrowserVersion(15u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.upper-alpha" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.upper-alpha" =>
 	CSSFeature { id : "css.properties.list-style-type.upper-alpha", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18158,7 +18172,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.upper-armenian" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.upper-armenian" =>
 	CSSFeature { id : "css.properties.list-style-type.upper-armenian", name :
 	"List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18170,7 +18184,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(33u16, 0u16), firefox_android : BrowserVersion(33u16, 0u16), safari :
 	BrowserVersion(5u16, 1u16), safari_ios : BrowserVersion(5u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.upper-latin" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.upper-latin" =>
 	CSSFeature { id : "css.properties.list-style-type.upper-latin", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18182,7 +18196,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style-type.upper-roman" =>
+	[], popularity : 67.235275f32, }, "css.properties.list-style-type.upper-roman" =>
 	CSSFeature { id : "css.properties.list-style-type.upper-roman", name : "List style",
 	description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
@@ -18194,8 +18208,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style.inside" => CSSFeature { id
-	: "css.properties.list-style.inside", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style.inside" => CSSFeature {
+	id : "css.properties.list-style.inside", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -18205,8 +18219,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style.none" => CSSFeature { id :
-	"css.properties.list-style.none", name : "List style", description :
+	[], popularity : 67.235275f32, }, "css.properties.list-style.none" => CSSFeature { id
+	: "css.properties.list-style.none", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
 	["lists"], baseline_status : BaselineStatus::High { since :
@@ -18216,7 +18230,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style.outside" => CSSFeature {
+	[], popularity : 67.235275f32, }, "css.properties.list-style.outside" => CSSFeature {
 	id : "css.properties.list-style.outside", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -18227,7 +18241,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 66.8365f32, }, "css.properties.list-style.symbols" => CSSFeature {
+	[], popularity : 67.235275f32, }, "css.properties.list-style.symbols" => CSSFeature {
 	id : "css.properties.list-style.symbols", name : "List style", description :
 	"The list-style shorthand CSS property and the list-style-image, list-style-position, and list-style-type longhand properties set the position and appearance of a list item's marker.",
 	spec : "https://drafts.csswg.org/css-lists-3/#list-style-property", groups : &
@@ -18235,7 +18249,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(35u16, 0u16), firefox_android :
 	BrowserVersion(35u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 66.8365f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 67.235275f32, },
 	"css.properties.margin" => CSSFeature { id : "css.properties.margin", name :
 	"margin", description :
 	"The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.",
@@ -18246,7 +18260,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, }, "css.properties.margin-block" =>
+	caniuse : & [], popularity : 91.14071f32, }, "css.properties.margin-block" =>
 	CSSFeature { id : "css.properties.margin-block", name : "Logical properties",
 	description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -18322,7 +18336,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, },
+	caniuse : & [], popularity : 91.14071f32, },
 	"css.properties.margin-bottom.anchor-size" => CSSFeature { id :
 	"css.properties.margin-bottom.anchor-size", name : "Anchor positioning", description
 	:
@@ -18344,7 +18358,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, }, "css.properties.margin-inline" =>
+	caniuse : & [], popularity : 91.14071f32, }, "css.properties.margin-inline" =>
 	CSSFeature { id : "css.properties.margin-inline", name : "Logical properties",
 	description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -18421,7 +18435,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, }, "css.properties.margin-left.anchor-size"
+	caniuse : & [], popularity : 91.14071f32, }, "css.properties.margin-left.anchor-size"
 	=> CSSFeature { id : "css.properties.margin-left.anchor-size", name :
 	"Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
@@ -18442,7 +18456,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, }, "css.properties.margin-right" =>
+	caniuse : & [], popularity : 91.14071f32, }, "css.properties.margin-right" =>
 	CSSFeature { id : "css.properties.margin-right", name : "margin", description :
 	"The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#margins", groups : & ["layout"],
@@ -18452,7 +18466,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, },
+	caniuse : & [], popularity : 91.14071f32, },
 	"css.properties.margin-right.anchor-size" => CSSFeature { id :
 	"css.properties.margin-right.anchor-size", name : "Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
@@ -18473,7 +18487,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, }, "css.properties.margin-top" =>
+	caniuse : & [], popularity : 91.14071f32, }, "css.properties.margin-top" =>
 	CSSFeature { id : "css.properties.margin-top", name : "margin", description :
 	"The margin CSS property sets space around an element. It is a shorthand for margin-top, margin-right, margin-bottom, and margin-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#margins", groups : & ["layout"],
@@ -18483,7 +18497,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, }, "css.properties.margin-top.anchor-size"
+	caniuse : & [], popularity : 91.14071f32, }, "css.properties.margin-top.anchor-size"
 	=> CSSFeature { id : "css.properties.margin-top.anchor-size", name :
 	"Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
@@ -18504,7 +18518,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, }, "css.properties.margin-trim" =>
+	caniuse : & [], popularity : 91.14071f32, }, "css.properties.margin-trim" =>
 	CSSFeature { id : "css.properties.margin-trim", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
@@ -18512,7 +18526,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001572f32, }, "css.properties.margin-trim.block" => CSSFeature {
+	[], popularity : 0.001299f32, }, "css.properties.margin-trim.block" => CSSFeature {
 	id : "css.properties.margin-trim.block", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
@@ -18520,7 +18534,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001572f32, }, "css.properties.margin-trim.block-end" => CSSFeature
+	[], popularity : 0.001299f32, }, "css.properties.margin-trim.block-end" => CSSFeature
 	{ id : "css.properties.margin-trim.block-end", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
@@ -18528,7 +18542,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001572f32, }, "css.properties.margin-trim.block-start" =>
+	[], popularity : 0.001299f32, }, "css.properties.margin-trim.block-start" =>
 	CSSFeature { id : "css.properties.margin-trim.block-start", name : "margin-trim",
 	description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
@@ -18537,7 +18551,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001572f32, }, "css.properties.margin-trim.inline" => CSSFeature {
+	[], popularity : 0.001299f32, }, "css.properties.margin-trim.inline" => CSSFeature {
 	id : "css.properties.margin-trim.inline", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
@@ -18545,7 +18559,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001572f32, }, "css.properties.margin-trim.inline-end" =>
+	[], popularity : 0.001299f32, }, "css.properties.margin-trim.inline-end" =>
 	CSSFeature { id : "css.properties.margin-trim.inline-end", name : "margin-trim",
 	description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
@@ -18554,7 +18568,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001572f32, }, "css.properties.margin-trim.inline-start" =>
+	[], popularity : 0.001299f32, }, "css.properties.margin-trim.inline-start" =>
 	CSSFeature { id : "css.properties.margin-trim.inline-start", name : "margin-trim",
 	description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
@@ -18563,7 +18577,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001572f32, }, "css.properties.margin-trim.none" => CSSFeature { id
+	[], popularity : 0.001299f32, }, "css.properties.margin-trim.none" => CSSFeature { id
 	: "css.properties.margin-trim.none", name : "margin-trim", description :
 	"The margin-trim CSS property removes the margins of child elements when they meet the edges of the container.",
 	spec : "https://drafts.csswg.org/css-box-4/#margin-trim", groups : & [],
@@ -18571,7 +18585,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), }, caniuse : &
-	[], popularity : 0.001572f32, }, "css.properties.margin.anchor-size" => CSSFeature {
+	[], popularity : 0.001299f32, }, "css.properties.margin.anchor-size" => CSSFeature {
 	id : "css.properties.margin.anchor-size", name : "Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
 	spec : "https://drafts.csswg.org/css-anchor-position-1/#anchoring", groups : & [],
@@ -18591,7 +18605,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.09008f32, }, "css.properties.marker" => CSSFeature {
+	caniuse : & [], popularity : 91.14071f32, }, "css.properties.marker" => CSSFeature {
 	id : "css.properties.marker", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -19035,7 +19049,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	[], popularity : 2.906365f32, }, "css.properties.mask-type.alpha" => CSSFeature { id
+	[], popularity : 2.754034f32, }, "css.properties.mask-type.alpha" => CSSFeature { id
 	: "css.properties.mask-type.alpha", name : "mask-type", description :
 	"The mask-type CSS property on an SVG <mask> element sets whether the mask is a luminance or alpha mask.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-mask-type", groups : &
@@ -19046,7 +19060,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	[], popularity : 2.906365f32, }, "css.properties.mask-type.luminance" => CSSFeature {
+	[], popularity : 2.754034f32, }, "css.properties.mask-type.luminance" => CSSFeature {
 	id : "css.properties.mask-type.luminance", name : "mask-type", description :
 	"The mask-type CSS property on an SVG <mask> element sets whether the mask is a luminance or alpha mask.",
 	spec : "https://drafts.csswg.org/css-masking-1/#the-mask-type", groups : &
@@ -19057,7 +19071,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	[], popularity : 2.906365f32, }, "css.properties.math-depth" => CSSFeature { id :
+	[], popularity : 2.754034f32, }, "css.properties.math-depth" => CSSFeature { id :
 	"css.properties.math-depth", name : "MathML", description :
 	"MathML, or the Mathematical Markup Language, describes mathematical notation, such as expressions and formulas. Also known as MathML Core.",
 	spec : "https://w3c.github.io/mathml-core/", groups : & ["mathml"], baseline_status :
@@ -19713,7 +19727,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(41u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-mixblendmode"], popularity : 12.567398f32, },
+	["https://caniuse.com/css-mixblendmode"], popularity : 13.028298f32, },
 	"css.properties.mix-blend-mode.plus-darker" => CSSFeature { id :
 	"css.properties.mix-blend-mode.plus-darker", name : "mix-blend-mode", description :
 	"The mix-blend-mode CSS property blends an element's content with its background or parent elements using blend modes like multiply, difference, or color.",
@@ -19723,7 +19737,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(9u16, 0u16), safari_ios :
 	BrowserVersion(9u16, 0u16), }, caniuse : & ["https://caniuse.com/css-mixblendmode"],
-	popularity : 12.567398f32, }, "css.properties.mix-blend-mode.plus-lighter" =>
+	popularity : 13.028298f32, }, "css.properties.mix-blend-mode.plus-lighter" =>
 	CSSFeature { id : "css.properties.mix-blend-mode.plus-lighter", name :
 	"mix-blend-mode", description :
 	"The mix-blend-mode CSS property blends an element's content with its background or parent elements using blend modes like multiply, difference, or color.",
@@ -19735,7 +19749,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(100u16, 0u16), edge : BrowserVersion(100u16, 0u16), firefox :
 	BrowserVersion(99u16, 0u16), firefox_android : BrowserVersion(99u16, 0u16), safari :
 	BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-mixblendmode"], popularity : 12.567398f32, },
+	["https://caniuse.com/css-mixblendmode"], popularity : 13.028298f32, },
 	"css.properties.mix-blend-mode.svg_elements" => CSSFeature { id :
 	"css.properties.mix-blend-mode.svg_elements", name : "mix-blend-mode", description :
 	"The mix-blend-mode CSS property blends an element's content with its background or parent elements using blend modes like multiply, difference, or color.",
@@ -19745,7 +19759,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(32u16, 0u16), firefox_android : BrowserVersion(32u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-mixblendmode"], popularity : 12.567398f32, },
+	["https://caniuse.com/css-mixblendmode"], popularity : 13.028298f32, },
 	"css.properties.object-fit" => CSSFeature { id : "css.properties.object-fit", name :
 	"object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19756,7 +19770,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.419876f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.16456f32, },
 	"css.properties.object-fit.contain" => CSSFeature { id :
 	"css.properties.object-fit.contain", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19767,7 +19781,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.419876f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.16456f32, },
 	"css.properties.object-fit.cover" => CSSFeature { id :
 	"css.properties.object-fit.cover", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19778,7 +19792,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.419876f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.16456f32, },
 	"css.properties.object-fit.fill" => CSSFeature { id :
 	"css.properties.object-fit.fill", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19789,7 +19803,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.419876f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.16456f32, },
 	"css.properties.object-fit.none" => CSSFeature { id :
 	"css.properties.object-fit.none", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19800,7 +19814,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.419876f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.16456f32, },
 	"css.properties.object-fit.scale-down" => CSSFeature { id :
 	"css.properties.object-fit.scale-down", name : "object-fit", description :
 	"The object-fit CSS property sets how images, videos, and other replaced elements are scaled within their container.",
@@ -19811,7 +19825,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & ["https://caniuse.com/object-fit"], popularity : 52.419876f32, },
+	caniuse : & ["https://caniuse.com/object-fit"], popularity : 55.16456f32, },
 	"css.properties.object-position" => CSSFeature { id :
 	"css.properties.object-position", name : "object-position", description :
 	"The object-position CSS property places images, videos, and other replaced elements within their boxes.",
@@ -19822,7 +19836,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(32u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(10u16, 0u16), safari_ios : BrowserVersion(10u16, 0u16), },
-	caniuse : & [], popularity : 20.605515f32, }, "css.properties.object-view-box" =>
+	caniuse : & [], popularity : 21.87523f32, }, "css.properties.object-view-box" =>
 	CSSFeature { id : "css.properties.object-view-box", name : "object-view-box",
 	description :
 	"The object-view-box CSS property crops and zooms to an inset area of an image.",
@@ -19831,7 +19845,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(104u16, 0u16), chrome_android : BrowserVersion(104u16, 0u16), edge :
 	BrowserVersion(104u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.071029f32, },
+	0), }, caniuse : & [], popularity : 0.060893f32, },
 	"css.properties.object-view-box.none" => CSSFeature { id :
 	"css.properties.object-view-box.none", name : "object-view-box", description :
 	"The object-view-box CSS property crops and zooms to an inset area of an image.",
@@ -19840,7 +19854,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(104u16, 0u16), chrome_android : BrowserVersion(104u16, 0u16), edge :
 	BrowserVersion(104u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.071029f32, }, "css.properties.offset" =>
+	0), }, caniuse : & [], popularity : 0.060893f32, }, "css.properties.offset" =>
 	CSSFeature { id : "css.properties.offset", name : "Motion path", description :
 	"The offset CSS property animates an element along a defined motion path.", spec :
 	"https://drafts.csswg.org/motion-1/", groups : & [], baseline_status :
@@ -20193,7 +20207,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(2u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.79417f32, },
+	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.61853f32, },
 	"css.properties.opacity.percentages" => CSSFeature { id :
 	"css.properties.opacity.percentages", name : "opacity", description :
 	"The opacity CSS property sets the transparency of an element.", spec :
@@ -20204,7 +20218,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(78u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), },
-	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.79417f32, },
+	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.61853f32, },
 	"css.properties.order" => CSSFeature { id : "css.properties.order", name : "Flexbox",
 	description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -20236,7 +20250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline-color" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline-color" =>
 	CSSFeature { id : "css.properties.outline-color", name : "Outlines", description :
 	"The outline-color, outline-style, and outline-width and outline-offset CSS properties style a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20453,7 +20467,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.dashed" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.dashed" =>
 	CSSFeature { id : "css.properties.outline.dashed", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20463,7 +20477,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.dotted" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.dotted" =>
 	CSSFeature { id : "css.properties.outline.dotted", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20473,7 +20487,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.double" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.double" =>
 	CSSFeature { id : "css.properties.outline.double", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20483,7 +20497,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.groove" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.groove" =>
 	CSSFeature { id : "css.properties.outline.groove", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20493,7 +20507,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.inset" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.inset" =>
 	CSSFeature { id : "css.properties.outline.inset", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20503,7 +20517,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.medium" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.medium" =>
 	CSSFeature { id : "css.properties.outline.medium", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20513,7 +20527,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.none" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.none" =>
 	CSSFeature { id : "css.properties.outline.none", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20523,7 +20537,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.outset" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.outset" =>
 	CSSFeature { id : "css.properties.outline.outset", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20533,7 +20547,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.ridge" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.ridge" =>
 	CSSFeature { id : "css.properties.outline.ridge", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20543,7 +20557,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.solid" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.solid" =>
 	CSSFeature { id : "css.properties.outline.solid", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20553,7 +20567,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.thick" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.thick" =>
 	CSSFeature { id : "css.properties.outline.thick", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20563,7 +20577,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.thin" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.thin" =>
 	CSSFeature { id : "css.properties.outline.thin", name : "outline", description :
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
 	spec : "https://drafts.csswg.org/css-ui-4/#outline", groups : & [], baseline_status :
@@ -20573,7 +20587,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.outline.transparent" =>
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.outline.transparent" =>
 	CSSFeature { id : "css.properties.outline.transparent", name : "outline", description
 	:
 	"The outline CSS shorthand sets the color, style, and width of a line around an element, outside of the border.",
@@ -20584,7 +20598,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(88u16, 0u16), firefox_android : BrowserVersion(88u16, 0u16),
 	safari : BrowserVersion(16u16, 4u16), safari_ios : BrowserVersion(16u16, 4u16), },
-	caniuse : & [], popularity : 76.858376f32, }, "css.properties.overflow" => CSSFeature
+	caniuse : & [], popularity : 76.79648f32, }, "css.properties.overflow" => CSSFeature
 	{ id : "css.properties.overflow", name : "overflow", description :
 	"The overflow CSS property sets the behavior for when content doesn't fit in an element.",
 	spec : "https://drafts.csswg.org/css-overflow-3/#propdef-overflow", groups : & [],
@@ -20604,7 +20618,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-overflow-anchor"], popularity : 9.222337f32, },
+	["https://caniuse.com/css-overflow-anchor"], popularity : 9.088204f32, },
 	"css.properties.overflow-anchor.auto" => CSSFeature { id :
 	"css.properties.overflow-anchor.auto", name : "overflow-anchor", description :
 	"The overflow-anchor CSS property sets an element as a possible scroll anchor, reducing unintended scrolling when document changes occur above the current scrollport. This is enabled by default where supported.",
@@ -20614,7 +20628,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-overflow-anchor"], popularity : 9.222337f32, },
+	["https://caniuse.com/css-overflow-anchor"], popularity : 9.088204f32, },
 	"css.properties.overflow-anchor.none" => CSSFeature { id :
 	"css.properties.overflow-anchor.none", name : "overflow-anchor", description :
 	"The overflow-anchor CSS property sets an element as a possible scroll anchor, reducing unintended scrolling when document changes occur above the current scrollport. This is enabled by default where supported.",
@@ -20624,7 +20638,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(66u16, 0u16), firefox_android : BrowserVersion(66u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-overflow-anchor"], popularity : 9.222337f32, },
+	["https://caniuse.com/css-overflow-anchor"], popularity : 9.088204f32, },
 	"css.properties.overflow-block" => CSSFeature { id : "css.properties.overflow-block",
 	name : "Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -20652,7 +20666,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(102u16, 0u16), firefox_android :
 	BrowserVersion(102u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.662081f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.354085f32, },
 	"css.properties.overflow-clip-margin.border-box" => CSSFeature { id :
 	"css.properties.overflow-clip-margin.border-box", name : "overflow-clip-margin",
 	description :
@@ -20662,7 +20676,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(148u16, 0u16), firefox_android :
 	BrowserVersion(148u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.662081f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.354085f32, },
 	"css.properties.overflow-clip-margin.content-box" => CSSFeature { id :
 	"css.properties.overflow-clip-margin.content-box", name : "overflow-clip-margin",
 	description :
@@ -20672,7 +20686,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(148u16, 0u16), firefox_android :
 	BrowserVersion(148u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.662081f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.354085f32, },
 	"css.properties.overflow-clip-margin.padding-box" => CSSFeature { id :
 	"css.properties.overflow-clip-margin.padding-box", name : "overflow-clip-margin",
 	description :
@@ -20682,7 +20696,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(148u16, 0u16), firefox_android :
 	BrowserVersion(148u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.662081f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 1.354085f32, },
 	"css.properties.overflow-inline" => CSSFeature { id :
 	"css.properties.overflow-inline", name : "Logical properties", description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -20713,7 +20727,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/wordwrap"], popularity : 40.42286f32, },
+	["https://caniuse.com/wordwrap"], popularity : 40.177864f32, },
 	"css.properties.overflow-wrap.anywhere" => CSSFeature { id :
 	"css.properties.overflow-wrap.anywhere", name : "overflow-wrap", description :
 	"The overflow-wrap CSS property breaks a line of text onto multiple lines inside the targeted element in an otherwise unbreakable place to prevent overflow. The legacy property is word-wrap.",
@@ -20725,7 +20739,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(80u16, 0u16), edge : BrowserVersion(80u16, 0u16), firefox :
 	BrowserVersion(65u16, 0u16), firefox_android : BrowserVersion(65u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/wordwrap"], popularity : 40.42286f32, },
+	["https://caniuse.com/wordwrap"], popularity : 40.177864f32, },
 	"css.properties.overflow-wrap.break-word" => CSSFeature { id :
 	"css.properties.overflow-wrap.break-word", name : "overflow-wrap", description :
 	"The overflow-wrap CSS property breaks a line of text onto multiple lines inside the targeted element in an otherwise unbreakable place to prevent overflow. The legacy property is word-wrap.",
@@ -20737,7 +20751,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/wordwrap"], popularity : 40.42286f32, },
+	["https://caniuse.com/wordwrap"], popularity : 40.177864f32, },
 	"css.properties.overflow-wrap.normal" => CSSFeature { id :
 	"css.properties.overflow-wrap.normal", name : "overflow-wrap", description :
 	"The overflow-wrap CSS property breaks a line of text onto multiple lines inside the targeted element in an otherwise unbreakable place to prevent overflow. The legacy property is word-wrap.",
@@ -20749,7 +20763,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(25u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/wordwrap"], popularity : 40.42286f32, },
+	["https://caniuse.com/wordwrap"], popularity : 40.177864f32, },
 	"css.properties.overflow-x" => CSSFeature { id : "css.properties.overflow-x", name :
 	"overflow", description :
 	"The overflow CSS property sets the behavior for when content doesn't fit in an element.",
@@ -20955,7 +20969,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), chrome_android : BrowserVersion(117u16, 0u16), edge :
 	BrowserVersion(117u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.105541f32, }, "css.properties.overlay.auto" =>
+	0), }, caniuse : & [], popularity : 0.088853f32, }, "css.properties.overlay.auto" =>
 	CSSFeature { id : "css.properties.overlay.auto", name : "overlay", description :
 	"The overlay CSS property, used as an allow-discrete CSS transition, prevents a top layer element, such as a popover or a <dialog>, from being removed from the top layer before it has finished animating. You can't set the value of the overlay property; only use it as transition property.",
 	spec : "https://drafts.csswg.org/css-position-4/#overlay", groups : & [],
@@ -20963,7 +20977,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), chrome_android : BrowserVersion(117u16, 0u16), edge :
 	BrowserVersion(117u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.105541f32, }, "css.properties.overlay.none" =>
+	0), }, caniuse : & [], popularity : 0.088853f32, }, "css.properties.overlay.none" =>
 	CSSFeature { id : "css.properties.overlay.none", name : "overlay", description :
 	"The overlay CSS property, used as an allow-discrete CSS transition, prevents a top layer element, such as a popover or a <dialog>, from being removed from the top layer before it has finished animating. You can't set the value of the overlay property; only use it as transition property.",
 	spec : "https://drafts.csswg.org/css-position-4/#overlay", groups : & [],
@@ -20971,7 +20985,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(117u16, 0u16), chrome_android : BrowserVersion(117u16, 0u16), edge :
 	BrowserVersion(117u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.105541f32, },
+	0), }, caniuse : & [], popularity : 0.088853f32, },
 	"css.properties.overscroll-behavior" => CSSFeature { id :
 	"css.properties.overscroll-behavior", name : "overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -20981,7 +20995,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-block" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-block" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-block", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -20991,7 +21005,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-block.auto" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-block.auto" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-block.auto", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21001,7 +21015,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-block.contain" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-block.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-block.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21011,7 +21025,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-block.none" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-block.none" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-block.none", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21021,7 +21035,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-inline" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-inline" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-inline", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21031,7 +21045,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-inline.auto" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-inline.auto" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-inline.auto", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21041,7 +21055,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-inline.contain" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-inline.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-inline.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21051,7 +21065,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-inline.none" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-inline.none" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-inline.none", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21061,7 +21075,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(144u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-x" => CSSFeature {
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-x" => CSSFeature {
 	id : "css.properties.overscroll-behavior-x", name : "overscroll-behavior",
 	description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21071,7 +21085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-x.auto" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-x.auto" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-x.auto", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21081,7 +21095,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-x.contain" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-x.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-x.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21091,7 +21105,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-x.none" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-x.none" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-x.none", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21101,7 +21115,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-y" => CSSFeature {
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-y" => CSSFeature {
 	id : "css.properties.overscroll-behavior-y", name : "overscroll-behavior",
 	description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21111,7 +21125,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-y.auto" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-y.auto" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-y.auto", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21121,7 +21135,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-y.contain" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-y.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-y.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21131,7 +21145,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior-y.none" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior-y.none" =>
 	CSSFeature { id : "css.properties.overscroll-behavior-y.none", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21141,7 +21155,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior.auto" => CSSFeature
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior.auto" => CSSFeature
 	{ id : "css.properties.overscroll-behavior.auto", name : "overscroll-behavior",
 	description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21151,7 +21165,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior.contain" =>
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior.contain" =>
 	CSSFeature { id : "css.properties.overscroll-behavior.contain", name :
 	"overscroll-behavior", description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21161,7 +21175,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.overscroll-behavior.none" => CSSFeature
+	popularity : 19.183035f32, }, "css.properties.overscroll-behavior.none" => CSSFeature
 	{ id : "css.properties.overscroll-behavior.none", name : "overscroll-behavior",
 	description :
 	"The overscroll-behavior CSS property disables default scrolling behaviors when the edges of a scrolling area are reached.",
@@ -21171,7 +21185,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(150u16, 0u16), firefox_android
 	: BrowserVersion(150u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-overscroll-behavior"],
-	popularity : 18.113768f32, }, "css.properties.padding" => CSSFeature { id :
+	popularity : 19.183035f32, }, "css.properties.padding" => CSSFeature { id :
 	"css.properties.padding", name : "padding", description :
 	"The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#paddings", groups : & ["layout"],
@@ -21181,7 +21195,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.10162f32, }, "css.properties.padding-block" =>
+	caniuse : & [], popularity : 90.74293f32, }, "css.properties.padding-block" =>
 	CSSFeature { id : "css.properties.padding-block", name : "Logical properties",
 	description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -21225,7 +21239,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.10162f32, }, "css.properties.padding-inline" =>
+	caniuse : & [], popularity : 90.74293f32, }, "css.properties.padding-inline" =>
 	CSSFeature { id : "css.properties.padding-inline", name : "Logical properties",
 	description :
 	"CSS logical properties control borders, size, margin, and padding with directions and dimensions relative to the writing mode. For example, in a left to right, top to bottom writing mode, block-end refers to the bottom. Also known as flow relative.",
@@ -21269,7 +21283,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.10162f32, }, "css.properties.padding-right" =>
+	caniuse : & [], popularity : 90.74293f32, }, "css.properties.padding-right" =>
 	CSSFeature { id : "css.properties.padding-right", name : "padding", description :
 	"The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#paddings", groups : & ["layout"],
@@ -21279,7 +21293,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.10162f32, }, "css.properties.padding-top" =>
+	caniuse : & [], popularity : 90.74293f32, }, "css.properties.padding-top" =>
 	CSSFeature { id : "css.properties.padding-top", name : "padding", description :
 	"The padding CSS property sets space between an element's edge and its contents. It is a shorthand for padding-top, padding-right, padding-bottom, and padding-left.",
 	spec : "https://drafts.csswg.org/css-box-4/#paddings", groups : & ["layout"],
@@ -21289,7 +21303,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 91.10162f32, }, "css.properties.page" => CSSFeature { id
+	caniuse : & [], popularity : 90.74293f32, }, "css.properties.page" => CSSFeature { id
 	: "css.properties.page", name : "Page setup", description :
 	"The @page CSS at-rule sets the page-specific dimensions and margins for content such as printed documents, ebooks, or slides.",
 	spec : "https://drafts.csswg.org/css-page-3/#at-page-rule", groups : & ["layout",
@@ -21445,7 +21459,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(123u16, 0u16), edge : BrowserVersion(123u16,
 	0u16), firefox : BrowserVersion(60u16, 0u16), firefox_android : BrowserVersion(60u16,
 	0u16), safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16,
-	0u16), }, caniuse : & [], popularity : 1.463433f32, }, "css.properties.perspective"
+	0u16), }, caniuse : & [], popularity : 1.263457f32, }, "css.properties.perspective"
 	=> CSSFeature { id : "css.properties.perspective", name : "3D transforms",
 	description :
 	"The transform CSS property and its 3D transform functions allow rotations and other transforms in three dimensions, including perspective transforms.",
@@ -21566,7 +21580,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(59u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(53u16, 0u16), firefox_android : BrowserVersion(53u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.place-items" => CSSFeature { id : "css.properties.place-items", name
 	: "Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -21610,7 +21624,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(59u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.place-self" => CSSFeature { id : "css.properties.place-self", name :
 	"Flexbox", description :
 	"Flexbox is a one-dimensional layout system, which places content either horizontally or vertically, with optional wrapping.",
@@ -21653,7 +21667,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(59u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(45u16, 0u16), firefox_android : BrowserVersion(45u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.place-self.position_absolute_context" => CSSFeature { id :
 	"css.properties.place-self.position_absolute_context", name : "Absolute positioning",
 	description :
@@ -21676,7 +21690,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), },
-	caniuse : & ["https://caniuse.com/pointer-events"], popularity : 70.6181f32, },
+	caniuse : & ["https://caniuse.com/pointer-events"], popularity : 71.09676f32, },
 	"css.properties.pointer-events.html_elements" => CSSFeature { id :
 	"css.properties.pointer-events.html_elements", name : "pointer-events", description :
 	"The pointer-events CSS property sets whether a user can interact with an element using a mouse, touch, or other pointing input device.",
@@ -21687,7 +21701,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(3u16, 6u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(4u16, 0u16), safari_ios : BrowserVersion(3u16, 2u16), },
-	caniuse : & ["https://caniuse.com/pointer-events"], popularity : 70.6181f32, },
+	caniuse : & ["https://caniuse.com/pointer-events"], popularity : 71.09676f32, },
 	"css.properties.position" => CSSFeature { id : "css.properties.position", name :
 	"Position", description :
 	"The position CSS property sets the origin position of an element to an element, the element's scrollport, or the viewport.",
@@ -21699,7 +21713,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 91.68091f32, }, "css.properties.position-anchor" => CSSFeature { id
+	[], popularity : 91.36861f32, }, "css.properties.position-anchor" => CSSFeature { id
 	: "css.properties.position-anchor", name : "Anchor positioning", description :
 	"Anchor positioning places an element based on the position of another element. For example, you can place a tooltip next to the content it references.",
 	spec : "https://drafts.csswg.org/css-anchor-position-1/#anchoring", groups : & [],
@@ -22721,7 +22735,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(136u16, 0u16), edge : BrowserVersion(136u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 3.200913f32, },
+	caniuse : & [], popularity : 2.891616f32, },
 	"css.properties.print-color-adjust.economy" => CSSFeature { id :
 	"css.properties.print-color-adjust.economy", name : "print-color-adjust", description
 	:
@@ -22733,7 +22747,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(136u16, 0u16), edge : BrowserVersion(136u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 3.200913f32, },
+	caniuse : & [], popularity : 2.891616f32, },
 	"css.properties.print-color-adjust.exact" => CSSFeature { id :
 	"css.properties.print-color-adjust.exact", name : "print-color-adjust", description :
 	"The print-color-adjust CSS property sets whether styles of printed pages should be adjusted to use less ink, in cases such as light text on a dark background.",
@@ -22744,7 +22758,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(136u16, 0u16), edge : BrowserVersion(136u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), },
-	caniuse : & [], popularity : 3.200913f32, }, "css.properties.quotes" => CSSFeature {
+	caniuse : & [], popularity : 2.891616f32, }, "css.properties.quotes" => CSSFeature {
 	id : "css.properties.quotes", name : "Quotes", description :
 	"The quotes CSS property sets the quotation marks inserted via the content CSS property or <q> element.",
 	spec : "https://drafts.csswg.org/css-content-3/#quotes", groups : & [],
@@ -22754,7 +22768,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), },
-	caniuse : & [], popularity : 8.604519f32, }, "css.properties.quotes.auto" =>
+	caniuse : & [], popularity : 8.852591f32, }, "css.properties.quotes.auto" =>
 	CSSFeature { id : "css.properties.quotes.auto", name : "Quotes", description :
 	"The quotes CSS property sets the quotation marks inserted via the content CSS property or <q> element.",
 	spec : "https://drafts.csswg.org/css-content-3/#quotes", groups : & [],
@@ -22764,7 +22778,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(14u16, 1u16), safari_ios : BrowserVersion(14u16, 5u16), },
-	caniuse : & [], popularity : 8.604519f32, }, "css.properties.quotes.none" =>
+	caniuse : & [], popularity : 8.852591f32, }, "css.properties.quotes.none" =>
 	CSSFeature { id : "css.properties.quotes.none", name : "Quotes", description :
 	"The quotes CSS property sets the quotation marks inserted via the content CSS property or <q> element.",
 	spec : "https://drafts.csswg.org/css-content-3/#quotes", groups : & [],
@@ -22774,7 +22788,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), },
-	caniuse : & [], popularity : 8.604519f32, }, "css.properties.r" => CSSFeature { id :
+	caniuse : & [], popularity : 8.852591f32, }, "css.properties.r" => CSSFeature { id :
 	"css.properties.r", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -22794,7 +22808,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.176743f32, }, "css.properties.reading-flow.flex-flow" => CSSFeature {
+	popularity : 0.178699f32, }, "css.properties.reading-flow.flex-flow" => CSSFeature {
 	id : "css.properties.reading-flow.flex-flow", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22803,7 +22817,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.176743f32, }, "css.properties.reading-flow.flex-visual" => CSSFeature
+	popularity : 0.178699f32, }, "css.properties.reading-flow.flex-visual" => CSSFeature
 	{ id : "css.properties.reading-flow.flex-visual", name : "reading-flow", description
 	:
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
@@ -22813,7 +22827,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.176743f32, }, "css.properties.reading-flow.grid-columns" => CSSFeature
+	popularity : 0.178699f32, }, "css.properties.reading-flow.grid-columns" => CSSFeature
 	{ id : "css.properties.reading-flow.grid-columns", name : "reading-flow", description
 	:
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
@@ -22823,7 +22837,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.176743f32, }, "css.properties.reading-flow.grid-order" => CSSFeature {
+	popularity : 0.178699f32, }, "css.properties.reading-flow.grid-order" => CSSFeature {
 	id : "css.properties.reading-flow.grid-order", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22832,7 +22846,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.176743f32, }, "css.properties.reading-flow.grid-rows" => CSSFeature {
+	popularity : 0.178699f32, }, "css.properties.reading-flow.grid-rows" => CSSFeature {
 	id : "css.properties.reading-flow.grid-rows", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22841,7 +22855,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.176743f32, }, "css.properties.reading-flow.normal" => CSSFeature { id
+	popularity : 0.178699f32, }, "css.properties.reading-flow.normal" => CSSFeature { id
 	: "css.properties.reading-flow.normal", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22850,7 +22864,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.176743f32, }, "css.properties.reading-flow.source-order" => CSSFeature
+	popularity : 0.178699f32, }, "css.properties.reading-flow.source-order" => CSSFeature
 	{ id : "css.properties.reading-flow.source-order", name : "reading-flow", description
 	:
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
@@ -22860,7 +22874,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.176743f32, }, "css.properties.reading-order" => CSSFeature { id :
+	popularity : 0.178699f32, }, "css.properties.reading-order" => CSSFeature { id :
 	"css.properties.reading-order", name : "reading-flow", description :
 	"The reading-flow CSS property sets the order in which flex or grid elements are rendered to speech or reached via focus navigation. The reading-order property overrides this order.",
 	spec : "https://drafts.csswg.org/css-display-4/#reading-flow", groups : &
@@ -22869,7 +22883,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(137u16, 0u16), edge : BrowserVersion(137u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.176743f32, }, "css.properties.resize" => CSSFeature { id :
+	popularity : 0.178699f32, }, "css.properties.resize" => CSSFeature { id :
 	"css.properties.resize", name : "resize (CSS property)", description :
 	"The resize CSS property sets whether an element can be resized by the user, and on which axes.",
 	spec : "https://drafts.csswg.org/css-ui-4/#resize", groups : & [], baseline_status :
@@ -22878,7 +22892,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(4u16, 0u16), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(3u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-resize"], popularity :
-	36.11727f32, }, "css.properties.resize.block" => CSSFeature { id :
+	35.079704f32, }, "css.properties.resize.block" => CSSFeature { id :
 	"css.properties.resize.block", name : "resize (CSS property)", description :
 	"The resize CSS property sets whether an element can be resized by the user, and on which axes.",
 	spec : "https://drafts.csswg.org/css-ui-4/#resize", groups : & [], baseline_status :
@@ -22887,7 +22901,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(118u16, 0u16), firefox : BrowserVersion(63u16, 0u16), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(16u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-resize"], popularity :
-	36.11727f32, }, "css.properties.resize.block_level_support" => CSSFeature { id :
+	35.079704f32, }, "css.properties.resize.block_level_support" => CSSFeature { id :
 	"css.properties.resize.block_level_support", name : "resize (CSS property)",
 	description :
 	"The resize CSS property sets whether an element can be resized by the user, and on which axes.",
@@ -22897,7 +22911,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(5u16, 0u16), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(4u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-resize"], popularity :
-	36.11727f32, }, "css.properties.resize.inline" => CSSFeature { id :
+	35.079704f32, }, "css.properties.resize.inline" => CSSFeature { id :
 	"css.properties.resize.inline", name : "resize (CSS property)", description :
 	"The resize CSS property sets whether an element can be resized by the user, and on which axes.",
 	spec : "https://drafts.csswg.org/css-ui-4/#resize", groups : & [], baseline_status :
@@ -22906,7 +22920,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(118u16, 0u16), firefox : BrowserVersion(63u16, 0u16), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(16u16, 0u16), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-resize"], popularity :
-	36.11727f32, }, "css.properties.right" => CSSFeature { id : "css.properties.right",
+	35.079704f32, }, "css.properties.right" => CSSFeature { id : "css.properties.right",
 	name : "Physical properties", description :
 	"The physical CSS properties, top, right, bottom, and left, set the inset position of an element relative to the corresponding side of a container determined by the element's position property.",
 	spec : "https://drafts.csswg.org/css-position-3/#insets", groups : & [],
@@ -22990,7 +23004,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(47u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.row-gap.flex_context" => CSSFeature { id :
 	"css.properties.row-gap.flex_context", name : "Flexbox gap", description :
 	"The gap CSS property in a flexbox layout sets the size of the space between items.",
@@ -23012,7 +23026,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(66u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(61u16, 0u16), firefox_android : BrowserVersion(61u16, 0u16),
 	safari : BrowserVersion(12u16, 0u16), safari_ios : BrowserVersion(12u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.row-gap.normal" => CSSFeature { id : "css.properties.row-gap.normal",
 	name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
@@ -23023,7 +23037,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(47u16, 0u16), edge : BrowserVersion(16u16, 0u16),
 	firefox : BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.properties.ruby-align" => CSSFeature { id : "css.properties.ruby-align", name :
 	"ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23033,7 +23047,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484215f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.530456f32, },
 	"css.properties.ruby-align.center" => CSSFeature { id :
 	"css.properties.ruby-align.center", name : "ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23043,7 +23057,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484215f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.530456f32, },
 	"css.properties.ruby-align.space-around" => CSSFeature { id :
 	"css.properties.ruby-align.space-around", name : "ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23053,7 +23067,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484215f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.530456f32, },
 	"css.properties.ruby-align.space-between" => CSSFeature { id :
 	"css.properties.ruby-align.space-between", name : "ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23063,7 +23077,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484215f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.530456f32, },
 	"css.properties.ruby-align.start" => CSSFeature { id :
 	"css.properties.ruby-align.start", name : "ruby-align", description :
 	"The ruby-align CSS property sets the spacing and alignment of ruby annotation text when it does not fill its available space.",
@@ -23073,7 +23087,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(128u16, 0u16), chrome_android : BrowserVersion(128u16, 0u16), edge :
 	BrowserVersion(128u16, 0u16), firefox : BrowserVersion(38u16, 0u16), firefox_android
 	: BrowserVersion(38u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.484215f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 0.530456f32, },
 	"css.properties.ruby-overhang" => CSSFeature { id : "css.properties.ruby-overhang",
 	name : "ruby-overhang", description :
 	"The ruby-overhang CSS property sets whether ruby annotations may overlap adjacent text.",
@@ -23082,7 +23096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), }, caniuse : &
-	[], popularity : 0.000076f32, }, "css.properties.ruby-overhang.auto" => CSSFeature {
+	[], popularity : 0.000054f32, }, "css.properties.ruby-overhang.auto" => CSSFeature {
 	id : "css.properties.ruby-overhang.auto", name : "ruby-overhang", description :
 	"The ruby-overhang CSS property sets whether ruby annotations may overlap adjacent text.",
 	spec : "https://drafts.csswg.org/css-ruby-1/#ruby-overhang", groups : & ["ruby"],
@@ -23090,7 +23104,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), }, caniuse : &
-	[], popularity : 0.000076f32, }, "css.properties.ruby-overhang.none" => CSSFeature {
+	[], popularity : 0.000054f32, }, "css.properties.ruby-overhang.none" => CSSFeature {
 	id : "css.properties.ruby-overhang.none", name : "ruby-overhang", description :
 	"The ruby-overhang CSS property sets whether ruby annotations may overlap adjacent text.",
 	spec : "https://drafts.csswg.org/css-ruby-1/#ruby-overhang", groups : & ["ruby"],
@@ -23098,7 +23112,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), }, caniuse : &
-	[], popularity : 0.000076f32, }, "css.properties.ruby-position" => CSSFeature { id :
+	[], popularity : 0.000054f32, }, "css.properties.ruby-position" => CSSFeature { id :
 	"css.properties.ruby-position", name : "ruby-position", description :
 	"The ruby-position CSS property sets the position of a ruby annotation in relation to its base text. Annotations can display over, under, or interleaved with the base text.",
 	spec : "https://drafts.csswg.org/css-ruby-1/#rubypos", groups : & ["ruby"],
@@ -23107,7 +23121,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(38u16, 0u16), firefox_android : BrowserVersion(38u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 0.260365f32, }, "css.properties.ruby-position.alternate"
+	caniuse : & [], popularity : 0.265991f32, }, "css.properties.ruby-position.alternate"
 	=> CSSFeature { id : "css.properties.ruby-position.alternate", name :
 	"display: ruby", description :
 	"The display: ruby CSS declaration renders an element with the box layout of a <ruby> HTML element. Child elements may use equivalents to <ruby> internal elements such as display: ruby-base for <rb>.",
@@ -23125,7 +23139,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), }, caniuse : &
-	[], popularity : 0.260365f32, }, "css.properties.ruby-position.over" => CSSFeature {
+	[], popularity : 0.265991f32, }, "css.properties.ruby-position.over" => CSSFeature {
 	id : "css.properties.ruby-position.over", name : "ruby-position", description :
 	"The ruby-position CSS property sets the position of a ruby annotation in relation to its base text. Annotations can display over, under, or interleaved with the base text.",
 	spec : "https://drafts.csswg.org/css-ruby-1/#rubypos", groups : & ["ruby"],
@@ -23134,7 +23148,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(38u16, 0u16), firefox_android : BrowserVersion(38u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 0.260365f32, }, "css.properties.ruby-position.under" =>
+	caniuse : & [], popularity : 0.265991f32, }, "css.properties.ruby-position.under" =>
 	CSSFeature { id : "css.properties.ruby-position.under", name : "ruby-position",
 	description :
 	"The ruby-position CSS property sets the position of a ruby annotation in relation to its base text. Annotations can display over, under, or interleaved with the base text.",
@@ -23144,7 +23158,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(84u16, 0u16), edge : BrowserVersion(84u16, 0u16),
 	firefox : BrowserVersion(38u16, 0u16), firefox_android : BrowserVersion(38u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 0.260365f32, }, "css.properties.rx" => CSSFeature { id :
+	caniuse : & [], popularity : 0.265991f32, }, "css.properties.rx" => CSSFeature { id :
 	"css.properties.rx", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -23198,7 +23212,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(61u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-scroll-behavior"], popularity : 19.808683f32, },
+	["https://caniuse.com/css-scroll-behavior"], popularity : 20.322418f32, },
 	"css.properties.scroll-behavior.auto" => CSSFeature { id :
 	"css.properties.scroll-behavior.auto", name : "scroll-behavior", description :
 	"The scroll-behavior CSS property controls whether scrolling is smooth or snaps, for scroll actions not performed by the user such as those triggered by navigation.",
@@ -23210,7 +23224,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(61u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-scroll-behavior"], popularity : 19.808683f32, },
+	["https://caniuse.com/css-scroll-behavior"], popularity : 20.322418f32, },
 	"css.properties.scroll-behavior.smooth" => CSSFeature { id :
 	"css.properties.scroll-behavior.smooth", name : "scroll-behavior", description :
 	"The scroll-behavior CSS property controls whether scrolling is smooth or snaps, for scroll actions not performed by the user such as those triggered by navigation.",
@@ -23222,7 +23236,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(61u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	["https://caniuse.com/css-scroll-behavior"], popularity : 19.808683f32, },
+	["https://caniuse.com/css-scroll-behavior"], popularity : 20.322418f32, },
 	"css.properties.scroll-initial-target" => CSSFeature { id :
 	"css.properties.scroll-initial-target", name : "scroll-initial-target", description :
 	"The scroll-initial-target: nearest CSS declaration sets the initial scroll position of its scroll container to the top of the element, much like scrolling to a URL fragment.",
@@ -23233,7 +23247,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), edge : BrowserVersion(133u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.063542f32, }, "css.properties.scroll-initial-target.nearest" =>
+	popularity : 0.052991f32, }, "css.properties.scroll-initial-target.nearest" =>
 	CSSFeature { id : "css.properties.scroll-initial-target.nearest", name :
 	"scroll-initial-target", description :
 	"The scroll-initial-target: nearest CSS declaration sets the initial scroll position of its scroll container to the top of the element, much like scrolling to a URL fragment.",
@@ -23244,7 +23258,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), edge : BrowserVersion(133u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.063542f32, }, "css.properties.scroll-initial-target.none" =>
+	popularity : 0.052991f32, }, "css.properties.scroll-initial-target.none" =>
 	CSSFeature { id : "css.properties.scroll-initial-target.none", name :
 	"scroll-initial-target", description :
 	"The scroll-initial-target: nearest CSS declaration sets the initial scroll position of its scroll container to the top of the element, much like scrolling to a URL fragment.",
@@ -23255,7 +23269,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), edge : BrowserVersion(133u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.063542f32, }, "css.properties.scroll-margin" => CSSFeature { id :
+	popularity : 0.052991f32, }, "css.properties.scroll-margin" => CSSFeature { id :
 	"css.properties.scroll-margin", name : "Scroll snap", description :
 	"CSS scroll snap controls the panning and scrolling behavior within a scroll container.",
 	spec : "https://drafts.csswg.org/css-scroll-snap-2/", groups : & ["scrolling"],
@@ -23785,7 +23799,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.198441f32, }, "css.properties.scroll-target-group.auto" => CSSFeature
+	popularity : 0.217614f32, }, "css.properties.scroll-target-group.auto" => CSSFeature
 	{ id : "css.properties.scroll-target-group.auto", name : "scroll-target-group",
 	description :
 	"The scroll-target-group CSS property sets the container where anchor links act as scroll markers. Using selectors such as :target-current, you can style elements when a target has scrolled into view. It's an alternative to the ::scroll-marker-group pseudo-element, which generates scroll markers.",
@@ -23795,7 +23809,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.198441f32, }, "css.properties.scroll-target-group.none" => CSSFeature
+	popularity : 0.217614f32, }, "css.properties.scroll-target-group.none" => CSSFeature
 	{ id : "css.properties.scroll-target-group.none", name : "scroll-target-group",
 	description :
 	"The scroll-target-group CSS property sets the container where anchor links act as scroll markers. Using selectors such as :target-current, you can style elements when a target has scrolled into view. It's an alternative to the ::scroll-marker-group pseudo-element, which generates scroll markers.",
@@ -23805,7 +23819,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.198441f32, }, "css.properties.scroll-timeline" => CSSFeature { id :
+	popularity : 0.217614f32, }, "css.properties.scroll-timeline" => CSSFeature { id :
 	"css.properties.scroll-timeline", name : "Scroll-driven animations", description :
 	"The animation-timeline, scroll-timeline, and view-timeline CSS properties advance animations based on the user's scroll position.",
 	spec : "https://drafts.csswg.org/scroll-animations-1/", groups : & ["scrolling",
@@ -23883,7 +23897,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 16.949642f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 15.820663f32, },
 	"css.properties.scrollbar-color.auto" => CSSFeature { id :
 	"css.properties.scrollbar-color.auto", name : "scrollbar-color", description :
 	"The scrollbar-color CSS property sets the color of the scrollbar track and thumb.",
@@ -23893,7 +23907,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(26u16, 2u16), safari_ios :
-	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 16.949642f32, },
+	BrowserVersion(26u16, 2u16), }, caniuse : & [], popularity : 15.820663f32, },
 	"css.properties.scrollbar-gutter" => CSSFeature { id :
 	"css.properties.scrollbar-gutter", name : "scrollbar-gutter", description :
 	"The scrollbar-gutter CSS property reserves space for the scrollbar, preventing unwanted layout changes as the scrollbar appears and disappears.",
@@ -23904,7 +23918,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 13.651831f32, }, "css.properties.scrollbar-gutter.auto"
+	caniuse : & [], popularity : 13.227409f32, }, "css.properties.scrollbar-gutter.auto"
 	=> CSSFeature { id : "css.properties.scrollbar-gutter.auto", name :
 	"scrollbar-gutter", description :
 	"The scrollbar-gutter CSS property reserves space for the scrollbar, preventing unwanted layout changes as the scrollbar appears and disappears.",
@@ -23915,7 +23929,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 13.651831f32, },
+	caniuse : & [], popularity : 13.227409f32, },
 	"css.properties.scrollbar-gutter.stable" => CSSFeature { id :
 	"css.properties.scrollbar-gutter.stable", name : "scrollbar-gutter", description :
 	"The scrollbar-gutter CSS property reserves space for the scrollbar, preventing unwanted layout changes as the scrollbar appears and disappears.",
@@ -23926,7 +23940,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(94u16, 0u16), edge : BrowserVersion(94u16, 0u16),
 	firefox : BrowserVersion(97u16, 0u16), firefox_android : BrowserVersion(97u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 13.651831f32, }, "css.properties.scrollbar-width" =>
+	caniuse : & [], popularity : 13.227409f32, }, "css.properties.scrollbar-width" =>
 	CSSFeature { id : "css.properties.scrollbar-width", name : "scrollbar-width",
 	description : "The scrollbar-width CSS property sets the width of the scrollbar.",
 	spec : "https://drafts.csswg.org/css-scrollbars-1/#scrollbar-width", groups : &
@@ -23935,7 +23949,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 39.805397f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 41.289124f32, },
 	"css.properties.scrollbar-width.auto" => CSSFeature { id :
 	"css.properties.scrollbar-width.auto", name : "scrollbar-width", description :
 	"The scrollbar-width CSS property sets the width of the scrollbar.", spec :
@@ -23945,7 +23959,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 39.805397f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 41.289124f32, },
 	"css.properties.scrollbar-width.none" => CSSFeature { id :
 	"css.properties.scrollbar-width.none", name : "scrollbar-width", description :
 	"The scrollbar-width CSS property sets the width of the scrollbar.", spec :
@@ -23955,7 +23969,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 39.805397f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 41.289124f32, },
 	"css.properties.scrollbar-width.thin" => CSSFeature { id :
 	"css.properties.scrollbar-width.thin", name : "scrollbar-width", description :
 	"The scrollbar-width CSS property sets the width of the scrollbar.", spec :
@@ -23965,7 +23979,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(121u16, 0u16), chrome_android : BrowserVersion(121u16, 0u16), edge :
 	BrowserVersion(121u16, 0u16), firefox : BrowserVersion(64u16, 0u16), firefox_android
 	: BrowserVersion(64u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 39.805397f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 41.289124f32, },
 	"css.properties.shape-image-threshold" => CSSFeature { id :
 	"css.properties.shape-image-threshold", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
@@ -23977,7 +23991,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.586775f32, }, "css.properties.shape-image-threshold.percentages"
+	[], popularity : 0.518772f32, }, "css.properties.shape-image-threshold.percentages"
 	=> CSSFeature { id : "css.properties.shape-image-threshold.percentages", name :
 	"shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
@@ -23987,7 +24001,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(78u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 0.586775f32, }, "css.properties.shape-margin" => CSSFeature { id :
+	popularity : 0.518772f32, }, "css.properties.shape-margin" => CSSFeature { id :
 	"css.properties.shape-margin", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -23998,7 +24012,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.586775f32, }, "css.properties.shape-outside" => CSSFeature { id :
+	[], popularity : 0.518772f32, }, "css.properties.shape-outside" => CSSFeature { id :
 	"css.properties.shape-outside", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24009,7 +24023,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.586775f32, }, "css.properties.shape-outside.circle" => CSSFeature
+	[], popularity : 0.518772f32, }, "css.properties.shape-outside.circle" => CSSFeature
 	{ id : "css.properties.shape-outside.circle", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24020,7 +24034,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.586775f32, }, "css.properties.shape-outside.gradient" =>
+	[], popularity : 0.518772f32, }, "css.properties.shape-outside.gradient" =>
 	CSSFeature { id : "css.properties.shape-outside.gradient", name : "shape-outside",
 	description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
@@ -24032,7 +24046,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.586775f32, }, "css.properties.shape-outside.image" => CSSFeature {
+	[], popularity : 0.518772f32, }, "css.properties.shape-outside.image" => CSSFeature {
 	id : "css.properties.shape-outside.image", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24043,7 +24057,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.586775f32, }, "css.properties.shape-outside.inset" => CSSFeature {
+	[], popularity : 0.518772f32, }, "css.properties.shape-outside.inset" => CSSFeature {
 	id : "css.properties.shape-outside.inset", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24054,7 +24068,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.586775f32, }, "css.properties.shape-outside.none" => CSSFeature {
+	[], popularity : 0.518772f32, }, "css.properties.shape-outside.none" => CSSFeature {
 	id : "css.properties.shape-outside.none", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24065,7 +24079,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.586775f32, }, "css.properties.shape-outside.path" => CSSFeature {
+	[], popularity : 0.518772f32, }, "css.properties.shape-outside.path" => CSSFeature {
 	id : "css.properties.shape-outside.path", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
 	spec : "https://drafts.csswg.org/css-shapes-1/#declaring-shapes", groups : &
@@ -24073,7 +24087,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	: BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.586775f32, },
+	0), }, caniuse : & [], popularity : 0.518772f32, },
 	"css.properties.shape-outside.polygon" => CSSFeature { id :
 	"css.properties.shape-outside.polygon", name : "shape-outside", description :
 	"The shape-outside CSS property, along with shape-margin and shape-image-threshold, sets the shape around which adjacent content will wrap.",
@@ -24085,7 +24099,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(37u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(62u16, 0u16), firefox_android : BrowserVersion(62u16, 0u16), safari :
 	BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), }, caniuse : &
-	[], popularity : 0.586775f32, }, "css.properties.shape-rendering" => CSSFeature { id
+	[], popularity : 0.518772f32, }, "css.properties.shape-rendering" => CSSFeature { id
 	: "css.properties.shape-rendering", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -24116,7 +24130,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 10.696738f32, }, "css.properties.speak-as" => CSSFeature { id :
+	popularity : 10.1802f32, }, "css.properties.speak-as" => CSSFeature { id :
 	"css.properties.speak-as", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
 	spec : "https://drafts.csswg.org/css-speech-1/#speaking-props-speak-as", groups : &
@@ -24124,7 +24138,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000502f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000477f32, },
 	"css.properties.speak-as.digits" => CSSFeature { id :
 	"css.properties.speak-as.digits", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24133,7 +24147,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000502f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000477f32, },
 	"css.properties.speak-as.literal-punctuation" => CSSFeature { id :
 	"css.properties.speak-as.literal-punctuation", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24142,7 +24156,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000502f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000477f32, },
 	"css.properties.speak-as.no-punctuation" => CSSFeature { id :
 	"css.properties.speak-as.no-punctuation", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24151,7 +24165,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000502f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000477f32, },
 	"css.properties.speak-as.normal" => CSSFeature { id :
 	"css.properties.speak-as.normal", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24160,7 +24174,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000502f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000477f32, },
 	"css.properties.speak-as.spell-out" => CSSFeature { id :
 	"css.properties.speak-as.spell-out", name : "speak-as", description :
 	"The speak-as CSS property sets how any element's content is spoken. Not to be confused with the speak-as descriptor of @counter-style at-rules.",
@@ -24169,7 +24183,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	{ chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(11u16, 1u16), safari_ios :
-	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000502f32, },
+	BrowserVersion(11u16, 3u16), }, caniuse : & [], popularity : 0.000477f32, },
 	"css.properties.stop-color" => CSSFeature { id : "css.properties.stop-color", name :
 	"SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -24438,7 +24452,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(25u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(91u16, 0u16), firefox_android : BrowserVersion(91u16, 0u16),
 	safari : BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css3-tabsize"], popularity : 13.42176f32, },
+	caniuse : & ["https://caniuse.com/css3-tabsize"], popularity : 13.027959f32, },
 	"css.properties.tab-size.length" => CSSFeature { id :
 	"css.properties.tab-size.length", name : "tab-size", description :
 	"The tab-size CSS property sets the width of the tab character.", spec :
@@ -24449,7 +24463,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(42u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(91u16, 0u16), firefox_android : BrowserVersion(91u16, 0u16),
 	safari : BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), },
-	caniuse : & ["https://caniuse.com/css3-tabsize"], popularity : 13.42176f32, },
+	caniuse : & ["https://caniuse.com/css3-tabsize"], popularity : 13.027959f32, },
 	"css.properties.table-layout" => CSSFeature { id : "css.properties.table-layout",
 	name : "Tables", description :
 	"The <table> HTML element, with several related elements, represents tabular data in rows and columns of cells.",
@@ -24494,7 +24508,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 87.58364f32, }, "css.properties.text-align-last" => CSSFeature { id
+	[], popularity : 87.47819f32, }, "css.properties.text-align-last" => CSSFeature { id
 	: "css.properties.text-align-last", name : "text-align-last", description :
 	"The text-align-last CSS property sets the alignment of the last line of text before a forced line break.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-last-property", groups : &
@@ -24505,7 +24519,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(47u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(16u16, 0u16), safari_ios : BrowserVersion(16u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-align-last"], popularity : 3.190221f32, },
+	["https://caniuse.com/css-text-align-last"], popularity : 3.401689f32, },
 	"css.properties.text-align-last.auto" => CSSFeature { id :
 	"css.properties.text-align-last.auto", name : "text-align-last", description :
 	"The text-align-last CSS property sets the alignment of the last line of text before a forced line break.",
@@ -24517,7 +24531,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(47u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(49u16, 0u16), firefox_android : BrowserVersion(49u16, 0u16), safari :
 	BrowserVersion(16u16, 0u16), safari_ios : BrowserVersion(16u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-align-last"], popularity : 3.190221f32, },
+	["https://caniuse.com/css-text-align-last"], popularity : 3.401689f32, },
 	"css.properties.text-align.center" => CSSFeature { id :
 	"css.properties.text-align.center", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
@@ -24529,7 +24543,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 87.58364f32, }, "css.properties.text-align.end" => CSSFeature { id :
+	popularity : 87.47819f32, }, "css.properties.text-align.end" => CSSFeature { id :
 	"css.properties.text-align.end", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
@@ -24540,7 +24554,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 87.58364f32, }, "css.properties.text-align.justify" => CSSFeature {
+	[], popularity : 87.47819f32, }, "css.properties.text-align.justify" => CSSFeature {
 	id : "css.properties.text-align.justify", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
@@ -24551,7 +24565,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 87.58364f32, }, "css.properties.text-align.left" => CSSFeature { id
+	[], popularity : 87.47819f32, }, "css.properties.text-align.left" => CSSFeature { id
 	: "css.properties.text-align.left", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
@@ -24562,7 +24576,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 87.58364f32, }, "css.properties.text-align.match-parent" => CSSFeature {
+	popularity : 87.47819f32, }, "css.properties.text-align.match-parent" => CSSFeature {
 	id : "css.properties.text-align.match-parent", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
@@ -24570,7 +24584,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(40u16, 0u16), firefox_android :
 	BrowserVersion(40u16, 0u16), safari : BrowserVersion(15u16, 4u16), safari_ios :
-	BrowserVersion(15u16, 4u16), }, caniuse : & [], popularity : 87.58364f32, },
+	BrowserVersion(15u16, 4u16), }, caniuse : & [], popularity : 87.47819f32, },
 	"css.properties.text-align.right" => CSSFeature { id :
 	"css.properties.text-align.right", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
@@ -24582,7 +24596,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 87.58364f32, }, "css.properties.text-align.start" => CSSFeature { id :
+	popularity : 87.47819f32, }, "css.properties.text-align.start" => CSSFeature { id :
 	"css.properties.text-align.start", name : "text-align", description :
 	"The text-align CSS property sets the horizontal placement of the inner content of a block element.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-align-property", groups : &
@@ -24593,7 +24607,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(2u16, 0u16), }, caniuse : &
-	[], popularity : 87.58364f32, }, "css.properties.text-anchor" => CSSFeature { id :
+	[], popularity : 87.47819f32, }, "css.properties.text-anchor" => CSSFeature { id :
 	"css.properties.text-anchor", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -24648,7 +24662,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16),
 	firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 1.247442f32, },
+	4u16), }, caniuse : & [], popularity : 0.357751f32, },
 	"css.properties.text-autospace.auto" => CSSFeature { id :
 	"css.properties.text-autospace.auto", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24657,7 +24671,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 1.247442f32, },
+	4u16), }, caniuse : & [], popularity : 0.357751f32, },
 	"css.properties.text-autospace.ideograph-alpha" => CSSFeature { id :
 	"css.properties.text-autospace.ideograph-alpha", name : "text-autospace", description
 	:
@@ -24667,7 +24681,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 1.247442f32, },
+	4u16), }, caniuse : & [], popularity : 0.357751f32, },
 	"css.properties.text-autospace.ideograph-numeric" => CSSFeature { id :
 	"css.properties.text-autospace.ideograph-numeric", name : "text-autospace",
 	description :
@@ -24677,7 +24691,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 1.247442f32, },
+	4u16), }, caniuse : & [], popularity : 0.357751f32, },
 	"css.properties.text-autospace.insert" => CSSFeature { id :
 	"css.properties.text-autospace.insert", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24686,7 +24700,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& [], popularity : 1.247442f32, }, "css.properties.text-autospace.no-autospace" =>
+	& [], popularity : 0.357751f32, }, "css.properties.text-autospace.no-autospace" =>
 	CSSFeature { id : "css.properties.text-autospace.no-autospace", name :
 	"text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24696,7 +24710,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16),
 	firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 1.247442f32, },
+	4u16), }, caniuse : & [], popularity : 0.357751f32, },
 	"css.properties.text-autospace.normal" => CSSFeature { id :
 	"css.properties.text-autospace.normal", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24706,7 +24720,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(140u16, 0u16), edge : BrowserVersion(140u16, 0u16),
 	firefox : BrowserVersion(145u16, 0u16), firefox_android : BrowserVersion(145u16,
 	0u16), safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16,
-	4u16), }, caniuse : & [], popularity : 1.247442f32, },
+	4u16), }, caniuse : & [], popularity : 0.357751f32, },
 	"css.properties.text-autospace.punctuation" => CSSFeature { id :
 	"css.properties.text-autospace.punctuation", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
@@ -24715,7 +24729,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 1.247442f32, }, "css.properties.text-autospace.replace" => CSSFeature {
+	popularity : 0.357751f32, }, "css.properties.text-autospace.replace" => CSSFeature {
 	id : "css.properties.text-autospace.replace", name : "text-autospace", description :
 	"The text-autospace CSS property sets whether and how to insert spaces in inter-script text (such as when mixing Latin and Chinese characters) and around punctuation.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-autospace-property", groups : & [],
@@ -24723,7 +24737,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse : & [],
-	popularity : 1.247442f32, }, "css.properties.text-box" => CSSFeature { id :
+	popularity : 0.357751f32, }, "css.properties.text-box" => CSSFeature { id :
 	"css.properties.text-box", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
 	spec : "https://drafts.csswg.org/css-inline-3/#leading-trim", groups : & ["text"],
@@ -24732,7 +24746,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.properties.text-box-edge" => CSSFeature { id : "css.properties.text-box-edge",
 	name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24742,7 +24756,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.properties.text-box-edge.auto" => CSSFeature { id :
 	"css.properties.text-box-edge.auto", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24752,7 +24766,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.properties.text-box-trim" => CSSFeature { id : "css.properties.text-box-trim",
 	name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24762,7 +24776,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.properties.text-box-trim.none" => CSSFeature { id :
 	"css.properties.text-box-trim.none", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24772,7 +24786,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.properties.text-box-trim.trim-both" => CSSFeature { id :
 	"css.properties.text-box-trim.trim-both", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24782,7 +24796,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.properties.text-box-trim.trim-end" => CSSFeature { id :
 	"css.properties.text-box-trim.trim-end", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24792,7 +24806,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.properties.text-box-trim.trim-start" => CSSFeature { id :
 	"css.properties.text-box-trim.trim-start", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24802,7 +24816,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.properties.text-box.normal" => CSSFeature { id :
 	"css.properties.text-box.normal", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -24812,7 +24826,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.properties.text-combine-upright" => CSSFeature { id :
 	"css.properties.text-combine-upright", name : "text-combine-upright", description :
 	"The text-combine-upright CSS property displays multiple characters in the space of a single character in vertical text. This is used in East Asian documents to display Latin-based strings such as components of a date or letters of an initialism.",
@@ -24824,7 +24838,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(48u16, 0u16), firefox_android : BrowserVersion(48u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 0.331419f32, }, "css.properties.text-combine-upright.all" =>
+	[], popularity : 0.327004f32, }, "css.properties.text-combine-upright.all" =>
 	CSSFeature { id : "css.properties.text-combine-upright.all", name :
 	"text-combine-upright", description :
 	"The text-combine-upright CSS property displays multiple characters in the space of a single character in vertical text. This is used in East Asian documents to display Latin-based strings such as components of a date or letters of an initialism.",
@@ -24836,7 +24850,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(48u16, 0u16), firefox_android : BrowserVersion(48u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 0.331419f32, }, "css.properties.text-combine-upright.none" =>
+	[], popularity : 0.327004f32, }, "css.properties.text-combine-upright.none" =>
 	CSSFeature { id : "css.properties.text-combine-upright.none", name :
 	"text-combine-upright", description :
 	"The text-combine-upright CSS property displays multiple characters in the space of a single character in vertical text. This is used in East Asian documents to display Latin-based strings such as components of a date or letters of an initialism.",
@@ -24848,7 +24862,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(48u16, 0u16), firefox_android : BrowserVersion(48u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 0.331419f32, }, "css.properties.text-decoration" => CSSFeature { id
+	[], popularity : 0.327004f32, }, "css.properties.text-decoration" => CSSFeature { id
 	: "css.properties.text-decoration", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
 	spec : "https://drafts.csswg.org/css-text-decor-4/#line-decoration", groups : & [],
@@ -24858,7 +24872,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-color" => CSSFeature { id :
 	"css.properties.text-decoration-color", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -24869,7 +24883,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-color.currentColor" => CSSFeature { id :
 	"css.properties.text-decoration-color.currentColor", name : "text-decoration",
 	description :
@@ -24881,7 +24895,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-color.transparent" => CSSFeature { id :
 	"css.properties.text-decoration-color.transparent", name : "text-decoration",
 	description :
@@ -24893,7 +24907,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-line" => CSSFeature { id :
 	"css.properties.text-decoration-line", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -24904,7 +24918,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-line.blink" => CSSFeature { id :
 	"css.properties.text-decoration-line.blink", name : "text-decoration-line: blink",
 	description :
@@ -24939,7 +24953,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-line.none" => CSSFeature { id :
 	"css.properties.text-decoration-line.none", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -24950,7 +24964,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-line.overline" => CSSFeature { id :
 	"css.properties.text-decoration-line.overline", name : "text-decoration", description
 	:
@@ -24962,7 +24976,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-line.spelling-error" => CSSFeature { id :
 	"css.properties.text-decoration-line.spelling-error", name :
 	"Spelling and grammar text decorations", description :
@@ -24986,7 +25000,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-skip-ink" => CSSFeature { id :
 	"css.properties.text-decoration-skip-ink", name : "text-decoration-skip-ink",
 	description :
@@ -25000,7 +25014,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 7.984667f32, }, "css.properties.text-decoration-skip-ink.all" =>
+	[], popularity : 7.902814f32, }, "css.properties.text-decoration-skip-ink.all" =>
 	CSSFeature { id : "css.properties.text-decoration-skip-ink.all", name :
 	"text-decoration-skip-ink: all", description :
 	"The text-decoration-skip-ink: all CSS declaration forces interruptions in underlines and overlines where the line would cross a glyph. This contrasts with auto, which does not skip for CJK glyphs.",
@@ -25025,7 +25039,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 7.984667f32, }, "css.properties.text-decoration-skip-ink.none" =>
+	[], popularity : 7.902814f32, }, "css.properties.text-decoration-skip-ink.none" =>
 	CSSFeature { id : "css.properties.text-decoration-skip-ink.none", name :
 	"text-decoration-skip-ink", description :
 	"The text-decoration-skip-ink CSS property sets whether underlines and overlines may be interrupted where the line would cross a glyph.",
@@ -25038,7 +25052,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(15u16, 4u16), safari_ios : BrowserVersion(15u16, 4u16), }, caniuse : &
-	[], popularity : 7.984667f32, }, "css.properties.text-decoration-style" => CSSFeature
+	[], popularity : 7.902814f32, }, "css.properties.text-decoration-style" => CSSFeature
 	{ id : "css.properties.text-decoration-style", name : "text-decoration", description
 	:
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -25049,7 +25063,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-style.wavy" => CSSFeature { id :
 	"css.properties.text-decoration-style.wavy", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -25060,7 +25074,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-thickness" => CSSFeature { id :
 	"css.properties.text-decoration-thickness", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -25071,7 +25085,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-thickness.auto" => CSSFeature { id :
 	"css.properties.text-decoration-thickness.auto", name : "text-decoration",
 	description :
@@ -25083,7 +25097,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-thickness.from-font" => CSSFeature { id :
 	"css.properties.text-decoration-thickness.from-font", name : "text-decoration",
 	description :
@@ -25095,7 +25109,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration-thickness.percentage" => CSSFeature { id :
 	"css.properties.text-decoration-thickness.percentage", name : "text-decoration",
 	description :
@@ -25106,7 +25120,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(89u16, 0u16), edge : BrowserVersion(89u16, 0u16),
 	firefox : BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16, 4u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration.currentColor" => CSSFeature { id :
 	"css.properties.text-decoration.currentColor", name : "text-decoration", description
 	:
@@ -25117,7 +25131,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(26u16, 2u16), safari_ios : BrowserVersion(26u16, 2u16), }, caniuse : &
-	["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration.includes_color-and-style" => CSSFeature { id :
 	"css.properties.text-decoration.includes_color-and-style", name : "text-decoration",
 	description :
@@ -25128,7 +25142,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(6u16, 0u16), firefox_android : BrowserVersion(6u16, 0u16),
 	safari : BrowserVersion(26u16, 2u16), safari_ios : BrowserVersion(26u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration.includes_thickness" => CSSFeature { id :
 	"css.properties.text-decoration.includes_thickness", name : "text-decoration",
 	description :
@@ -25139,7 +25153,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16),
 	firefox : BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(26u16, 2u16), safari_ios : BrowserVersion(26u16, 2u16), },
-	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	caniuse : & ["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-decoration.transparent" => CSSFeature { id :
 	"css.properties.text-decoration.transparent", name : "text-decoration", description :
 	"The text-decoration CSS property sets the style and color of decorative lines including underline, overline, line-through, or a combination of lines.",
@@ -25149,7 +25163,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(57u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(26u16, 2u16), safari_ios : BrowserVersion(26u16, 2u16), }, caniuse : &
-	["https://caniuse.com/text-decoration"], popularity : 83.08164f32, },
+	["https://caniuse.com/text-decoration"], popularity : 83.120026f32, },
 	"css.properties.text-emphasis" => CSSFeature { id : "css.properties.text-emphasis",
 	name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25161,7 +25175,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-color" => CSSFeature { id :
 	"css.properties.text-emphasis-color", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25173,7 +25187,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-color.currentColor" => CSSFeature { id :
 	"css.properties.text-emphasis-color.currentColor", name : "text-emphasis",
 	description :
@@ -25186,7 +25200,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-color.transparent" => CSSFeature { id :
 	"css.properties.text-emphasis-color.transparent", name : "text-emphasis", description
 	:
@@ -25199,7 +25213,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-position" => CSSFeature { id :
 	"css.properties.text-emphasis-position", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25211,7 +25225,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-position.auto" => CSSFeature { id :
 	"css.properties.text-emphasis-position.auto", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25221,7 +25235,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), firefox : BrowserVersion(132u16, 0u16), firefox_android :
 	BrowserVersion(132u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/text-emphasis"],
-	popularity : 0.267033f32, }, "css.properties.text-emphasis-position.left" =>
+	popularity : 0.186267f32, }, "css.properties.text-emphasis-position.left" =>
 	CSSFeature { id : "css.properties.text-emphasis-position.left", name :
 	"text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25233,7 +25247,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-position.over" => CSSFeature { id :
 	"css.properties.text-emphasis-position.over", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25245,7 +25259,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(108u16, 0u16), firefox_android : BrowserVersion(108u16, 0u16), safari
 	: BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-position.right" => CSSFeature { id :
 	"css.properties.text-emphasis-position.right", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25257,7 +25271,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-position.under" => CSSFeature { id :
 	"css.properties.text-emphasis-position.under", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25269,7 +25283,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(108u16, 0u16), firefox_android : BrowserVersion(108u16, 0u16), safari
 	: BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-style" => CSSFeature { id :
 	"css.properties.text-emphasis-style", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25281,7 +25295,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-style.circle" => CSSFeature { id :
 	"css.properties.text-emphasis-style.circle", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25293,7 +25307,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-style.dot" => CSSFeature { id :
 	"css.properties.text-emphasis-style.dot", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25305,7 +25319,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-style.double-circle" => CSSFeature { id :
 	"css.properties.text-emphasis-style.double-circle", name : "text-emphasis",
 	description :
@@ -25318,7 +25332,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-style.filled" => CSSFeature { id :
 	"css.properties.text-emphasis-style.filled", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25330,7 +25344,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-style.none" => CSSFeature { id :
 	"css.properties.text-emphasis-style.none", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25342,7 +25356,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-style.sesame" => CSSFeature { id :
 	"css.properties.text-emphasis-style.sesame", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25354,7 +25368,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis-style.triangle" => CSSFeature { id :
 	"css.properties.text-emphasis-style.triangle", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25366,7 +25380,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis.currentColor" => CSSFeature { id :
 	"css.properties.text-emphasis.currentColor", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25378,7 +25392,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-emphasis.transparent" => CSSFeature { id :
 	"css.properties.text-emphasis.transparent", name : "text-emphasis", description :
 	"The text-emphasis CSS property sets position and style for text emphasis marks, especially for East Asian languages.",
@@ -25390,7 +25404,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(99u16, 0u16), edge : BrowserVersion(99u16, 0u16), firefox :
 	BrowserVersion(46u16, 0u16), firefox_android : BrowserVersion(46u16, 0u16), safari :
 	BrowserVersion(7u16, 0u16), safari_ios : BrowserVersion(7u16, 0u16), }, caniuse : &
-	["https://caniuse.com/text-emphasis"], popularity : 0.267033f32, },
+	["https://caniuse.com/text-emphasis"], popularity : 0.186267f32, },
 	"css.properties.text-indent" => CSSFeature { id : "css.properties.text-indent", name
 	: "text-indent", description :
 	"The text-indent CSS property sets the size of the empty space (indentation) at the beginning of lines in a text.",
@@ -25401,7 +25415,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-text-indent"], popularity : 35.998272f32, },
+	caniuse : & ["https://caniuse.com/css-text-indent"], popularity : 35.187996f32, },
 	"css.properties.text-indent.each-line" => CSSFeature { id :
 	"css.properties.text-indent.each-line", name : "text-indent: each-line", description
 	:
@@ -25431,7 +25445,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.131523f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.148123f32, },
 	"css.properties.text-justify.auto" => CSSFeature { id :
 	"css.properties.text-justify.auto", name : "text-justify", description :
 	"The text-justify CSS property sets the justification method of text when text-align: justify is set.",
@@ -25441,7 +25455,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.131523f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.148123f32, },
 	"css.properties.text-justify.inter-character" => CSSFeature { id :
 	"css.properties.text-justify.inter-character", name : "text-justify", description :
 	"The text-justify CSS property sets the justification method of text when text-align: justify is set.",
@@ -25451,7 +25465,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.131523f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.148123f32, },
 	"css.properties.text-justify.inter-word" => CSSFeature { id :
 	"css.properties.text-justify.inter-word", name : "text-justify", description :
 	"The text-justify CSS property sets the justification method of text when text-align: justify is set.",
@@ -25461,7 +25475,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.131523f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.148123f32, },
 	"css.properties.text-justify.none" => CSSFeature { id :
 	"css.properties.text-justify.none", name : "text-justify", description :
 	"The text-justify CSS property sets the justification method of text when text-align: justify is set.",
@@ -25471,7 +25485,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(145u16, 0u16), firefox : BrowserVersion(55u16, 0u16),
 	firefox_android : BrowserVersion(55u16, 0u16), safari : BrowserVersion(0, 0),
 	safari_ios : BrowserVersion(0, 0), }, caniuse : &
-	["https://caniuse.com/css-text-justify"], popularity : 1.131523f32, },
+	["https://caniuse.com/css-text-justify"], popularity : 1.148123f32, },
 	"css.properties.text-orientation" => CSSFeature { id :
 	"css.properties.text-orientation", name : "text-orientation", description :
 	"The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.",
@@ -25483,7 +25497,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(41u16, 0u16), firefox_android : BrowserVersion(41u16, 0u16), safari :
 	BrowserVersion(14u16, 0u16), safari_ios : BrowserVersion(14u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-orientation"], popularity : 1.353937f32, },
+	["https://caniuse.com/css-text-orientation"], popularity : 1.432163f32, },
 	"css.properties.text-orientation.mixed" => CSSFeature { id :
 	"css.properties.text-orientation.mixed", name : "text-orientation", description :
 	"The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.",
@@ -25495,7 +25509,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(41u16, 0u16), firefox_android : BrowserVersion(41u16, 0u16), safari :
 	BrowserVersion(14u16, 0u16), safari_ios : BrowserVersion(14u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-orientation"], popularity : 1.353937f32, },
+	["https://caniuse.com/css-text-orientation"], popularity : 1.432163f32, },
 	"css.properties.text-orientation.sideways" => CSSFeature { id :
 	"css.properties.text-orientation.sideways", name : "text-orientation", description :
 	"The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.",
@@ -25507,7 +25521,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(0, 0), firefox_android : BrowserVersion(0, 0), safari :
 	BrowserVersion(14u16, 0u16), safari_ios : BrowserVersion(14u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-orientation"], popularity : 1.353937f32, },
+	["https://caniuse.com/css-text-orientation"], popularity : 1.432163f32, },
 	"css.properties.text-orientation.upright" => CSSFeature { id :
 	"css.properties.text-orientation.upright", name : "text-orientation", description :
 	"The text-orientation CSS property sets the how text is typeset within a line when the writing mode is vertical.",
@@ -25519,7 +25533,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(48u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(41u16, 0u16), firefox_android : BrowserVersion(41u16, 0u16), safari :
 	BrowserVersion(14u16, 0u16), safari_ios : BrowserVersion(14u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-text-orientation"], popularity : 1.353937f32, },
+	["https://caniuse.com/css-text-orientation"], popularity : 1.432163f32, },
 	"css.properties.text-overflow" => CSSFeature { id : "css.properties.text-overflow",
 	name : "Text overflow", description :
 	"The text-overflow CSS property sets how hidden overflow content appears to users. The property can clip content, truncate content with an ellipsis (…), or truncate with a custom string.",
@@ -25530,7 +25544,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(7u16, 0u16), firefox_android : BrowserVersion(7u16, 0u16),
 	safari : BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 64.89393f32, },
+	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 65.85675f32, },
 	"css.properties.text-overflow.clip" => CSSFeature { id :
 	"css.properties.text-overflow.clip", name : "Text overflow", description :
 	"The text-overflow CSS property sets how hidden overflow content appears to users. The property can clip content, truncate content with an ellipsis (…), or truncate with a custom string.",
@@ -25541,7 +25555,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(7u16, 0u16), firefox_android : BrowserVersion(7u16, 0u16),
 	safari : BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 64.89393f32, },
+	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 65.85675f32, },
 	"css.properties.text-overflow.ellipsis" => CSSFeature { id :
 	"css.properties.text-overflow.ellipsis", name : "Text overflow", description :
 	"The text-overflow CSS property sets how hidden overflow content appears to users. The property can clip content, truncate content with an ellipsis (…), or truncate with a custom string.",
@@ -25552,7 +25566,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(7u16, 0u16), firefox_android : BrowserVersion(7u16, 0u16),
 	safari : BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 64.89393f32, },
+	caniuse : & ["https://caniuse.com/text-overflow"], popularity : 65.85675f32, },
 	"css.properties.text-overflow.string" => CSSFeature { id :
 	"css.properties.text-overflow.string", name : "Custom ellipses", description :
 	"The text-overflow CSS property with a string value sets the string representing clipped text.",
@@ -25570,7 +25584,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(9u16, 0u16), firefox_android : BrowserVersion(9u16,
 	0u16), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0, 0), }, caniuse :
-	& ["https://caniuse.com/text-overflow"], popularity : 64.89393f32, },
+	& ["https://caniuse.com/text-overflow"], popularity : 65.85675f32, },
 	"css.properties.text-rendering" => CSSFeature { id : "css.properties.text-rendering",
 	name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -25617,7 +25631,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 1u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-textshadow"], popularity : 44.252502f32, },
+	["https://caniuse.com/css-textshadow"], popularity : 45.56972f32, },
 	"css.properties.text-size-adjust" => CSSFeature { id :
 	"css.properties.text-size-adjust", name : "text-size-adjust", description :
 	"The text-size-adjust CSS property disables or modifies the browser's default text size adjustment for small screen sizes.",
@@ -25627,7 +25641,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/text-size-adjust"], popularity :
-	21.379974f32, }, "css.properties.text-size-adjust.auto" => CSSFeature { id :
+	22.453901f32, }, "css.properties.text-size-adjust.auto" => CSSFeature { id :
 	"css.properties.text-size-adjust.auto", name : "text-size-adjust", description :
 	"The text-size-adjust CSS property disables or modifies the browser's default text size adjustment for small screen sizes.",
 	spec : "https://drafts.csswg.org/css-size-adjust-1/#adjustment-control", groups : &
@@ -25636,7 +25650,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/text-size-adjust"], popularity :
-	21.379974f32, }, "css.properties.text-size-adjust.none" => CSSFeature { id :
+	22.453901f32, }, "css.properties.text-size-adjust.none" => CSSFeature { id :
 	"css.properties.text-size-adjust.none", name : "text-size-adjust", description :
 	"The text-size-adjust CSS property disables or modifies the browser's default text size adjustment for small screen sizes.",
 	spec : "https://drafts.csswg.org/css-size-adjust-1/#adjustment-control", groups : &
@@ -25645,7 +25659,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/text-size-adjust"], popularity :
-	21.379974f32, }, "css.properties.text-size-adjust.percentages" => CSSFeature { id :
+	22.453901f32, }, "css.properties.text-size-adjust.percentages" => CSSFeature { id :
 	"css.properties.text-size-adjust.percentages", name : "text-size-adjust", description
 	:
 	"The text-size-adjust CSS property disables or modifies the browser's default text size adjustment for small screen sizes.",
@@ -25655,7 +25669,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/text-size-adjust"], popularity :
-	21.379974f32, }, "css.properties.text-spacing-trim" => CSSFeature { id :
+	22.453901f32, }, "css.properties.text-spacing-trim" => CSSFeature { id :
 	"css.properties.text-spacing-trim", name : "text-spacing-trim", description :
 	"The text-spacing-trim CSS property controls spacing around CJK characters, avoiding excessive whitespace when using full-width punctuation characters.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-spacing-trim-property", groups : &
@@ -25663,7 +25677,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.677223f32, },
+	0), }, caniuse : & [], popularity : 0.506772f32, },
 	"css.properties.text-spacing-trim.normal" => CSSFeature { id :
 	"css.properties.text-spacing-trim.normal", name : "text-spacing-trim", description :
 	"The text-spacing-trim CSS property controls spacing around CJK characters, avoiding excessive whitespace when using full-width punctuation characters.",
@@ -25672,7 +25686,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.677223f32, },
+	0), }, caniuse : & [], popularity : 0.506772f32, },
 	"css.properties.text-spacing-trim.space-all" => CSSFeature { id :
 	"css.properties.text-spacing-trim.space-all", name : "text-spacing-trim", description
 	:
@@ -25682,7 +25696,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.677223f32, },
+	0), }, caniuse : & [], popularity : 0.506772f32, },
 	"css.properties.text-spacing-trim.space-first" => CSSFeature { id :
 	"css.properties.text-spacing-trim.space-first", name : "text-spacing-trim",
 	description :
@@ -25692,7 +25706,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.677223f32, },
+	0), }, caniuse : & [], popularity : 0.506772f32, },
 	"css.properties.text-spacing-trim.trim-start" => CSSFeature { id :
 	"css.properties.text-spacing-trim.trim-start", name : "text-spacing-trim",
 	description :
@@ -25702,7 +25716,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(123u16, 0u16), chrome_android : BrowserVersion(123u16, 0u16),
 	edge : BrowserVersion(123u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.677223f32, }, "css.properties.text-transform"
+	0), }, caniuse : & [], popularity : 0.506772f32, }, "css.properties.text-transform"
 	=> CSSFeature { id : "css.properties.text-transform", name : "text-transform",
 	description : "The text-transform CSS property sets text case and capitalization.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-transform-property", groups : &
@@ -25713,7 +25727,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 72.079025f32, }, "css.properties.text-transform.capitalize" =>
+	[], popularity : 72.4777f32, }, "css.properties.text-transform.capitalize" =>
 	CSSFeature { id : "css.properties.text-transform.capitalize", name :
 	"text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
@@ -25724,7 +25738,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 72.079025f32, },
+	caniuse : & [], popularity : 72.4777f32, },
 	"css.properties.text-transform.dutch_ij_digraph" => CSSFeature { id :
 	"css.properties.text-transform.dutch_ij_digraph", name : "text-transform",
 	description : "The text-transform CSS property sets text case and capitalization.",
@@ -25733,7 +25747,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge :
 	BrowserVersion(0, 0), firefox : BrowserVersion(14u16, 0u16), firefox_android :
 	BrowserVersion(14u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
-	BrowserVersion(0, 0), }, caniuse : & [], popularity : 72.079025f32, },
+	BrowserVersion(0, 0), }, caniuse : & [], popularity : 72.4777f32, },
 	"css.properties.text-transform.full-size-kana" => CSSFeature { id :
 	"css.properties.text-transform.full-size-kana", name : "text-transform", description
 	: "The text-transform CSS property sets text case and capitalization.", spec :
@@ -25742,7 +25756,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(64u16, 0u16), firefox_android : BrowserVersion(64u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & [], popularity : 72.079025f32, },
+	0u16), }, caniuse : & [], popularity : 72.4777f32, },
 	"css.properties.text-transform.full-width" => CSSFeature { id :
 	"css.properties.text-transform.full-width", name : "text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
@@ -25751,7 +25765,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(0, 0), chrome_android : BrowserVersion(0, 0), edge : BrowserVersion(0,
 	0), firefox : BrowserVersion(19u16, 0u16), firefox_android : BrowserVersion(19u16,
 	0u16), safari : BrowserVersion(17u16, 0u16), safari_ios : BrowserVersion(17u16,
-	0u16), }, caniuse : & [], popularity : 72.079025f32, },
+	0u16), }, caniuse : & [], popularity : 72.4777f32, },
 	"css.properties.text-transform.greek_accented_characters" => CSSFeature { id :
 	"css.properties.text-transform.greek_accented_characters", name : "text-transform",
 	description : "The text-transform CSS property sets text case and capitalization.",
@@ -25760,7 +25774,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(34u16, 0u16), chrome_android : BrowserVersion(34u16, 0u16),
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(15u16, 0u16),
 	firefox_android : BrowserVersion(15u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 72.079025f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 72.4777f32, },
 	"css.properties.text-transform.lowercase" => CSSFeature { id :
 	"css.properties.text-transform.lowercase", name : "text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
@@ -25771,7 +25785,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 72.079025f32, },
+	caniuse : & [], popularity : 72.4777f32, },
 	"css.properties.text-transform.lowercase_sigma" => CSSFeature { id :
 	"css.properties.text-transform.lowercase_sigma", name : "text-transform", description
 	: "The text-transform CSS property sets text case and capitalization.", spec :
@@ -25782,9 +25796,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(30u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(14u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & [], popularity : 72.079025f32, },
-	"css.properties.text-transform.math-auto" => CSSFeature { id :
-	"css.properties.text-transform.math-auto", name : "MathML", description :
+	caniuse : & [], popularity : 72.4777f32, }, "css.properties.text-transform.math-auto"
+	=> CSSFeature { id : "css.properties.text-transform.math-auto", name : "MathML",
+	description :
 	"MathML, or the Mathematical Markup Language, describes mathematical notation, such as expressions and formulas. Also known as MathML Core.",
 	spec : "https://w3c.github.io/mathml-core/", groups : & ["mathml"], baseline_status :
 	BaselineStatus::False, browser_support : BrowserSupport { chrome :
@@ -25802,9 +25816,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 72.079025f32, },
-	"css.properties.text-transform.turkic_is" => CSSFeature { id :
-	"css.properties.text-transform.turkic_is", name : "text-transform", description :
+	caniuse : & [], popularity : 72.4777f32, }, "css.properties.text-transform.turkic_is"
+	=> CSSFeature { id : "css.properties.text-transform.turkic_is", name :
+	"text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
 	"https://drafts.csswg.org/css-text-4/#text-transform-property", groups : & ["text"],
 	baseline_status : BaselineStatus::High { since : NaiveDate::from_ymd_opt(2018i32,
@@ -25813,9 +25827,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(31u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(14u16, 0u16), firefox_android : BrowserVersion(14u16, 0u16),
 	safari : BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), },
-	caniuse : & [], popularity : 72.079025f32, },
-	"css.properties.text-transform.uppercase" => CSSFeature { id :
-	"css.properties.text-transform.uppercase", name : "text-transform", description :
+	caniuse : & [], popularity : 72.4777f32, }, "css.properties.text-transform.uppercase"
+	=> CSSFeature { id : "css.properties.text-transform.uppercase", name :
+	"text-transform", description :
 	"The text-transform CSS property sets text case and capitalization.", spec :
 	"https://drafts.csswg.org/css-text-4/#text-transform-property", groups : & ["text"],
 	baseline_status : BaselineStatus::High { since : NaiveDate::from_ymd_opt(2018i32,
@@ -25824,7 +25838,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 72.079025f32, },
+	caniuse : & [], popularity : 72.4777f32, },
 	"css.properties.text-transform.uppercase_eszett" => CSSFeature { id :
 	"css.properties.text-transform.uppercase_eszett", name : "text-transform",
 	description : "The text-transform CSS property sets text case and capitalization.",
@@ -25836,9 +25850,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(18u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 72.079025f32, }, "css.properties.text-underline-offset" =>
-	CSSFeature { id : "css.properties.text-underline-offset", name :
-	"text-underline-offset", description :
+	[], popularity : 72.4777f32, }, "css.properties.text-underline-offset" => CSSFeature
+	{ id : "css.properties.text-underline-offset", name : "text-underline-offset",
+	description :
 	"The text-underline-offset CSS property shifts underlines on text from the initial position by a given distance. The initial position is affected by the text-underline-position property.",
 	spec : "https://drafts.csswg.org/css-text-decor-4/#underline-offset", groups : &
 	["text"], baseline_status : BaselineStatus::High { since :
@@ -25848,7 +25862,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 16.460884f32, }, "css.properties.text-underline-offset.auto" =>
+	[], popularity : 16.48933f32, }, "css.properties.text-underline-offset.auto" =>
 	CSSFeature { id : "css.properties.text-underline-offset.auto", name :
 	"text-underline-offset", description :
 	"The text-underline-offset CSS property shifts underlines on text from the initial position by a given distance. The initial position is affected by the text-underline-position property.",
@@ -25860,8 +25874,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16), firefox :
 	BrowserVersion(70u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 16.460884f32, }, "css.properties.text-underline-offset.percentage"
-	=> CSSFeature { id : "css.properties.text-underline-offset.percentage", name :
+	[], popularity : 16.48933f32, }, "css.properties.text-underline-offset.percentage" =>
+	CSSFeature { id : "css.properties.text-underline-offset.percentage", name :
 	"text-underline-offset", description :
 	"The text-underline-offset CSS property shifts underlines on text from the initial position by a given distance. The initial position is affected by the text-underline-position property.",
 	spec : "https://drafts.csswg.org/css-text-decor-4/#underline-offset", groups : &
@@ -25870,7 +25884,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), chrome_android : BrowserVersion(87u16, 0u16), edge :
 	BrowserVersion(87u16, 0u16), firefox : BrowserVersion(74u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(18u16, 2u16), safari_ios :
-	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 16.460884f32, },
+	BrowserVersion(18u16, 2u16), }, caniuse : & [], popularity : 16.48933f32, },
 	"css.properties.text-underline-position" => CSSFeature { id :
 	"css.properties.text-underline-position", name : "text-underline-position",
 	description :
@@ -25883,7 +25897,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 6.850803f32, }, "css.properties.text-underline-position.auto" =>
+	[], popularity : 7.105786f32, }, "css.properties.text-underline-position.auto" =>
 	CSSFeature { id : "css.properties.text-underline-position.auto", name :
 	"text-underline-position", description :
 	"The text-underline-position CSS property sets the position of underlines on text. For example, text-underline-position: under places the underline below the text, avoiding crossing descenders. The underline may be further adjusted by the text-underline-offset property.",
@@ -25895,7 +25909,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 6.850803f32, }, "css.properties.text-underline-position.from-font"
+	[], popularity : 7.105786f32, }, "css.properties.text-underline-position.from-font"
 	=> CSSFeature { id : "css.properties.text-underline-position.from-font", name :
 	"text-underline-position", description :
 	"The text-underline-position CSS property sets the position of underlines on text. For example, text-underline-position: under places the underline below the text, avoiding crossing descenders. The underline may be further adjusted by the text-underline-offset property.",
@@ -25907,7 +25921,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(87u16, 0u16), edge : BrowserVersion(87u16, 0u16), firefox :
 	BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 6.850803f32, }, "css.properties.text-underline-position.left" =>
+	[], popularity : 7.105786f32, }, "css.properties.text-underline-position.left" =>
 	CSSFeature { id : "css.properties.text-underline-position.left", name :
 	"text-underline-position", description :
 	"The text-underline-position CSS property sets the position of underlines on text. For example, text-underline-position: under places the underline below the text, avoiding crossing descenders. The underline may be further adjusted by the text-underline-offset property.",
@@ -25918,7 +25932,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(71u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 6.850803f32, },
+	caniuse : & [], popularity : 7.105786f32, },
 	"css.properties.text-underline-position.right" => CSSFeature { id :
 	"css.properties.text-underline-position.right", name : "text-underline-position",
 	description :
@@ -25930,7 +25944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(71u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16),
 	safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16, 2u16), },
-	caniuse : & [], popularity : 6.850803f32, },
+	caniuse : & [], popularity : 7.105786f32, },
 	"css.properties.text-underline-position.under" => CSSFeature { id :
 	"css.properties.text-underline-position.under", name : "text-underline-position",
 	description :
@@ -25943,7 +25957,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(33u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(74u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(12u16, 1u16), safari_ios : BrowserVersion(12u16, 2u16), }, caniuse : &
-	[], popularity : 6.850803f32, }, "css.properties.text-wrap" => CSSFeature { id :
+	[], popularity : 7.105786f32, }, "css.properties.text-wrap" => CSSFeature { id :
 	"css.properties.text-wrap", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#text-wrap-shorthand", groups : &
@@ -25952,7 +25966,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(114u16, 0u16), chrome_android : BrowserVersion(114u16, 0u16), edge :
 	BrowserVersion(114u16, 0u16), firefox : BrowserVersion(121u16, 0u16), firefox_android
 	: BrowserVersion(121u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.text-wrap-mode" => CSSFeature { id : "css.properties.text-wrap-mode",
 	name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -25962,7 +25976,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.text-wrap-mode.nowrap" => CSSFeature { id :
 	"css.properties.text-wrap-mode.nowrap", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -25972,7 +25986,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.text-wrap-mode.wrap" => CSSFeature { id :
 	"css.properties.text-wrap-mode.wrap", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -25982,7 +25996,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.text-wrap-style" => CSSFeature { id :
 	"css.properties.text-wrap-style", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -25992,7 +26006,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 5u16), safari_ios :
-	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.text-wrap-style.auto" => CSSFeature { id :
 	"css.properties.text-wrap-style.auto", name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -26002,7 +26016,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 5u16), safari_ios :
-	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.text-wrap-style.balance" => CSSFeature { id :
 	"css.properties.text-wrap-style.balance", name : "text-wrap: balance", description :
 	"The text-wrap: balance CSS declaration balances the length of each line when text is broken into multiple lines. Also known as headline balancing.",
@@ -26032,7 +26046,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 5u16), safari_ios :
-	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.text-wrap.balance" => CSSFeature { id :
 	"css.properties.text-wrap.balance", name : "text-wrap: balance", description :
 	"The text-wrap: balance CSS declaration balances the length of each line when text is broken into multiple lines. Also known as headline balancing.",
@@ -26053,7 +26067,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(114u16, 0u16), chrome_android : BrowserVersion(114u16, 0u16), edge :
 	BrowserVersion(114u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.text-wrap.pretty" => CSSFeature { id :
 	"css.properties.text-wrap.pretty", name : "text-wrap: pretty", description :
 	"The text-wrap: pretty CSS declaration prioritizes better layout over speed when text is broken into multiple lines.",
@@ -26072,7 +26086,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(130u16, 0u16), chrome_android : BrowserVersion(130u16, 0u16), edge :
 	BrowserVersion(130u16, 0u16), firefox : BrowserVersion(121u16, 0u16), firefox_android
 	: BrowserVersion(121u16, 0u16), safari : BrowserVersion(17u16, 5u16), safari_ios :
-	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 5u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.text-wrap.wrap" => CSSFeature { id : "css.properties.text-wrap.wrap",
 	name : "text-wrap", description :
 	"The text-wrap CSS property sets how lines break in text that overflows the container. It is a shorthand for text-wrap-style and text-wrap-mode.",
@@ -26082,7 +26096,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(114u16, 0u16), chrome_android : BrowserVersion(114u16, 0u16), edge :
 	BrowserVersion(114u16, 0u16), firefox : BrowserVersion(124u16, 0u16), firefox_android
 	: BrowserVersion(124u16, 0u16), safari : BrowserVersion(17u16, 4u16), safari_ios :
-	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 22.074099f32, },
+	BrowserVersion(17u16, 4u16), }, caniuse : & [], popularity : 21.678053f32, },
 	"css.properties.timeline-scope" => CSSFeature { id : "css.properties.timeline-scope",
 	name : "Scroll-driven animations", description :
 	"The animation-timeline, scroll-timeline, and view-timeline CSS properties advance animations based on the user's scroll position.",
@@ -26162,7 +26176,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.84196f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.80381f32, },
 	"css.properties.touch-action.manipulation" => CSSFeature { id :
 	"css.properties.touch-action.manipulation", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26174,7 +26188,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(9u16, 3u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.84196f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.80381f32, },
 	"css.properties.touch-action.none" => CSSFeature { id :
 	"css.properties.touch-action.none", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26186,7 +26200,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.84196f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.80381f32, },
 	"css.properties.touch-action.pan-down" => CSSFeature { id :
 	"css.properties.touch-action.pan-down", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26196,7 +26210,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-touch-action"], popularity :
-	43.84196f32, }, "css.properties.touch-action.pan-left" => CSSFeature { id :
+	44.80381f32, }, "css.properties.touch-action.pan-left" => CSSFeature { id :
 	"css.properties.touch-action.pan-left", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
 	spec : "https://w3c.github.io/pointerevents/#the-touch-action-css-property", groups :
@@ -26205,7 +26219,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-touch-action"], popularity :
-	43.84196f32, }, "css.properties.touch-action.pan-right" => CSSFeature { id :
+	44.80381f32, }, "css.properties.touch-action.pan-right" => CSSFeature { id :
 	"css.properties.touch-action.pan-right", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
 	spec : "https://w3c.github.io/pointerevents/#the-touch-action-css-property", groups :
@@ -26214,7 +26228,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-touch-action"], popularity :
-	43.84196f32, }, "css.properties.touch-action.pan-up" => CSSFeature { id :
+	44.80381f32, }, "css.properties.touch-action.pan-up" => CSSFeature { id :
 	"css.properties.touch-action.pan-up", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
 	spec : "https://w3c.github.io/pointerevents/#the-touch-action-css-property", groups :
@@ -26223,7 +26237,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	edge : BrowserVersion(79u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
 	0), }, caniuse : & ["https://caniuse.com/css-touch-action"], popularity :
-	43.84196f32, }, "css.properties.touch-action.pan-x" => CSSFeature { id :
+	44.80381f32, }, "css.properties.touch-action.pan-x" => CSSFeature { id :
 	"css.properties.touch-action.pan-x", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
 	spec : "https://w3c.github.io/pointerevents/#the-touch-action-css-property", groups :
@@ -26234,7 +26248,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.84196f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.80381f32, },
 	"css.properties.touch-action.pan-y" => CSSFeature { id :
 	"css.properties.touch-action.pan-y", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26246,7 +26260,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(36u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(52u16, 0u16), firefox_android : BrowserVersion(52u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.84196f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.80381f32, },
 	"css.properties.touch-action.pinch-zoom" => CSSFeature { id :
 	"css.properties.touch-action.pinch-zoom", name : "touch-action", description :
 	"The touch-action CSS property sets whether an element on a touch screen can be panned or pinched to zoom.",
@@ -26258,7 +26272,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(56u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(85u16, 0u16), firefox_android : BrowserVersion(85u16, 0u16), safari :
 	BrowserVersion(13u16, 0u16), safari_ios : BrowserVersion(13u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-touch-action"], popularity : 43.84196f32, },
+	["https://caniuse.com/css-touch-action"], popularity : 44.80381f32, },
 	"css.properties.transform" => CSSFeature { id : "css.properties.transform", name :
 	"2D transforms", description :
 	"The transform CSS property and its 2D transform functions allow rotating, scaling, skewing, and translating an element. Arbitrary 2D transforms are also possible using a transformation matrix.",
@@ -26280,7 +26294,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(55u16, 0u16), firefox_android : BrowserVersion(55u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & [], popularity : 4.922097f32, },
+	caniuse : & [], popularity : 4.821462f32, },
 	"css.properties.transform-box.border-box" => CSSFeature { id :
 	"css.properties.transform-box.border-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26291,7 +26305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	0u16), chrome_android : BrowserVersion(118u16, 0u16), edge : BrowserVersion(118u16,
 	0u16), firefox : BrowserVersion(55u16, 0u16), firefox_android : BrowserVersion(55u16,
 	0u16), safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16,
-	0u16), }, caniuse : & [], popularity : 4.922097f32, },
+	0u16), }, caniuse : & [], popularity : 4.821462f32, },
 	"css.properties.transform-box.content-box" => CSSFeature { id :
 	"css.properties.transform-box.content-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26301,7 +26315,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(118u16, 0u16), edge : BrowserVersion(118u16, 0u16),
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16,
-	4u16), }, caniuse : & [], popularity : 4.922097f32, },
+	4u16), }, caniuse : & [], popularity : 4.821462f32, },
 	"css.properties.transform-box.fill-box" => CSSFeature { id :
 	"css.properties.transform-box.fill-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26312,7 +26326,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(55u16, 0u16), firefox_android : BrowserVersion(55u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & [], popularity : 4.922097f32, },
+	caniuse : & [], popularity : 4.821462f32, },
 	"css.properties.transform-box.stroke-box" => CSSFeature { id :
 	"css.properties.transform-box.stroke-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26322,7 +26336,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(118u16, 0u16), edge : BrowserVersion(118u16, 0u16),
 	firefox : BrowserVersion(125u16, 0u16), firefox_android : BrowserVersion(125u16,
 	0u16), safari : BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16,
-	4u16), }, caniuse : & [], popularity : 4.922097f32, },
+	4u16), }, caniuse : & [], popularity : 4.821462f32, },
 	"css.properties.transform-box.view-box" => CSSFeature { id :
 	"css.properties.transform-box.view-box", name : "transform-box", description :
 	"The transform-box CSS property sets the position and dimensions of the reference box relative to which an element's transformations are calculated.",
@@ -26333,7 +26347,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(64u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(55u16, 0u16), firefox_android : BrowserVersion(55u16, 0u16),
 	safari : BrowserVersion(11u16, 0u16), safari_ios : BrowserVersion(11u16, 0u16), },
-	caniuse : & [], popularity : 4.922097f32, }, "css.properties.transform-origin" =>
+	caniuse : & [], popularity : 4.821462f32, }, "css.properties.transform-origin" =>
 	CSSFeature { id : "css.properties.transform-origin", name : "2D transforms",
 	description :
 	"The transform CSS property and its 2D transform functions allow rotating, scaling, skewing, and translating an element. Arbitrary 2D transforms are also possible using a transformation matrix.",
@@ -26478,7 +26492,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16),
 	firefox : BrowserVersion(129u16, 0u16), firefox_android : BrowserVersion(129u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 2.273573f32, },
+	4u16), }, caniuse : & [], popularity : 2.269456f32, },
 	"css.properties.transition-behavior.transitionable_content-visibility" => CSSFeature
 	{ id : "css.properties.transition-behavior.transitionable_content-visibility", name :
 	"display animation", description :
@@ -26794,7 +26808,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(117u16, 0u16), edge : BrowserVersion(117u16, 0u16),
 	firefox : BrowserVersion(129u16, 0u16), firefox_android : BrowserVersion(129u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 2.273573f32, }, "css.properties.translate" =>
+	4u16), }, caniuse : & [], popularity : 2.269456f32, }, "css.properties.translate" =>
 	CSSFeature { id : "css.properties.translate", name :
 	"Individual transform properties", description :
 	"The translate, rotate, and scale CSS properties apply single transformations independently, as opposed to applying multiple transformations with the transform CSS property.",
@@ -26903,7 +26917,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 67.11791f32, }, "css.properties.user-select.all" => CSSFeature { id :
+	popularity : 67.298874f32, }, "css.properties.user-select.all" => CSSFeature { id :
 	"css.properties.user-select.all", name : "user-select", description :
 	"The user-select CSS property controls which elements can be selected by the user.",
 	spec : "https://drafts.csswg.org/css-ui-4/#content-selection", groups : & [],
@@ -26912,7 +26926,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 67.11791f32, }, "css.properties.user-select.auto" => CSSFeature { id :
+	popularity : 67.298874f32, }, "css.properties.user-select.auto" => CSSFeature { id :
 	"css.properties.user-select.auto", name : "user-select", description :
 	"The user-select CSS property controls which elements can be selected by the user.",
 	spec : "https://drafts.csswg.org/css-ui-4/#content-selection", groups : & [],
@@ -26921,7 +26935,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 67.11791f32, }, "css.properties.user-select.none" => CSSFeature { id :
+	popularity : 67.298874f32, }, "css.properties.user-select.none" => CSSFeature { id :
 	"css.properties.user-select.none", name : "user-select", description :
 	"The user-select CSS property controls which elements can be selected by the user.",
 	spec : "https://drafts.csswg.org/css-ui-4/#content-selection", groups : & [],
@@ -26930,7 +26944,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 67.11791f32, }, "css.properties.user-select.text" => CSSFeature { id :
+	popularity : 67.298874f32, }, "css.properties.user-select.text" => CSSFeature { id :
 	"css.properties.user-select.text", name : "user-select", description :
 	"The user-select CSS property controls which elements can be selected by the user.",
 	spec : "https://drafts.csswg.org/css-ui-4/#content-selection", groups : & [],
@@ -26939,7 +26953,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(79u16, 0u16), firefox : BrowserVersion(69u16, 0u16), firefox_android :
 	BrowserVersion(79u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/user-select-none"],
-	popularity : 67.11791f32, }, "css.properties.vector-effect" => CSSFeature { id :
+	popularity : 67.298874f32, }, "css.properties.vector-effect" => CSSFeature { id :
 	"css.properties.vector-effect", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
 	spec : "https://w3c.github.io/svgwg/svg2-draft/", groups : & ["svg",
@@ -26961,9 +26975,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.581184f32, },
-	"css.properties.vertical-align.baseline" => CSSFeature { id :
-	"css.properties.vertical-align.baseline", name : "vertical-align", description :
+	caniuse : & [], popularity : 81.4903f32, }, "css.properties.vertical-align.baseline"
+	=> CSSFeature { id : "css.properties.vertical-align.baseline", name :
+	"vertical-align", description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
 	spec : "https://drafts.csswg.org/css2/#propdef-vertical-align", groups : & [],
 	baseline_status : BaselineStatus::High { since : NaiveDate::from_ymd_opt(2018i32,
@@ -26972,8 +26986,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.581184f32, }, "css.properties.vertical-align.bottom"
-	=> CSSFeature { id : "css.properties.vertical-align.bottom", name : "vertical-align",
+	caniuse : & [], popularity : 81.4903f32, }, "css.properties.vertical-align.bottom" =>
+	CSSFeature { id : "css.properties.vertical-align.bottom", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
 	spec : "https://drafts.csswg.org/css2/#propdef-vertical-align", groups : & [],
@@ -26983,8 +26997,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.581184f32, }, "css.properties.vertical-align.middle"
-	=> CSSFeature { id : "css.properties.vertical-align.middle", name : "vertical-align",
+	caniuse : & [], popularity : 81.4903f32, }, "css.properties.vertical-align.middle" =>
+	CSSFeature { id : "css.properties.vertical-align.middle", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
 	spec : "https://drafts.csswg.org/css2/#propdef-vertical-align", groups : & [],
@@ -26994,7 +27008,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.581184f32, }, "css.properties.vertical-align.sub" =>
+	caniuse : & [], popularity : 81.4903f32, }, "css.properties.vertical-align.sub" =>
 	CSSFeature { id : "css.properties.vertical-align.sub", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -27005,8 +27019,8 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.581184f32, }, "css.properties.vertical-align.super"
-	=> CSSFeature { id : "css.properties.vertical-align.super", name : "vertical-align",
+	caniuse : & [], popularity : 81.4903f32, }, "css.properties.vertical-align.super" =>
+	CSSFeature { id : "css.properties.vertical-align.super", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
 	spec : "https://drafts.csswg.org/css2/#propdef-vertical-align", groups : & [],
@@ -27016,7 +27030,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.581184f32, },
+	caniuse : & [], popularity : 81.4903f32, },
 	"css.properties.vertical-align.text-bottom" => CSSFeature { id :
 	"css.properties.vertical-align.text-bottom", name : "vertical-align", description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -27027,9 +27041,9 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.581184f32, },
-	"css.properties.vertical-align.text-top" => CSSFeature { id :
-	"css.properties.vertical-align.text-top", name : "vertical-align", description :
+	caniuse : & [], popularity : 81.4903f32, }, "css.properties.vertical-align.text-top"
+	=> CSSFeature { id : "css.properties.vertical-align.text-top", name :
+	"vertical-align", description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
 	spec : "https://drafts.csswg.org/css2/#propdef-vertical-align", groups : & [],
 	baseline_status : BaselineStatus::High { since : NaiveDate::from_ymd_opt(2018i32,
@@ -27038,7 +27052,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.581184f32, }, "css.properties.vertical-align.top" =>
+	caniuse : & [], popularity : 81.4903f32, }, "css.properties.vertical-align.top" =>
 	CSSFeature { id : "css.properties.vertical-align.top", name : "vertical-align",
 	description :
 	"The vertical-align CSS property sets the vertical alignment of inline, inline-block, and table cell elements. It has no effect on block-level elements.",
@@ -27049,7 +27063,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 81.581184f32, }, "css.properties.view-timeline" =>
+	caniuse : & [], popularity : 81.4903f32, }, "css.properties.view-timeline" =>
 	CSSFeature { id : "css.properties.view-timeline", name : "Scroll-driven animations",
 	description :
 	"The animation-timeline, scroll-timeline, and view-timeline CSS properties advance animations based on the user's scroll position.",
@@ -27148,7 +27162,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(125u16, 0u16), edge : BrowserVersion(125u16, 0u16),
 	firefox : BrowserVersion(144u16, 0u16), firefox_android : BrowserVersion(144u16,
 	0u16), safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16,
-	2u16), }, caniuse : & [], popularity : 0.235136f32, },
+	2u16), }, caniuse : & [], popularity : 0.224175f32, },
 	"css.properties.view-transition-class.none" => CSSFeature { id :
 	"css.properties.view-transition-class.none", name : "view-transition-class",
 	description :
@@ -27161,7 +27175,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(125u16, 0u16), edge : BrowserVersion(125u16, 0u16),
 	firefox : BrowserVersion(144u16, 0u16), firefox_android : BrowserVersion(144u16,
 	0u16), safari : BrowserVersion(18u16, 2u16), safari_ios : BrowserVersion(18u16,
-	2u16), }, caniuse : & [], popularity : 0.235136f32, },
+	2u16), }, caniuse : & [], popularity : 0.224175f32, },
 	"css.properties.view-transition-name" => CSSFeature { id :
 	"css.properties.view-transition-name", name : "View transitions", description :
 	"View transitions allow you to create animated visual transitions between different states of a document.",
@@ -27236,7 +27250,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.2638f32, }, "css.properties.visibility.collapse" =>
+	caniuse : & [], popularity : 78.94326f32, }, "css.properties.visibility.collapse" =>
 	CSSFeature { id : "css.properties.visibility.collapse", name : "visibility",
 	description :
 	"The visibility CSS property sets whether an element is shown. Invisible elements still affect the document layout.",
@@ -27247,7 +27261,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.2638f32, }, "css.properties.visibility.hidden" =>
+	caniuse : & [], popularity : 78.94326f32, }, "css.properties.visibility.hidden" =>
 	CSSFeature { id : "css.properties.visibility.hidden", name : "visibility",
 	description :
 	"The visibility CSS property sets whether an element is shown. Invisible elements still affect the document layout.",
@@ -27258,7 +27272,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.2638f32, }, "css.properties.visibility.visible" =>
+	caniuse : & [], popularity : 78.94326f32, }, "css.properties.visibility.visible" =>
 	CSSFeature { id : "css.properties.visibility.visible", name : "visibility",
 	description :
 	"The visibility CSS property sets whether an element is shown. Invisible elements still affect the document layout.",
@@ -27269,7 +27283,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 79.2638f32, }, "css.properties.white-space" =>
+	caniuse : & [], popularity : 78.94326f32, }, "css.properties.white-space" =>
 	CSSFeature { id : "css.properties.white-space", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27280,7 +27294,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 80.67208f32, }, "css.properties.white-space-collapse" => CSSFeature
+	[], popularity : 80.71571f32, }, "css.properties.white-space-collapse" => CSSFeature
 	{ id : "css.properties.white-space-collapse", name : "white-space-collapse",
 	description :
 	"The white-space-collapse CSS property sets whether new line characters are shown as line breaks, and whether multiple consecutive spaces are all displayed or combined.",
@@ -27291,7 +27305,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.985192f32, },
+	4u16), }, caniuse : & [], popularity : 0.880547f32, },
 	"css.properties.white-space-collapse.break-spaces" => CSSFeature { id :
 	"css.properties.white-space-collapse.break-spaces", name : "white-space-collapse",
 	description :
@@ -27303,7 +27317,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.985192f32, },
+	4u16), }, caniuse : & [], popularity : 0.880547f32, },
 	"css.properties.white-space-collapse.collapse" => CSSFeature { id :
 	"css.properties.white-space-collapse.collapse", name : "white-space-collapse",
 	description :
@@ -27315,7 +27329,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.985192f32, },
+	4u16), }, caniuse : & [], popularity : 0.880547f32, },
 	"css.properties.white-space-collapse.preserve" => CSSFeature { id :
 	"css.properties.white-space-collapse.preserve", name : "white-space-collapse",
 	description :
@@ -27327,7 +27341,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.985192f32, },
+	4u16), }, caniuse : & [], popularity : 0.880547f32, },
 	"css.properties.white-space-collapse.preserve-breaks" => CSSFeature { id :
 	"css.properties.white-space-collapse.preserve-breaks", name : "white-space-collapse",
 	description :
@@ -27339,7 +27353,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(114u16, 0u16), edge : BrowserVersion(114u16, 0u16),
 	firefox : BrowserVersion(124u16, 0u16), firefox_android : BrowserVersion(124u16,
 	0u16), safari : BrowserVersion(17u16, 4u16), safari_ios : BrowserVersion(17u16,
-	4u16), }, caniuse : & [], popularity : 0.985192f32, },
+	4u16), }, caniuse : & [], popularity : 0.880547f32, },
 	"css.properties.white-space-collapse.preserve-spaces" => CSSFeature { id :
 	"css.properties.white-space-collapse.preserve-spaces", name : "white-space-collapse",
 	description :
@@ -27349,7 +27363,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(124u16, 0u16),
 	firefox_android : BrowserVersion(124u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.985192f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 0.880547f32, },
 	"css.properties.white-space.break-spaces" => CSSFeature { id :
 	"css.properties.white-space.break-spaces", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
@@ -27361,7 +27375,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(76u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(69u16, 0u16), firefox_android : BrowserVersion(79u16, 0u16), safari :
 	BrowserVersion(13u16, 1u16), safari_ios : BrowserVersion(13u16, 4u16), }, caniuse : &
-	[], popularity : 80.67208f32, }, "css.properties.white-space.normal" => CSSFeature {
+	[], popularity : 80.71571f32, }, "css.properties.white-space.normal" => CSSFeature {
 	id : "css.properties.white-space.normal", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27372,7 +27386,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 80.67208f32, }, "css.properties.white-space.nowrap" => CSSFeature {
+	[], popularity : 80.71571f32, }, "css.properties.white-space.nowrap" => CSSFeature {
 	id : "css.properties.white-space.nowrap", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27383,7 +27397,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 80.67208f32, }, "css.properties.white-space.pre" => CSSFeature { id
+	[], popularity : 80.71571f32, }, "css.properties.white-space.pre" => CSSFeature { id
 	: "css.properties.white-space.pre", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27394,7 +27408,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 80.67208f32, }, "css.properties.white-space.pre-line" => CSSFeature
+	[], popularity : 80.71571f32, }, "css.properties.white-space.pre-line" => CSSFeature
 	{ id : "css.properties.white-space.pre-line", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27405,7 +27419,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 5u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 80.67208f32, }, "css.properties.white-space.pre-wrap" => CSSFeature
+	[], popularity : 80.71571f32, }, "css.properties.white-space.pre-wrap" => CSSFeature
 	{ id : "css.properties.white-space.pre-wrap", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
 	spec : "https://drafts.csswg.org/css-text-4/#white-space-property", groups : &
@@ -27416,7 +27430,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(3u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 80.67208f32, }, "css.properties.white-space.shorthand_values" =>
+	[], popularity : 80.71571f32, }, "css.properties.white-space.shorthand_values" =>
 	CSSFeature { id : "css.properties.white-space.shorthand_values", name :
 	"white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
@@ -27425,7 +27439,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 80.67208f32, },
+	0), }, caniuse : & [], popularity : 80.71571f32, },
 	"css.properties.white-space.svg_elements" => CSSFeature { id :
 	"css.properties.white-space.svg_elements", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
@@ -27434,7 +27448,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserSupport { chrome : BrowserVersion(0, 0), chrome_android : BrowserVersion(0,
 	0), edge : BrowserVersion(0, 0), firefox : BrowserVersion(36u16, 0u16),
 	firefox_android : BrowserVersion(36u16, 0u16), safari : BrowserVersion(0, 0),
-	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 80.67208f32, },
+	safari_ios : BrowserVersion(0, 0), }, caniuse : & [], popularity : 80.71571f32, },
 	"css.properties.white-space.textarea_support" => CSSFeature { id :
 	"css.properties.white-space.textarea_support", name : "white-space", description :
 	"The white-space CSS property sets how white space is collapsed and how lines wrap. It is a shorthand for white-space-collapse and text-wrap-mode.",
@@ -27446,7 +27460,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16), safari :
 	BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 80.67208f32, }, "css.properties.widows" => CSSFeature { id :
+	[], popularity : 80.71571f32, }, "css.properties.widows" => CSSFeature { id :
 	"css.properties.widows", name : "Widows and orphans", description :
 	"The widows and orphans CSS properties set the minimum lines included in a text fragment created by page, column, or region breaks.",
 	spec : "https://drafts.csswg.org/css-break-4/#widows-orphans", groups : & ["layout"],
@@ -27563,7 +27577,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(36u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/will-change"], popularity : 39.31049f32, },
+	caniuse : & ["https://caniuse.com/will-change"], popularity : 39.710117f32, },
 	"css.properties.will-change.auto" => CSSFeature { id :
 	"css.properties.will-change.auto", name : "will-change", description :
 	"The will-change CSS property gives hints to the browser about expected changes to an element's scroll position, contents, or style. These hints allow browsers to optimize for upcoming style changes.",
@@ -27574,7 +27588,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(36u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/will-change"], popularity : 39.31049f32, },
+	caniuse : & ["https://caniuse.com/will-change"], popularity : 39.710117f32, },
 	"css.properties.will-change.contents" => CSSFeature { id :
 	"css.properties.will-change.contents", name : "will-change", description :
 	"The will-change CSS property gives hints to the browser about expected changes to an element's scroll position, contents, or style. These hints allow browsers to optimize for upcoming style changes.",
@@ -27585,7 +27599,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(36u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/will-change"], popularity : 39.31049f32, },
+	caniuse : & ["https://caniuse.com/will-change"], popularity : 39.710117f32, },
 	"css.properties.will-change.scroll-position" => CSSFeature { id :
 	"css.properties.will-change.scroll-position", name : "will-change", description :
 	"The will-change CSS property gives hints to the browser about expected changes to an element's scroll position, contents, or style. These hints allow browsers to optimize for upcoming style changes.",
@@ -27596,7 +27610,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(36u16, 0u16), edge : BrowserVersion(79u16, 0u16),
 	firefox : BrowserVersion(36u16, 0u16), firefox_android : BrowserVersion(36u16, 0u16),
 	safari : BrowserVersion(9u16, 1u16), safari_ios : BrowserVersion(9u16, 3u16), },
-	caniuse : & ["https://caniuse.com/will-change"], popularity : 39.31049f32, },
+	caniuse : & ["https://caniuse.com/will-change"], popularity : 39.710117f32, },
 	"css.properties.word-break" => CSSFeature { id : "css.properties.word-break", name :
 	"word-break", description :
 	"The word-break CSS property sets how lines break within words.", spec :
@@ -27607,7 +27621,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16),
 	safari : BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), },
-	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.005928f32, },
+	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.543293f32, },
 	"css.properties.word-break.auto-phrase" => CSSFeature { id :
 	"css.properties.word-break.auto-phrase", name : "word-break: auto-phrase",
 	description :
@@ -27628,7 +27642,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16),
 	safari : BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), },
-	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.005928f32, },
+	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.543293f32, },
 	"css.properties.word-break.break-word" => CSSFeature { id :
 	"css.properties.word-break.break-word", name : "word-break: break-word", description
 	:
@@ -27649,7 +27663,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(44u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16),
 	safari : BrowserVersion(9u16, 0u16), safari_ios : BrowserVersion(9u16, 0u16), },
-	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.005928f32, },
+	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.543293f32, },
 	"css.properties.word-break.normal" => CSSFeature { id :
 	"css.properties.word-break.normal", name : "word-break", description :
 	"The word-break CSS property sets how lines break within words.", spec :
@@ -27660,7 +27674,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(15u16, 0u16), firefox_android : BrowserVersion(15u16, 0u16),
 	safari : BrowserVersion(3u16, 0u16), safari_ios : BrowserVersion(2u16, 0u16), },
-	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.005928f32, },
+	caniuse : & ["https://caniuse.com/word-break"], popularity : 56.543293f32, },
 	"css.properties.word-spacing" => CSSFeature { id : "css.properties.word-spacing",
 	name : "word-spacing", description :
 	"The word-spacing CSS property sets the amount of white space between words.", spec :
@@ -27671,7 +27685,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 13.138111f32, }, "css.properties.word-spacing.normal" =>
+	caniuse : & [], popularity : 13.24979f32, }, "css.properties.word-spacing.normal" =>
 	CSSFeature { id : "css.properties.word-spacing.normal", name : "word-spacing",
 	description :
 	"The word-spacing CSS property sets the amount of white space between words.", spec :
@@ -27682,7 +27696,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 13.138111f32, },
+	caniuse : & [], popularity : 13.24979f32, },
 	"css.properties.word-spacing.svg_elements" => CSSFeature { id :
 	"css.properties.word-spacing.svg_elements", name : "SVG", description :
 	"The SVG image format, represented by the <svg> element, creates two-dimensional vector graphics with declarative or scripted interaction and animation.",
@@ -27704,7 +27718,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(48u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(41u16, 0u16), firefox_android : BrowserVersion(41u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.485071f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 9.02013f32, },
 	"css.properties.writing-mode.horizontal-tb" => CSSFeature { id :
 	"css.properties.writing-mode.horizontal-tb", name : "writing-mode", description :
 	"The writing-mode CSS property sets whether text is laid out horizontally or vertically, and left to right, or right to left.",
@@ -27715,7 +27729,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(48u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.485071f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 9.02013f32, },
 	"css.properties.writing-mode.lr" => CSSFeature { id :
 	"css.properties.writing-mode.lr", name : "writing-mode SVG 1.1 values", description :
 	"The lr, lr-tb, rl, rl-tb, tb, and tb-rl keyword values for the writing-mode CSS property set the text direction for elements in SVG 1.1 documents.",
@@ -27763,7 +27777,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(132u16, 0u16), edge : BrowserVersion(132u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16, 4u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.485071f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 9.02013f32, },
 	"css.properties.writing-mode.sideways-rl" => CSSFeature { id :
 	"css.properties.writing-mode.sideways-rl", name : "writing-mode", description :
 	"The writing-mode CSS property sets whether text is laid out horizontally or vertically, and left to right, or right to left.",
@@ -27773,7 +27787,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(132u16, 0u16), edge : BrowserVersion(132u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(18u16, 4u16), safari_ios : BrowserVersion(18u16, 4u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.485071f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 9.02013f32, },
 	"css.properties.writing-mode.tb" => CSSFeature { id :
 	"css.properties.writing-mode.tb", name : "writing-mode SVG 1.1 values", description :
 	"The lr, lr-tb, rl, rl-tb, tb, and tb-rl keyword values for the writing-mode CSS property set the text direction for elements in SVG 1.1 documents.",
@@ -27803,7 +27817,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(48u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.485071f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 9.02013f32, },
 	"css.properties.writing-mode.vertical-rl" => CSSFeature { id :
 	"css.properties.writing-mode.vertical-rl", name : "writing-mode", description :
 	"The writing-mode CSS property sets whether text is laid out horizontally or vertically, and left to right, or right to left.",
@@ -27814,7 +27828,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(48u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(43u16, 0u16), firefox_android : BrowserVersion(43u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 8.485071f32, },
+	caniuse : & ["https://caniuse.com/css-writing-mode"], popularity : 9.02013f32, },
 	"css.properties.writing-mode.vertical_oriented_form_controls" => CSSFeature { id :
 	"css.properties.writing-mode.vertical_oriented_form_controls", name :
 	"Vertical form controls", description :
@@ -27857,7 +27871,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 86.25085f32, }, "css.properties.z-index.auto" =>
+	caniuse : & [], popularity : 86.38554f32, }, "css.properties.z-index.auto" =>
 	CSSFeature { id : "css.properties.z-index.auto", name : "z-index", description :
 	"The z-index CSS property orders overlapping elements, with higher values appearing in front of or on top of lower values.",
 	spec : "https://drafts.csswg.org/css2/#z-index", groups : & [], baseline_status :
@@ -27867,7 +27881,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 86.25085f32, }, "css.properties.z-index.negative_values"
+	caniuse : & [], popularity : 86.38554f32, }, "css.properties.z-index.negative_values"
 	=> CSSFeature { id : "css.properties.z-index.negative_values", name : "z-index",
 	description :
 	"The z-index CSS property orders overlapping elements, with higher values appearing in front of or on top of lower values.",
@@ -27878,7 +27892,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(3u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 86.25085f32, }, "css.properties.zoom" => CSSFeature { id
+	caniuse : & [], popularity : 86.38554f32, }, "css.properties.zoom" => CSSFeature { id
 	: "css.properties.zoom", name : "zoom", description :
 	"The zoom CSS property scales the size of an element. Unlike the transform property, a zoomed element affects page layout.",
 	spec : "https://drafts.csswg.org/css-viewport/#zoom-property", groups : & [],
@@ -27887,7 +27901,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(126u16, 0u16), firefox_android : BrowserVersion(126u16,
 	0u16), safari : BrowserVersion(3u16, 1u16), safari_ios : BrowserVersion(3u16, 0u16),
-	}, caniuse : & ["https://caniuse.com/css-zoom"], popularity : 29.417858f32, },
+	}, caniuse : & ["https://caniuse.com/css-zoom"], popularity : 28.673351f32, },
 	"css.selectors.active" => CSSFeature { id : "css.selectors.active", name :
 	"User action pseudo-classes", description :
 	"The :active, :focus, and :hover CSS pseudo-classes match elements based on how users are interacting with them.",
@@ -28814,7 +28828,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(86u16, 0u16), firefox : BrowserVersion(68u16, 0u16), firefox_android :
 	BrowserVersion(68u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-marker-pseudo"],
-	popularity : 0.061972f32, }, "css.selectors.marker.animation_and_transition_support"
+	popularity : 0.058014f32, }, "css.selectors.marker.animation_and_transition_support"
 	=> CSSFeature { id : "css.selectors.marker.animation_and_transition_support", name :
 	"::marker", description :
 	"The ::marker CSS pseudo-element selects list item markers for styling numbers or bullets.",
@@ -28824,7 +28838,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(86u16, 0u16), firefox : BrowserVersion(80u16, 0u16), firefox_android :
 	BrowserVersion(80u16, 0u16), safari : BrowserVersion(0, 0), safari_ios :
 	BrowserVersion(0, 0), }, caniuse : & ["https://caniuse.com/css-marker-pseudo"],
-	popularity : 0.061972f32, }, "css.selectors.modal" => CSSFeature { id :
+	popularity : 0.058014f32, }, "css.selectors.modal" => CSSFeature { id :
 	"css.selectors.modal", name : ":modal", description :
 	"The :modal pseudo-class selects elements that put other elements into a non-interactive state, such as a fullscreen element or a <dialog> element used with showModal().",
 	spec : "https://drafts.csswg.org/selectors-4/#modal-state", groups : & ["selectors"],
@@ -30223,7 +30237,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(59u16, 0u16), edge : BrowserVersion(79u16, 0u16), firefox :
 	BrowserVersion(30u16, 0u16), firefox_android : BrowserVersion(54u16, 0u16), safari :
 	BrowserVersion(8u16, 0u16), safari_ios : BrowserVersion(8u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-backgroundblendmode"], popularity : 3.720315f32, },
+	["https://caniuse.com/css-backgroundblendmode"], popularity : 3.632732f32, },
 	"css.types.calc" => CSSFeature { id : "css.types.calc", name : "calc()", description
 	:
 	"The calc() CSS function computes mathematical expressions such a calc(100%/3 - 1em).",
@@ -30362,7 +30376,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 90.34877f32, }, "css.types.color.color" => CSSFeature {
+	caniuse : & [], popularity : 90.24377f32, }, "css.types.color.color" => CSSFeature {
 	id : "css.types.color.color", name : "color()", description :
 	"The color() function picks a color from a given color space. Wide gamut color spaces like display-p3 allow showing more vibrant and saturated colors than the standard srgb color space.",
 	spec : "https://drafts.csswg.org/css-color-4/#color-function", groups : &
@@ -30838,7 +30852,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 90.34877f32, }, "css.types.corner-shape-value" =>
+	caniuse : & [], popularity : 90.24377f32, }, "css.types.corner-shape-value" =>
 	CSSFeature { id : "css.types.corner-shape-value", name : "corner-shape", description
 	:
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30847,7 +30861,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.types.corner-shape-value.bevel" => CSSFeature { id :
 	"css.types.corner-shape-value.bevel", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30856,7 +30870,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.types.corner-shape-value.notch" => CSSFeature { id :
 	"css.types.corner-shape-value.notch", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30865,7 +30879,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.types.corner-shape-value.round" => CSSFeature { id :
 	"css.types.corner-shape-value.round", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30874,7 +30888,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.types.corner-shape-value.scoop" => CSSFeature { id :
 	"css.types.corner-shape-value.scoop", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30883,7 +30897,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.types.corner-shape-value.square" => CSSFeature { id :
 	"css.types.corner-shape-value.square", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30892,7 +30906,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.types.corner-shape-value.squircle" => CSSFeature { id :
 	"css.types.corner-shape-value.squircle", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30901,7 +30915,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, },
+	0), }, caniuse : & [], popularity : 0.713874f32, },
 	"css.types.corner-shape-value.superellipse" => CSSFeature { id :
 	"css.types.corner-shape-value.superellipse", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
@@ -30910,7 +30924,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, }, "css.types.cos" => CSSFeature {
+	0), }, caniuse : & [], popularity : 0.713874f32, }, "css.types.cos" => CSSFeature {
 	id : "css.types.cos", name :
 	"sin(), cos(), tan(), asin(), acos(), atan(), and atan2() (CSS)", description :
 	"The sin(), cos(), tan(), asin(), acos(), atan(), and atan2() CSS functions compute various trigonometric functions.",
@@ -30972,7 +30986,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome : BrowserVersion(136u16, 0u16), chrome_android : BrowserVersion(136u16, 0u16),
 	edge : BrowserVersion(136u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android
 	: BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.458151f32, }, "css.types.easing-function" =>
+	0), }, caniuse : & [], popularity : 0.497623f32, }, "css.types.easing-function" =>
 	CSSFeature { id : "css.types.easing-function", name : "cubic-bezier() easing",
 	description :
 	"The cubic-bezier() CSS easing function interpolates along a smooth curve, creating animations and transitions with continuous changes in speed. The ease, ease-in, ease-out, and ease-in-out keyword values are presets for common Bézier curves.",
@@ -31201,7 +31215,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.blur" => CSSFeature { id :
 	"css.types.filter-function.blur", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31212,7 +31226,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.brightness" => CSSFeature { id :
 	"css.types.filter-function.brightness", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31223,7 +31237,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.contrast" => CSSFeature { id :
 	"css.types.filter-function.contrast", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31234,7 +31248,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.drop-shadow" => CSSFeature { id :
 	"css.types.filter-function.drop-shadow", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31245,7 +31259,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.grayscale" => CSSFeature { id :
 	"css.types.filter-function.grayscale", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31256,7 +31270,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.hue-rotate" => CSSFeature { id :
 	"css.types.filter-function.hue-rotate", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31267,7 +31281,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.invert" => CSSFeature { id :
 	"css.types.filter-function.invert", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31278,7 +31292,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.opacity" => CSSFeature { id :
 	"css.types.filter-function.opacity", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31289,7 +31303,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.saturate" => CSSFeature { id :
 	"css.types.filter-function.saturate", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31300,7 +31314,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.filter-function.sepia" => CSSFeature { id :
 	"css.types.filter-function.sepia", name : "filter", description :
 	"The filter CSS property applies one or more graphic effects to an element. You can use filter functions, such as blur() and drop-shadow(), alone or combined to produce different effects. For instance, filter: blur(2px).",
@@ -31311,7 +31325,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(53u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(35u16, 0u16), firefox_android : BrowserVersion(35u16, 0u16),
 	safari : BrowserVersion(6u16, 0u16), safari_ios : BrowserVersion(6u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-filters"], popularity : 50.3775f32, },
+	caniuse : & ["https://caniuse.com/css-filters"], popularity : 51.036434f32, },
 	"css.types.flex" => CSSFeature { id : "css.types.flex", name : "Grid", description :
 	"CSS grid is a two-dimensional layout system, which lays content out in rows and columns.",
 	spec : "https://drafts.csswg.org/css-grid-3/", groups : & ["grid"], baseline_status :
@@ -31321,7 +31335,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(29u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(40u16, 0u16), firefox_android : BrowserVersion(40u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.645424f32, },
+	caniuse : & ["https://caniuse.com/css-grid"], popularity : 0.673725f32, },
 	"css.types.global_keywords" => CSSFeature { id : "css.types.global_keywords", name :
 	"inherit", description :
 	"The inherit keyword resets any CSS property to the computed value of that property from the parent element.",
@@ -31355,7 +31369,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(13u16, 0u16), firefox :
 	BrowserVersion(19u16, 0u16), firefox_android : BrowserVersion(19u16, 0u16), safari :
 	BrowserVersion(1u16, 2u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	["https://caniuse.com/css-initial-value"], popularity : 12.841515f32, },
+	["https://caniuse.com/css-initial-value"], popularity : 12.398604f32, },
 	"css.types.global_keywords.revert" => CSSFeature { id :
 	"css.types.global_keywords.revert", name : "revert", description :
 	"The revert CSS keyword resets any property to its previous default, provided by either the user or browser stylesheets. For example, setting display: revert on a <div> will likely result in display: block, the browser default style. This is often confused with initial.",
@@ -31963,7 +31977,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 86.25085f32, }, "css.types.length" => CSSFeature { id :
+	caniuse : & [], popularity : 86.38554f32, }, "css.types.length" => CSSFeature { id :
 	"css.types.length", name : "Width and height", description :
 	"The width and height CSS properties set the preferred physical size of an element.",
 	spec : "https://drafts.csswg.org/css-sizing-3/#preferred-size-properties", groups : &
@@ -32312,7 +32326,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.79417f32, },
+	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.61853f32, },
 	"css.types.number.scientific_notation" => CSSFeature { id :
 	"css.types.number.scientific_notation", name : "opacity", description :
 	"The opacity CSS property sets the transparency of an element.", spec :
@@ -32323,7 +32337,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(43u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(29u16, 0u16), firefox_android : BrowserVersion(29u16, 0u16),
 	safari : BrowserVersion(10u16, 1u16), safari_ios : BrowserVersion(10u16, 3u16), },
-	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.79417f32, },
+	caniuse : & ["https://caniuse.com/css-opacity"], popularity : 86.61853f32, },
 	"css.types.overflow" => CSSFeature { id : "css.types.overflow", name : "overflow",
 	description :
 	"The overflow CSS property sets the behavior for when content doesn't fit in an element.",
@@ -32582,7 +32596,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 52.409042f32, }, "css.types.shape.rect" => CSSFeature { id :
+	[], popularity : 51.87419f32, }, "css.types.shape.rect" => CSSFeature { id :
 	"css.types.shape.rect", name : "clip", description :
 	"The clip CSS property sets the visible area of an absolutely positioned element.",
 	spec : "https://drafts.csswg.org/css-masking-1/#clip-property", groups : &
@@ -32591,7 +32605,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16), firefox :
 	BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16), safari :
 	BrowserVersion(1u16, 3u16), safari_ios : BrowserVersion(1u16, 0u16), }, caniuse : &
-	[], popularity : 52.409042f32, }, "css.types.sibling-count" => CSSFeature { id :
+	[], popularity : 51.87419f32, }, "css.types.sibling-count" => CSSFeature { id :
 	"css.types.sibling-count", name : "sibling-count() and sibling-index()", description
 	:
 	"The sibling-count() and sibling-index() CSS functions return integers that are useful to style elements based on their positions among siblings or on the number of siblings, for example as part of a calc() expression.",
@@ -32650,7 +32664,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, },
+	caniuse : & [], popularity : 81.013176f32, },
 	"css.types.string.unicode_escaped_characters" => CSSFeature { id :
 	"css.types.string.unicode_escaped_characters", name : "Content", description :
 	"The content CSS property sets the content inside of an element or pseudo-element, replacing the current value. It's often used with the ::before and ::after pseudo-elements to generate cosmetic content.",
@@ -32661,15 +32675,15 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	chrome_android : BrowserVersion(18u16, 0u16), edge : BrowserVersion(12u16, 0u16),
 	firefox : BrowserVersion(1u16, 0u16), firefox_android : BrowserVersion(4u16, 0u16),
 	safari : BrowserVersion(1u16, 0u16), safari_ios : BrowserVersion(1u16, 0u16), },
-	caniuse : & [], popularity : 80.86071f32, }, "css.types.superellipse" => CSSFeature {
-	id : "css.types.superellipse", name : "corner-shape", description :
+	caniuse : & [], popularity : 81.013176f32, }, "css.types.superellipse" => CSSFeature
+	{ id : "css.types.superellipse", name : "corner-shape", description :
 	"The corner-shape CSS property sets the shape of an element's corners when using border-radius, allowing for shapes other than rounded corners. For example, corner-shape: squircle is a shape in between a square and rounded corner.",
 	spec : "https://drafts.csswg.org/css-borders-4/#corner-shaping", groups : & [],
 	baseline_status : BaselineStatus::False, browser_support : BrowserSupport { chrome :
 	BrowserVersion(139u16, 0u16), chrome_android : BrowserVersion(139u16, 0u16), edge :
 	BrowserVersion(139u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(0, 0), safari_ios : BrowserVersion(0,
-	0), }, caniuse : & [], popularity : 0.739584f32, }, "css.types.tan" => CSSFeature {
+	0), }, caniuse : & [], popularity : 0.713874f32, }, "css.types.tan" => CSSFeature {
 	id : "css.types.tan", name :
 	"sin(), cos(), tan(), asin(), acos(), atan(), and atan2() (CSS)", description :
 	"The sin(), cos(), tan(), asin(), acos(), atan(), and atan2() CSS functions compute various trigonometric functions.",
@@ -32690,7 +32704,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.types.text-edge.alphabetic" => CSSFeature { id :
 	"css.types.text-edge.alphabetic", name : "text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -32700,7 +32714,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.types.text-edge.cap" => CSSFeature { id : "css.types.text-edge.cap", name :
 	"text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -32710,7 +32724,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.types.text-edge.ex" => CSSFeature { id : "css.types.text-edge.ex", name :
 	"text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -32720,7 +32734,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.types.text-edge.text" => CSSFeature { id : "css.types.text-edge.text", name :
 	"text-box", description :
 	"The text-box CSS property sets the spacing above and below text based on a font's typographic features. For example, text-box: trim-both ex alphabetic trims the top to the top of the letter x and the bottom to the bottom of most letters, without descenders.",
@@ -32730,7 +32744,7 @@ pub static CSS_FEATURES: Map<&'static str, CSSFeature> = phf_map! {
 	BrowserVersion(133u16, 0u16), firefox : BrowserVersion(0, 0), firefox_android :
 	BrowserVersion(0, 0), safari : BrowserVersion(18u16, 2u16), safari_ios :
 	BrowserVersion(18u16, 2u16), }, caniuse : &
-	["https://caniuse.com/css-text-box-trim"], popularity : 0.603114f32, },
+	["https://caniuse.com/css-text-box-trim"], popularity : 0.570941f32, },
 	"css.types.time" => CSSFeature { id : "css.types.time", name : "Animations (CSS)",
 	description :
 	"The animation CSS property animates an element's style over time, using keyframes described in @keyframes rules.",


### PR DESCRIPTION
Updates to the latest specs from w3c/csswg-drafts

No changes - csswg-drafts is already at commit [`3317e61`](https://github.com/w3c/csswg-drafts/commit/3317e61fe2d6744744f69ee6f43994f6f9696455)
