### PR TITLE
Release v0.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,46 @@
+## [0.0.24] - 2026-06-04
+
+### Other Changes
+- Update css-minify-tests (#1150) ([#1150](https://github.com/csskit/csskit/pull/1150))
+- Chore(deps): update rust crate dashmap to v6.2.1 (#1151) ([#1151](https://github.com/csskit/csskit/pull/1151))
+- Chore(deps): update rust crate insta to v1.47.2 (#1152) ([#1152](https://github.com/csskit/csskit/pull/1152))
+- Coverage: refactor csskit-acceptance script to allow arbitrary command syntax (#1167) ([#1167](https://github.com/csskit/csskit/pull/1167))
+- Coverage: add more csskit-acceptance snapshot tests (#1168) ([#1168](https://github.com/csskit/csskit/pull/1168))
+- Coverage: try and be consistent with trailing newlines (#1170) ([#1170](https://github.com/csskit/csskit/pull/1170))
+
+
+### Chromashift
+- chromashift/css_ast: Completely rewrite color mixing, support `none` channels & N-colors (#1162) ([#1162](https://github.com/csskit/csskit/pull/1162))
+
+
+### Css_ast
+- Regenerate css_ast/src/values from csswg drafts (#1142) ([#1142](https://github.com/csskit/csskit/pull/1142))
+- css_ast: resolve `none` channels to 0 (#1154) ([#1154](https://github.com/csskit/csskit/pull/1154))
+- css_ast: Rewrite <position> and <bg-position> (#1164) ([#1164](https://github.com/csskit/csskit/pull/1164))
+
+
+### Csskit
+- chore(deps): update dependencies (patch) (#1143) ([#1143](https://github.com/csskit/csskit/pull/1143))
+
+
+### Csskit_proc_macro
+- csskit_proc_macro: Generate name suffixes for colliding properties (#1163) ([#1163](https://github.com/csskit/csskit/pull/1163))
+
+
+### Csskit_transform
+- coverage: update snapshot data (#1153) ([#1153](https://github.com/csskit/csskit/pull/1153))
+- coverage: update css-minify-tests (#1161) ([#1161](https://github.com/csskit/csskit/pull/1161))
+
+
+### Csskit_vscode
+- Release csskit vscode extension v1.0.8 (#1107) ([#1107](https://github.com/csskit/csskit/pull/1107))
+- Release csskit vscode extension v1.0.9 (#1147) ([#1147](https://github.com/csskit/csskit/pull/1147))
+- chore(deps): update dependency oxlint to v1.65.0 (#1146) ([#1146](https://github.com/csskit/csskit/pull/1146))
+- chore(deps): update dependency oxlint to v1.66.0 (#1148) ([#1148](https://github.com/csskit/csskit/pull/1148))
+- chore(deps): update dependencies (patch) (#1156) ([#1156](https://github.com/csskit/csskit/pull/1156))
+- chore(deps): update dependency oxlint to v1.67.0 (#1159) ([#1159](https://github.com/csskit/csskit/pull/1159))
+- fix(deps): update dependency vscode-languageclient to v10 (#1165) ([#1165](https://github.com/csskit/csskit/pull/1165))
+
 ## [0.0.23] - 2026-05-22
 
 ### Other Changes
@@ -28,6 +71,7 @@
 
 ### Csskit
 - chore(deps): update dependencies (patch) (#1124) ([#1124](https://github.com/csskit/csskit/pull/1124))
+- Release v0.0.23 (#1116) ([#1116](https://github.com/csskit/csskit/pull/1116))
 
 
 ### Csskit_spec_generator

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,25 +11,25 @@ homepage = "https://csskit.rs"
 keywords = ["CSS", "parser"]
 license = "MIT"
 repository = "https://github.com/csskit/csskit"
-version = "0.0.23"                                      #@release
+version = "0.0.24"                                      #@release
 
 [workspace.dependencies]
 # Local packages
-csskit = { version = "0.0.23", path = "crates/csskit" }                                           #@release
-csskit_derives = { version = "0.0.23", path = "crates/csskit_derives" }                           #@release
-csskit_proc_macro = { version = "0.0.23", path = "crates/csskit_proc_macro" }                     #@release
-css_value_definition_parser = { version = "0.0.23", path = "crates/css_value_definition_parser" } #@release
-css_parse = { version = "0.0.23", path = "crates/css_parse" }                                     #@release
-css_lexer = { version = "0.0.23", path = "crates/css_lexer" }                                     #@release
-css_ast = { version = "0.0.23", path = "crates/css_ast" }                                         #@release
-derive_atom_set = { version = "0.0.23", path = "crates/derive_atom_set" }                         #@release
-css_feature_data = { version = "0.0.23", path = "crates/css_feature_data" }                       #@release
-csskit_source_finder = { version = "0.0.23", path = "crates/csskit_source_finder" }               #@release
-csskit_transform = { version = "0.0.23", path = "crates/csskit_transform" }                       #@release
-csskit_highlight = { version = "0.0.23", path = "crates/csskit_highlight" }                       #@release
-csskit_lsp = { version = "0.0.23", path = "crates/csskit_lsp" }                                   #@release
-csskit_ast = { version = "0.0.23", path = "crates/csskit_ast" }                                   #@release
-chromashift = { version = "0.0.23", path = "crates/chromashift" }                                 #@release
+csskit = { version = "0.0.24", path = "crates/csskit" }                                           #@release
+csskit_derives = { version = "0.0.24", path = "crates/csskit_derives" }                           #@release
+csskit_proc_macro = { version = "0.0.24", path = "crates/csskit_proc_macro" }                     #@release
+css_value_definition_parser = { version = "0.0.24", path = "crates/css_value_definition_parser" } #@release
+css_parse = { version = "0.0.24", path = "crates/css_parse" }                                     #@release
+css_lexer = { version = "0.0.24", path = "crates/css_lexer" }                                     #@release
+css_ast = { version = "0.0.24", path = "crates/css_ast" }                                         #@release
+derive_atom_set = { version = "0.0.24", path = "crates/derive_atom_set" }                         #@release
+css_feature_data = { version = "0.0.24", path = "crates/css_feature_data" }                       #@release
+csskit_source_finder = { version = "0.0.24", path = "crates/csskit_source_finder" }               #@release
+csskit_transform = { version = "0.0.24", path = "crates/csskit_transform" }                       #@release
+csskit_highlight = { version = "0.0.24", path = "crates/csskit_highlight" }                       #@release
+csskit_lsp = { version = "0.0.24", path = "crates/csskit_lsp" }                                   #@release
+csskit_ast = { version = "0.0.24", path = "crates/csskit_ast" }                                   #@release
+chromashift = { version = "0.0.24", path = "crates/chromashift" }                                 #@release
 csskit_spec_generator = { version = "0.0.0", path = "crates/csskit_spec_generator" }
 
 # Memory

--- a/packages/csskit-darwin-arm64/package.json
+++ b/packages/csskit-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-arm64",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "description": "Refreshing CSS - macOS arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-darwin-x64/package.json
+++ b/packages/csskit-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-x64",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "description": "Refreshing CSS - macOS x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-arm64/package.json
+++ b/packages/csskit-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-arm64",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "description": "Refreshing CSS - Linux arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-x64/package.json
+++ b/packages/csskit-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-x64",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "description": "Refreshing CSS - Linux x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-arm64/package.json
+++ b/packages/csskit-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-arm64",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "description": "Refreshing CSS - Windows arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-x64/package.json
+++ b/packages/csskit-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-x64",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "description": "Refreshing CSS - Windows x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit/package-lock.json
+++ b/packages/csskit/package-lock.json
@@ -1,21 +1,13 @@
 {
     "name": "csskit",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "csskit",
-            "version": "0.0.23",
+            "version": "0.0.24",
             "license": "MIT",
-            "dependencies": {
-                "csskit-darwin-arm64": "^0.0.23",
-                "csskit-darwin-x64": "^0.0.23",
-                "csskit-linux-arm64": "^0.0.23",
-                "csskit-linux-x64": "^0.0.23",
-                "csskit-win32-arm64": "^0.0.23",
-                "csskit-win32-x64": "^0.0.23"
-            },
             "bin": {
                 "csskit": "bin/csskit"
             },

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit",
-    "version": "0.0.23",
+    "version": "0.0.24",
     "description": "Refreshing CSS",
     "keywords": [],
     "license": "MIT",
@@ -11,12 +11,12 @@
         "./bin"
     ],
     "optionalDependencies": {
-        "csskit-linux-x64": "0.0.23",
-        "csskit-linux-arm64": "0.0.23",
-        "csskit-darwin-x64": "0.0.23",
-        "csskit-darwin-arm64": "0.0.23",
-        "csskit-win32-x64": "0.0.23",
-        "csskit-win32-arm64": "0.0.23"
+        "csskit-linux-x64": "0.0.24",
+        "csskit-linux-arm64": "0.0.24",
+        "csskit-darwin-x64": "0.0.24",
+        "csskit-darwin-arm64": "0.0.24",
+        "csskit-win32-x64": "0.0.24",
+        "csskit-win32-arm64": "0.0.24"
     },
     "funding": {
         "url": "https://github.com/sponsors/keithamus"


### PR DESCRIPTION
## [0.0.24] - 2026-06-04

### Other Changes
- Update css-minify-tests (#1150) ([#1150](https://github.com/csskit/csskit/pull/1150))
- Chore(deps): update rust crate dashmap to v6.2.1 (#1151) ([#1151](https://github.com/csskit/csskit/pull/1151))
- Chore(deps): update rust crate insta to v1.47.2 (#1152) ([#1152](https://github.com/csskit/csskit/pull/1152))
- Coverage: refactor csskit-acceptance script to allow arbitrary command syntax (#1167) ([#1167](https://github.com/csskit/csskit/pull/1167))
- Coverage: add more csskit-acceptance snapshot tests (#1168) ([#1168](https://github.com/csskit/csskit/pull/1168))
- Coverage: try and be consistent with trailing newlines (#1170) ([#1170](https://github.com/csskit/csskit/pull/1170))


### Chromashift
- chromashift/css_ast: Completely rewrite color mixing, support `none` channels & N-colors (#1162) ([#1162](https://github.com/csskit/csskit/pull/1162))


### Css_ast
- Regenerate css_ast/src/values from csswg drafts (#1142) ([#1142](https://github.com/csskit/csskit/pull/1142))
- css_ast: resolve `none` channels to 0 (#1154) ([#1154](https://github.com/csskit/csskit/pull/1154))
- css_ast: Rewrite <position> and <bg-position> (#1164) ([#1164](https://github.com/csskit/csskit/pull/1164))


### Csskit
- chore(deps): update dependencies (patch) (#1143) ([#1143](https://github.com/csskit/csskit/pull/1143))


### Csskit_proc_macro
- csskit_proc_macro: Generate name suffixes for colliding properties (#1163) ([#1163](https://github.com/csskit/csskit/pull/1163))


### Csskit_transform
- coverage: update snapshot data (#1153) ([#1153](https://github.com/csskit/csskit/pull/1153))
- coverage: update css-minify-tests (#1161) ([#1161](https://github.com/csskit/csskit/pull/1161))


### Csskit_vscode
- Release csskit vscode extension v1.0.8 (#1107) ([#1107](https://github.com/csskit/csskit/pull/1107))
- Release csskit vscode extension v1.0.9 (#1147) ([#1147](https://github.com/csskit/csskit/pull/1147))
- chore(deps): update dependency oxlint to v1.65.0 (#1146) ([#1146](https://github.com/csskit/csskit/pull/1146))
- chore(deps): update dependency oxlint to v1.66.0 (#1148) ([#1148](https://github.com/csskit/csskit/pull/1148))
- chore(deps): update dependencies (patch) (#1156) ([#1156](https://github.com/csskit/csskit/pull/1156))
- chore(deps): update dependency oxlint to v1.67.0 (#1159) ([#1159](https://github.com/csskit/csskit/pull/1159))
- fix(deps): update dependency vscode-languageclient to v10 (#1165) ([#1165](https://github.com/csskit/csskit/pull/1165))