### PR TITLE
chromashift/css_ast: Completely rewrite color mixing, support `none` channels & N-colors

### DIFF
--- a/crates/chromashift/src/channels.rs
+++ b/crates/chromashift/src/channels.rs
@@ -13,3 +13,70 @@ pub trait ToAlpha: Sized {
 		self.to_alpha() == 0.0
 	}
 }
+
+/// A generic single color channel value, which may be None
+///
+/// `none` channels in `color-mix` adopt the analogous channel's value from the other color in the interpolation space
+/// (see [`crate::mix_channels`]).
+pub type Channel = Option<f64>;
+
+/// Marks colour spaces with a polar (hue) channel.
+pub trait PolarLayout {
+	/// Index of the hue channel within the 3 colour components, or `None` for rectangular spaces.
+	const HUE_INDEX: Option<usize> = None;
+}
+
+use crate::{
+	A98Rgb, DisplayP3, Hsl, Hwb, Lab, Lch, LinearRgb, Oklab, Oklch, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
+};
+
+macro_rules! impl_channels {
+	(@cast $v:expr, u8) => { $v.round() as u8 };
+	(@cast $v:expr, f64) => { $v };
+	(@cast $v:expr, f32) => { $v as f32 };
+	($ty:ident { $f1:ident: $t1:tt, $f2:ident: $t2:tt, $f3:ident: $t3:tt $(,)? }) => {
+		impl_channels!($ty { $f1: $t1, $f2: $t2, $f3: $t3 }, polar = None);
+	};
+	($ty:ident { $f1:ident: $t1:tt, $f2:ident: $t2:tt, $f3:ident: $t3:tt $(,)? }, polar = $hue:expr) => {
+		impl From<$ty> for [Channel; 4] {
+			fn from(c: $ty) -> Self {
+				[
+					Some(c.$f1 as f64),
+					Some(c.$f2 as f64),
+					Some(c.$f3 as f64),
+					Some(c.alpha as f64),
+				]
+			}
+		}
+
+		impl From<[Channel; 4]> for $ty {
+			fn from(c: [Channel; 4]) -> Self {
+				$ty::new(
+					impl_channels!(@cast c[0].unwrap_or(0.0), $t1),
+					impl_channels!(@cast c[1].unwrap_or(0.0), $t2),
+					impl_channels!(@cast c[2].unwrap_or(0.0), $t3),
+					c[3].unwrap_or(0.0) as f32,
+				)
+			}
+		}
+
+		impl PolarLayout for $ty {
+			const HUE_INDEX: Option<usize> = $hue;
+		}
+	};
+}
+
+impl_channels!(Srgb { red: u8, green: u8, blue: u8 });
+impl_channels!(LinearRgb { red: f64, green: f64, blue: f64 });
+impl_channels!(A98Rgb { red: f64, green: f64, blue: f64 });
+impl_channels!(DisplayP3 { red: f64, green: f64, blue: f64 });
+impl_channels!(ProphotoRgb { red: f64, green: f64, blue: f64 });
+impl_channels!(Rec2020 { red: f64, green: f64, blue: f64 });
+impl_channels!(Lab { lightness: f64, a: f64, b: f64 });
+impl_channels!(Oklab { lightness: f64, a: f64, b: f64 });
+impl_channels!(XyzD50 { x: f64, y: f64, z: f64 });
+impl_channels!(XyzD65 { x: f64, y: f64, z: f64 });
+impl_channels!(Hsl { hue: f32, saturation: f32, lightness: f32 }, polar = Some(0));
+impl_channels!(Hwb { hue: f32, whiteness: f32, blackness: f32 }, polar = Some(0));
+impl_channels!(Lch { lightness: f64, chroma: f64, hue: f64 }, polar = Some(2));
+impl_channels!(Oklch { lightness: f64, chroma: f64, hue: f64 }, polar = Some(2));

--- a/crates/chromashift/src/lib.rs
+++ b/crates/chromashift/src/lib.rs
@@ -30,7 +30,7 @@ mod xyzd50;
 mod xyzd65;
 
 pub use a98_rgb::A98Rgb;
-pub use channels::ToAlpha;
+pub use channels::{Channel, PolarLayout, ToAlpha};
 pub use color_space::ColorSpace;
 pub use display_p3::DisplayP3;
 pub use distance::ColorDistance;
@@ -42,7 +42,7 @@ pub use hwb::Hwb;
 pub use lab::Lab;
 pub use lch::Lch;
 pub use linear_rgb::LinearRgb;
-pub use mix::{ColorMix, ColorMixPolar, HueInterpolation};
+pub use mix::{ColorMix, ColorMixPolar, HueInterpolation, mix_channels};
 pub use named::{Named, ToNamedError};
 pub use oklab::Oklab;
 pub use oklch::Oklch;
@@ -201,6 +201,77 @@ impl ToAlpha for Color {
 			Color::XyzD50(x) => x.to_alpha(),
 			Color::XyzD65(x) => x.to_alpha(),
 		}
+	}
+}
+
+impl From<A98Rgb> for Color {
+	fn from(c: A98Rgb) -> Self {
+		Color::A98Rgb(c)
+	}
+}
+impl From<DisplayP3> for Color {
+	fn from(c: DisplayP3) -> Self {
+		Color::DisplayP3(c)
+	}
+}
+impl From<Hsl> for Color {
+	fn from(c: Hsl) -> Self {
+		Color::Hsl(c)
+	}
+}
+impl From<Hwb> for Color {
+	fn from(c: Hwb) -> Self {
+		Color::Hwb(c)
+	}
+}
+impl From<Lab> for Color {
+	fn from(c: Lab) -> Self {
+		Color::Lab(c)
+	}
+}
+impl From<Lch> for Color {
+	fn from(c: Lch) -> Self {
+		Color::Lch(c)
+	}
+}
+impl From<LinearRgb> for Color {
+	fn from(c: LinearRgb) -> Self {
+		Color::LinearRgb(c)
+	}
+}
+impl From<Oklab> for Color {
+	fn from(c: Oklab) -> Self {
+		Color::Oklab(c)
+	}
+}
+impl From<Oklch> for Color {
+	fn from(c: Oklch) -> Self {
+		Color::Oklch(c)
+	}
+}
+impl From<ProphotoRgb> for Color {
+	fn from(c: ProphotoRgb) -> Self {
+		Color::ProphotoRgb(c)
+	}
+}
+impl From<Rec2020> for Color {
+	fn from(c: Rec2020) -> Self {
+		Color::Rec2020(c)
+	}
+}
+impl From<Srgb> for Color {
+	fn from(c: Srgb) -> Self {
+		Color::Srgb(c)
+	}
+}
+impl From<XyzD50> for Color {
+	fn from(c: XyzD50) -> Self {
+		Color::XyzD50(c)
+	}
+}
+impl From<XyzD65> for Color {
+	fn from(c: XyzD65) -> Self {
+		Color::XyzD65(c)
 	}
 }
 

