### PR TITLE
css_ast: Avoid hanging on `={-->}` input.

### DIFF
--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -204,4 +204,10 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, Rule, "@media screen{}", Rule::Media(_));
 		assert_parse!(CssAtomSet::ATOMS, Rule, "@layer foo{}", Rule::Layer(_));
 	}
+
+	#[test]
+	fn cdc_in_unknown_rule_block() {
+		assert_parse!(CssAtomSet::ATOMS, StyleSheet, "={-->}", "={}");
+		assert_parse!(CssAtomSet::ATOMS, StyleSheet, "={-->", "={");
+	}
 }

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -88,7 +88,14 @@ where
 			// While by default the parser will skip whitespace, the Declaration or Rule type may be a whitespace sensitive
 			// node, for example `ComponentValues`. As such whitespace needs to be consumed here, before Declarations and
 			// Rules are parsed.
-			if p.parse_if_peek::<T![' ']>()?.is_some() || p.parse_if_peek::<T![;]>()?.is_some() {
+			// CDC (`-->`) and CDO (`<!--`) tokens are not valid component values and are not consumed by the
+			// declaration/rule/bad-declaration recovery paths below. Left unconsumed they cause a zero-progress
+			// loop and unbounded allocation. Per CSS Syntax they are only meaningful at the stylesheet top
+			// level, so discard them here, mirroring the stylesheet top-level loop.
+			if p.parse_if_peek::<T![' ']>()?.is_some()
+				|| p.parse_if_peek::<T![;]>()?.is_some()
+				|| p.parse_if_peek::<T![CdcOrCdo]>()?.is_some()
+			{
 				continue;
 			}
 			if p.at_end() {

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -26,6 +26,26 @@
 /// ```
 #[macro_export]
 macro_rules! assert_parse {
+	($atomset: path, $ty: ty, $str: literal, $expected: literal) => {
+		let source_text = $str;
+		let bump = ::bumpalo::Bump::default();
+		let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
+		let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
+		let result = parser.parse_entirely::<$ty>().with_trivia();
+		if !result.errors.is_empty() {
+			panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
+		}
+		let mut actual = ::bumpalo::collections::String::new_in(&bump);
+		{
+			let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
+			let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+			use $crate::ToCursors;
+			result.to_cursors(&mut ordered_sink);
+		}
+		if $expected.trim() != actual.trim() {
+			panic!("\n\nParse failed: did not match expected output:\n\n   parser input: {:?}\n  parser output: {:?}\n       expected: {:?}\n", source_text, actual, $expected);
+		}
+	};
 	($atomset: path, $ty: ty, $str: literal, $($ast: pat)+) => {
 		let source_text = $str;
 		let bump = ::bumpalo::Bump::default();


### PR DESCRIPTION
When running csskit through the httparchive I found on one file I got OOM
illed. It was an HTML file, but reducing it down, this seems the minimal input
was `={-->}`. This causes an unknown block to enter into component values, and
repeatedly re-wind and re-parse, consuming infinite ram.

This fixes the issue by skipping --> during ComponentValues parsing, which is
very unlikely to run into issues.
