### PR TITLE
csskit_derives: Ensure generics expect Peek when using it.

### DIFF
--- a/crates/csskit_derives/src/parse.rs
+++ b/crates/csskit_derives/src/parse.rs
@@ -1197,7 +1197,18 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	};
 
 	let generics = input.generics.clone();
-	let where_clause = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::Parse<'a> });
+	let mut where_clause = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::Parse<'a> });
+	// Add Peek<'a> predicate for each collected type param too.
+	if let Some(ref mut wc) = where_clause {
+		let additional = where_collector.extend_where_clause(&generics, parse_quote! { ::css_parse::Peek<'a> });
+		if let Some(additional) = additional {
+			for pred in additional.predicates {
+				if !wc.predicates.iter().any(|p| p == &pred) {
+					wc.predicates.push(pred);
+				}
+			}
+		}
+	}
 
 	Ok(quote! {
 		#[automatically_derived]

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_enum_nested_generics.snap
@@ -6,6 +6,7 @@ expression: pretty
 impl<'a, T> ::css_parse::Parse<'a> for Container<T>
 where
     T: ::css_parse::Parse<'a>,
+    T: ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_multiple_generics.snap
@@ -7,6 +7,8 @@ impl<'a, T, U> ::css_parse::Parse<'a> for Container<T, U>
 where
     T: ::css_parse::Parse<'a>,
     U: ::css_parse::Parse<'a>,
+    T: ::css_parse::Peek<'a>,
+    U: ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_single_generic.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_single_generic.snap
@@ -6,6 +6,7 @@ expression: pretty
 impl<'a, T> ::css_parse::Parse<'a> for Wrapper<T>
 where
     T: ::css_parse::Parse<'a>,
+    T: ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_unused_generic.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_struct_with_unused_generic.snap
@@ -6,6 +6,7 @@ expression: pretty
 impl<'a, T, U> ::css_parse::Parse<'a> for PartialWrapper<T, U>
 where
     T: ::css_parse::Parse<'a>,
+    T: ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_generics.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_parse__parse_tuple_struct_with_generics.snap
@@ -7,6 +7,8 @@ impl<'a, T, U> ::css_parse::Parse<'a> for Pair<T, U>
 where
     T: ::css_parse::Parse<'a>,
     U: ::css_parse::Parse<'a>,
+    T: ::css_parse::Peek<'a>,
+    U: ::css_parse::Peek<'a>,
 {
     fn parse<I>(p: &mut css_parse::Parser<'a, I>) -> css_parse::Result<Self>
     where


### PR DESCRIPTION
Many impls of Parse on generics will use Peek, despite it not being in the where
clause. This works coincidentally, but can sometimes fail.

This change ensures we add a Peek predicate for these params.
