### PR TITLE
csskit_wasm/csskit(node): Provide csskit library functions in csskit package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,8 +140,15 @@ jobs:
       - name: Print packages/ tree
         run: tree packages/
 
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Install Dependencies
         run: npm i
+        working-directory: ./packages/csskit
+
+      - name: Build wasm
+        run: npm run build
         working-directory: ./packages/csskit
 
       - name: Release

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ website/_site
 *.vsix
 packages/csskit_vscode/dist/
 packages/csskit-*/bin/csskit
+packages/csskit/index.*
+packages/csskit/csskit_wasm_bg.wasm*
+packages/csskit/bundle/
+packages/csskit/node_modules/

--- a/crates/csskit_wasm/src/lib.rs
+++ b/crates/csskit_wasm/src/lib.rs
@@ -7,7 +7,7 @@ use css_parse::{
 	CursorCompactWriteSink, CursorOverlaySink, CursorPrettyWriteSink, Diagnostic, DiagnosticMeta, Parser, ToCursors,
 };
 use csskit_transform::{CssMinifierFeature, Transformer};
-#[cfg(not(feature = "fancy"))]
+#[cfg(all(feature = "miette", not(feature = "fancy")))]
 use miette::JSONReportHandler;
 #[cfg(feature = "fancy")]
 use miette::{GraphicalReportHandler, GraphicalTheme};
@@ -94,9 +94,9 @@ pub fn minify(source_text: String) -> Result<String, serde_wasm_bindgen::Error> 
 pub fn format(source_text: String, options: JsValue) -> Result<String, serde_wasm_bindgen::Error> {
 	let options: FormatOptions = match serde_wasm_bindgen::from_value(options) {
 		Ok(opts) => opts,
-		Err(e) => {
+		Err(_e) => {
 			#[cfg(feature = "console_error_panic_hook")]
-			web_sys::console::warn_1(&format!("Failed to parse format options: {}. Using defaults.", e).into());
+			web_sys::console::warn_1(&format!("Failed to parse format options: {}. Using defaults.", _e).into());
 			FormatOptions::default()
 		}
 	};

--- a/packages/csskit/package-lock.json
+++ b/packages/csskit/package-lock.json
@@ -8,16 +8,11 @@
             "name": "csskit",
             "version": "0.0.25",
             "license": "MIT",
-            "dependencies": {
-                "csskit-darwin-arm64": "^0.0.25",
-                "csskit-darwin-x64": "^0.0.25",
-                "csskit-linux-arm64": "^0.0.25",
-                "csskit-linux-x64": "^0.0.25",
-                "csskit-win32-arm64": "^0.0.25",
-                "csskit-win32-x64": "^0.0.25"
-            },
             "bin": {
                 "csskit": "bin/csskit"
+            },
+            "devDependencies": {
+                "wasm-opt": "1.4.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/keithamus"
@@ -29,6 +24,16 @@
                 "csskit-linux-x64": "0.0.25",
                 "csskit-win32-arm64": "0.0.25",
                 "csskit-win32-x64": "0.0.25"
+            }
+        },
+        "node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/csskit-darwin-arm64": {
@@ -144,6 +149,169 @@
             "funding": {
                 "url": "https://github.com/sponsors/keithamus"
             }
+        },
+        "node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/fs-minipass/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tar": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+            "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^5.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/wasm-opt": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/wasm-opt/-/wasm-opt-1.4.0.tgz",
+            "integrity": "sha512-wIsxxp0/FOSphokH4VOONy1zPkVREQfALN+/JTvJPK8gFSKbsmrcfECu2hT7OowqPfb4WEMSMceHgNL0ipFRyw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-fetch": "^2.6.9",
+                "tar": "^6.1.13"
+            },
+            "bin": {
+                "wasm-opt": "bin/wasm-opt.js"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
+            "license": "ISC"
         }
     }
 }

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -1,24 +1,45 @@
 {
-    "name": "csskit",
-    "version": "0.0.25",
-    "description": "Refreshing CSS",
-    "keywords": [],
-    "license": "MIT",
-    "author": "Keith Cirkel (https://keithcirkel.co.uk)",
-    "repository": "https://github.com/csskit/csskit",
-    "bin": "./bin/csskit",
-    "files": [
-        "./bin"
-    ],
-    "optionalDependencies": {
-        "csskit-linux-x64": "0.0.25",
-        "csskit-linux-arm64": "0.0.25",
-        "csskit-darwin-x64": "0.0.25",
-        "csskit-darwin-arm64": "0.0.25",
-        "csskit-win32-x64": "0.0.25",
-        "csskit-win32-arm64": "0.0.25"
-    },
-    "funding": {
-        "url": "https://github.com/sponsors/keithamus"
-    }
+	"name": "csskit",
+	"version": "0.0.25",
+	"description": "Refreshing CSS",
+	"keywords": [],
+	"repository": "https://github.com/csskit/csskit",
+	"funding": {
+		"url": "https://github.com/sponsors/keithamus"
+	},
+	"license": "MIT",
+	"author": "Keith Cirkel (https://keithcirkel.co.uk)",
+	"exports": {
+		".": "./index.js",
+		"./bundler": "./bundle/csskit_wasm.js",
+		"./wasm": "./bundle/csskit_wasm_bg.wasm",
+		"./bin/csskit": "./bin/csskit"
+	},
+	"main": "./index.js",
+	"bin": "./bin/csskit",
+	"files": [
+		"./bin",
+		"./index.js",
+		"./index.d.ts",
+		"./csskit_wasm_bg.wasm",
+		"./csskit_wasm_bg.wasm.d.ts",
+		"./bundle"
+	],
+	"scripts": {
+		"build": "cargo build --target wasm32-unknown-unknown --release -p csskit_wasm --no-default-features --features serde && wasm-bindgen --out-dir ./ --target nodejs ../../target/wasm32-unknown-unknown/release/csskit_wasm.wasm && mv ./csskit_wasm.js ./index.js && mv ./csskit_wasm.d.ts ./index.d.ts && wasm-bindgen --out-dir ./bundle --target bundler ../../target/wasm32-unknown-unknown/release/csskit_wasm.wasm && wasm-opt --enable-bulk-memory --enable-nontrapping-float-to-int -Oz -o ./csskit_wasm_bg.wasm ./csskit_wasm_bg.wasm && wasm-opt --enable-bulk-memory --enable-nontrapping-float-to-int -Oz -o ./bundle/csskit_wasm_bg.wasm ./bundle/csskit_wasm_bg.wasm"
+	},
+	"devDependencies": {
+		"wasm-opt": "1.4.0"
+	},
+	"optionalDependencies": {
+		"csskit-darwin-arm64": "0.0.25",
+		"csskit-darwin-x64": "0.0.25",
+		"csskit-linux-arm64": "0.0.25",
+		"csskit-linux-x64": "0.0.25",
+		"csskit-win32-arm64": "0.0.25",
+		"csskit-win32-x64": "0.0.25"
+	},
+	"allowScripts": {
+		"wasm-opt@1.4.0": true
+	}
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -20,7 +20,7 @@
 				"@mdit/plugin-alert": "^0.22.2",
 				"apexcharts": "^5.3.5",
 				"codemirror": "6.0.2",
-				"csskit_wasm": "../crates/csskit_wasm/pkg/",
+				"csskit": "../packages/csskit/",
 				"markdown-it-anchor": "^9.2.0",
 				"openswatch": "^0.1.0"
 			},