--- a/crates/chromashift/src/mix.rs
+++ b/crates/chromashift/src/mix.rs
@@ -1,5 +1,6 @@
 use crate::{
-	A98Rgb, DisplayP3, Hsl, Hwb, Lab, Lch, LinearRgb, Oklab, Oklch, ProphotoRgb, Rec2020, Srgb, XyzD50, XyzD65,
+	A98Rgb, Channel, DisplayP3, Hsl, Hwb, Lab, Lch, LinearRgb, Oklab, Oklch, PolarLayout, ProphotoRgb, Rec2020, Srgb,
+	XyzD50, XyzD65,
 };
 
 /// A direction to interopolate hue values between, when mixing colours.
@@ -108,6 +109,65 @@ pub fn interpolate_hue(h1: f64, h2: f64, t: f64, interpolation: HueInterpolation
 	(h1 + diff * t).rem_euclid(360.0)
 }
 
+/// Mixes two colours channel-by-channel, honouring `none` channels by adopting the analogous channel from the other
+/// colour. When both are missing the result resolves to 0.
+///
+/// Non-hue colour components and alpha use premultiplied alpha interpolation. Polar colours use `hue_index` to select
+/// which (if any) component is a hue: that channel uses hue interpolation with the given direction.
+pub fn mix_channels(
+	first: [Channel; 4],
+	second: [Channel; 4],
+	percentage: f64,
+	hue_index: Option<usize>,
+	hue_interpolation: HueInterpolation,
+) -> [Channel; 4] {
+	let t = percentage / 100.0;
+	let mut out = [Channel::default(); 4];
+
+	// Alpha: resolve none, then lerp. Store in 0..100 range.
+	let (alpha_a, alpha_b) = match (first[3], second[3]) {
+		(None, None) => (0.0, 0.0),
+		(None, Some(b)) => (b, b),
+		(Some(a), None) => (a, a),
+		(Some(a), Some(b)) => (a, b),
+	};
+	let a1 = alpha_a / 100.0;
+	let a2 = alpha_b / 100.0;
+	let alpha = a1 * (1.0 - t) + a2 * t;
+	out[3] = if first[3].or(second[3]).is_none() { None } else { Some(alpha * 100.0) };
+
+	for i in 0..3 {
+		let (l, r) = (first[i], second[i]);
+		let (a, b) = match (l, r) {
+			(None, None) => (None, None),
+			(None, Some(b)) => (Some(b), Some(b)),
+			(Some(a), None) => (Some(a), Some(a)),
+			(Some(a), Some(b)) => (Some(a), Some(b)),
+		};
+		out[i] = match (a, b) {
+			(None, _) | (_, None) => None,
+			(Some(av), Some(bv)) => Some(if hue_index == Some(i) {
+				interpolate_hue(av, bv, t, hue_interpolation)
+			} else {
+				premultiply_lerp(av, a1, bv, a2, t, alpha)
+			}),
+		};
+	}
+
+	out
+}
+
+/// Mixes two values of the same colour type via [`mix_channels`]. Devolves types to [Channel; 4] before mixing.
+fn mix_in<C, T, U>(first: T, second: U, percentage: f64, hue_interpolation: HueInterpolation) -> C
+where
+	C: From<T> + From<U> + From<[Channel; 4]> + Into<[Channel; 4]> + PolarLayout,
+{
+	let first: [Channel; 4] = C::from(first).into();
+	let second: [Channel; 4] = C::from(second).into();
+	let out = mix_channels(first, second, percentage, C::HUE_INDEX, hue_interpolation);
+	C::from(out)
+}
+
 mod sealed {
 	pub trait PolarColor {}
 }
@@ -128,257 +188,48 @@ where
 	}
 }
 
-impl<T, U> ColorMix<T, U> for Srgb
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let r = premultiply_lerp(first.red as f64, a1, second.red as f64, a2, t, a);
-		let g = premultiply_lerp(first.green as f64, a1, second.green as f64, a2, t, a);
-		let b = premultiply_lerp(first.blue as f64, a1, second.blue as f64, a2, t, a);
-		Srgb::new(r.round() as u8, g.round() as u8, b.round() as u8, (a * 100.0) as f32)
-	}
+/// Implements [`ColorMix`] for a rectangular space by delegating to [`mix_in`].
+macro_rules! impl_color_mix {
+	($ty:ty) => {
+		impl<T, U> ColorMix<T, U> for $ty
+		where
+			Self: From<T> + From<U>,
+		{
+			fn mix(first: T, second: U, percentage: f64) -> Self {
+				mix_in::<Self, T, U>(first, second, percentage, HueInterpolation::Shorter)
+			}
+		}
+	};
 }
 
-impl<T, U> ColorMix<T, U> for LinearRgb
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
-		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
-		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
-		LinearRgb::new(r, g, b, (a * 100.0) as f32)
-	}
+/// Implements [`ColorMixPolar`] for a polar space by delegating to [`mix_in`].
+macro_rules! impl_color_mix_polar {
+	($ty:ty) => {
+		impl<T, U> ColorMixPolar<T, U> for $ty
+		where
+			Self: From<T> + From<U>,
+		{
+			fn mix_polar(first: T, second: U, percentage: f64, hue_interpolation: HueInterpolation) -> Self {
+				mix_in::<Self, T, U>(first, second, percentage, hue_interpolation)
+			}
+		}
+	};
 }
 
