### PR TITLE
csskit_spec_generator: Replace non-breaking spaces with whitespace

### DIFF
--- a/crates/csskit_spec_generator/src/codegen.rs
+++ b/crates/csskit_spec_generator/src/codegen.rs
@@ -688,7 +688,7 @@ fn generate_property_type(
 	let doc_grammar_header = " The grammar is defined as:";
 	let grammar = &extended_value;
 
-	let syntax_value = format!(" {} ", extended_value.replace('\n', " "));
+	let syntax_value = format!(" {} ", extended_value.replace(['\n', '\u{a0}'], " "));
 
 	// Build declaration_metadata attributes
 	let initial = &prop.initial;


### PR DESCRIPTION
Currently some properties (transform-origin) fail to properly generate due to
unrecognised characters, such as nbsp.
