### PR TITLE
csskit_derives/css_ast: make derive(IntoCursor) work with generics

### DIFF
--- a/crates/css_ast/src/constraints.rs
+++ b/crates/css_ast/src/constraints.rs
@@ -1,50 +1,15 @@
 use crate::CssDiagnostic;
-#[cfg(feature = "visitable")]
-use crate::visit::{Visit, VisitMut, Visitable, VisitableMut};
-use css_parse::{
-	Cursor, Diagnostic, KindSet, Parse, Parser, Peek, Result, SemanticEq, ToCursors, ToNumberValue, ToSpan,
-};
-use csskit_derives::{NodeWithMetadata, ToCursors as DeriveToCursors, ToSpan as DeriveToSpan};
+use css_parse::{Cursor, Diagnostic, KindSet, Parse, Parser, Peek, Result, ToNumberValue};
+use csskit_derives::*;
 
 /// A non-negative value wrapper.
 ///
 /// This wrapper validates that literal values are >= 0 at parse time.
-#[derive(DeriveToCursors, DeriveToSpan, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, IntoCursor, ToCursors, ToSpan, SemanticEq, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit(children))]
 #[derive(NodeWithMetadata)]
 pub struct NonNegative<T>(pub T);
-
-impl<T: Into<Cursor>> From<NonNegative<T>> for Cursor {
-	fn from(value: NonNegative<T>) -> Self {
-		value.0.into()
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: Visitable> Visitable for NonNegative<T> {
-	fn accept<V: Visit>(&self, visitor: &mut V) {
-		self.0.accept(visitor);
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: VisitableMut> VisitableMut for NonNegative<T> {
-	fn accept_mut<V: VisitMut>(&mut self, visitor: &mut V) {
-		self.0.accept_mut(visitor);
-	}
-}
-
-impl<'a, T: Peek<'a>> Peek<'a> for NonNegative<T> {
-	const PEEK_KINDSET: KindSet = T::PEEK_KINDSET;
-
-	#[inline(always)]
-	fn peek<I>(p: &Parser<'a, I>, c: Cursor) -> bool
-	where
-		I: Iterator<Item = Cursor> + Clone,
-	{
-		T::peek(p, c)
-	}
-}
 
 impl<'a, T: Parse<'a> + ToNumberValue> Parse<'a> for NonNegative<T> {
 	fn parse<I>(p: &mut Parser<'a, I>) -> Result<Self>
@@ -63,12 +28,6 @@ impl<'a, T: Parse<'a> + ToNumberValue> Parse<'a> for NonNegative<T> {
 	}
 }
 
-impl<T: SemanticEq> SemanticEq for NonNegative<T> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.0.semantic_eq(&other.0)
-	}
-}
-
 impl<T> NonNegative<T> {
 	/// Returns a reference to the inner value.
 	pub fn inner(&self) -> &T {
@@ -84,42 +43,11 @@ impl<T> NonNegative<T> {
 /// A positive value wrapper.
 ///
 /// This wrapper validates that literal values are > 0 at parse time.
-#[derive(DeriveToCursors, DeriveToSpan, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit(children))]
 #[derive(NodeWithMetadata)]
 pub struct Positive<T>(pub T);
-
-impl<T: Into<Cursor>> From<Positive<T>> for Cursor {
-	fn from(value: Positive<T>) -> Self {
-		value.0.into()
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: Visitable> Visitable for Positive<T> {
-	fn accept<V: Visit>(&self, visitor: &mut V) {
-		self.0.accept(visitor);
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: VisitableMut> VisitableMut for Positive<T> {
-	fn accept_mut<V: VisitMut>(&mut self, visitor: &mut V) {
-		self.0.accept_mut(visitor);
-	}
-}
-
-impl<'a, T: Peek<'a>> Peek<'a> for Positive<T> {
-	const PEEK_KINDSET: KindSet = T::PEEK_KINDSET;
-
-	#[inline(always)]
-	fn peek<I>(p: &Parser<'a, I>, c: Cursor) -> bool
-	where
-		I: Iterator<Item = Cursor> + Clone,
-	{
-		T::peek(p, c)
-	}
-}
 
 impl<'a, T: Parse<'a> + ToNumberValue> Parse<'a> for Positive<T> {
 	fn parse<I>(p: &mut Parser<'a, I>) -> Result<Self>
@@ -139,12 +67,6 @@ impl<'a, T: Parse<'a> + ToNumberValue> Parse<'a> for Positive<T> {
 	}
 }
 
-impl<T: SemanticEq> SemanticEq for Positive<T> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.0.semantic_eq(&other.0)
-	}
-}
-
 impl<T> Positive<T> {
 	/// Returns a reference to the inner value.
 	pub fn inner(&self) -> &T {
@@ -160,42 +82,11 @@ impl<T> Positive<T> {
 /// A non-zero value wrapper.
 ///
 /// This wrapper validates that literal values are != 0 at parse time.
-#[derive(DeriveToCursors, DeriveToSpan, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit(children))]
 #[derive(NodeWithMetadata)]
 pub struct NonZero<T>(pub T);
-
-impl<T: Into<Cursor>> From<NonZero<T>> for Cursor {
-	fn from(value: NonZero<T>) -> Self {
-		value.0.into()
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: Visitable> Visitable for NonZero<T> {
-	fn accept<V: Visit>(&self, visitor: &mut V) {
-		self.0.accept(visitor);
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: VisitableMut> VisitableMut for NonZero<T> {
-	fn accept_mut<V: VisitMut>(&mut self, visitor: &mut V) {
-		self.0.accept_mut(visitor);
-	}
-}
-
-impl<'a, T: Peek<'a>> Peek<'a> for NonZero<T> {
-	const PEEK_KINDSET: KindSet = T::PEEK_KINDSET;
-
-	#[inline(always)]
-	fn peek<I>(p: &Parser<'a, I>, c: Cursor) -> bool
-	where
-		I: Iterator<Item = Cursor> + Clone,
-	{
-		T::peek(p, c)
-	}
-}
 
 impl<'a, T: Parse<'a> + ToNumberValue> Parse<'a> for NonZero<T> {
 	fn parse<I>(p: &mut Parser<'a, I>) -> Result<Self>
@@ -215,12 +106,6 @@ impl<'a, T: Parse<'a> + ToNumberValue> Parse<'a> for NonZero<T> {
 	}
 }
 
-impl<T: SemanticEq> SemanticEq for NonZero<T> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.0.semantic_eq(&other.0)
-	}
-}
-
 impl<T> NonZero<T> {
 	/// Returns a reference to the inner value.
 	pub fn inner(&self) -> &T {
@@ -236,42 +121,11 @@ impl<T> NonZero<T> {
 /// A range-constrained value wrapper using const generics.
 ///
 /// This wrapper validates that literal values fall within [MIN, MAX] at parse time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToSpan, IntoCursor, ToCursors, SemanticEq, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit(children))]
 #[derive(NodeWithMetadata)]
 pub struct Ranged<T, const MIN: i32, const MAX: i32>(pub T);
-
-impl<T: Into<Cursor>, const MIN: i32, const MAX: i32> From<Ranged<T, MIN, MAX>> for Cursor {
-	fn from(value: Ranged<T, MIN, MAX>) -> Self {
-		value.0.into()
-	}
-}
-
-impl<T: ToCursors, const MIN: i32, const MAX: i32> ToCursors for Ranged<T, MIN, MAX> {
-	fn to_cursors(&self, s: &mut impl css_parse::CursorSink) {
-		self.0.to_cursors(s);
-	}
-}
-
-impl<T: ToSpan, const MIN: i32, const MAX: i32> ToSpan for Ranged<T, MIN, MAX> {
-	fn to_span(&self) -> css_lexer::Span {
-		self.0.to_span()
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: Visitable, const MIN: i32, const MAX: i32> Visitable for Ranged<T, MIN, MAX> {
-	fn accept<V: Visit>(&self, visitor: &mut V) {
-		self.0.accept(visitor);
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: VisitableMut, const MIN: i32, const MAX: i32> VisitableMut for Ranged<T, MIN, MAX> {
-	fn accept_mut<V: VisitMut>(&mut self, visitor: &mut V) {
-		self.0.accept_mut(visitor);
-	}
-}
 
 impl<'a, T: Peek<'a>, const MIN: i32, const MAX: i32> Peek<'a> for Ranged<T, MIN, MAX> {
 	const PEEK_KINDSET: KindSet = T::PEEK_KINDSET;
@@ -311,12 +165,6 @@ impl<'a, T: Parse<'a> + ToNumberValue, const MIN: i32, const MAX: i32> Parse<'a>
 	}
 }
 
-impl<T: SemanticEq, const MIN: i32, const MAX: i32> SemanticEq for Ranged<T, MIN, MAX> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.0.semantic_eq(&other.0)
-	}
-}
-
 impl<T: ToNumberValue, const MIN: i32, const MAX: i32> ToNumberValue for Ranged<T, MIN, MAX> {
 	fn to_number_value(&self) -> Option<f32> {
 		self.0.to_number_value()
@@ -338,42 +186,11 @@ impl<T, const MIN: i32, const MAX: i32> Ranged<T, MIN, MAX> {
 /// An exact value wrapper using const generics.
 ///
 /// This wrapper validates that literal values are exactly equal to the specified VALUE at parse time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, ToCursors, ToSpan, SemanticEq, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
+#[cfg_attr(feature = "visitable", derive(Visitable), visit(children))]
 #[derive(NodeWithMetadata)]
 pub struct Exact<T, const VALUE: i32>(pub T);
-
-impl<T: Into<Cursor>, const VALUE: i32> From<Exact<T, VALUE>> for Cursor {
-	fn from(value: Exact<T, VALUE>) -> Self {
-		value.0.into()
-	}
-}
-
-impl<T: ToCursors, const VALUE: i32> ToCursors for Exact<T, VALUE> {
-	fn to_cursors(&self, s: &mut impl css_parse::CursorSink) {
-		self.0.to_cursors(s);
-	}
-}
-
-impl<T: ToSpan, const VALUE: i32> ToSpan for Exact<T, VALUE> {
-	fn to_span(&self) -> css_lexer::Span {
-		self.0.to_span()
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: Visitable, const VALUE: i32> Visitable for Exact<T, VALUE> {
-	fn accept<V: Visit>(&self, visitor: &mut V) {
-		self.0.accept(visitor);
-	}
-}
-
-#[cfg(feature = "visitable")]
-impl<T: VisitableMut, const VALUE: i32> VisitableMut for Exact<T, VALUE> {
-	fn accept_mut<V: VisitMut>(&mut self, visitor: &mut V) {
-		self.0.accept_mut(visitor);
-	}
-}
 
 impl<'a, T: Peek<'a>, const VALUE: i32> Peek<'a> for Exact<T, VALUE> {
 	const PEEK_KINDSET: KindSet = T::PEEK_KINDSET;
@@ -409,12 +226,6 @@ impl<'a, T: Parse<'a> + ToNumberValue, const VALUE: i32> Parse<'a> for Exact<T, 
 		}
 
 		Ok(Self(value))
-	}
-}
-
-impl<T: SemanticEq, const VALUE: i32> SemanticEq for Exact<T, VALUE> {
-	fn semantic_eq(&self, other: &Self) -> bool {
-		self.0.semantic_eq(&other.0)
 	}
 }
 

--- a/crates/css_ast/src/functions/color_function.rs
+++ b/crates/css_ast/src/functions/color_function.rs
@@ -5,7 +5,9 @@ use crate::functions::relative_color::RelativeColorFunction;
 use crate::{AngleOrNumber, NoneOr, NumberOrPercentage};
 use css_parse::BumpBox;
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -30,7 +32,7 @@ pub enum ColorSpace {
 	XyzD65(T![Ident]),
 }
 
-#[derive(IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/functions/color_mix_function.rs
+++ b/crates/css_ast/src/functions/color_mix_function.rs
@@ -57,7 +57,9 @@ pub enum InterpolationColorSpace {
 /// <rectangular-color-space> = srgb | srgb-linear | display-p3 | a98-rgb |
 ///     prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -91,7 +93,9 @@ pub enum RectangularColorSpace {
 /// ```text,ignore
 /// <polar-color-space> = hsl | hwb | lch | oklch
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -126,7 +130,9 @@ pub struct HueInterpolationMethod {
 /// ```text,ignore
 /// shorter | longer | increasing | decreasing
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/functions/content_function.rs
+++ b/crates/css_ast/src/functions/content_function.rs
@@ -16,7 +16,9 @@ pub struct ContentFunction {
 	pub close: T![')'],
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/functions/leader_function.rs
+++ b/crates/css_ast/src/functions/leader_function.rs
@@ -22,7 +22,9 @@ pub struct LeaderFunction {
 /// ```text,ignore
 /// <leader-type> = dotted | solid | space | <string>
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum LeaderType {
 	#[atom(CssAtomSet::Dotted)]

--- a/crates/css_ast/src/functions/relative_color.rs
+++ b/crates/css_ast/src/functions/relative_color.rs
@@ -22,7 +22,9 @@ pub struct RelativeColorOrigin<'a> {
 /// Channel keyword for `rgb()` / `rgba()` relative color syntax.
 ///
 /// Valid keywords: `r`, `g`, `b`, `alpha`
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -40,7 +42,9 @@ pub enum RgbChannelKeyword {
 /// Channel keyword for `hsl()` / `hsla()` relative color syntax.
 ///
 /// Valid keywords: `h`, `s`, `l`, `alpha`
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -58,7 +62,9 @@ pub enum HslChannelKeyword {
 /// Channel keyword for `hwb()` relative color syntax.
 ///
 /// Valid keywords: `h`, `w`, `b`, `alpha`
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -76,7 +82,9 @@ pub enum HwbChannelKeyword {
 /// Channel keyword for `lab()` / `oklab()` relative color syntax.
 ///
 /// Valid keywords: `l`, `a`, `b`, `alpha`
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -94,7 +102,9 @@ pub enum LabChannelKeyword {
 /// Channel keyword for `lch()` / `oklch()` relative color syntax.
 ///
 /// Valid keywords: `l`, `c`, `h`, `alpha`
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -112,7 +122,9 @@ pub enum LchChannelKeyword {
 /// Channel keyword for `color()` relative color syntax with xyz spaces.
 ///
 /// Valid keywords: `x`, `y`, `z`, `alpha`
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -130,7 +142,9 @@ pub enum XyzChannelKeyword {
 /// Channel keyword for `color()` relative color syntax - union of predefined-rgb and xyz keywords.
 ///
 /// Valid keywords: `r`, `g`, `b`, `x`, `y`, `z`, `alpha`
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/functions/target_functions.rs
+++ b/crates/css_ast/src/functions/target_functions.rs
@@ -16,7 +16,9 @@ pub enum TextFunctionContent {
 	FirstLetter(T![Ident]),
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum TargetCounterKind {
 	String(T![String]),

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -7,7 +7,7 @@ use css_parse::{
 	AtomSet, ComponentValues, Cursor, Declaration, DeclarationValue, Diagnostic, KindSet, NodeWithMetadata, Parser,
 	Peek, Result as ParserResult, SemanticEq as SemanticEqTrait, State, T,
 };
-use csskit_derives::{Parse, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 use std::{fmt::Debug, hash::Hash};
 
 // The build.rs generates a list of CSS properties from the value mods

--- a/crates/css_ast/src/rules/counter_style.rs
+++ b/crates/css_ast/src/rules/counter_style.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 #[cfg(feature = "visitable")]
 use crate::visit::{NodeId, QueryableNode};
 use crate::{Computed, Inherits, PropertyGroup, Todo};
-use csskit_derives::{DeclarationMetadata, IntoCursor, Parse, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 use csskit_proc_macro::syntax;
 
 /// <https://drafts.csswg.org/css-counter-styles-3/#the-counter-style-rule>
@@ -32,7 +32,9 @@ impl<'a> QueryableNode for CounterStyleRule<'a> {
 	}
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct CounterStyleName(T![Ident]);

--- a/crates/css_ast/src/rules/keyframes.rs
+++ b/crates/css_ast/src/rules/keyframes.rs
@@ -32,7 +32,7 @@ impl<'a> QueryableNode for KeyframesRule<'a> {
 	}
 }
 
-#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -84,7 +84,9 @@ pub struct Keyframe<'a>(
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 pub struct KeyframeSelectors<'a>(pub CommaSeparated<'a, KeyframeSelector>);
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Peek, Parse, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/rules/media/features/hack.rs
+++ b/crates/css_ast/src/rules/media/features/hack.rs
@@ -1,6 +1,6 @@
 use crate::CssAtomSet;
 use css_parse::{Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/rules/media/features/mod.rs
+++ b/crates/css_ast/src/rules/media/features/mod.rs
@@ -87,5 +87,5 @@ pub use width::*;
 mod prelude {
 	pub(crate) use crate::CssAtomSet;
 	pub(crate) use css_parse::{T, boolean_feature, discrete_feature, ranged_feature};
-	pub(crate) use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
+	pub(crate) use csskit_derives::*;
 }

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -43,7 +43,9 @@ pub struct MediaRuleBlock<'a>(pub Block<'a, StyleValue<'a>, Rule<'a>, CssMetadat
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub struct MediaQueryList<'a>(pub CommaSeparated<'a, MediaQuery<'a>, 1>);
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/rules/mod.rs
+++ b/crates/css_ast/src/rules/mod.rs
@@ -50,5 +50,5 @@ mod prelude {
 		FeatureConditionList, Kind, KindSet, NodeMetadata, NodeWithMetadata, Parse, Parser, Peek, QualifiedRule,
 		Result as ParserResult, RuleList, T,
 	};
-	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, SemanticEq, ToCursors, ToSpan};
+	pub(crate) use csskit_derives::*;
 }

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -60,7 +60,9 @@ pub enum PropertyRuleStyleValue<'a> {
 	Unknown(ComponentValues<'a>),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -71,7 +73,9 @@ pub enum InheritsValue {
 	False(T![Ident]),
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -62,7 +62,9 @@ pub enum AttributeOperator {
 	Contains(T![*=]),
 }
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Peek, Parse, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -71,7 +73,9 @@ pub enum AttributeValue {
 	Ident(T![Ident]),
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/selector/class.rs
+++ b/crates/css_ast/src/selector/class.rs
@@ -1,5 +1,5 @@
 use css_parse::{Cursor, Kind, KindSet, Parser, Peek, T};
-use csskit_derives::{Parse, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 #[derive(Parse, ToSpan, ToCursors, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -1,5 +1,5 @@
 use css_parse::T;
-use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 /// <https://drafts.csswg.org/selectors/#combinators>
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use css_lexer::Kind;
 use css_parse::{CommaSeparated, Cursor, Diagnostic, KindSet, Parse, Parser, Peek, Result as ParserResult, State, T};
-use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 use super::{ForgivingSelector, Nth, RelativeSelector, SelectorList};
 

--- a/crates/css_ast/src/selector/functional_pseudo_element.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_element.rs
@@ -2,7 +2,7 @@ use crate::{CssAtomSet, CssDiagnostic};
 use bumpalo::collections::Vec;
 use css_lexer::Kind;
 use css_parse::{Cursor, Diagnostic, KindSet, Parse, Parser, Peek, Result as ParserResult, T};
-use csskit_derives::{Parse, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 use super::CompoundSelector;
 

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -7,7 +7,7 @@ use css_parse::{
 	CompoundSelector as CompoundSelectorTrait, Cursor, NodeMetadata, NodeWithMetadata, Parse, Parser,
 	Result as ParserResult, SelectorComponent as SelectorComponentTrait, T, syntax::CommaSeparated,
 };
-use csskit_derives::{IntoCursor, Parse, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 mod attribute;
 mod class;
@@ -85,13 +85,17 @@ pub type ComplexSelector<'a> = SelectorList<'a>;
 pub type ForgivingSelector<'a> = SelectorList<'a>;
 pub type RelativeSelector<'a> = SelectorList<'a>;
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Peek, Parse, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct Id(T![Hash]);
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Peek, Parse, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/selector/moz.rs
+++ b/crates/css_ast/src/selector/moz.rs
@@ -2,7 +2,7 @@ use crate::{CssAtomSet, CssDiagnostic, DirValue};
 use css_parse::{
 	Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T, pseudo_class, pseudo_element, syntax::CommaSeparated,
 };
-use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 pseudo_element!(
 	/// https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#pseudo-elements_and_pseudo-classes

--- a/crates/css_ast/src/selector/ms.rs
+++ b/crates/css_ast/src/selector/ms.rs
@@ -1,6 +1,6 @@
 use crate::CssAtomSet;
 use css_parse::{Diagnostic, pseudo_class, pseudo_element};
-use csskit_derives::{SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 pseudo_element!(
 	#[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -1,5 +1,5 @@
 use css_parse::{Cursor, Diagnostic, KindSet, Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{IntoCursor, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 use super::Tag;
 
@@ -77,7 +77,7 @@ impl<'a> Parse<'a> for NamespacePrefix {
 	}
 }
 
-#[derive(Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NamespaceTag {
 	Wildcard(T![*]),

--- a/crates/css_ast/src/selector/o.rs
+++ b/crates/css_ast/src/selector/o.rs
@@ -1,6 +1,6 @@
 use crate::CssAtomSet;
 use css_parse::{Diagnostic, pseudo_class, pseudo_element};
-use csskit_derives::{SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 pseudo_element!(
 	#[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/selector/pseudo_class.rs
+++ b/crates/css_ast/src/selector/pseudo_class.rs
@@ -1,6 +1,6 @@
 use crate::{CssAtomSet, CssDiagnostic};
 use css_parse::{Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T};
-use csskit_derives::{Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 use super::{moz::MozPseudoClass, ms::MsPseudoClass, o::OPseudoClass, webkit::WebkitPseudoClass};
 

--- a/crates/css_ast/src/selector/pseudo_element.rs
+++ b/crates/css_ast/src/selector/pseudo_element.rs
@@ -1,7 +1,7 @@
 use crate::{CssAtomSet, CssDiagnostic, MozPseudoElement, MsPseudoElement, OPseudoElement, WebkitPseudoElement};
 use css_lexer::Kind;
 use css_parse::{Cursor, Diagnostic, KindSet, Parse, Parser, Peek, Result as ParserResult, T, pseudo_class};
-use csskit_derives::{SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 macro_rules! apply_pseudo_element {
 	($macro: ident) => {

--- a/crates/css_ast/src/selector/tag.rs
+++ b/crates/css_ast/src/selector/tag.rs
@@ -1,8 +1,10 @@
 use crate::CssAtomSet;
 use css_parse::{Cursor, Diagnostic, Kind, KindSet, Parse, Parser, Peek, Result, T};
-use csskit_derives::{IntoCursor, Parse, Peek, ToCursors};
+use csskit_derives::*;
 
-#[derive(Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 pub enum Tag {
@@ -44,7 +46,7 @@ impl css_parse::NodeWithMetadata<crate::CssMetadata> for Tag {
 	}
 }
 
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -129,7 +131,9 @@ impl<'a> Parse<'a> for CustomElementTag {
 }
 
 /// <https://html.spec.whatwg.org/multipage/indices.html#elements-3>
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -361,7 +365,9 @@ pub enum HtmlTag {
 }
 
 /// <https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features>
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -427,7 +433,9 @@ pub enum HtmlNonConformingTag {
 	Xmp(T![Ident]),
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -448,7 +456,9 @@ pub enum HtmlNonStandardTag {
 }
 
 /// <https://svgwg.org/svg2-draft/eltindex.html>
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -584,7 +594,9 @@ pub enum SvgTag {
 }
 
 /// <https://w3c.github.io/mathml/#mmlindex_elements>
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -907,7 +919,9 @@ pub enum MathmlTag {
 	Xo(T![Ident]),
 }
 
-#[derive(ToCursors, Parse, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	ToCursors, Parse, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/selector/webkit.rs
+++ b/crates/css_ast/src/selector/webkit.rs
@@ -1,6 +1,6 @@
 use crate::{CompoundSelector, CssAtomSet, CssDiagnostic};
 use css_parse::{Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T, pseudo_class, pseudo_element};
-use csskit_derives::{SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 pseudo_element!(
 	/// <https://searchfox.org/wubkat/source/Source/WebCore/css/CSSPseudoSelectors.json>

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -6,7 +6,7 @@ use css_parse::{
 	BumpBox, Cursor, DeclarationGroup, Diagnostic, NodeMetadata, NodeWithMetadata, Parse, Parser, QualifiedRule,
 	Result as ParserResult, RuleVariants,
 };
-use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 /// Represents a "Style Rule", such as `body { width: 100% }`. See also the CSS-OM [CSSStyleRule][1] interface.
 ///

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -4,7 +4,7 @@ use css_parse::{
 	BumpBox, ComponentValues, Cursor, Diagnostic, NodeWithMetadata, Parse, Parser, QualifiedRule,
 	Result as ParserResult, RuleVariants, StyleSheet as StyleSheetTrait, T, UnknownRuleBlock,
 };
-use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 /// <https://drafts.csswg.org/cssom-1/#the-cssstylesheet-interface>
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/types/absolute_size.rs
+++ b/crates/css_ast/src/types/absolute_size.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <absolute-size> = [ xx-small | x-small | small | medium | large | x-large | xx-large ]
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/anchor_name.rs
+++ b/crates/css_ast/src/types/anchor_name.rs
@@ -6,7 +6,9 @@ use super::prelude::*;
 /// <anchor-name> = <dashed-ident>
 /// ```
 #[syntax("<dashed-ident>")]
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/animateable_feature.rs
+++ b/crates/css_ast/src/types/animateable_feature.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <animateable-feature> = scroll-position | contents | <custom-ident>
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/animation_action.rs
+++ b/crates/css_ast/src/types/animation_action.rs
@@ -1,7 +1,9 @@
 use super::prelude::*;
 
 /// <https://drafts.csswg.org/css-animations-2/#typedef-animation-action>
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/attachment.rs
+++ b/crates/css_ast/src/types/attachment.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <attachment> = scroll | fixed | local
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/auto_or.rs
+++ b/crates/css_ast/src/types/auto_or.rs
@@ -3,7 +3,9 @@ use crate::CssMetadata;
 use css_parse::NodeWithMetadata;
 use css_parse::token_macros::Ident;
 
-#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub enum AutoOr<T> {
@@ -32,19 +34,6 @@ impl<T: ToNumberValue> ToNumberValue for AutoOr<T> {
 }
 
 impl<T: Copy> Copy for AutoOr<T> {}
-
-impl<T> From<AutoOr<T>> for Cursor
-where
-	T: Copy,
-	Cursor: From<T>,
-{
-	fn from(value: AutoOr<T>) -> Self {
-		match value {
-			AutoOr::Auto(ident) => ident.into(),
-			AutoOr::Some(t) => t.into(),
-		}
-	}
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/autonone_or.rs
+++ b/crates/css_ast/src/types/autonone_or.rs
@@ -3,7 +3,9 @@ use crate::CssMetadata;
 use css_parse::NodeWithMetadata;
 use css_parse::token_macros::Ident;
 
-#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub enum AutoNoneOr<T> {
@@ -36,20 +38,6 @@ impl<T: ToNumberValue> ToNumberValue for AutoNoneOr<T> {
 }
 
 impl<T: Copy> Copy for AutoNoneOr<T> {}
-
-impl<T> From<AutoNoneOr<T>> for Cursor
-where
-	T: Copy,
-	Cursor: From<T>,
-{
-	fn from(value: AutoNoneOr<T>) -> Self {
-		match value {
-			AutoNoneOr::Auto(ident) => ident.into(),
-			AutoNoneOr::None(ident) => ident.into(),
-			AutoNoneOr::Some(t) => t.into(),
-		}
-	}
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/baseline_metric.rs
+++ b/crates/css_ast/src/types/baseline_metric.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <baseline-metric> = text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/baseline_position.rs
+++ b/crates/css_ast/src/types/baseline_position.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <baseline-position> = [ first | last ]? && baseline
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/bg_clip.rs
+++ b/crates/css_ast/src/types/bg_clip.rs
@@ -7,7 +7,9 @@ use super::prelude::*;
 /// <bg-clip> = <visual-box> | border-area | text
 /// <visual-box> = <visual-box> | margin-box
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/blend_mode.rs
+++ b/crates/css_ast/src/types/blend_mode.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <blend-mode> = darken | multiply | color-burn | lighten | screen | color-dodge | overlay | soft-light | hard-light | difference | exclusion | hue | saturation | color | luminosity
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/color/mod.rs
+++ b/crates/css_ast/src/types/color/mod.rs
@@ -3,7 +3,7 @@ mod system;
 
 use crate::{ColorFunction, CssAtomSet};
 use css_parse::{BumpBox, T};
-use csskit_derives::{NodeWithMetadata, Parse, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 pub use named::*;
 pub use system::*;

--- a/crates/css_ast/src/types/color/system.rs
+++ b/crates/css_ast/src/types/color/system.rs
@@ -1,6 +1,6 @@
 use crate::CssAtomSet;
 use css_parse::T;
-use csskit_derives::{Parse, Peek, SemanticEq, ToCursors, ToSpan};
+use csskit_derives::*;
 
 #[derive(Peek, Parse, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/types/common_lig_values.rs
+++ b/crates/css_ast/src/types/common_lig_values.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <common-lig-values> = [ common-ligatures | no-common-ligatures ]
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/compositing_operator.rs
+++ b/crates/css_ast/src/types/compositing_operator.rs
@@ -7,7 +7,9 @@ use super::prelude::*;
 ///   destination-in | source-out | destination-out | source-atop | destination-atop |
 ///   xor | lighter | add
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/content_distribution.rs
+++ b/crates/css_ast/src/types/content_distribution.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <content-distribution> = space-between | space-around | space-evenly | stretch
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/content_position.rs
+++ b/crates/css_ast/src/types/content_position.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <content-position> = center | start | end | flex-start | flex-end
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/contextual_alt_values.rs
+++ b/crates/css_ast/src/types/contextual_alt_values.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <contextual-alt-values> = [ contextual | no-contextual ]
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/counter_name.rs
+++ b/crates/css_ast/src/types/counter_name.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <counter-name> = <custom-ident>
 /// ```
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/custom_ident.rs
+++ b/crates/css_ast/src/types/custom_ident.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 ///
 /// Wraps `T![Ident]`, but exists for the purposes of Visitable/VisitableMut.
 /// Excludes CSS-wide keywords: `initial`, `inherit`, `unset`, `revert`, `revert-layer`, `default`.
-#[derive(IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/dashed_ident.rs
+++ b/crates/css_ast/src/types/dashed_ident.rs
@@ -3,7 +3,9 @@ use super::prelude::*;
 /// <https://drafts.csswg.org/css-values/#dashed-idents>
 ///
 /// Wraps `T![DashedIdent]`, but exists for the purposes of Visitable/VisitableMut.
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/discretionary_lig_values.rs
+++ b/crates/css_ast/src/types/discretionary_lig_values.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <discretionary-lig-values> = [ discretionary-ligatures | no-discretionary-ligatures ]
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/display_box.rs
+++ b/crates/css_ast/src/types/display_box.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <display-box> = contents | none
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DisplayBox {

--- a/crates/css_ast/src/types/display_inside.rs
+++ b/crates/css_ast/src/types/display_inside.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <display-inside> = flow | flow-root | table | flex | grid | ruby
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/display_internal.rs
+++ b/crates/css_ast/src/types/display_internal.rs
@@ -9,7 +9,9 @@ use super::prelude::*;
 ///           ruby-base | ruby-text | ruby-base-container |
 ///           ruby-text-container
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DisplayInternal {

--- a/crates/css_ast/src/types/display_legacy.rs
+++ b/crates/css_ast/src/types/display_legacy.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <display-box> = inline-block | inline-table | inline-flex | inline-grid
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DisplayLegacy {

--- a/crates/css_ast/src/types/display_legacy_vendor.rs
+++ b/crates/css_ast/src/types/display_legacy_vendor.rs
@@ -11,7 +11,9 @@ use super::prelude::*;
 ///                         | -ms-flex | -ms-inline-flex | -ms-flexbox | -ms-inline-flexbox | -ms-grid
 ///                         | -o-flex
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DisplayLegacyVendor {

--- a/crates/css_ast/src/types/display_listitem.rs
+++ b/crates/css_ast/src/types/display_listitem.rs
@@ -37,7 +37,9 @@ impl<'a> Parse<'a> for DisplayListitem {
 	}
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum DisplayListitemInside {

--- a/crates/css_ast/src/types/display_outside.rs
+++ b/crates/css_ast/src/types/display_outside.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <display-outside>  = block | inline | run-in
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/east_asian_variant_values.rs
+++ b/crates/css_ast/src/types/east_asian_variant_values.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <east-asian-variant-values> = [ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/east_asian_width_values.rs
+++ b/crates/css_ast/src/types/east_asian_width_values.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <east-asian-width-values> = [ full-width | proportional-width ]
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/feature_tag_value.rs
+++ b/crates/css_ast/src/types/feature_tag_value.rs
@@ -13,7 +13,9 @@ use crate::{CSSInt, NonNegative, OpentypeTag};
 pub struct FeatureTagValue(pub OpentypeTag, pub Option<FeatureTagToggle>);
 
 /// The optional value for a feature tag: `<integer [0,∞]> | on | off`
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub enum FeatureTagToggle {

--- a/crates/css_ast/src/types/font_weight_absolute.rs
+++ b/crates/css_ast/src/types/font_weight_absolute.rs
@@ -6,7 +6,9 @@ use super::prelude::*;
 /// <font-weight-absolute> = [normal | bold | <number [1,1000]>]
 /// ```
 #[syntax(" normal | bold | <number [1,1000]> ")]
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/historical_lig_values.rs
+++ b/crates/css_ast/src/types/historical_lig_values.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <historical-lig-values> = [ historical-ligatures | no-historical-ligatures ]
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/inset_value.rs
+++ b/crates/css_ast/src/types/inset_value.rs
@@ -6,7 +6,9 @@ use crate::LengthPercentage;
 /// ```text,ignore
 /// <inset-value> = <length-percentage> | overlap-join
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/isolation_mode.rs
+++ b/crates/css_ast/src/types/isolation_mode.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <isolation-mode> = [ auto | isolate ]
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/line_style.rs
+++ b/crates/css_ast/src/types/line_style.rs
@@ -1,6 +1,8 @@
 use super::prelude::*;
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/masking_mode.rs
+++ b/crates/css_ast/src/types/masking_mode.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <masking-mode> = alpha | luminance | match-source
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/mod.rs
+++ b/crates/css_ast/src/types/mod.rs
@@ -264,7 +264,7 @@ mod prelude {
 	pub(crate) use css_parse::{
 		Cursor, Diagnostic, Kind, KindSet, Parse, Parser, Peek, Result as ParserResult, T, ToNumberValue,
 	};
-	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, SemanticEq, ToCursors, ToSpan};
+	pub(crate) use csskit_derives::*;
 	pub(crate) use csskit_proc_macro::syntax;
 }
 

--- a/crates/css_ast/src/types/none_or.rs
+++ b/crates/css_ast/src/types/none_or.rs
@@ -3,7 +3,9 @@ use crate::CssMetadata;
 use css_parse::NodeWithMetadata;
 use css_parse::token_macros::Ident;
 
-#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub enum NoneOr<T> {
@@ -32,19 +34,6 @@ impl<T: ToNumberValue> ToNumberValue for NoneOr<T> {
 }
 
 impl<T: Copy> Copy for NoneOr<T> {}
-
-impl<T> From<NoneOr<T>> for Cursor
-where
-	T: Copy,
-	Cursor: From<T>,
-{
-	fn from(value: NoneOr<T>) -> Self {
-		match value {
-			NoneOr::None(ident) => ident.into(),
-			NoneOr::Some(t) => t.into(),
-		}
-	}
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/normal_or.rs
+++ b/crates/css_ast/src/types/normal_or.rs
@@ -3,7 +3,9 @@ use crate::CssMetadata;
 use css_parse::NodeWithMetadata;
 use css_parse::token_macros::Ident;
 
-#[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable))]
 pub enum NormalOr<T> {
@@ -23,19 +25,6 @@ impl<T: NodeWithMetadata<CssMetadata>> NodeWithMetadata<CssMetadata> for NormalO
 }
 
 impl<T: Copy> Copy for NormalOr<T> {}
-
-impl<T> From<NormalOr<T>> for Cursor
-where
-	T: Copy,
-	Cursor: From<T>,
-{
-	fn from(value: NormalOr<T>) -> Self {
-		match value {
-			NormalOr::Normal(ident) => ident.into(),
-			NormalOr::Some(t) => t.into(),
-		}
-	}
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/types/numeric_figure_values.rs
+++ b/crates/css_ast/src/types/numeric_figure_values.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <numeric-figure-values> = [ lining-nums | oldstyle-nums ]
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/numeric_fraction_values.rs
+++ b/crates/css_ast/src/types/numeric_fraction_values.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <numeric-fraction-values> = [ diagonal-fractions | stacked-fractions ]
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/numeric_spacing_values.rs
+++ b/crates/css_ast/src/types/numeric_spacing_values.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <numeric-spacing-values> = [ proportional-nums | tabular-nums ]
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/opacity_value.rs
+++ b/crates/css_ast/src/types/opacity_value.rs
@@ -1,7 +1,9 @@
 use super::prelude::*;
 use crate::Percentage;
 
-#[derive(IntoCursor, Peek, Parse, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Peek, Parse, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/opentype_tag.rs
+++ b/crates/css_ast/src/types/opentype_tag.rs
@@ -6,7 +6,7 @@ use super::prelude::*;
 /// exactly 4 ASCII characters (U+20-7E).
 ///
 /// Wraps `T![String]` for parsing purposes.
-#[derive(IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/overflow_position.rs
+++ b/crates/css_ast/src/types/overflow_position.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <overflow-position> = unsafe | safe
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/position.rs
+++ b/crates/css_ast/src/types/position.rs
@@ -57,7 +57,9 @@ impl<'a> Parse<'a> for Position {
 ///   <length-percentage>
 /// ]
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/position_area.rs
+++ b/crates/css_ast/src/types/position_area.rs
@@ -95,7 +95,9 @@ impl<'a> Parse<'a> for PositionArea {
 	}
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionAreaPhsyicalHorizontal {
 	#[atom(CssAtomSet::Left)]
@@ -128,7 +130,9 @@ pub enum PositionAreaPhsyicalHorizontal {
 	SpanAll(T![Ident]),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionAreaPhsyicalVertical {
 	#[atom(CssAtomSet::Top)]
@@ -161,7 +165,9 @@ pub enum PositionAreaPhsyicalVertical {
 	SpanAll(T![Ident]),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionAreaBlock {
 	#[atom(CssAtomSet::BlockStart)]
@@ -178,7 +184,9 @@ pub enum PositionAreaBlock {
 	SpanAll(T![Ident]),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionAreaInline {
 	#[atom(CssAtomSet::InlineStart)]
@@ -195,7 +203,9 @@ pub enum PositionAreaInline {
 	SpanAll(T![Ident]),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionAreaSelfBlock {
 	#[atom(CssAtomSet::SelfBlockStart)]
@@ -212,7 +222,9 @@ pub enum PositionAreaSelfBlock {
 	SpanAll(T![Ident]),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionAreaSelfInline {
 	#[atom(CssAtomSet::SelfInlineStart)]
@@ -229,7 +241,9 @@ pub enum PositionAreaSelfInline {
 	SpanAll(T![Ident]),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionAreaPosition {
 	#[atom(CssAtomSet::Start)]
@@ -246,7 +260,9 @@ pub enum PositionAreaPosition {
 	SpanAll(T![Ident]),
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PositionAreaSelfPosition {
 	#[atom(CssAtomSet::SelfStart)]

--- a/crates/css_ast/src/types/quote.rs
+++ b/crates/css_ast/src/types/quote.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <quote> = open-quote | close-quote | no-open-quote | no-close-quote
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/relative_size.rs
+++ b/crates/css_ast/src/types/relative_size.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <relative-size> = larger | smaller
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/repeat_style.rs
+++ b/crates/css_ast/src/types/repeat_style.rs
@@ -22,7 +22,9 @@ pub enum RepeatStyle {
 /// ```text,ignore
 /// <repetition> = repeat | space | round | no-repeat
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/self_position.rs
+++ b/crates/css_ast/src/types/self_position.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <self-position> = center | start | end | self-start | self-end | flex-start | flex-end
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/single_animation_composition.rs
+++ b/crates/css_ast/src/types/single_animation_composition.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-composition> = replace | add | accumulate
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/single_animation_direction.rs
+++ b/crates/css_ast/src/types/single_animation_direction.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-direction> = normal | reverse | alternate | alternate-reverse
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/single_animation_fill_mode.rs
+++ b/crates/css_ast/src/types/single_animation_fill_mode.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-fill-mode> = none | forwards | backwards | both
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/single_animation_iteration_count.rs
+++ b/crates/css_ast/src/types/single_animation_iteration_count.rs
@@ -6,7 +6,9 @@ use crate::NonNegative;
 /// ```text,ignore
 /// <single-animation-iteration-count> = infinite | <number [0,∞]>
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/single_animation_play_state.rs
+++ b/crates/css_ast/src/types/single_animation_play_state.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-play-state> = running | paused
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/single_animation_timeline.rs
+++ b/crates/css_ast/src/types/single_animation_timeline.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-timeline> = auto | none | <dashed-ident> | <scroll()> | <view()>
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/single_animation_trigger_behavior.rs
+++ b/crates/css_ast/src/types/single_animation_trigger_behavior.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <single-animation-trigger-behavior> = once | repeat | alternate | state
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/spacing_trim.rs
+++ b/crates/css_ast/src/types/spacing_trim.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <spacing-trim> = space-all | normal | space-first | trim-start | trim-both | trim-all
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/timeline_range_name.rs
+++ b/crates/css_ast/src/types/timeline_range_name.rs
@@ -6,7 +6,9 @@ use super::prelude::*;
 /// <timeline-range-name> = cover | contain | entry | exit | entry-crossing | exit-crossing | scroll
 /// ```
 #[syntax(" cover | contain | entry | exit | entry-crossing | exit-crossing | scroll ")]
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/try_size.rs
+++ b/crates/css_ast/src/types/try_size.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <try-size> = most-width | most-height | most-block-size | most-inline-size
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/types/visual_box.rs
+++ b/crates/css_ast/src/types/visual_box.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <visual-box> = content-box | padding-box | border-box
 /// ```
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <angle> = <dimension-token>
 /// ```
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.types.angle"))]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
@@ -54,7 +56,9 @@ impl Angle {
 	}
 }
 
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -64,7 +68,9 @@ pub enum AngleOrZero {
 	Zero(Exact<T![Number], 0>),
 }
 
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/units/custom.rs
+++ b/crates/css_ast/src/units/custom.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct CustomDimension(T![Dimension]);
 

--- a/crates/css_ast/src/units/decibel.rs
+++ b/crates/css_ast/src/units/decibel.rs
@@ -1,6 +1,8 @@
 use super::prelude::*;
 
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/units/flex.rs
+++ b/crates/css_ast/src/units/flex.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <flex> = <dimension-token>
 /// ```
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/units/float.rs
+++ b/crates/css_ast/src/units/float.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-#[derive(ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 pub struct CSSFloat(T![Number]);

--- a/crates/css_ast/src/units/frequency.rs
+++ b/crates/css_ast/src/units/frequency.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <frequency> = <dimension-token>
 /// ```
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum Frequency {
 	#[atom(CssAtomSet::Hz)]

--- a/crates/css_ast/src/units/int.rs
+++ b/crates/css_ast/src/units/int.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-#[derive(IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -66,7 +66,7 @@ macro_rules! apply_lengths {
 
 macro_rules! define_length {
 	( $($name: ident),+ $(,)* ) => {
-		#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+		#[derive(Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 		#[derive(csskit_derives::NodeWithMetadata)]
@@ -131,7 +131,9 @@ impl ToNumberValue for Length {
 	}
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -159,7 +161,9 @@ impl ToNumberValue for LengthPercentage {
 	}
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -187,7 +191,9 @@ impl ToNumberValue for LengthPercentageNumber {
 	}
 }
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -211,7 +217,9 @@ impl ToNumberValue for LengthPercentageOrFlex {
 	}
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/units/line_width.rs
+++ b/crates/css_ast/src/units/line_width.rs
@@ -2,7 +2,9 @@ use super::prelude::*;
 
 use super::Length;
 
-#[derive(Parse, Peek, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/units/mod.rs
+++ b/crates/css_ast/src/units/mod.rs
@@ -31,7 +31,7 @@ mod prelude {
 	pub(crate) use css_parse::{
 		Cursor, Diagnostic, Kind, KindSet, Parse, Parser, Peek, Result as ParserResult, T, ToNumberValue,
 	};
-	pub(crate) use csskit_derives::{IntoCursor, Parse, Peek, ToCursors};
+	pub(crate) use csskit_derives::*;
 }
 
 pub trait AbsoluteUnit {

--- a/crates/css_ast/src/units/number.rs
+++ b/crates/css_ast/src/units/number.rs
@@ -1,7 +1,9 @@
 use super::prelude::*;
 use crate::Percentage;
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NumberOrInfinity {
 	Number(T![Number]),
@@ -11,7 +13,9 @@ pub enum NumberOrInfinity {
 	NegInfinity(T![Ident]),
 }
 
-#[derive(Parse, Peek, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NumberOrPercentage {
 	Number(T![Number]),

--- a/crates/css_ast/src/units/percentage.rs
+++ b/crates/css_ast/src/units/percentage.rs
@@ -1,6 +1,8 @@
 use super::prelude::*;
 
-#[derive(Peek, Parse, IntoCursor, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Peek, Parse, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
@@ -31,7 +33,9 @@ impl ToNumberValue for Percentage {
 	}
 }
 
-#[derive(Peek, Parse, ToCursors, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	Peek, Parse, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/units/resolution.rs
+++ b/crates/css_ast/src/units/resolution.rs
@@ -8,7 +8,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <resolution> = <dimension-token>
 /// ```
-#[derive(ToCursors, Parse, Peek, IntoCursor, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	ToCursors, Parse, Peek, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -5,7 +5,9 @@ use super::prelude::*;
 /// ```text,ignore
 /// <time> = <dimension-token>
 /// ```
-#[derive(IntoCursor, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+	IntoCursor, ToSpan, SemanticEq, Parse, Peek, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]

--- a/crates/csskit_derives/src/into_cursor.rs
+++ b/crates/csskit_derives/src/into_cursor.rs
@@ -1,11 +1,32 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Result};
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Result, parse_quote};
+
+use crate::WhereCollector;
 
 pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let ident = input.ident;
-	let generics = &mut input.generics.clone();
-	let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
+	let generics = &input.generics;
+	let (impl_generics, type_generics, _) = generics.split_for_impl();
+
+	let mut wc = WhereCollector::new();
+	match &input.data {
+		Data::Struct(DataStruct { fields, .. }) => {
+			for field in fields {
+				wc.add(&field.ty);
+			}
+		}
+		Data::Enum(DataEnum { variants, .. }) => {
+			for variant in variants {
+				for field in &variant.fields {
+					wc.add(&field.ty);
+				}
+			}
+		}
+		Data::Union(_) => {}
+	}
+	let where_clause = wc.extend_where_clause(generics, parse_quote! { Into<::css_parse::Cursor> });
+
 	let body = match input.data {
 		Data::Union(_) => return Err(Error::new(ident.span(), "Cannot derive Into<Cursor> on a Union")),
 
@@ -37,32 +58,19 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 			}
 		}
 	};
+
 	Ok(quote! {
 		#[automatically_derived]
 		impl #impl_generics From<#ident #type_generics> for ::css_parse::Cursor #where_clause {
-			fn from(value: #ident) -> ::css_parse::Cursor {
+			fn from(value: #ident #type_generics) -> ::css_parse::Cursor {
 				#body
 			}
 		}
 
 		#[automatically_derived]
 		impl #impl_generics From<#ident #type_generics> for ::css_parse::Token #where_clause {
-			fn from(value: #ident) -> ::css_parse::Token {
-				Cursor::from(value).token()
-			}
-		}
-
-		#[automatically_derived]
-		impl #impl_generics ::css_parse::ToSpan for #ident #type_generics #where_clause {
-			fn to_span(&self) -> ::css_parse::Span {
-				Cursor::from(*self).span()
-			}
-		}
-
-		#[automatically_derived]
-		impl #impl_generics ::css_parse::SemanticEq for #ident #type_generics #where_clause {
-			fn semantic_eq(&self, other: &Self) -> bool  {
-				Cursor::from(*self).semantic_eq(&Cursor::from(*other))
+			fn from(value: #ident #type_generics) -> ::css_parse::Token {
+				::css_parse::Cursor::from(value).token()
 			}
 		}
 	})


### PR DESCRIPTION
Currently derive(IntoCursor) is one of the only derives that doesn't work on
generics, which means generic impls have to be manual. This shouldn't be the
case, as it would be easy to make these generics use derive. The one downside is
that generics don't necessarily want to impl ToSpan/SemanticEq the same way as
they won't strictly guarantee that the generic type impls Into<Cursor> (i.e.
we'd want to delegate to T::SemanticEq, not T::into::<Cursor>().semantic_eq()).

So this change drops the ToSpan/SemanticEq auto-derives from IntoCursor and
makes the derive work on generics. The downside is this means a lot of new
derive(ToSpan, SemanticEq) on types which had this for free, but the upside is
a lot of derive(IntoCursor) on generics! A net win!