-impl<T, U> ColorMixPolar<T, U> for Hsl
-where
-	Self: From<T> + From<U>,
-{
-	fn mix_polar(first: T, second: U, percentage: f64, hue_interpolation: HueInterpolation) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let h = interpolate_hue(first.hue as f64, second.hue as f64, t, hue_interpolation);
-		let s = premultiply_lerp(first.saturation as f64, a1, second.saturation as f64, a2, t, a);
-		let l = premultiply_lerp(first.lightness as f64, a1, second.lightness as f64, a2, t, a);
-		Hsl::new(h as f32, s as f32, l as f32, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMixPolar<T, U> for Hwb
-where
-	Self: From<T> + From<U>,
-{
-	fn mix_polar(first: T, second: U, percentage: f64, hue_interpolation: HueInterpolation) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let h = interpolate_hue(first.hue as f64, second.hue as f64, t, hue_interpolation);
-		let w = premultiply_lerp(first.whiteness as f64, a1, second.whiteness as f64, a2, t, a);
-		let b = premultiply_lerp(first.blackness as f64, a1, second.blackness as f64, a2, t, a);
-		Hwb::new(h as f32, w as f32, b as f32, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMix<T, U> for A98Rgb
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
-		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
-		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
-		A98Rgb::new(r, g, b, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMix<T, U> for DisplayP3
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
-		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
-		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
-		DisplayP3::new(r, g, b, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMix<T, U> for ProphotoRgb
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
-		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
-		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
-		ProphotoRgb::new(r, g, b, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMix<T, U> for Rec2020
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let r = premultiply_lerp(first.red, a1, second.red, a2, t, a);
-		let g = premultiply_lerp(first.green, a1, second.green, a2, t, a);
-		let b = premultiply_lerp(first.blue, a1, second.blue, a2, t, a);
-		Rec2020::new(r, g, b, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMix<T, U> for Lab
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let l = premultiply_lerp(first.lightness, a1, second.lightness, a2, t, a);
-		let ab_a = premultiply_lerp(first.a, a1, second.a, a2, t, a);
-		let ab_b = premultiply_lerp(first.b, a1, second.b, a2, t, a);
-		Lab::new(l, ab_a, ab_b, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMixPolar<T, U> for Lch
-where
-	Self: From<T> + From<U>,
-{
-	fn mix_polar(first: T, second: U, percentage: f64, hue_interpolation: HueInterpolation) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let l = premultiply_lerp(first.lightness, a1, second.lightness, a2, t, a);
-		let c = premultiply_lerp(first.chroma, a1, second.chroma, a2, t, a);
-		let h = interpolate_hue(first.hue, second.hue, t, hue_interpolation);
-		Lch::new(l, c, h, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMix<T, U> for Oklab
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let l = premultiply_lerp(first.lightness, a1, second.lightness, a2, t, a);
-		let ab_a = premultiply_lerp(first.a, a1, second.a, a2, t, a);
-		let ab_b = premultiply_lerp(first.b, a1, second.b, a2, t, a);
-		Oklab::new(l, ab_a, ab_b, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMixPolar<T, U> for Oklch
-where
-	Self: From<T> + From<U>,
-{
-	fn mix_polar(first: T, second: U, percentage: f64, hue_interpolation: HueInterpolation) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let l = premultiply_lerp(first.lightness, a1, second.lightness, a2, t, a);
-		let c = premultiply_lerp(first.chroma, a1, second.chroma, a2, t, a);
-		let h = interpolate_hue(first.hue, second.hue, t, hue_interpolation);
-		Oklch::new(l, c, h, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMix<T, U> for XyzD50
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let x = premultiply_lerp(first.x, a1, second.x, a2, t, a);
-		let y = premultiply_lerp(first.y, a1, second.y, a2, t, a);
-		let z = premultiply_lerp(first.z, a1, second.z, a2, t, a);
-		XyzD50::new(x, y, z, (a * 100.0) as f32)
-	}
-}
-
-impl<T, U> ColorMix<T, U> for XyzD65
-where
-	Self: From<T> + From<U>,
-{
-	fn mix(first: T, second: U, percentage: f64) -> Self {
-		let first: Self = first.into();
-		let second: Self = second.into();
-		let t = percentage / 100.0;
-		let a1 = first.alpha as f64 / 100.0;
-		let a2 = second.alpha as f64 / 100.0;
-		let a = a1 * (1.0 - t) + a2 * t;
-		let x = premultiply_lerp(first.x, a1, second.x, a2, t, a);
-		let y = premultiply_lerp(first.y, a1, second.y, a2, t, a);
-		let z = premultiply_lerp(first.z, a1, second.z, a2, t, a);
-		XyzD65::new(x, y, z, (a * 100.0) as f32)
-	}
-}
+impl_color_mix!(Srgb);
+impl_color_mix!(LinearRgb);
+impl_color_mix!(A98Rgb);
+impl_color_mix!(DisplayP3);
+impl_color_mix!(ProphotoRgb);
+impl_color_mix!(Rec2020);
+impl_color_mix!(Lab);
+impl_color_mix!(Oklab);
+impl_color_mix!(XyzD50);
+impl_color_mix!(XyzD65);
+impl_color_mix_polar!(Hsl);
+impl_color_mix_polar!(Hwb);
+impl_color_mix_polar!(Lch);
+impl_color_mix_polar!(Oklch);
 
 #[cfg(test)]
 mod tests {
@@ -496,5 +347,15 @@ mod tests {
 		let c2 = Lab::new(50.0, 60.0, 70.0, 100.0);
 		let mixed = Lab::mix(c1, c2, 50.0);
 		assert_close_to!(mixed, Lab::new(30.0, 40.0, 50.0, 100.0));
+	}
+
+	/// `None` channel in one input adopts the analogous channel from the other.
+	#[test]
+	fn test_none_channel_substitution() {
+		let first = [None, Some(0.0), Some(0.0), Some(100.0)];
+		let second: [Channel; 4] = Srgb::new(200, 0, 0, 100.0).into();
+		let out = mix_channels(first, second, 50.0, Srgb::HUE_INDEX, HueInterpolation::Shorter);
+		let mixed: Srgb = out.into();
+		assert_eq!(mixed, Srgb::new(200, 0, 0, 100.0));
 	}
 }

--- a/crates/css_ast/src/functions/color_mix_function.rs
+++ b/crates/css_ast/src/functions/color_mix_function.rs
@@ -4,7 +4,7 @@ use crate::Percentage;
 /// <https://drafts.csswg.org/css-color-5/#color-mix>
 ///
 /// ```text,ignore
-/// color-mix() = color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2} )
+/// color-mix() = color-mix( <color-interpolation-method>? , [ <color> && <percentage [0,100]>? ]# )
 /// ```
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -14,13 +14,10 @@ pub struct ColorMixFunction<'a> {
 	#[atom(CssAtomSet::ColorMix)]
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub name: T![Function],
-	pub interpolation: ColorInterpolationMethod,
+	pub interpolation: Option<ColorInterpolationMethod>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
-	pub comma: T![,],
-	pub first: ColorMixPart<'a>,
-	#[cfg_attr(feature = "visitable", visit(skip))]
-	pub comma2: T![,],
-	pub second: ColorMixPart<'a>,
+	pub interpolation_comma: Option<T![,]>,
+	pub parts: CommaSeparated<'a, ColorMixPart<'a>, 1>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub close: T![')'],
 }
@@ -201,87 +198,219 @@ impl HueInterpolationDirection {
 }
 
 #[cfg(feature = "chromashift")]
-impl InterpolationColorSpace {
-	/// Mixes two colours in this interpolation colour space.
-	///
-	/// `percentage` is how much of the second colour to use (0.0 = all first, 100.0 = all second).
-	pub fn mix(&self, first: chromashift::Color, second: chromashift::Color, percentage: f64) -> chromashift::Color {
-		use chromashift::{
-			A98Rgb, ColorMix, ColorMixPolar, DisplayP3, Hsl, Hwb, Lab, Lch, LinearRgb, Oklab, Oklch, ProphotoRgb,
-			Rec2020, Srgb, XyzD50, XyzD65,
-		};
-		match self {
-			Self::Rectangular(space) => match space {
-				RectangularColorSpace::Srgb(_) => chromashift::Color::Srgb(Srgb::mix(first, second, percentage)),
-				RectangularColorSpace::SrgbLinear(_) => {
-					chromashift::Color::LinearRgb(LinearRgb::mix(first, second, percentage))
-				}
-				RectangularColorSpace::DisplayP3(_) => {
-					chromashift::Color::DisplayP3(DisplayP3::mix(first, second, percentage))
-				}
-				RectangularColorSpace::A98Rgb(_) => chromashift::Color::A98Rgb(A98Rgb::mix(first, second, percentage)),
-				RectangularColorSpace::ProphotoRgb(_) => {
-					chromashift::Color::ProphotoRgb(ProphotoRgb::mix(first, second, percentage))
-				}
-				RectangularColorSpace::Rec2020(_) => {
-					chromashift::Color::Rec2020(Rec2020::mix(first, second, percentage))
-				}
-				RectangularColorSpace::Lab(_) => chromashift::Color::Lab(Lab::mix(first, second, percentage)),
-				RectangularColorSpace::Oklab(_) => chromashift::Color::Oklab(Oklab::mix(first, second, percentage)),
-				RectangularColorSpace::XyzD50(_) => chromashift::Color::XyzD50(XyzD50::mix(first, second, percentage)),
-				RectangularColorSpace::Xyz(_) | RectangularColorSpace::XyzD65(_) => {
-					chromashift::Color::XyzD65(XyzD65::mix(first, second, percentage))
-				}
-			},
-			Self::Polar(space, hue_method) => {
-				let dir = match hue_method {
-					None => chromashift::HueInterpolation::Shorter,
-					Some(him) => him.direction.to_hue_interpolation(),
-				};
-				match space {
-					PolarColorSpace::Hsl(_) => chromashift::Color::Hsl(Hsl::mix_polar(first, second, percentage, dir)),
-					PolarColorSpace::Hwb(_) => chromashift::Color::Hwb(Hwb::mix_polar(first, second, percentage, dir)),
-					PolarColorSpace::Lch(_) => chromashift::Color::Lch(Lch::mix_polar(first, second, percentage, dir)),
-					PolarColorSpace::Oklch(_) => {
-						chromashift::Color::Oklch(Oklch::mix_polar(first, second, percentage, dir))
-					}
-				}
-			}
-		}
-	}
-}
-
-#[cfg(feature = "chromashift")]
 impl crate::ToChromashift for ColorMixFunction<'_> {
 	fn to_chromashift(&self) -> Option<chromashift::Color> {
-		let first_color = self.first.color.to_chromashift()?;
-		let second_color = self.second.color.to_chromashift()?;
-
-		// Resolve percentages per the spec:
-		// - If both omitted: 50% / 50%
-		// - If one omitted: other = 100% - given
-		// - If both given: use as-is (may need normalization if they don't sum to 100%)
-		let p1 = self.first.percentage.as_ref().map(|p| p.value() as f64);
-		let p2 = self.second.percentage.as_ref().map(|p| p.value() as f64);
-
-		let (p1, p2) = match (p1, p2) {
-			(None, None) => (50.0, 50.0),
-			(Some(a), None) => (a, 100.0 - a),
-			(None, Some(b)) => (100.0 - b, b),
-			(Some(a), Some(b)) => (a, b),
+		use chromashift::{
+			A98Rgb, Channel, DisplayP3, Hsl, Hwb, Lab, Lch, LinearRgb, Oklab, Oklch, PolarLayout, ProphotoRgb, Rec2020,
+			Srgb, XyzD50, XyzD65, mix_channels,
 		};
 
-		// Normalize so that p1 + p2 = 100
-		let sum = p1 + p2;
-		if sum == 0.0 {
-			return None;
+		/// Two-color mix in space `C`, returning the result as `chromashift::Color`.
+		fn mix_in<C>(
+			a: &Color<'_>,
+			b: &Color<'_>,
+			percentage: f64,
+			hue: chromashift::HueInterpolation,
+		) -> Option<chromashift::Color>
+		where
+			C: From<chromashift::Color>
+				+ Into<[Channel; 4]>
+				+ From<[Channel; 4]>
+				+ Into<chromashift::Color>
+				+ PolarLayout,
+		{
+			let fa = a.to_mix_channels::<C>()?;
+			let fb = b.to_mix_channels::<C>()?;
+			Some(C::from(mix_channels(fa, fb, percentage, C::HUE_INDEX, hue)).into())
 		}
-		let p1 = p1 / sum * 100.0;
 
-		// The percentage for mixing is "how much of the second color"
-		let mix_percentage = 100.0 - p1;
+		let color_space = self.interpolation.as_ref().map(|i| &i.color_space);
 
-		Some(self.interpolation.color_space.mix(first_color, second_color, mix_percentage))
+		let hue = match color_space {
+			Some(InterpolationColorSpace::Polar(_, Some(him))) => him.direction.to_hue_interpolation(),
+			_ => chromashift::HueInterpolation::Shorter,
+		};
+
+		// Collect (color, percentage) pairs, defaulting missing percentages to None.
+		let parts: std::vec::Vec<(&Color<'_>, Option<f64>)> = (&self.parts)
+			.into_iter()
+			.map(|(p, _)| (&p.color, p.percentage.as_ref().map(|pct| pct.value() as f64)))
+			.collect();
+
+		// Normalise percentages: fill missing as equal shares summing to 100.
+		let n = parts.len() as f64;
+		let default_pct = 100.0 / n;
+		let mut stack: std::vec::Vec<(chromashift::Color, f64)> = std::vec::Vec::with_capacity(parts.len());
+		for (color, pct) in &parts {
+			let p = pct.unwrap_or(default_pct);
+			stack.push((color.to_chromashift()?, p));
+		}
+
+		// Per spec: if the sum of all percentages is 0, return transparent black.
+		if stack.iter().map(|(_, p)| p).sum::<f64>() == 0.0 {
+			return Some(chromashift::Color::Srgb(chromashift::Srgb::new(0, 0, 0, 0.0)));
+		}
+
+		// Pairwise left-to-right reduction per the spec stack algorithm.
+		while stack.len() >= 2 {
+			let (color_b, pct_b) = stack.remove(1);
+			let (color_a, pct_a) = stack.remove(0);
+			let combined = pct_a + pct_b;
+			let progress = pct_b / combined;
+
+			// Get the source Color AST nodes for none-channel preservation.
+			let idx = parts.len() - stack.len() - 2;
+			let ast_a = parts[idx].0;
+			let ast_b = parts[idx + 1].0;
+
+			// We need to_mix_channels for none-aware mixing, but we have a resolved
+			// chromashift::Color for intermediate results. For intermediates (idx > 0),
+			// none channels are already resolved so we use the chromashift color directly.
+			let mixed = if idx == 0 {
+				let dispatch = |space: &InterpolationColorSpace| match space {
+					InterpolationColorSpace::Rectangular(s) => match s {
+						RectangularColorSpace::Srgb(_) => mix_in::<Srgb>(ast_a, ast_b, progress * 100.0, hue),
+						RectangularColorSpace::SrgbLinear(_) => {
+							mix_in::<LinearRgb>(ast_a, ast_b, progress * 100.0, hue)
+						}
+						RectangularColorSpace::DisplayP3(_) => mix_in::<DisplayP3>(ast_a, ast_b, progress * 100.0, hue),
+						RectangularColorSpace::A98Rgb(_) => mix_in::<A98Rgb>(ast_a, ast_b, progress * 100.0, hue),
+						RectangularColorSpace::ProphotoRgb(_) => {
+							mix_in::<ProphotoRgb>(ast_a, ast_b, progress * 100.0, hue)
+						}
+						RectangularColorSpace::Rec2020(_) => mix_in::<Rec2020>(ast_a, ast_b, progress * 100.0, hue),
+						RectangularColorSpace::Lab(_) => mix_in::<Lab>(ast_a, ast_b, progress * 100.0, hue),
+						RectangularColorSpace::Oklab(_) => mix_in::<Oklab>(ast_a, ast_b, progress * 100.0, hue),
+						RectangularColorSpace::XyzD50(_) => mix_in::<XyzD50>(ast_a, ast_b, progress * 100.0, hue),
+						RectangularColorSpace::Xyz(_) | RectangularColorSpace::XyzD65(_) => {
+							mix_in::<XyzD65>(ast_a, ast_b, progress * 100.0, hue)
+						}
+					},
+					InterpolationColorSpace::Polar(s, _) => match s {
+						PolarColorSpace::Hsl(_) => mix_in::<Hsl>(ast_a, ast_b, progress * 100.0, hue),
+						PolarColorSpace::Hwb(_) => mix_in::<Hwb>(ast_a, ast_b, progress * 100.0, hue),
+						PolarColorSpace::Lch(_) => mix_in::<Lch>(ast_a, ast_b, progress * 100.0, hue),
+						PolarColorSpace::Oklch(_) => mix_in::<Oklch>(ast_a, ast_b, progress * 100.0, hue),
+					},
+				};
+				// Default to oklab when no interpolation method specified.
+				if let Some(space) = color_space {
+					dispatch(space)
+				} else {
+					mix_in::<Oklab>(ast_a, ast_b, progress * 100.0, hue)
+				}
+			} else {
+				// Intermediate results have no none channels; mix directly in target space.
+				let mix_direct = |space: &InterpolationColorSpace| {
+					let fa: [Channel; 4] = match space {
+						InterpolationColorSpace::Rectangular(s) => match s {
+							RectangularColorSpace::Srgb(_) => Srgb::from(color_a).into(),
+							RectangularColorSpace::SrgbLinear(_) => LinearRgb::from(color_a).into(),
+							RectangularColorSpace::DisplayP3(_) => DisplayP3::from(color_a).into(),
+							RectangularColorSpace::A98Rgb(_) => A98Rgb::from(color_a).into(),
+							RectangularColorSpace::ProphotoRgb(_) => ProphotoRgb::from(color_a).into(),
+							RectangularColorSpace::Rec2020(_) => Rec2020::from(color_a).into(),
+							RectangularColorSpace::Lab(_) => Lab::from(color_a).into(),
+							RectangularColorSpace::Oklab(_) => Oklab::from(color_a).into(),
+							RectangularColorSpace::XyzD50(_) => XyzD50::from(color_a).into(),
+							RectangularColorSpace::Xyz(_) | RectangularColorSpace::XyzD65(_) => {
+								XyzD65::from(color_a).into()
+							}
+						},
+						InterpolationColorSpace::Polar(s, _) => match s {
+							PolarColorSpace::Hsl(_) => Hsl::from(color_a).into(),
+							PolarColorSpace::Hwb(_) => Hwb::from(color_a).into(),
+							PolarColorSpace::Lch(_) => Lch::from(color_a).into(),
+							PolarColorSpace::Oklch(_) => Oklch::from(color_a).into(),
+						},
+					};
+					let fb: [Channel; 4] = match space {
+						InterpolationColorSpace::Rectangular(s) => match s {
+							RectangularColorSpace::Srgb(_) => Srgb::from(color_b).into(),
+							RectangularColorSpace::SrgbLinear(_) => LinearRgb::from(color_b).into(),
+							RectangularColorSpace::DisplayP3(_) => DisplayP3::from(color_b).into(),
+							RectangularColorSpace::A98Rgb(_) => A98Rgb::from(color_b).into(),
+							RectangularColorSpace::ProphotoRgb(_) => ProphotoRgb::from(color_b).into(),
+							RectangularColorSpace::Rec2020(_) => Rec2020::from(color_b).into(),
+							RectangularColorSpace::Lab(_) => Lab::from(color_b).into(),
+							RectangularColorSpace::Oklab(_) => Oklab::from(color_b).into(),
+							RectangularColorSpace::XyzD50(_) => XyzD50::from(color_b).into(),
+							RectangularColorSpace::Xyz(_) | RectangularColorSpace::XyzD65(_) => {
+								XyzD65::from(color_b).into()
+							}
+						},
+						InterpolationColorSpace::Polar(s, _) => match s {
+							PolarColorSpace::Hsl(_) => Hsl::from(color_b).into(),
+							PolarColorSpace::Hwb(_) => Hwb::from(color_b).into(),
+							PolarColorSpace::Lch(_) => Lch::from(color_b).into(),
+							PolarColorSpace::Oklch(_) => Oklch::from(color_b).into(),
+						},
+					};
+					Some(match space {
+						InterpolationColorSpace::Rectangular(s) => match s {
+							RectangularColorSpace::Srgb(_) => {
+								Srgb::from(mix_channels(fa, fb, progress * 100.0, Srgb::HUE_INDEX, hue)).into()
+							}
+							RectangularColorSpace::SrgbLinear(_) => {
+								LinearRgb::from(mix_channels(fa, fb, progress * 100.0, LinearRgb::HUE_INDEX, hue))
+									.into()
+							}
+							RectangularColorSpace::DisplayP3(_) => {
+								DisplayP3::from(mix_channels(fa, fb, progress * 100.0, DisplayP3::HUE_INDEX, hue))
+									.into()
+							}
+							RectangularColorSpace::A98Rgb(_) => {
+								A98Rgb::from(mix_channels(fa, fb, progress * 100.0, A98Rgb::HUE_INDEX, hue)).into()
+							}
+							RectangularColorSpace::ProphotoRgb(_) => {
+								ProphotoRgb::from(mix_channels(fa, fb, progress * 100.0, ProphotoRgb::HUE_INDEX, hue))
+									.into()
+							}
+							RectangularColorSpace::Rec2020(_) => {
+								Rec2020::from(mix_channels(fa, fb, progress * 100.0, Rec2020::HUE_INDEX, hue)).into()
+							}
+							RectangularColorSpace::Lab(_) => {
+								Lab::from(mix_channels(fa, fb, progress * 100.0, Lab::HUE_INDEX, hue)).into()
+							}
+							RectangularColorSpace::Oklab(_) => {
+								Oklab::from(mix_channels(fa, fb, progress * 100.0, Oklab::HUE_INDEX, hue)).into()
+							}
+							RectangularColorSpace::XyzD50(_) => {
+								XyzD50::from(mix_channels(fa, fb, progress * 100.0, XyzD50::HUE_INDEX, hue)).into()
+							}
+							RectangularColorSpace::Xyz(_) | RectangularColorSpace::XyzD65(_) => {
+								XyzD65::from(mix_channels(fa, fb, progress * 100.0, XyzD65::HUE_INDEX, hue)).into()
+							}
+						},
+						InterpolationColorSpace::Polar(s, _) => match s {
+							PolarColorSpace::Hsl(_) => {
+								Hsl::from(mix_channels(fa, fb, progress * 100.0, Hsl::HUE_INDEX, hue)).into()
+							}
+							PolarColorSpace::Hwb(_) => {
+								Hwb::from(mix_channels(fa, fb, progress * 100.0, Hwb::HUE_INDEX, hue)).into()
+							}
+							PolarColorSpace::Lch(_) => {
+								Lch::from(mix_channels(fa, fb, progress * 100.0, Lch::HUE_INDEX, hue)).into()
+							}
+							PolarColorSpace::Oklch(_) => {
+								Oklch::from(mix_channels(fa, fb, progress * 100.0, Oklch::HUE_INDEX, hue)).into()
+							}
+						},
+					})
+				};
+				if let Some(space) = color_space {
+					mix_direct(space)
+				} else {
+					let fa: [Channel; 4] = Oklab::from(color_a).into();
+					let fb: [Channel; 4] = Oklab::from(color_b).into();
+					Some(Oklab::from(mix_channels(fa, fb, progress * 100.0, Oklab::HUE_INDEX, hue)).into())
+				}
+			}?;
+
+			stack.insert(0, (mixed, combined));
+		}
+
+		stack.into_iter().next().map(|(c, _)| c)
 	}
 }
 
@@ -293,7 +422,7 @@ mod tests {
 
 	#[test]
 	fn size_test() {
-		assert_eq!(std::mem::size_of::<ColorMixFunction>(), 184);
+		assert_eq!(std::mem::size_of::<ColorMixFunction>(), 128);
 		assert_eq!(std::mem::size_of::<ColorInterpolationMethod>(), 56);
 		assert_eq!(std::mem::size_of::<InterpolationColorSpace>(), 44);
 		assert_eq!(std::mem::size_of::<RectangularColorSpace>(), 16);
@@ -319,6 +448,11 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(in xyz-d50,red,green)");
 		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(in xyz-d65,red,green)");
 		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(in srgb-linear,red,green)");
+		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(red,blue)");
+		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(red 50%,blue 50%)");
+		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(in oklab,red,blue,green)");
+		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(in srgb,red 33%,blue 33%,green 34%)");
+		assert_parse!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(red,blue,green)");
 	}
 
 	#[test]
@@ -355,15 +489,19 @@ mod tests {
 			Color,
 			Color,
 		);
+		assert_visits!("color-mix(red, blue)", ColorMixFunction, Color, Color,);
+		assert_visits!(
+			"color-mix(in oklab, red, blue, green)",
+			ColorMixFunction,
+			ColorInterpolationMethod,
+			Color,
+			Color,
+			Color,
+		);
 	}
 
 	#[test]
 	fn test_errors() {
-		// Missing interpolation method
-		assert_parse_error!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(red,blue)");
-		// Missing "in" keyword
 		assert_parse_error!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(srgb,red,blue)");
-		// Missing second color
-		assert_parse_error!(CssAtomSet::ATOMS, ColorMixFunction, "color-mix(in srgb,red)");
 	}
 }

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -48,6 +48,75 @@ impl ToChromashift for T![Hash] {
 }
 
 #[cfg(feature = "chromashift")]
+impl Color<'_> {
+	/// Convert this colour to `[Channel; 4]` in interpolation space `C`, preserving `none` channels.
+	///
+	/// Returns `None` if the colour has no fixed value (e.g. `currentcolor`).
+	pub fn to_mix_channels<C>(&self) -> Option<[chromashift::Channel; 4]>
+	where
+		C: From<chromashift::Color> + Into<[chromashift::Channel; 4]>,
+	{
+		use crate::{ColorFunction, NoneOr};
+
+		// Determine which of the first three channels are `none` in the AST.
+		let none = match self {
+			Color::Function(func) => match &**func {
+				ColorFunction::Rgb(f) => {
+					let p = &f.params;
+					[matches!(p.0, NoneOr::None(_)), matches!(p.2, NoneOr::None(_)), matches!(p.4, NoneOr::None(_))]
+				}
+				ColorFunction::Rgba(f) => {
+					let p = &f.params;
+					[matches!(p.0, NoneOr::None(_)), matches!(p.2, NoneOr::None(_)), matches!(p.4, NoneOr::None(_))]
+				}
+				ColorFunction::Hsl(f) => {
+					let p = &f.params;
+					[matches!(p.0, NoneOr::None(_)), matches!(p.2, NoneOr::None(_)), matches!(p.4, NoneOr::None(_))]
+				}
+				ColorFunction::Hsla(f) => {
+					let p = &f.params;
+					[matches!(p.0, NoneOr::None(_)), matches!(p.2, NoneOr::None(_)), matches!(p.4, NoneOr::None(_))]
+				}
+				ColorFunction::Hwb(f) => {
+					let p = &f.params;
+					[matches!(p.0, NoneOr::None(_)), matches!(p.1, NoneOr::None(_)), matches!(p.2, NoneOr::None(_))]
+				}
+				ColorFunction::Lab(f) => {
+					let p = &f.params;
+					[matches!(p.0, NoneOr::None(_)), matches!(p.1, NoneOr::None(_)), matches!(p.2, NoneOr::None(_))]
+				}
+				ColorFunction::Lch(f) => {
+					let p = &f.params;
+					[matches!(p.0, NoneOr::None(_)), matches!(p.1, NoneOr::None(_)), matches!(p.2, NoneOr::None(_))]
+				}
+				ColorFunction::Oklab(f) => {
+					let p = &f.params;
+					[matches!(p.0, NoneOr::None(_)), matches!(p.1, NoneOr::None(_)), matches!(p.2, NoneOr::None(_))]
+				}
+				ColorFunction::Oklch(f) => {
+					let p = &f.params;
+					[matches!(p.0, NoneOr::None(_)), matches!(p.1, NoneOr::None(_)), matches!(p.2, NoneOr::None(_))]
+				}
+				ColorFunction::Color(f) => {
+					let p = &f.params;
+					[matches!(p.1, NoneOr::None(_)), matches!(p.2, NoneOr::None(_)), matches!(p.3, NoneOr::None(_))]
+				}
+				_ => [false; 3],
+			},
+			_ => [false; 3],
+		};
+
+		let mut ch: [chromashift::Channel; 4] = C::from(self.to_chromashift()?).into();
+		for i in 0..3 {
+			if none[i] {
+				ch[i] = None;
+			}
+		}
+		Some(ch)
+	}
+}
+
+#[cfg(feature = "chromashift")]
 impl ToChromashift for Color<'_> {
 	fn to_chromashift(&self) -> Option<chromashift::Color> {
 		use chromashift::Srgb;

--- a/crates/csskit_transform/src/reduce_colors.rs
+++ b/crates/csskit_transform/src/reduce_colors.rs
@@ -209,86 +209,68 @@ where
 		let outer_span = mix.to_span();
 		let outer_len = outer_span.len() as usize;
 
-		let first_chroma = mix.first.color.to_chromashift();
-		let second_chroma = mix.second.color.to_chromashift();
-		let delta_e = first_chroma.and_then(|first| second_chroma.map(|second| first.delta_e(second)));
+		let n = mix.parts.len();
+		let default_pct = 100.0 / n as f32;
 
-		// Compute effective percentages per CSS Color 5 3.2:
-		// - If only one percentage is given, the other is 100% - given
-		// - If neither is given, both default to 50%
-		// - If both are given, they're used as-is (and may not sum to 100%)
-		let p1_explicit = mix.first.percentage.as_ref().map(|p| p.value());
-		let p2_explicit = mix.second.percentage.as_ref().map(|p| p.value());
-		let (p1, p2) = match (p1_explicit, p2_explicit) {
-			(Some(a), Some(b)) => (a, b),
-			(Some(a), None) => (a, 100.0 - a),
-			(None, Some(b)) => (100.0 - b, b),
-			(None, None) => (50.0, 50.0),
-		};
-		let sum = p1 + p2;
+		// Resolve effective percentages
+		let explicit_sum: f32 =
+			(&mix.parts).into_iter().filter_map(|(p, _)| p.percentage.as_ref().map(|pct| pct.value())).sum();
+		let implicit_count = (&mix.parts).into_iter().filter(|(p, _)| p.percentage.is_none()).count();
+		let implicit_share = if implicit_count > 0 { (100.0 - explicit_sum) / implicit_count as f32 } else { 0.0 };
+		let pcts: Vec<f32> = (&mix.parts)
+			.into_iter()
+			.map(|(p, _)| p.percentage.as_ref().map(|pct| pct.value()).unwrap_or(implicit_share))
+			.collect();
+		let sum: f32 = pcts.iter().sum();
 
-		// The same color on both sides should just shrink to the one color,
-		// but only when alpha_mult is 1 (sum >= 100)
-		if delta_e.is_some_and(|delta| delta < COLOR_EPSILON) && sum >= 100.0 {
-			let str = first_chroma.and_then(|color| color.shortest()).unwrap_or_else(|| {
-				let span = mix.first.color.to_span();
-				self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
-			});
-			self.transformer.clear_pending_edits(outer_span);
-			self.transformer.replace_parsed::<Color>(outer_span, &str);
-			self.replacing_outer = true;
-			return;
-		}
-
-		// 100%/0% elimination — only when sum == 100 (no alpha multiplier, no normalization)
-		if sum == 100.0 && (p1 == 100.0 || p2 == 0.0) {
-			let str = first_chroma.and_then(|color| color.shortest()).unwrap_or_else(|| {
-				let span = mix.first.color.to_span();
-				self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
-			});
-			self.transformer.clear_pending_edits(outer_span);
-			self.transformer.replace_parsed::<Color>(outer_span, &str);
-			self.replacing_outer = true;
-			return;
-		}
-
-		// 0%/100% elimination — only when sum == 100
-		if sum == 100.0 && (p2 == 100.0 || p1 == 0.0) {
-			let str = second_chroma.and_then(|color| color.shortest()).unwrap_or_else(|| {
-				let span = mix.second.color.to_span();
-				self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
-			});
-			self.transformer.clear_pending_edits(outer_span);
-			self.transformer.replace_parsed::<Color>(outer_span, &str);
-			self.replacing_outer = true;
-			return;
-		}
-
-		// Try to statically mix both colors if they're both known
-		if let (Some(first), Some(second)) = (first_chroma, second_chroma)
-			&& sum > 0.0
+		// If exactly one part has all the weight (sum == 100 and all others are 0), collapse to it.
+		if sum == 100.0
+			&& let Some(dominant) = pcts.iter().position(|&p| p == 100.0)
 		{
-			// Normalize so that p1_norm + p2_norm = 100
-			let np1 = (p1 as f64) / (sum as f64) * 100.0;
-			// The percentage for mixing is "how much of the second color"
-			let percentage = 100.0 - np1;
+			{
+				let (part, _) = &mix.parts[dominant];
+				let chroma = part.color.to_chromashift();
+				let str = chroma.and_then(|c| c.shortest()).unwrap_or_else(|| {
+					let span = part.color.to_span();
+					self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
+				});
+				self.transformer.clear_pending_edits(outer_span);
+				self.transformer.replace_parsed::<Color>(outer_span, &str);
+				self.replacing_outer = true;
+				return;
+			}
+		}
 
-			let mixed = mix.interpolation.color_space.mix(first, second, percentage);
+		// All identical colors with alpha_mult == 1 (sum >= 100): collapse to first.
+		if sum >= 100.0 {
+			let chromata: Vec<_> = (&mix.parts).into_iter().map(|(p, _)| p.color.to_chromashift()).collect();
+			if chromata.iter().all(Option::is_some) {
+				let first = chromata[0].unwrap();
+				if chromata[1..].iter().all(|c| c.unwrap().delta_e(first) < COLOR_EPSILON) {
+					let (part, _) = &mix.parts[0];
+					let str = first.shortest().unwrap_or_else(|| {
+						let span = part.color.to_span();
+						self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
+					});
+					self.transformer.clear_pending_edits(outer_span);
+					self.transformer.replace_parsed::<Color>(outer_span, &str);
+					self.replacing_outer = true;
+					return;
+				}
+			}
+		}
 
-			// Apply alpha multiplier per CSS Color 5 3.3:
-			// alpha_mult = 1 - leftover, where leftover = max(1 - sum/100, 0)
+		// Try static mix to reduce colors:
+		let all_known = (&mix.parts).into_iter().all(|(p, _)| p.color.to_chromashift().is_some());
+		if all_known && let Some(mixed) = mix.to_chromashift() {
 			let alpha_mult = (sum as f64 / 100.0).min(1.0);
 			let mixed_alpha = (mixed.to_alpha() as f64 / 100.0 * alpha_mult * 100.0) as f32;
 			let mixed = mixed.with_alpha(mixed_alpha);
-
-			// Try the perceptually-rounded native-space form first, then sRGB
-			// candidates if the result is in gamut.
 			let rounded = mixed.round();
 			let native_css = rounded.to_css();
 			let srgb_css = if mixed.in_gamut_of(ColorSpace::Srgb) { mixed.shortest() } else { None };
 			let candidate =
 				native_css.into_iter().chain(srgb_css).min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
-
 			if let Some(ref candidate) = candidate
 				&& candidate.len() < outer_len
 			{
@@ -298,25 +280,20 @@ where
 			}
 		}
 
-		// Partial optimizations (only when not replacing the entire expression)
-
-		// Remove redundant 50% percentages — only when both effective percentages are 50%
-		// (i.e. the sum is 100, so no alpha multiplier effect)
-		if sum == 100.0 {
-			if p1 == 50.0
-				&& let Some(ref pct) = mix.first.percentage
-			{
-				self.transformer.delete(pct.to_span());
-			}
-			if p2 == 50.0
-				&& let Some(ref pct) = mix.second.percentage
-			{
-				self.transformer.delete(pct.to_span());
+		// Remove redundant percentages on an equal N-way split (partial optimisation).
+		if (sum - 100.0).abs() < 0.01 {
+			for ((part, _), &effective) in (&mix.parts).into_iter().zip(&pcts) {
+				if let Some(ref pct) = part.percentage
+					&& (effective - default_pct).abs() < 0.01
+				{
+					self.transformer.delete(pct.to_span());
+				}
 			}
 		}
 
 		// Remove redundant "shorter hue" (shorter is the default hue interpolation direction)
-		if let InterpolationColorSpace::Polar(_, Some(ref hue_method)) = mix.interpolation.color_space
+		if let Some(ref interp) = mix.interpolation
+			&& let InterpolationColorSpace::Polar(_, Some(ref hue_method)) = interp.color_space
 			&& matches!(hue_method.direction, HueInterpolationDirection::Shorter(_))
 		{
 			self.transformer.delete(hue_method.to_span());
@@ -442,6 +419,18 @@ mod tests {
 	}
 
 	#[test]
+	fn color_mix_all_zero_percent() {
+		// Per CSS Color 5 §3.3: sum of 0% → transparent black.
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, red 0%, green 0%, blue 0%); }",
+			"a { color: #0000; }"
+		);
+	}
+
+	#[test]
 	fn color_mix_same_color_both_sides() {
 		assert_transform!(
 			CssMinifierFeature::ReduceColors,
@@ -460,6 +449,17 @@ mod tests {
 			StyleSheet,
 			"a { color: color-mix(in srgb, currentcolor 50%, red 50%); }",
 			"a { color: color-mix(in srgb, currentcolor, red); }"
+		);
+	}
+
+	#[test]
+	fn color_mix_removes_redundant_equal_n_way_split() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, currentcolor 33.33%, red 33.33%, blue 33.33%); }",
+			"a { color: color-mix(in srgb, currentcolor, red, blue); }"
 		);
 	}
 
@@ -584,6 +584,17 @@ mod tests {
 			StyleSheet,
 			"a { color: color-mix(in oklch, lime, blue); }",
 			"a { color: oklch(0.659 0.304 203.3); }"
+		);
+	}
+
+	#[test]
+	fn color_mix_none_channel_adopts_other() {
+		assert_transform!(
+			CssMinifierFeature::ReduceColors,
+			CssAtomSet,
+			StyleSheet,
+			"a { color: color-mix(in srgb, rgb(none 0 0) 50%, rgb(200 0 0) 50%); }",
+			"a { color: #c80000; }"
 		);
 	}
 

--- a/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
+++ b/crates/csskit_transform/tests/snapshots/css_minify_tests__css_minify_failures.snap
@@ -25,10 +25,6 @@ FAIL charset/0002
 -@charset"ISO-8859-1";@charset"ISO-8859-15";a{color:red}
 +@charset "ISO-8859-1";a{color:red}
 
-FAIL colors/0024
--a{color:#640000}
-+a{color:#c80000}
-
 FAIL colors/0031
 -a{color:color-mix(in oklch,rgba(255,255,255,1),var(--foo))}
 +a{color:color-mix(in oklch,#fff,var(--foo))}
@@ -48,14 +44,6 @@ FAIL colors/0034
 FAIL colors/0035
 -a{color:color(display-p3 1.2 -.3 .5)}
 +a{color:color(display-p3 1.2-.3 .5)}
-
-FAIL colors/0060
--a{color:color-mix(in oklab,red,orange,purple)}
-+a{color:#d45456}
-
-FAIL colors/0061
--a{color:color-mix(in srgb,red 0%,green 0%,blue 0%)}
-+a{color:#0000}
 
 FAIL comments/0003
 -a{color:red}


### PR DESCRIPTION
Currently the ColorMix and ColorMixPolar traits can be used to provide
mix/mix_polar methods, which allow mixing new colours into the primary colour.
This works okay but it's lacking a few important features. It's also a bit too
much boilerplate as the mixing of colours effectively is a lerp, once you've
separated and normalized the channels. In addition, CSS Color 5 now supports
"N-colors" in color-mix, changing some of the mixing algorithms, as opposed to
CSS Color 4 which allowed only 2 colours.

So this change introduces N-colors in ColorMixFunction, and introduces a slew of
changes to support proper mixin in chromashift; adding a generic Channel type,
which is an effective "untyped" optional colour channel. It also implements
From<[Channel; 4]> for each colour, allowing colours to devolve into an untyped
slice of 3 channels plus alpha. We then implement generic channel lerping which
also includes the correct semantics per CSS Color 4 which states a missing
channel in one color-mix argument is replaced by the corresponding channel from
the other argument, after both are converted to the interpolation space.

This also rewrites css_ast's ColorMixFunction::to_chromashift() to directly mix
the colours by first converting to Channel types. It also introduces the CSS
Color 5 changes which suggest that if leftover percentages add up to 100%, to
return transparent black in the target color space.
