### PR TITLE
css_ast: Box all Gradient types

### DIFF
--- a/crates/css_ast/src/functions/gradient_functions.rs
+++ b/crates/css_ast/src/functions/gradient_functions.rs
@@ -13,9 +13,9 @@ use crate::{Length, LengthPercentage};
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum Gradient<'a> {
 	#[atom(CssAtomSet::LinearGradient)]
-	LinearGradientFunction(LinearGradientFunction<'a>),
+	LinearGradientFunction(BumpBox<'a, LinearGradientFunction<'a>>),
 	#[atom(CssAtomSet::RepeatingLinearGradient)]
-	RepeatingLinearGradientFunction(RepeatingLinearGradientFunction<'a>),
+	RepeatingLinearGradientFunction(BumpBox<'a, RepeatingLinearGradientFunction<'a>>),
 	#[atom(CssAtomSet::RadialGradient)]
 	RadialGradientFunction(BumpBox<'a, RadialGradientFunction<'a>>),
 	#[atom(CssAtomSet::RepeatingRadialGradient)]
@@ -243,7 +243,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<Gradient>(), 128);
+		assert_eq!(std::mem::size_of::<Gradient>(), 24);
 		assert_eq!(std::mem::size_of::<LinearDirection>(), 44);
 		assert_eq!(std::mem::size_of::<RadialSize>(), 32);
 		assert_eq!(std::mem::size_of::<ColorStopOrHint<'_>>(), 40);

--- a/crates/css_ast/src/functions/symbols_function.rs
+++ b/crates/css_ast/src/functions/symbols_function.rs
@@ -74,7 +74,7 @@ mod tests {
 	#[test]
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<SymbolsFunction>(), 72);
-		assert_eq!(std::mem::size_of::<Symbol>(), 128);
+		assert_eq!(std::mem::size_of::<Symbol>(), 40);
 		assert_eq!(std::mem::size_of::<SymbolsType>(), 16);
 	}
 

--- a/crates/css_ast/src/rules/counter_style.rs
+++ b/crates/css_ast/src/rules/counter_style.rs
@@ -231,15 +231,15 @@ mod tests {
 		assert_eq!(std::mem::size_of::<CounterStyleRule>(), 128);
 		assert_eq!(std::mem::size_of::<CounterStyleName>(), 12);
 		assert_eq!(std::mem::size_of::<CounterStyleRuleBlock>(), 96);
-		assert_eq!(std::mem::size_of::<CounterStyleRuleStyleValue>(), 256);
+		assert_eq!(std::mem::size_of::<CounterStyleRuleStyleValue>(), 80);
 		assert_eq!(std::mem::size_of::<AdditiveSymbolsStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<FallbackStyleValue>(), 12);
-		assert_eq!(std::mem::size_of::<NegativeStyleValue>(), 256);
-		assert_eq!(std::mem::size_of::<PadStyleValue>(), 144);
-		assert_eq!(std::mem::size_of::<PrefixStyleValue>(), 128);
+		assert_eq!(std::mem::size_of::<NegativeStyleValue>(), 80);
+		assert_eq!(std::mem::size_of::<PadStyleValue>(), 56);
+		assert_eq!(std::mem::size_of::<PrefixStyleValue>(), 40);
 		// assert_eq!(std::mem::size_of::<RangeStyleValue>(), 1);
 		assert_eq!(std::mem::size_of::<SpeakAsStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<SuffixStyleValue>(), 128);
+		assert_eq!(std::mem::size_of::<SuffixStyleValue>(), 40);
 		assert_eq!(std::mem::size_of::<SymbolsStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<SystemStyleValue>(), 28);
 	}

--- a/crates/css_ast/src/types/image.rs
+++ b/crates/css_ast/src/types/image.rs
@@ -24,7 +24,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<Image>(), 128);
+		assert_eq!(std::mem::size_of::<Image>(), 40);
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/borders/impls.rs
+++ b/crates/css_ast/src/values/borders/impls.rs
@@ -119,7 +119,7 @@ mod tests {
 		assert_eq!(std::mem::size_of::<BoxShadowSpreadStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<BoxShadowPositionStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<BoxShadowStyleValue>(), 32);
-		assert_eq!(std::mem::size_of::<BorderImageSourceStyleValue>(), 128);
+		assert_eq!(std::mem::size_of::<BorderImageSourceStyleValue>(), 40);
 		assert_eq!(std::mem::size_of::<BorderImageSliceStyleValue>(), 80);
 		assert_eq!(std::mem::size_of::<BorderImageWidthStyleValue>(), 64);
 		assert_eq!(std::mem::size_of::<BorderImageOutsetStyleValue>(), 64);

--- a/crates/css_ast/src/values/content/impls.rs
+++ b/crates/css_ast/src/values/content/impls.rs
@@ -9,7 +9,7 @@ mod tests {
 		assert_eq!(std::mem::size_of::<BookmarkLevelStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<BookmarkLabelStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<BookmarkStateStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<ContentStyleValue>(), 176);
+		assert_eq!(std::mem::size_of::<ContentStyleValue>(), 88);
 		assert_eq!(std::mem::size_of::<QuotesStyleValue>(), 40);
 	}
 

--- a/crates/css_ast/src/values/lists/impls.rs
+++ b/crates/css_ast/src/values/lists/impls.rs
@@ -9,9 +9,9 @@ mod tests {
 		assert_eq!(std::mem::size_of::<CounterIncrementStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<CounterResetStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<CounterSetStyleValue>(), 32);
-		assert_eq!(std::mem::size_of::<ListStyleImageStyleValue>(), 128);
+		assert_eq!(std::mem::size_of::<ListStyleImageStyleValue>(), 40);
 		assert_eq!(std::mem::size_of::<ListStylePositionStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<ListStyleStyleValue>(), 216);
+		assert_eq!(std::mem::size_of::<ListStyleStyleValue>(), 128);
 		assert_eq!(std::mem::size_of::<ListStyleTypeStyleValue>(), 72);
 		assert_eq!(std::mem::size_of::<MarkerSideStyleValue>(), 16);
 	}

--- a/crates/css_ast/src/values/masking/impls.rs
+++ b/crates/css_ast/src/values/masking/impls.rs
@@ -10,7 +10,7 @@ mod tests {
 		assert_eq!(std::mem::size_of::<MaskBorderModeStyleValue>(), 16);
 		assert_eq!(std::mem::size_of::<MaskBorderOutsetStyleValue>(), 64);
 		assert_eq!(std::mem::size_of::<MaskBorderRepeatStyleValue>(), 32);
-		assert_eq!(std::mem::size_of::<MaskBorderSourceStyleValue>(), 128);
+		assert_eq!(std::mem::size_of::<MaskBorderSourceStyleValue>(), 40);
 		assert_eq!(std::mem::size_of::<MaskClipStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<MaskOriginStyleValue>(), 32);
 		assert_eq!(std::mem::size_of::<MaskPositionStyleValue>(), 32);

--- a/crates/css_ast/src/values/shapes/impls.rs
+++ b/crates/css_ast/src/values/shapes/impls.rs
@@ -7,9 +7,9 @@ mod tests {
 	#[test]
 	fn size_test() {
 		assert_eq!(std::mem::size_of::<ShapeImageThresholdStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<ShapeInsideStyleValue>(), 128);
+		assert_eq!(std::mem::size_of::<ShapeInsideStyleValue>(), 40);
 		assert_eq!(std::mem::size_of::<ShapeMarginStyleValue>(), 16);
-		assert_eq!(std::mem::size_of::<ShapeOutsideStyleValue>(), 128);
+		assert_eq!(std::mem::size_of::<ShapeOutsideStyleValue>(), 40);
 		assert_eq!(std::mem::size_of::<ShapePaddingStyleValue>(), 16);
 	}
 


### PR DESCRIPTION
The LinearGradient/RepeatingLinearGradient types can cause extremely large style
values due to Image, and are rarely (comparative to other images) used, this
helps reduce that.
