### PR TITLE
css_parse: Improve assert_parse! macros to use a block/closure

### DIFF
--- a/crates/css_parse/src/syntax/either.rs
+++ b/crates/css_parse/src/syntax/either.rs
@@ -108,9 +108,8 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{Parser, T, assert_parse, assert_parse_error};
-	use bumpalo::Bump;
-	use css_lexer::{EmptyAtomSet, Lexer};
+	use crate::{T, assert_parse, assert_parse_error};
+	use css_lexer::EmptyAtomSet;
 
 	type IdentOrNumber = Either<T![Ident], T![Number]>;
 	type NumberOrDimension = Either<T![Number], T![Dimension]>;
@@ -136,17 +135,11 @@ mod tests {
 
 	#[test]
 	fn test_to_number_value() {
-		let bump = Bump::default();
-		let source_text = "47";
-		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-		let mut p = Parser::new(&bump, source_text, lexer);
-		let num = p.parse_entirely::<NumberOrDimension>().output.unwrap();
-		assert_eq!(num.to_number_value(), Some(47.0));
-
-		let source_text = "47px";
-		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-		let mut p = Parser::new(&bump, source_text, lexer);
-		let num = p.parse_entirely::<NumberOrDimension>().output.unwrap();
-		assert_eq!(num.to_number_value(), Some(47.0));
+		assert_parse!(EmptyAtomSet::ATOMS, NumberOrDimension, "47", |node| {
+			assert_eq!(node.to_number_value(), Some(47.0));
+		});
+		assert_parse!(EmptyAtomSet::ATOMS, NumberOrDimension, "47px", |node| {
+			assert_eq!(node.to_number_value(), Some(47.0));
+		});
 	}
 }

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -27,56 +27,84 @@
 #[macro_export]
 macro_rules! assert_parse {
 	($atomset: path, $ty: ty, $str: literal, $expected: literal) => {
-		let source_text = $str;
-		let bump = ::bumpalo::Bump::default();
-		let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
-		let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
-		let result = parser.parse_entirely::<$ty>().with_trivia();
-		if !result.errors.is_empty() {
-			panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
-		}
-		let mut actual = ::bumpalo::collections::String::new_in(&bump);
 		{
-			let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
-			let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
-			use $crate::ToCursors;
-			result.to_cursors(&mut ordered_sink);
+			let source_text = $str;
+			let bump = ::bumpalo::Bump::default();
+			let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
+			let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
+			let result = parser.parse_entirely::<$ty>().with_trivia();
+			if !result.errors.is_empty() {
+				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
+			}
+			let mut actual = ::bumpalo::collections::String::new_in(&bump);
+			{
+				let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
+				let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+				use $crate::ToCursors;
+				result.to_cursors(&mut ordered_sink);
+			}
+			if $expected.trim() != actual.trim() {
+				panic!("\n\nParse failed: did not match expected output:\n\n   parser input: {:?}\n  parser output: {:?}\n       expected: {:?}\n", source_text, actual, $expected);
+			}
 		}
-		if $expected.trim() != actual.trim() {
-			panic!("\n\nParse failed: did not match expected output:\n\n   parser input: {:?}\n  parser output: {:?}\n       expected: {:?}\n", source_text, actual, $expected);
+	};
+	($atomset: path, $ty: ty, $str: literal) => {
+		assert_parse!($atomset, $ty, $str, _);
+	};
+	($atomset: path, $ty: ty, $str: literal, |$node: ident| $body: expr) => {
+		{
+			let source_text = $str;
+			let bump = ::bumpalo::Bump::default();
+			let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
+			let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
+			let result = parser.parse_entirely::<$ty>().with_trivia();
+			if !result.errors.is_empty() {
+				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
+			}
+			let mut actual = ::bumpalo::collections::String::new_in(&bump);
+			{
+				let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
+				let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+				use $crate::ToCursors;
+				result.to_cursors(&mut ordered_sink);
+			}
+			if source_text.trim() != actual.trim() {
+				panic!("\n\nParse failed: did not match expected format:\n\n   parser input: {:?}\n  parser output: {:?}\n", source_text, actual);
+			}
+			let $node = result.output.expect("parse succeeded");
+			$body
 		}
 	};
 	($atomset: path, $ty: ty, $str: literal, $($ast: pat)+) => {
-		let source_text = $str;
-		let bump = ::bumpalo::Bump::default();
-		let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
-		let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
-		let result = parser.parse_entirely::<$ty>().with_trivia();
-		if !result.errors.is_empty() {
-			panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
-		}
-		let mut actual = ::bumpalo::collections::String::new_in(&bump);
 		{
-			let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
-			let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
-			use $crate::ToCursors;
-			result.to_cursors(&mut ordered_sink);
-		}
-		if source_text.trim() != actual.trim() {
-			panic!("\n\nParse failed: did not match expected format:\n\n   parser input: {:?}\n  parser output: {:?}\n", source_text, actual);
-		}
-		#[allow(clippy::redundant_pattern_matching)] // Avoid .clone().unwrap()
-		if !matches!(result.output, Some($($ast)|+)) {
-			panic!(
+			let source_text = $str;
+			let bump = ::bumpalo::Bump::default();
+			let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
+			let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
+			let result = parser.parse_entirely::<$ty>().with_trivia();
+			if !result.errors.is_empty() {
+				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
+			}
+			let mut actual = ::bumpalo::collections::String::new_in(&bump);
+			{
+				let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
+				let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+				use $crate::ToCursors;
+				result.to_cursors(&mut ordered_sink);
+			}
+			if source_text.trim() != actual.trim() {
+				panic!("\n\nParse failed: did not match expected format:\n\n   parser input: {:?}\n  parser output: {:?}\n", source_text, actual);
+			}
+			#[allow(clippy::redundant_pattern_matching)] // Avoid .clone().unwrap()
+			if !matches!(result.output, Some($($ast)|+)) {
+				panic!(
 					"\n\nParse succeeded but struct did not match given match pattern:\n\n           input: {:?}\n  match pattern: {}\n  parsed struct: {:#?}\n",
 					source_text,
 					stringify!($($ast)|+),
 					result.output.unwrap(),
 				);
+			}
 		}
-	};
-	($atomset: path, $ty: ty, $str: literal) => {
-		assert_parse!($atomset, $ty, $str, _);
 	};
 }
 #[cfg(test)]


### PR DESCRIPTION
This allows for additional assertions based on the parsed node.
