### PR TITLE
Release v0.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## [0.0.26] - 2026-06-20
+
+### Other Changes
+- Chore(deps): update dependencies to v1.48.0 (#1227) ([#1227](https://github.com/csskit/csskit/pull/1227))
+
+
+### Css_ast
+- Regenerate css_ast/src/values from csswg drafts (#1221) ([#1221](https://github.com/csskit/csskit/pull/1221))
+- fuzz(css_parse): Mark more erroneous tokens in blocks as trivia. (#1225) ([#1225](https://github.com/csskit/csskit/pull/1225))
+
+
+### Css_lexer
+- fuzz(css_lex): avoid buffer overflows with SmallStr buffer (#1220) ([#1220](https://github.com/csskit/csskit/pull/1220))
+
+
+### Css_parse
+- fuzz(css_parse): consume `Bad` tokens as trivia in blocks. (#1228) ([#1228](https://github.com/csskit/csskit/pull/1228))
+
+
+### Csskit
+- chore(deps): update dependencies (patch) (#1222) ([#1222](https://github.com/csskit/csskit/pull/1222))
+- csskit_wasm/csskit(node): Provide csskit library functions in csskit package (#1234) ([#1234](https://github.com/csskit/csskit/pull/1234))
+- csskit(node): manage wasm-opt with mise (#1235) ([#1235](https://github.com/csskit/csskit/pull/1235))
+- csskit(node): Move build script to Mise (#1237) ([#1237](https://github.com/csskit/csskit/pull/1237))
+
 ## [0.0.25] - 2026-06-13
 
 ### Other Changes
@@ -30,6 +55,7 @@
 ### Csskit
 - csskit: improve json output for subcommands (#1182) ([#1182](https://github.com/csskit/csskit/pull/1182))
 - chore(deps): update dependencies (patch) (#1185) ([#1185](https://github.com/csskit/csskit/pull/1185))
+- Release v0.0.25 (#1181) ([#1181](https://github.com/csskit/csskit/pull/1181))
 
 
 ### Csskit_derives

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chromashift"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "anstyle",
  "owo-colors",
@@ -690,7 +690,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "css_ast"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "css_feature_data"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "browserslist-rs",
  "chrono",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "css_lexer"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "allocator-api2",
  "bitmask-enum",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "css_parse"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "css_value_definition_parser"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "css_lexer",
  "heck",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "csskit"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "anstyle",
  "bumpalo",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_ast"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_derives"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "darling",
  "heck",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_highlight"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "anstyle",
  "bitmask-enum",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_lsp"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_proc_macro"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "css_lexer",
  "css_value_definition_parser",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_source_finder"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "glob",
  "grep-matcher",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_spec_generator"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "anyhow",
  "clap",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_transform"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "bitmask-enum",
  "bumpalo",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "csskit_wasm"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "bumpalo",
  "console_error_panic_hook",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "derive_atom_set"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "heck",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 exclude = ["packages/csskit_zed"]
 
 [workspace.package]
-version = "0.0.25"  # @release
+version = "0.0.26"  # @release
 authors = ["Keith Cirkel (https://keithcirkel.co.uk)"]
 edition = "2024"
 description = "Refreshing CSS!"
@@ -14,23 +14,23 @@ license = "MIT"
 keywords = ["CSS", "parser"]
 
 [workspace.dependencies]
-chromashift = { path = "crates/chromashift", version = "0.0.25" }  # @release
-css_ast = { path = "crates/css_ast", version = "0.0.25" }  # @release
-css_feature_data = { path = "crates/css_feature_data", version = "0.0.25" }  # @release
-css_lexer = { path = "crates/css_lexer", version = "0.0.25" }  # @release
-css_parse = { path = "crates/css_parse", version = "0.0.25" }  # @release
-css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.25" }  # @release
+chromashift = { path = "crates/chromashift", version = "0.0.26" }  # @release
+css_ast = { path = "crates/css_ast", version = "0.0.26" }  # @release
+css_feature_data = { path = "crates/css_feature_data", version = "0.0.26" }  # @release
+css_lexer = { path = "crates/css_lexer", version = "0.0.26" }  # @release
+css_parse = { path = "crates/css_parse", version = "0.0.26" }  # @release
+css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.26" }  # @release
 # Local packages
-csskit = { path = "crates/csskit", version = "0.0.25" }  # @release
-csskit_ast = { path = "crates/csskit_ast", version = "0.0.25" }  # @release
-csskit_derives = { path = "crates/csskit_derives", version = "0.0.25" }  # @release
-csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.25" }  # @release
-csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.25" }  # @release
-csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.25" }  # @release
-csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.25" }  # @release
+csskit = { path = "crates/csskit", version = "0.0.26" }  # @release
+csskit_ast = { path = "crates/csskit_ast", version = "0.0.26" }  # @release
+csskit_derives = { path = "crates/csskit_derives", version = "0.0.26" }  # @release
+csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.26" }  # @release
+csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.26" }  # @release
+csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.26" }  # @release
+csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.26" }  # @release
 csskit_spec_generator = { path = "crates/csskit_spec_generator", version = "0.0.0" }
-csskit_transform = { path = "crates/csskit_transform", version = "0.0.25" }  # @release
-derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.25" }  # @release
+csskit_transform = { path = "crates/csskit_transform", version = "0.0.26" }  # @release
+derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.26" }  # @release
 
 # Memory
 allocator-api2 = { version = "0.2.21" }  # Held back for bumpalo (https://github.com/fitzgen/bumpalo/pull/288)

--- a/packages/csskit-darwin-arm64/package.json
+++ b/packages/csskit-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-arm64",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "description": "Refreshing CSS - macOS arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-darwin-x64/package.json
+++ b/packages/csskit-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-x64",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "description": "Refreshing CSS - macOS x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-arm64/package.json
+++ b/packages/csskit-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-arm64",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "description": "Refreshing CSS - Linux arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-x64/package.json
+++ b/packages/csskit-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-x64",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "description": "Refreshing CSS - Linux x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-arm64/package.json
+++ b/packages/csskit-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-arm64",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "description": "Refreshing CSS - Windows arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-x64/package.json
+++ b/packages/csskit-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-x64",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "description": "Refreshing CSS - Windows x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit/package-lock.json
+++ b/packages/csskit/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "csskit",
-    "version": "0.0.25",
+    "version": "0.0.26",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "csskit",
-            "version": "0.0.25",
+            "version": "0.0.26",
             "license": "MIT",
             "bin": {
                 "csskit": "bin/csskit"

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "csskit",
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"description": "Refreshing CSS",
 	"keywords": [],
 	"repository": "https://github.com/csskit/csskit",
@@ -25,13 +25,13 @@
 		"./csskit_wasm_bg.wasm.d.ts",
 		"./bundle"
 	],
-    "optionalDependencies": {
-		"csskit-darwin-arm64": "0.0.25",
-		"csskit-darwin-x64": "0.0.25",
-		"csskit-linux-arm64": "0.0.25",
-		"csskit-linux-x64": "0.0.25",
-		"csskit-win32-arm64": "0.0.25",
-		"csskit-win32-x64": "0.0.25"
+	"optionalDependencies": {
+		"csskit-darwin-arm64": "0.0.26",
+		"csskit-darwin-x64": "0.0.26",
+		"csskit-linux-arm64": "0.0.26",
+		"csskit-linux-x64": "0.0.26",
+		"csskit-win32-arm64": "0.0.26",
+		"csskit-win32-x64": "0.0.26"
 	},
 	"allowScripts": {
 		"wasm-opt@1.4.0": true


### PR DESCRIPTION
## [0.0.26] - 2026-06-20

### Other Changes
- Chore(deps): update dependencies to v1.48.0 (#1227) ([#1227](https://github.com/csskit/csskit/pull/1227))


### Css_ast
- Regenerate css_ast/src/values from csswg drafts (#1221) ([#1221](https://github.com/csskit/csskit/pull/1221))
- fuzz(css_parse): Mark more erroneous tokens in blocks as trivia. (#1225) ([#1225](https://github.com/csskit/csskit/pull/1225))


### Css_lexer
- fuzz(css_lex): avoid buffer overflows with SmallStr buffer (#1220) ([#1220](https://github.com/csskit/csskit/pull/1220))


### Css_parse
- fuzz(css_parse): consume `Bad` tokens as trivia in blocks. (#1228) ([#1228](https://github.com/csskit/csskit/pull/1228))


### Csskit
- chore(deps): update dependencies (patch) (#1222) ([#1222](https://github.com/csskit/csskit/pull/1222))
- csskit_wasm/csskit(node): Provide csskit library functions in csskit package (#1234) ([#1234](https://github.com/csskit/csskit/pull/1234))
- csskit(node): manage wasm-opt with mise (#1235) ([#1235](https://github.com/csskit/csskit/pull/1235))
- csskit(node): Move build script to Mise (#1237) ([#1237](https://github.com/csskit/csskit/pull/1237))