@@ -41,10 +41,26 @@
 				"sharp": "0.35.1"
 			}
 		},
-		"../crates/csskit_wasm/pkg": {
-			"name": "csskit_wasm",
-			"version": "0.0.20",
-			"license": "MIT"
+		"../packages/csskit": {
+			"version": "0.0.25",
+			"license": "MIT",
+			"bin": {
+				"csskit": "bin/csskit"
+			},
+			"devDependencies": {
+				"wasm-opt": "1.4.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/keithamus"
+			},
+			"optionalDependencies": {
+				"csskit-darwin-arm64": "0.0.25",
+				"csskit-darwin-x64": "0.0.25",
+				"csskit-linux-arm64": "0.0.25",
+				"csskit-linux-x64": "0.0.25",
+				"csskit-win32-arm64": "0.0.25",
+				"csskit-win32-x64": "0.0.25"
+			}
 		},
 		"node_modules/@11ty/dependency-tree": {
 			"version": "4.0.2",
@@ -3608,8 +3624,8 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/csskit_wasm": {
-			"resolved": "../crates/csskit_wasm/pkg",
+		"node_modules/csskit": {
+			"resolved": "../packages/csskit",
 			"link": true
 		},
 		"node_modules/cssnano": {

--- a/website/package.json
+++ b/website/package.json
@@ -4,18 +4,16 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"prebuild": "npm run wasm-build",
+		"prebuild": "npm run build --prefix ../packages/csskit",
 		"build": "eleventy",
 		"postbuild": "npm run clean-old",
-		"prebuild:dev": "npm run wasm-build:dev",
+		"prebuild:dev": "npm run build --prefix ../packages/csskit",
 		"build:dev": "eleventy",
 		"postbuild:dev": "npm run clean-old",
 		"clean-old": "ls -t playground/ | grep csskit | tail -n +2 | xargs rm -f",
 		"postinstall": "[ \"$NODE_ENV\" = \"production\" ] && npm run build || npm run build:dev",
 		"prestart": "npm run postinstall",
-		"start": "eleventy --serve",
-		"wasm-build": "cargo build --target wasm32-unknown-unknown --release -p csskit_wasm && wasm-bindgen --out-dir ../crates/csskit_wasm/pkg --target bundler ../target/wasm32-unknown-unknown/release/csskit_wasm.wasm",
-		"wasm-build:dev": "cargo build --target wasm32-unknown-unknown -p csskit_wasm && wasm-bindgen --out-dir ../crates/csskit_wasm/pkg --target bundler ../target/wasm32-unknown-unknown/debug/csskit_wasm.wasm"
+		"start": "eleventy --serve"
 	},
 	"dependencies": {
 		"@codemirror/lang-css": "6.3.1",
@@ -29,7 +27,7 @@
 		"@mdit/plugin-alert": "^0.22.2",
 		"apexcharts": "^5.3.5",
 		"codemirror": "6.0.2",
-		"csskit_wasm": "../crates/csskit_wasm/pkg/",
+		"csskit": "../packages/csskit/",
 		"markdown-it-anchor": "^9.2.0",
 		"openswatch": "^0.1.0"
 	},

--- a/website/script/index.js
+++ b/website/script/index.js
@@ -21,7 +21,7 @@ import {
 } from "@codemirror/language";
 import { csskitLight } from "./theme.js";
 
-import { format, lex, minify, parse, parse_error_report } from "csskit_wasm";
+import { format, lex, minify, parse, parse_error_report } from "csskit/bundler";
 
 function createHighlightEffect(view, { start, end }) {
   let range = EditorSelection.range(start, end);


### PR DESCRIPTION
We use the wasm bundle to build csskit for the website frontend, but this
package is also generally very useful for other downstream projects, e.g.
css-minify-tests.

This change bundles the wasm directly into the csskit package, offering the
library functions to downstream consumers, and makes the website more like a
downstream consumer.
