### PR TITLE
css_ast/css_parse: Improve peeking robustness.

### DIFF
--- a/crates/css_ast/src/constraints.rs
+++ b/crates/css_ast/src/constraints.rs
@@ -291,7 +291,7 @@ mod tests {
 	use super::*;
 	use crate::CssAtomSet;
 	use bumpalo::collections::Vec;
-	use css_parse::{T, assert_parse, assert_parse_error};
+	use css_parse::{T, assert_parse, assert_parse_error, assert_peek_false};
 
 	type ExactOne = Exact<T![Number], 1>;
 	type RangedZeroOne = Ranged<T![Number], 0, 1>;
@@ -303,7 +303,7 @@ mod tests {
 
 	#[test]
 	fn test_exact_rejects_wrong_value() {
-		assert_parse_error!(CssAtomSet::ATOMS, ExactOne, "2");
+		assert_peek_false!(CssAtomSet::ATOMS, ExactOne, "2");
 	}
 
 	#[test]
@@ -313,7 +313,7 @@ mod tests {
 
 	#[test]
 	fn test_ranged_rejects_out_of_range() {
-		assert_parse_error!(CssAtomSet::ATOMS, RangedZeroOne, "1.5");
+		assert_peek_false!(CssAtomSet::ATOMS, RangedZeroOne, "1.5");
 	}
 
 	#[test]
@@ -363,6 +363,6 @@ mod tests {
 
 	#[test]
 	fn test_non_empty_rejects_empty() {
-		assert_parse_error!(CssAtomSet::ATOMS, NonEmpty<Vec<T![Ident]>>, "");
+		assert_peek_false!(CssAtomSet::ATOMS, NonEmpty<Vec<T![Ident]>>, "");
 	}
 }

--- a/crates/css_ast/src/functions/attr_function.rs
+++ b/crates/css_ast/src/functions/attr_function.rs
@@ -77,7 +77,7 @@ pub enum AttrType {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -98,7 +98,7 @@ mod tests {
 	#[test]
 	fn test_errors() {
 		assert_parse_error!(CssAtomSet::ATOMS, AttrName, "a|b|c");
-		assert_parse_error!(CssAtomSet::ATOMS, AttrFunction, "attrr(foo)");
+		assert_peek_false!(CssAtomSet::ATOMS, AttrFunction, "attrr(foo)");
 		assert_parse_error!(CssAtomSet::ATOMS, AttrFunction, "attr()");
 		assert_parse_error!(CssAtomSet::ATOMS, AttrFunction, "attr(|)");
 	}

--- a/crates/css_ast/src/functions/easing_functions.rs
+++ b/crates/css_ast/src/functions/easing_functions.rs
@@ -148,7 +148,7 @@ pub enum StepPosition {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -172,7 +172,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, EasingFunction, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, EasingFunction, "foo");
 		assert_parse_error!(CssAtomSet::ATOMS, EasingFunction, "linear()");
 		assert_parse_error!(CssAtomSet::ATOMS, EasingFunction, "cubic-bezier(0.1, red, 1.0, green)");
 	}

--- a/crates/css_ast/src/functions/filter_functions.rs
+++ b/crates/css_ast/src/functions/filter_functions.rs
@@ -185,7 +185,7 @@ pub struct SepiaFunction {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -220,8 +220,8 @@ mod tests {
 
 	#[test]
 	fn test_filter_function_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, FilterFunction, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, FilterFunction, "foo()");
+		assert_peek_false!(CssAtomSet::ATOMS, FilterFunction, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, FilterFunction, "foo()");
 		assert_parse_error!(CssAtomSet::ATOMS, FilterFunction, "blur(-5px)");
 	}
 
@@ -235,6 +235,6 @@ mod tests {
 
 	#[test]
 	fn test_filter_value_list_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, FilterValueList, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, FilterValueList, "none");
 	}
 }

--- a/crates/css_ast/src/functions/leader_function.rs
+++ b/crates/css_ast/src/functions/leader_function.rs
@@ -40,7 +40,7 @@ pub enum LeaderType {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -59,7 +59,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, LeaderType, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, LeaderType, "foo");
 		assert_parse_error!(CssAtomSet::ATOMS, LeaderFunction, "leader(foo)");
 	}
 }

--- a/crates/css_ast/src/functions/relative_color.rs
+++ b/crates/css_ast/src/functions/relative_color.rs
@@ -949,7 +949,7 @@ mod chromashift_impl {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -971,7 +971,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, RgbChannelKeyword, "h");
-		assert_parse_error!(CssAtomSet::ATOMS, HslChannelKeyword, "r");
+		assert_peek_false!(CssAtomSet::ATOMS, RgbChannelKeyword, "h");
+		assert_peek_false!(CssAtomSet::ATOMS, HslChannelKeyword, "r");
 	}
 }

--- a/crates/css_ast/src/functions/snap_block_function.rs
+++ b/crates/css_ast/src/functions/snap_block_function.rs
@@ -38,7 +38,7 @@ pub enum SnapBlockKeyword {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -53,7 +53,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, SnapBlockFunction, "snap-inline(10%)");
+		assert_peek_false!(CssAtomSet::ATOMS, SnapBlockFunction, "snap-inline(10%)");
 		assert_parse_error!(CssAtomSet::ATOMS, SnapBlockFunction, "snap-block(start)");
 	}
 }

--- a/crates/css_ast/src/functions/snap_inline_function.rs
+++ b/crates/css_ast/src/functions/snap_inline_function.rs
@@ -38,7 +38,7 @@ pub enum SnapInlineKeyword {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -53,7 +53,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, SnapInlineFunction, "snap-block(10%)");
+		assert_peek_false!(CssAtomSet::ATOMS, SnapInlineFunction, "snap-block(10%)");
 		assert_parse_error!(CssAtomSet::ATOMS, SnapInlineFunction, "snap-inline(near)");
 	}
 }

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -1,13 +1,14 @@
 use super::prelude::*;
 
 /// <https://drafts.csswg.org/css-syntax-3/#charset-rule>
-#[derive(ToSpan, ToCursors, SemanticEq, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToSpan, ToCursors, SemanticEq, Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.at-rules.charset"))]
 #[derive(csskit_derives::NodeWithMetadata)]
 #[metadata(node_kinds = AtRule, used_at_rules = Charset)]
 pub struct CharsetRule {
+	#[atom(CssAtomSet::Charset)]
 	at_keyword: T![AtKeyword],
 	space: T![' '],
 	string: T![String],

--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -84,6 +84,10 @@ pub enum StyleQuery<'a> {
 	Or(Vec<'a, (StyleFeature<'a>, Option<T![Ident]>)>),
 }
 
+impl<'a> Peek<'a> for StyleQuery<'a> {
+	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::LeftParen, Kind::Ident]);
+}
+
 #[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit)]
@@ -159,6 +163,16 @@ pub enum ScrollStateQuery<'a> {
 	Not(T![Ident], ScrollStateFeature),
 	And(Vec<'a, (ScrollStateFeature, Option<T![Ident]>)>),
 	Or(Vec<'a, (ScrollStateFeature, Option<T![Ident]>)>),
+}
+
+impl<'a> Peek<'a> for ScrollStateQuery<'a> {
+	const PEEK_KINDSET: KindSet = ScrollStateFeature::PEEK_KINDSET.add(Kind::Ident);
+	fn peek<I>(p: &Parser<'a, I>, c: Cursor) -> bool
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		<ScrollStateFeature>::peek(p, c) || (c == Kind::Ident && p.equals_atom(c, &CssAtomSet::Not))
+	}
 }
 
 impl<'a> FeatureConditionList<'a> for ScrollStateQuery<'a> {

--- a/crates/css_ast/src/rules/media/features/grid.rs
+++ b/crates/css_ast/src/rules/media/features/grid.rs
@@ -6,7 +6,7 @@ boolean_feature!(
 	#[derive(csskit_derives::FeatureMetadata)]
 	#[feature_metadata(CssAtomSet::Grid)]
 	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
-#[derive(csskit_derives::NodeWithMetadata)]
+	#[derive(csskit_derives::NodeWithMetadata)]
 	pub enum GridMediaFeature{CssAtomSet::Grid}
 );
 

--- a/crates/css_ast/src/rules/media/features/hack.rs
+++ b/crates/css_ast/src/rules/media/features/hack.rs
@@ -2,7 +2,7 @@ use crate::CssAtomSet;
 use css_parse::{Cursor, Diagnostic, Parse, Parser, Result as ParserResult, T};
 use csskit_derives::*;
 
-#[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum HackMediaFeature {
 	IEBackslashZero(T!['('], T![Ident], T![:], T![Dimension], T![')']),

--- a/crates/css_ast/src/rules/media/mod.rs
+++ b/crates/css_ast/src/rules/media/mod.rs
@@ -205,6 +205,10 @@ macro_rules! media_feature {
 
 apply_medias!(media_feature);
 
+impl<'a> Peek<'a> for MediaFeature {
+	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::LeftParen]);
+}
+
 impl<'a> Parse<'a> for MediaFeature {
 	fn parse<I>(p: &mut Parser<'a, I>) -> ParserResult<Self>
 	where

--- a/crates/css_ast/src/selector/moz.rs
+++ b/crates/css_ast/src/selector/moz.rs
@@ -88,20 +88,20 @@ pseudo_element!(
 	}
 );
 
-#[derive(ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum MozFunctionalPseudoElement<'a> {
-	TreeCell(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeCellText(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeCheckbox(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeColumn(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeImage(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeLine(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeRow(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeSeparator(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeTwisty(T![::], T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeCell(T![::], #[atom(CssAtomSet::TreeCell)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeCellText(T![::], #[atom(CssAtomSet::TreeCellText)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeCheckbox(T![::], #[atom(CssAtomSet::TreeCheckbox)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeColumn(T![::], #[atom(CssAtomSet::TreeColumn)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeImage(T![::], #[atom(CssAtomSet::TreeImage)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeLine(T![::], #[atom(CssAtomSet::TreeLine)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeRow(T![::], #[atom(CssAtomSet::TreeRow)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeSeparator(T![::], #[atom(CssAtomSet::TreeSeparator)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeTwisty(T![::], #[atom(CssAtomSet::TreeTwisty)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
 }
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -16,7 +16,7 @@ pub enum Nth {
 }
 
 impl<'a> Peek<'a> for Nth {
-	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Number, Kind::Ident]);
+	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Number, Kind::Ident, Kind::Dimension, Kind::Delim]);
 }
 
 impl<'a> Parse<'a> for Nth {

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -1,7 +1,8 @@
 use crate::{CssAtomSet, CssMetadata, StyleValue, rules, stylerule::StyleRule};
 use bumpalo::collections::Vec;
+use css_lexer::KindSet;
 use css_parse::{
-	BumpBox, ComponentValues, Cursor, Diagnostic, NodeWithMetadata, Parse, Parser, QualifiedRule,
+	BumpBox, ComponentValues, Cursor, Diagnostic, NodeWithMetadata, Parse, Parser, Peek, QualifiedRule,
 	Result as ParserResult, RuleVariants, StyleSheet as StyleSheetTrait, T, UnknownRuleBlock,
 };
 use csskit_derives::*;
@@ -22,6 +23,10 @@ impl<'a> NodeWithMetadata<CssMetadata> for StyleSheet<'a> {
 	fn metadata(&self) -> CssMetadata {
 		self.meta
 	}
+}
+
+impl<'a> Peek<'a> for StyleSheet<'a> {
+	const PEEK_KINDSET: KindSet = KindSet::ANY;
 }
 
 // A StyleSheet represents the root node of a CSS-like language.
@@ -170,6 +175,10 @@ impl<'a> RuleVariants<'a> for Rule<'a> {
 	{
 		p.parse::<UnknownQualifiedRule>().map(Self::Unknown)
 	}
+}
+
+impl<'a> Peek<'a> for Rule<'a> {
+	const PEEK_KINDSET: KindSet = KindSet::ANY;
 }
 
 impl<'a> Parse<'a> for Rule<'a> {

--- a/crates/css_ast/src/types/anchor_name.rs
+++ b/crates/css_ast/src/types/anchor_name.rs
@@ -18,7 +18,7 @@ pub struct AnchorName;
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -32,7 +32,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnchorName, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, AnchorName, "foo");
 	}
 
 	#[test]

--- a/crates/css_ast/src/types/auto_or.rs
+++ b/crates/css_ast/src/types/auto_or.rs
@@ -40,7 +40,7 @@ mod tests {
 	use super::*;
 	use crate::CssAtomSet;
 	use crate::Length;
-	use css_parse::{T, assert_parse, assert_parse_error};
+	use css_parse::{T, assert_parse, assert_parse_error, assert_peek_false};
 
 	type AutoOrIdent = AutoOr<T![Ident]>;
 	type AutoOrNumber = AutoOr<T![Number]>;
@@ -61,8 +61,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AutoOrIdent, "");
-		assert_parse_error!(CssAtomSet::ATOMS, AutoOrIdent, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, AutoOrIdent, "");
+		assert_peek_false!(CssAtomSet::ATOMS, AutoOrIdent, "0");
 		assert_parse_error!(CssAtomSet::ATOMS, AutoOrIdent, "auto auto");
 		assert_parse_error!(CssAtomSet::ATOMS, AutoOrIdent, "auto all");
 	}

--- a/crates/css_ast/src/types/autonone_or.rs
+++ b/crates/css_ast/src/types/autonone_or.rs
@@ -44,7 +44,7 @@ mod tests {
 	use super::*;
 	use crate::CssAtomSet;
 	use crate::Length;
-	use css_parse::{T, assert_parse, assert_parse_error};
+	use css_parse::{T, assert_parse, assert_parse_error, assert_peek_false};
 
 	type AuroNoneOrIdent = AutoNoneOr<T![Ident]>;
 	type AutoNoneOrNumber = AutoNoneOr<T![Number]>;
@@ -65,8 +65,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AuroNoneOrIdent, "");
-		assert_parse_error!(CssAtomSet::ATOMS, AuroNoneOrIdent, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, AuroNoneOrIdent, "");
+		assert_peek_false!(CssAtomSet::ATOMS, AuroNoneOrIdent, "0");
 		assert_parse_error!(CssAtomSet::ATOMS, AuroNoneOrIdent, "auto none");
 		assert_parse_error!(CssAtomSet::ATOMS, AuroNoneOrIdent, "none none");
 		assert_parse_error!(CssAtomSet::ATOMS, AuroNoneOrIdent, "auto auto");

--- a/crates/css_ast/src/types/bg_layer.rs
+++ b/crates/css_ast/src/types/bg_layer.rs
@@ -135,7 +135,7 @@ impl<'a> Parse<'a> for BgLayer<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -161,6 +161,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BgLayer, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BgLayer, "");
 	}
 }

--- a/crates/css_ast/src/types/bg_position.rs
+++ b/crates/css_ast/src/types/bg_position.rs
@@ -131,7 +131,7 @@ impl PositionHorizontal {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -157,7 +157,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BgPosition, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BgPosition, "");
 		assert_parse_error!(CssAtomSet::ATOMS, BgPosition, "left left");
 		assert_parse_error!(CssAtomSet::ATOMS, BgPosition, "top top");
 	}

--- a/crates/css_ast/src/types/bg_position_and_size.rs
+++ b/crates/css_ast/src/types/bg_position_and_size.rs
@@ -48,7 +48,7 @@ impl<'a> Parse<'a> for BgPositionAndSize {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -66,6 +66,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BgPositionAndSize, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BgPositionAndSize, "");
 	}
 }

--- a/crates/css_ast/src/types/color_scheme_name.rs
+++ b/crates/css_ast/src/types/color_scheme_name.rs
@@ -21,7 +21,7 @@ pub enum ColorSchemeName {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -37,6 +37,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ColorSchemeName, "123");
+		assert_peek_false!(CssAtomSet::ATOMS, ColorSchemeName, "123");
 	}
 }

--- a/crates/css_ast/src/types/content_alt_item.rs
+++ b/crates/css_ast/src/types/content_alt_item.rs
@@ -22,7 +22,7 @@ pub enum ContentAltItem<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -38,6 +38,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ContentAltItem, "open-quote");
+		assert_peek_false!(CssAtomSet::ATOMS, ContentAltItem, "open-quote");
 	}
 }

--- a/crates/css_ast/src/types/counter_name.rs
+++ b/crates/css_ast/src/types/counter_name.rs
@@ -17,7 +17,7 @@ pub struct CounterName(T![Ident]);
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -32,6 +32,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, CounterName, "");
+		assert_peek_false!(CssAtomSet::ATOMS, CounterName, "");
 	}
 }

--- a/crates/css_ast/src/types/display_box.rs
+++ b/crates/css_ast/src/types/display_box.rs
@@ -21,7 +21,7 @@ pub enum DisplayBox {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -36,6 +36,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayBox, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayBox, "foo");
 	}
 }

--- a/crates/css_ast/src/types/display_inside.rs
+++ b/crates/css_ast/src/types/display_inside.rs
@@ -30,7 +30,7 @@ pub enum DisplayInside {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -49,6 +49,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayInside, "block");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayInside, "block");
 	}
 }

--- a/crates/css_ast/src/types/display_internal.rs
+++ b/crates/css_ast/src/types/display_internal.rs
@@ -45,7 +45,7 @@ pub enum DisplayInternal {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -59,6 +59,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayInternal, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayInternal, "foo");
 	}
 }

--- a/crates/css_ast/src/types/display_legacy.rs
+++ b/crates/css_ast/src/types/display_legacy.rs
@@ -25,7 +25,7 @@ pub enum DisplayLegacy {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -42,6 +42,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayLegacy, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayLegacy, "foo");
 	}
 }

--- a/crates/css_ast/src/types/display_legacy_vendor.rs
+++ b/crates/css_ast/src/types/display_legacy_vendor.rs
@@ -55,7 +55,7 @@ pub enum DisplayLegacyVendor {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -84,7 +84,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayLegacyVendor, "flex");
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayLegacyVendor, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayLegacyVendor, "flex");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayLegacyVendor, "foo");
 	}
 }

--- a/crates/css_ast/src/types/display_listitem.rs
+++ b/crates/css_ast/src/types/display_listitem.rs
@@ -53,7 +53,7 @@ pub enum DisplayListitemInside {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -88,8 +88,8 @@ mod tests {
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "list item"); // missing hyphen
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "listitem"); // missing hyphen
 		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitem, "block flow-root flow list-item");
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitemInside, "foo");
-		assert_parse_error!(CssAtomSet::ATOMS, DisplayListitemInside, "list-item");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayListitemInside, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, DisplayListitemInside, "list-item");
 
 		// These tests verify that `list-item` is required (the `&&` semantics).
 		// Without the explicit check for `list_item.is_some()`, these would incorrectly parse

--- a/crates/css_ast/src/types/feature_tag_value.rs
+++ b/crates/css_ast/src/types/feature_tag_value.rs
@@ -30,7 +30,7 @@ pub enum FeatureTagToggle {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -56,6 +56,6 @@ mod tests {
 		assert_parse_error!(CssAtomSet::ATOMS, FeatureTagValue, "\"ker\"");
 		assert_parse_error!(CssAtomSet::ATOMS, FeatureTagValue, "\"kerns\"");
 		assert_parse_error!(CssAtomSet::ATOMS, FeatureTagValue, "\"kern\" -1");
-		assert_parse_error!(CssAtomSet::ATOMS, FeatureTagValue, "kern");
+		assert_peek_false!(CssAtomSet::ATOMS, FeatureTagValue, "kern");
 	}
 }

--- a/crates/css_ast/src/types/font_weight_absolute.rs
+++ b/crates/css_ast/src/types/font_weight_absolute.rs
@@ -18,7 +18,7 @@ pub enum FontWeightAbsolute {}
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -37,6 +37,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, FontWeightAbsolute, "1000.1");
+		assert_peek_false!(CssAtomSet::ATOMS, FontWeightAbsolute, "1000.1");
 	}
 }

--- a/crates/css_ast/src/types/generic_font_family.rs
+++ b/crates/css_ast/src/types/generic_font_family.rs
@@ -93,7 +93,7 @@ pub enum GenericIncomplete {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -109,7 +109,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, GenericFontFamily, "");
-		assert_parse_error!(CssAtomSet::ATOMS, GenericFontFamily, "'foo' bar");
+		assert_peek_false!(CssAtomSet::ATOMS, GenericFontFamily, "");
+		assert_peek_false!(CssAtomSet::ATOMS, GenericFontFamily, "'foo' bar");
 	}
 }

--- a/crates/css_ast/src/types/generic_voice.rs
+++ b/crates/css_ast/src/types/generic_voice.rs
@@ -79,7 +79,7 @@ impl<'a> Parse<'a> for GenericVoice {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -100,8 +100,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, GenericVoice, "");
+		assert_peek_false!(CssAtomSet::ATOMS, GenericVoice, "");
 		assert_parse_error!(CssAtomSet::ATOMS, GenericVoice, "child");
-		assert_parse_error!(CssAtomSet::ATOMS, GenericVoice, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, GenericVoice, "auto");
 	}
 }

--- a/crates/css_ast/src/types/line_style.rs
+++ b/crates/css_ast/src/types/line_style.rs
@@ -33,7 +33,7 @@ pub enum LineStyle {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -48,8 +48,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, LineStyle, "florp");
+		assert_peek_false!(CssAtomSet::ATOMS, LineStyle, "florp");
 		// Empty!
-		assert_parse_error!(CssAtomSet::ATOMS, LineStyle, "");
+		assert_peek_false!(CssAtomSet::ATOMS, LineStyle, "");
 	}
 }

--- a/crates/css_ast/src/types/none_or.rs
+++ b/crates/css_ast/src/types/none_or.rs
@@ -40,7 +40,7 @@ mod tests {
 	use super::*;
 	use crate::CssAtomSet;
 	use crate::Length;
-	use css_parse::{T, assert_parse, assert_parse_error};
+	use css_parse::{T, assert_parse, assert_parse_error, assert_peek_false};
 
 	type NoneOrIdent = NoneOr<T![Ident]>;
 	type NoneOrNumber = NoneOr<T![Number]>;
@@ -61,8 +61,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, NoneOrIdent, "");
-		assert_parse_error!(CssAtomSet::ATOMS, NoneOrIdent, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, NoneOrIdent, "");
+		assert_peek_false!(CssAtomSet::ATOMS, NoneOrIdent, "0");
 		assert_parse_error!(CssAtomSet::ATOMS, NoneOrIdent, "none none");
 		assert_parse_error!(CssAtomSet::ATOMS, NoneOrIdent, "none all");
 	}

--- a/crates/css_ast/src/types/normal_or.rs
+++ b/crates/css_ast/src/types/normal_or.rs
@@ -30,7 +30,7 @@ impl<T: Copy> Copy for NormalOr<T> {}
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{T, assert_parse, assert_parse_error};
+	use css_parse::{T, assert_parse, assert_parse_error, assert_peek_false};
 
 	type NormalOrIdent = NormalOr<T![Ident]>;
 
@@ -49,8 +49,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, NormalOrIdent, "");
-		assert_parse_error!(CssAtomSet::ATOMS, NormalOrIdent, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, NormalOrIdent, "");
+		assert_peek_false!(CssAtomSet::ATOMS, NormalOrIdent, "0");
 		assert_parse_error!(CssAtomSet::ATOMS, NormalOrIdent, "normal normal");
 		assert_parse_error!(CssAtomSet::ATOMS, NormalOrIdent, "normal all");
 	}

--- a/crates/css_ast/src/types/opacity_value.rs
+++ b/crates/css_ast/src/types/opacity_value.rs
@@ -42,7 +42,7 @@ impl From<OpacityValue> for f32 {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -61,7 +61,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, OpacityValue, "red");
-		assert_parse_error!(CssAtomSet::ATOMS, OpacityValue, "10px");
+		assert_peek_false!(CssAtomSet::ATOMS, OpacityValue, "red");
+		assert_peek_false!(CssAtomSet::ATOMS, OpacityValue, "10px");
 	}
 }

--- a/crates/css_ast/src/types/opentype_tag.rs
+++ b/crates/css_ast/src/types/opentype_tag.rs
@@ -46,7 +46,7 @@ impl<'a> Parse<'a> for OpentypeTag {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -69,6 +69,6 @@ mod tests {
 		assert_parse_error!(CssAtomSet::ATOMS, OpentypeTag, "\"ker\"");
 		assert_parse_error!(CssAtomSet::ATOMS, OpentypeTag, "\"kerns\"");
 		assert_parse_error!(CssAtomSet::ATOMS, OpentypeTag, "\"\"");
-		assert_parse_error!(CssAtomSet::ATOMS, OpentypeTag, "kern");
+		assert_peek_false!(CssAtomSet::ATOMS, OpentypeTag, "kern");
 	}
 }

--- a/crates/css_ast/src/types/positive_non_zero_int.rs
+++ b/crates/css_ast/src/types/positive_non_zero_int.rs
@@ -9,7 +9,7 @@ pub struct PositiveNonZeroInt(pub Positive<CSSInt>);
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -25,9 +25,9 @@ mod tests {
 	#[test]
 	fn test_errors() {
 		assert_parse_error!(CssAtomSet::ATOMS, PositiveNonZeroInt, "0");
-		assert_parse_error!(CssAtomSet::ATOMS, PositiveNonZeroInt, "0.0");
+		assert_peek_false!(CssAtomSet::ATOMS, PositiveNonZeroInt, "0.0");
 		assert_parse_error!(CssAtomSet::ATOMS, PositiveNonZeroInt, "-1");
-		assert_parse_error!(CssAtomSet::ATOMS, PositiveNonZeroInt, "1.2");
-		assert_parse_error!(CssAtomSet::ATOMS, PositiveNonZeroInt, "-1.2");
+		assert_peek_false!(CssAtomSet::ATOMS, PositiveNonZeroInt, "1.2");
+		assert_peek_false!(CssAtomSet::ATOMS, PositiveNonZeroInt, "-1.2");
 	}
 }

--- a/crates/css_ast/src/types/reversed_counter_name.rs
+++ b/crates/css_ast/src/types/reversed_counter_name.rs
@@ -21,7 +21,7 @@ pub struct ReversedCounterName {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -36,8 +36,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ReversedCounterName, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ReversedCounterName, "my-counter");
-		assert_parse_error!(CssAtomSet::ATOMS, ReversedCounterName, "counter(foo)");
+		assert_peek_false!(CssAtomSet::ATOMS, ReversedCounterName, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ReversedCounterName, "my-counter");
+		assert_peek_false!(CssAtomSet::ATOMS, ReversedCounterName, "counter(foo)");
 	}
 }

--- a/crates/css_ast/src/types/shadow.rs
+++ b/crates/css_ast/src/types/shadow.rs
@@ -22,7 +22,7 @@ pub struct Shadow<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -62,8 +62,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, Shadow, "");
-		assert_parse_error!(CssAtomSet::ATOMS, Shadow, "10% 20%");
+		assert_peek_false!(CssAtomSet::ATOMS, Shadow, "");
+		assert_peek_false!(CssAtomSet::ATOMS, Shadow, "10% 20%");
 		assert_parse_error!(CssAtomSet::ATOMS, Shadow, "10px");
 		assert_parse_error!(CssAtomSet::ATOMS, Shadow, "red");
 		assert_parse_error!(CssAtomSet::ATOMS, Shadow, "inset");

--- a/crates/css_ast/src/types/single_transition.rs
+++ b/crates/css_ast/src/types/single_transition.rs
@@ -49,7 +49,7 @@ impl<'a> Parse<'a> for SingleTransition<'a> {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	type NoneOrSingleTransitionProperty = NoneOr<SingleTransitionProperty>;
 
@@ -94,7 +94,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, SingleTransition, "1deg");
+		assert_peek_false!(CssAtomSet::ATOMS, SingleTransition, "1deg");
 		assert_parse_error!(CssAtomSet::ATOMS, SingleTransition, "none none");
 	}
 

--- a/crates/css_ast/src/types/single_transition_property.rs
+++ b/crates/css_ast/src/types/single_transition_property.rs
@@ -19,7 +19,7 @@ pub enum SingleTransitionProperty {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -34,6 +34,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, SingleTransitionProperty, "123deg");
+		assert_peek_false!(CssAtomSet::ATOMS, SingleTransitionProperty, "123deg");
 	}
 }

--- a/crates/css_ast/src/types/spread_shadow.rs
+++ b/crates/css_ast/src/types/spread_shadow.rs
@@ -35,7 +35,7 @@ pub enum ShadowPosition {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -76,7 +76,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, SpreadShadow, "");
+		assert_peek_false!(CssAtomSet::ATOMS, SpreadShadow, "");
 		assert_parse_error!(CssAtomSet::ATOMS, SpreadShadow, "10px");
 		assert_parse_error!(CssAtomSet::ATOMS, SpreadShadow, "red");
 		assert_parse_error!(CssAtomSet::ATOMS, SpreadShadow, "inset");

--- a/crates/css_ast/src/types/text_overflow_single_axis.rs
+++ b/crates/css_ast/src/types/text_overflow_single_axis.rs
@@ -26,7 +26,7 @@ pub enum TextOverflowSingleAxis {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -44,7 +44,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TextOverflowSingleAxis, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextOverflowSingleAxis, "");
 		assert_parse_error!(CssAtomSet::ATOMS, TextOverflowSingleAxis, "clip clip");
 	}
 }

--- a/crates/css_ast/src/types/transform_list.rs
+++ b/crates/css_ast/src/types/transform_list.rs
@@ -17,7 +17,7 @@ pub struct TransformList<'a>(pub Vec<'a, TransformFunction<'a>>);
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -51,7 +51,7 @@ mod tests {
 	#[test]
 	fn test_errors() {
 		assert_parse_error!(CssAtomSet::ATOMS, TransformList, "rotate(45deg) auto");
-		assert_parse_error!(CssAtomSet::ATOMS, TransformList, "auto rotate(45deg)");
+		assert_peek_false!(CssAtomSet::ATOMS, TransformList, "auto rotate(45deg)");
 	}
 
 	#[test]

--- a/crates/css_ast/src/types/try_tactic.rs
+++ b/crates/css_ast/src/types/try_tactic.rs
@@ -27,7 +27,7 @@ pub struct TryTactic {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -46,8 +46,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TryTactic, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TryTactic, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, TryTactic, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, TryTactic, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TryTactic, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, TryTactic, "none");
 	}
 }

--- a/crates/css_ast/src/types/variation_tag_value.rs
+++ b/crates/css_ast/src/types/variation_tag_value.rs
@@ -16,7 +16,7 @@ pub struct VariationTagValue(pub OpentypeTag, pub T![Number]);
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -36,6 +36,6 @@ mod tests {
 	fn test_errors() {
 		assert_parse_error!(CssAtomSet::ATOMS, VariationTagValue, "\"wght\"");
 		assert_parse_error!(CssAtomSet::ATOMS, VariationTagValue, "\"wg\" 700");
-		assert_parse_error!(CssAtomSet::ATOMS, VariationTagValue, "wght 700");
+		assert_peek_false!(CssAtomSet::ATOMS, VariationTagValue, "wght 700");
 	}
 }

--- a/crates/css_ast/src/types/voice_family_name.rs
+++ b/crates/css_ast/src/types/voice_family_name.rs
@@ -16,7 +16,7 @@ pub enum VoiceFamilyName<'a> {}
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -32,7 +32,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, VoiceFamilyName, "");
+		assert_peek_false!(CssAtomSet::ATOMS, VoiceFamilyName, "");
 		assert_parse_error!(CssAtomSet::ATOMS, VoiceFamilyName, "\"foo\" bar");
 	}
 }

--- a/crates/css_ast/src/units/frequency.rs
+++ b/crates/css_ast/src/units/frequency.rs
@@ -29,7 +29,7 @@ impl From<Frequency> for f32 {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -44,7 +44,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, Frequency, "40w");
-		assert_parse_error!(CssAtomSet::ATOMS, Frequency, "40kw");
+		assert_peek_false!(CssAtomSet::ATOMS, Frequency, "40w");
+		assert_peek_false!(CssAtomSet::ATOMS, Frequency, "40kw");
 	}
 }

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -47,7 +47,7 @@ impl ToNumberValue for Time {
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -64,8 +64,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, Time, "0");
-		assert_parse_error!(CssAtomSet::ATOMS, Time, "1");
-		assert_parse_error!(CssAtomSet::ATOMS, Time, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, Time, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, Time, "1");
+		assert_peek_false!(CssAtomSet::ATOMS, Time, "foo");
 	}
 }

--- a/crates/css_ast/src/values/align/impls.rs
+++ b/crates/css_ast/src/values/align/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::{ColumnGapStyleValue, CssAtomSet, GapStyleValue, RowGapStyleValue};
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -39,6 +39,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AlignSelfStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, AlignSelfStyleValue, "none");
 	}
 }

--- a/crates/css_ast/src/values/anchor_position/impls.rs
+++ b/crates/css_ast/src/values/anchor_position/impls.rs
@@ -6,7 +6,7 @@ pub(crate) use csskit_proc_macro::*;
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	pub fn size_test() {
@@ -28,8 +28,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, PositionVisibilityStyleValue, "no-overflow");
 		assert_parse!(CssAtomSet::ATOMS, PositionVisibilityStyleValue, "anchor-valid anchor-visible");
 		assert_parse!(CssAtomSet::ATOMS, PositionVisibilityStyleValue, "anchor-valid anchor-visible no-overflow");
-		assert_parse_error!(CssAtomSet::ATOMS, PositionVisibilityStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, PositionVisibilityStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, PositionVisibilityStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, PositionVisibilityStyleValue, "none");
 	}
 
 	#[test]
@@ -41,8 +41,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, PositionTryFallbacksStyleValue, "--my-fallback flip-block");
 		assert_parse!(CssAtomSet::ATOMS, PositionTryFallbacksStyleValue, "top");
 		assert_parse!(CssAtomSet::ATOMS, PositionTryFallbacksStyleValue, "--a,--b,flip-block");
-		assert_parse_error!(CssAtomSet::ATOMS, PositionTryFallbacksStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, PositionTryFallbacksStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, PositionTryFallbacksStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, PositionTryFallbacksStyleValue, "auto");
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/animation_triggers/impls.rs
+++ b/crates/css_ast/src/values/animation_triggers/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -69,10 +69,10 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationTriggerStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationTriggerStyleValue, "play");
-		assert_parse_error!(CssAtomSet::ATOMS, EventTriggerNameStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, TimelineTriggerNameStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, TriggerScopeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationTriggerStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationTriggerStyleValue, "play");
+		assert_peek_false!(CssAtomSet::ATOMS, EventTriggerNameStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, TimelineTriggerNameStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, TriggerScopeStyleValue, "auto");
 	}
 }

--- a/crates/css_ast/src/values/animations/impls.rs
+++ b/crates/css_ast/src/values/animations/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -38,9 +38,9 @@ mod tests {
 
 	#[test]
 	fn test_animation_delay_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationDelayStyleValue, "0");
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationDelayStyleValue, "0px");
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationDelayStyleValue, "infinite");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationDelayStyleValue, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationDelayStyleValue, "0px");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationDelayStyleValue, "infinite");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationDelayStyleValue, "1s 2s 3s");
 	}
 
@@ -55,7 +55,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_direction_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationDirectionStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationDirectionStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationDirectionStyleValue, "normal reverse");
 	}
 
@@ -68,10 +68,10 @@ mod tests {
 
 	#[test]
 	fn test_animation_duration_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationDurationStyleValue, "0");
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationDurationStyleValue, "0px");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationDurationStyleValue, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationDurationStyleValue, "0px");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationDurationStyleValue, "-3s");
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationDurationStyleValue, "infinite");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationDurationStyleValue, "infinite");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationDurationStyleValue, "1s 2s");
 	}
 
@@ -86,7 +86,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_fill_mode_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationFillModeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationFillModeStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationFillModeStyleValue, "forwards backwards");
 	}
 
@@ -101,7 +101,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_iteration_count_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationIterationCountStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationIterationCountStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationIterationCountStyleValue, "-2");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationIterationCountStyleValue, "3 4");
 	}
@@ -118,7 +118,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_name_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationNameStyleValue, "12");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationNameStyleValue, "12");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationNameStyleValue, "one two");
 	}
 
@@ -131,7 +131,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_play_state_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationPlayStateStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationPlayStateStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationPlayStateStyleValue, "paused running");
 	}
 
@@ -145,7 +145,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_composition_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationCompositionStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationCompositionStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationCompositionStyleValue, "add replace");
 	}
 

--- a/crates/css_ast/src/values/backgrounds/impls.rs
+++ b/crates/css_ast/src/values/backgrounds/impls.rs
@@ -7,7 +7,7 @@ use css_parse::{CommaSeparated, Parse};
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -45,6 +45,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BackgroundStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BackgroundStyleValue, "");
 	}
 }

--- a/crates/css_ast/src/values/borders/impls.rs
+++ b/crates/css_ast/src/values/borders/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	pub fn size_test() {
@@ -135,8 +135,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, BoxShadowOffsetStyleValue, "10px 20px");
 		assert_parse!(CssAtomSet::ATOMS, BoxShadowOffsetStyleValue, "none,10px");
 		assert_parse!(CssAtomSet::ATOMS, BoxShadowOffsetStyleValue, "10px,20px 30px");
-		assert_parse_error!(CssAtomSet::ATOMS, BoxShadowOffsetStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, BoxShadowOffsetStyleValue, "red");
+		assert_peek_false!(CssAtomSet::ATOMS, BoxShadowOffsetStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BoxShadowOffsetStyleValue, "red");
 	}
 
 	#[test]
@@ -148,7 +148,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, BoxShadowStyleValue, "10px 20px inset");
 		assert_parse!(CssAtomSet::ATOMS, BoxShadowStyleValue, "0 0 0 transparent,0 0 0 transparent");
 		assert_parse!(CssAtomSet::ATOMS, BoxShadowStyleValue, "0 1px 1px rgba(0,0,0,.075),0 0 6px rgba(0,0,0,.05)");
-		assert_parse_error!(CssAtomSet::ATOMS, BoxShadowStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BoxShadowStyleValue, "");
 		assert_parse_error!(CssAtomSet::ATOMS, BoxShadowStyleValue, "red");
 	}
 
@@ -182,8 +182,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, BorderColorStyleValue, "red blue green yellow");
 		assert_parse!(CssAtomSet::ATOMS, BorderColorStyleValue, "stripes(red 1fr,blue 2fr)");
 		assert_parse!(CssAtomSet::ATOMS, BorderColorStyleValue, "red stripes(red 1fr,blue 2fr)");
-		assert_parse_error!(CssAtomSet::ATOMS, BorderColorStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, BorderColorStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderColorStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderColorStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, BorderColorStyleValue, "red blue green yellow purple");
 	}
 
@@ -195,8 +195,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, BorderImageSliceStyleValue, "10 20 30 40");
 		assert_parse!(CssAtomSet::ATOMS, BorderImageSliceStyleValue, "10% fill");
 		assert_parse!(CssAtomSet::ATOMS, BorderImageSliceStyleValue, "fill 10%");
-		assert_parse_error!(CssAtomSet::ATOMS, BorderImageSliceStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, BorderImageSliceStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderImageSliceStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderImageSliceStyleValue, "auto");
 	}
 
 	#[test]
@@ -208,15 +208,15 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, BorderImageWidthStyleValue, "1 2");
 		assert_parse!(CssAtomSet::ATOMS, BorderImageWidthStyleValue, "1 2 3 4");
 		assert_parse!(CssAtomSet::ATOMS, BorderImageWidthStyleValue, "auto 10px 1 50%");
-		assert_parse_error!(CssAtomSet::ATOMS, BorderImageWidthStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, BorderImageWidthStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderImageWidthStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderImageWidthStyleValue, "none");
 	}
 
 	#[test]
 	fn test_border_shape() {
 		assert_parse!(CssAtomSet::ATOMS, BorderShapeStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, BorderShapeStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, BorderShapeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderShapeStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderShapeStyleValue, "auto");
 	}
 
 	#[test]
@@ -227,7 +227,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, CornerTopRightStyleValue, "5px squircle");
 		assert_parse!(CssAtomSet::ATOMS, CornerTopStyleValue, "10px");
 		assert_parse!(CssAtomSet::ATOMS, CornerTopStyleValue, "10px 20px");
-		assert_parse_error!(CssAtomSet::ATOMS, CornerTopLeftStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, CornerTopLeftStyleValue, "red");
+		assert_peek_false!(CssAtomSet::ATOMS, CornerTopLeftStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, CornerTopLeftStyleValue, "red");
 	}
 }

--- a/crates/css_ast/src/values/box/impls.rs
+++ b/crates/css_ast/src/values/box/impls.rs
@@ -13,7 +13,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	pub fn size_test() {
@@ -40,8 +40,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "inline-start");
 		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "inline-end");
 		assert_parse!(CssAtomSet::ATOMS, MarginTrimStyleValue, "block inline");
-		assert_parse_error!(CssAtomSet::ATOMS, MarginTrimStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, MarginTrimStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, MarginTrimStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, MarginTrimStyleValue, "auto");
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/break/impls.rs
+++ b/crates/css_ast/src/values/break/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -29,7 +29,7 @@ mod tests {
 
 	#[test]
 	fn test_break_after_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BreakAfterStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, BreakAfterStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, BreakAfterStyleValue, "avoid region");
 	}
 
@@ -43,7 +43,7 @@ mod tests {
 
 	#[test]
 	fn test_break_before_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BreakBeforeStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, BreakBeforeStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, BreakBeforeStyleValue, "avoid region");
 	}
 
@@ -57,7 +57,7 @@ mod tests {
 
 	#[test]
 	fn test_break_inside_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BreakInsideStyleValue, "region");
+		assert_peek_false!(CssAtomSet::ATOMS, BreakInsideStyleValue, "region");
 		assert_parse_error!(CssAtomSet::ATOMS, BreakInsideStyleValue, "auto avoid");
 	}
 
@@ -69,7 +69,7 @@ mod tests {
 
 	#[test]
 	fn test_box_decoration_break_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BoxDecorationBreakStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BoxDecorationBreakStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, BoxDecorationBreakStyleValue, "slice clone");
 	}
 
@@ -81,7 +81,7 @@ mod tests {
 
 	#[test]
 	fn test_orphans_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, OrphansStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, OrphansStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, OrphansStyleValue, "1 234");
 		assert_parse_error!(CssAtomSet::ATOMS, OrphansStyleValue, "-234");
 		assert_parse_error!(CssAtomSet::ATOMS, OrphansStyleValue, "0");
@@ -95,7 +95,7 @@ mod tests {
 
 	#[test]
 	fn test_widows_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WidowsStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, WidowsStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, WidowsStyleValue, "-1");
 		assert_parse_error!(CssAtomSet::ATOMS, WidowsStyleValue, "0");
 	}

--- a/crates/css_ast/src/values/cascade/impls.rs
+++ b/crates/css_ast/src/values/cascade/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -20,8 +20,8 @@ mod tests {
 
 	#[test]
 	fn test_all_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AllStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, AllStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, AllStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, AllStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, AllStyleValue, "unset inherit");
 	}
 }

--- a/crates/css_ast/src/values/color_adjust/impls.rs
+++ b/crates/css_ast/src/values/color_adjust/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -32,7 +32,7 @@ mod tests {
 
 	#[test]
 	fn test_forced_color_adjust_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ForcedColorAdjustStyleValue, "exact");
+		assert_peek_false!(CssAtomSet::ATOMS, ForcedColorAdjustStyleValue, "exact");
 		assert_parse_error!(CssAtomSet::ATOMS, ForcedColorAdjustStyleValue, "auto none");
 	}
 
@@ -44,7 +44,7 @@ mod tests {
 
 	#[test]
 	fn test_print_color_adjust_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, PrintColorAdjustStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, PrintColorAdjustStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, PrintColorAdjustStyleValue, "economy exact");
 	}
 }

--- a/crates/css_ast/src/values/compositing/impls.rs
+++ b/crates/css_ast/src/values/compositing/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -33,7 +33,7 @@ mod tests {
 
 	#[test]
 	fn test_background_blend_mode_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BackgroundBlendModeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BackgroundBlendModeStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, BackgroundBlendModeStyleValue, "normal luminosity");
 	}
 
@@ -45,7 +45,7 @@ mod tests {
 
 	#[test]
 	fn test_isolation_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, IsolationStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, IsolationStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, IsolationStyleValue, "auto isolate");
 	}
 
@@ -60,7 +60,7 @@ mod tests {
 
 	#[test]
 	fn test_mix_blend_mode_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MixBlendModeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, MixBlendModeStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, MixBlendModeStyleValue, "normal luminosity");
 		assert_parse_error!(CssAtomSet::ATOMS, MixBlendModeStyleValue, "normal, luminosity");
 	}

--- a/crates/css_ast/src/values/conditional/impls.rs
+++ b/crates/css_ast/src/values/conditional/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	pub fn size_test() {
@@ -19,8 +19,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ContainerTypeStyleValue, "scroll-state");
 		assert_parse!(CssAtomSet::ATOMS, ContainerTypeStyleValue, "size scroll-state");
 		assert_parse!(CssAtomSet::ATOMS, ContainerTypeStyleValue, "inline-size scroll-state");
-		assert_parse_error!(CssAtomSet::ATOMS, ContainerTypeStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ContainerTypeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ContainerTypeStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ContainerTypeStyleValue, "auto");
 	}
 
 	#[test]
@@ -29,7 +29,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ContainerStyleValue, "sidebar");
 		assert_parse!(CssAtomSet::ATOMS, ContainerStyleValue, "sidebar / size");
 		assert_parse!(CssAtomSet::ATOMS, ContainerStyleValue, "none / inline-size");
-		assert_parse_error!(CssAtomSet::ATOMS, ContainerStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, ContainerStyleValue, "1px");
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/contain/impls.rs
+++ b/crates/css_ast/src/values/contain/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -19,7 +19,7 @@ mod tests {
 
 	#[test]
 	fn test_content_visibility_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ContentVisibilityStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ContentVisibilityStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, ContentVisibilityStyleValue, "visible hidden");
 	}
 
@@ -35,7 +35,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ContainStyleValue, "paint");
 		assert_parse!(CssAtomSet::ATOMS, ContainStyleValue, "size layout");
 		assert_parse!(CssAtomSet::ATOMS, ContainStyleValue, "size layout style paint");
-		assert_parse_error!(CssAtomSet::ATOMS, ContainStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ContainStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ContainStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ContainStyleValue, "auto");
 	}
 }

--- a/crates/css_ast/src/values/content/impls.rs
+++ b/crates/css_ast/src/values/content/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	pub fn size_test() {
@@ -32,6 +32,6 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ContentStyleValue, "invalid-keyword");
+		assert_peek_false!(CssAtomSet::ATOMS, ContentStyleValue, "invalid-keyword");
 	}
 }

--- a/crates/css_ast/src/values/css2/impls.rs
+++ b/crates/css_ast/src/values/css2/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -20,8 +20,8 @@ mod tests {
 
 	#[test]
 	fn test_z_index_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ZIndexStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, ZIndexStyleValue, "1.5");
-		assert_parse_error!(CssAtomSet::ATOMS, ZIndexStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ZIndexStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ZIndexStyleValue, "1.5");
+		assert_peek_false!(CssAtomSet::ATOMS, ZIndexStyleValue, "");
 	}
 }

--- a/crates/css_ast/src/values/exclusions/impls.rs
+++ b/crates/css_ast/src/values/exclusions/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -25,9 +25,9 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WrapFlowStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, WrapFlowStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, WrapFlowStyleValue, "auto both");
-		assert_parse_error!(CssAtomSet::ATOMS, WrapThroughStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, WrapThroughStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, WrapThroughStyleValue, "wrap none");
 	}
 }

--- a/crates/css_ast/src/values/fill_stroke/impls.rs
+++ b/crates/css_ast/src/values/fill_stroke/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -129,8 +129,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, StrokeDashJustifyStyleValue, "dashes");
 		assert_parse!(CssAtomSet::ATOMS, StrokeDashJustifyStyleValue, "stretch dashes");
 		assert_parse!(CssAtomSet::ATOMS, StrokeDashJustifyStyleValue, "stretch dashes gaps");
-		assert_parse_error!(CssAtomSet::ATOMS, StrokeDashJustifyStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, StrokeDashJustifyStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, StrokeDashJustifyStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, StrokeDashJustifyStyleValue, "1px");
 	}
 
 	#[test]
@@ -139,20 +139,20 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, StrokeLinejoinStyleValue, "arcs");
 		assert_parse!(CssAtomSet::ATOMS, StrokeLinejoinStyleValue, "miter");
 		assert_parse!(CssAtomSet::ATOMS, StrokeLinejoinStyleValue, "crop bevel");
-		assert_parse_error!(CssAtomSet::ATOMS, StrokeLinejoinStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, StrokeLinejoinStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, StrokeLinejoinStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, StrokeLinejoinStyleValue, "1px");
 	}
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, FillBreakStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, FillBreakStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, FillBreakStyleValue, "bounding-box slice");
-		assert_parse_error!(CssAtomSet::ATOMS, FillRuleStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, FillRuleStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, FillRuleStyleValue, "nonzero evenodd");
-		assert_parse_error!(CssAtomSet::ATOMS, StrokeAlignStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, StrokeAlignStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, StrokeAlignStyleValue, "center inset");
-		assert_parse_error!(CssAtomSet::ATOMS, StrokeBreakStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, StrokeLinecapStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, StrokeBreakStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, StrokeLinecapStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, StrokeLinecapStyleValue, "butt round");
 	}
 }

--- a/crates/css_ast/src/values/filter_effects/impls.rs
+++ b/crates/css_ast/src/values/filter_effects/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -53,20 +53,20 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ColorInterpolationFiltersStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ColorInterpolationFiltersStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, ColorInterpolationFiltersStyleValue, "linearrgb srgb");
 
-		assert_parse_error!(CssAtomSet::ATOMS, FloodColorStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, FloodColorStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, FloodColorStyleValue, "black white");
 
 		assert_parse_error!(CssAtomSet::ATOMS, FloodOpacityStyleValue, "2 3");
 
-		assert_parse_error!(CssAtomSet::ATOMS, BackdropFilterStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BackdropFilterStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, BackdropFilterStyleValue, "blur(10)");
 		assert_parse_error!(CssAtomSet::ATOMS, BackdropFilterStyleValue, "blur(-100px)");
 		assert_parse_error!(CssAtomSet::ATOMS, BackdropFilterStyleValue, "hue-rotate(90)");
 
-		assert_parse_error!(CssAtomSet::ATOMS, FilterStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, FilterStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, FilterStyleValue, "blur(10)");
 		assert_parse_error!(CssAtomSet::ATOMS, FilterStyleValue, "blur(-100px)");
 		assert_parse_error!(CssAtomSet::ATOMS, FilterStyleValue, "hue-rotate(90)");

--- a/crates/css_ast/src/values/flexbox/impls.rs
+++ b/crates/css_ast/src/values/flexbox/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -25,8 +25,8 @@ mod tests {
 
 	#[test]
 	fn test_flex_wrap_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, FlexWrapStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, FlexWrapStyleValue, "reverse");
+		assert_peek_false!(CssAtomSet::ATOMS, FlexWrapStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, FlexWrapStyleValue, "reverse");
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/fonts/impls.rs
+++ b/crates/css_ast/src/values/fonts/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -54,8 +54,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, FontSynthesisStyleValue, "position");
 		assert_parse!(CssAtomSet::ATOMS, FontSynthesisStyleValue, "weight style");
 		assert_parse!(CssAtomSet::ATOMS, FontSynthesisStyleValue, "weight style small-caps position");
-		assert_parse_error!(CssAtomSet::ATOMS, FontSynthesisStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, FontSynthesisStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, FontSynthesisStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, FontSynthesisStyleValue, "auto");
 	}
 
 	#[test]
@@ -71,8 +71,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, FontVariantNumericStyleValue, "slashed-zero");
 		assert_parse!(CssAtomSet::ATOMS, FontVariantNumericStyleValue, "lining-nums ordinal");
 		assert_parse!(CssAtomSet::ATOMS, FontVariantNumericStyleValue, "tabular-nums slashed-zero diagonal-fractions");
-		assert_parse_error!(CssAtomSet::ATOMS, FontVariantNumericStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, FontVariantNumericStyleValue, "bold");
+		assert_peek_false!(CssAtomSet::ATOMS, FontVariantNumericStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, FontVariantNumericStyleValue, "bold");
 	}
 
 	#[test]
@@ -86,8 +86,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, FontVariantLigaturesStyleValue, "contextual");
 		assert_parse!(CssAtomSet::ATOMS, FontVariantLigaturesStyleValue, "no-contextual");
 		assert_parse!(CssAtomSet::ATOMS, FontVariantLigaturesStyleValue, "common-ligatures discretionary-ligatures");
-		assert_parse_error!(CssAtomSet::ATOMS, FontVariantLigaturesStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, FontVariantLigaturesStyleValue, "bold");
+		assert_peek_false!(CssAtomSet::ATOMS, FontVariantLigaturesStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, FontVariantLigaturesStyleValue, "bold");
 	}
 
 	#[test]
@@ -103,8 +103,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, FontVariantEastAsianStyleValue, "proportional-width");
 		assert_parse!(CssAtomSet::ATOMS, FontVariantEastAsianStyleValue, "ruby");
 		assert_parse!(CssAtomSet::ATOMS, FontVariantEastAsianStyleValue, "jis78 full-width");
-		assert_parse_error!(CssAtomSet::ATOMS, FontVariantEastAsianStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, FontVariantEastAsianStyleValue, "bold");
+		assert_peek_false!(CssAtomSet::ATOMS, FontVariantEastAsianStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, FontVariantEastAsianStyleValue, "bold");
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/gcpm/impls.rs
+++ b/crates/css_ast/src/values/gcpm/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -30,14 +30,14 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, StringSetStyleValue, "header contents");
 		assert_parse!(CssAtomSet::ATOMS, StringSetStyleValue, "header string(chapter)");
 		assert_parse!(CssAtomSet::ATOMS, StringSetStyleValue, "header contents, footer string(chapter)");
-		assert_parse_error!(CssAtomSet::ATOMS, StringSetStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, StringSetStyleValue, "");
 	}
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, FootnoteDisplayStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, FootnoteDisplayStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, FootnoteDisplayStyleValue, "block inline");
-		assert_parse_error!(CssAtomSet::ATOMS, FootnotePolicyStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, FootnotePolicyStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, FootnotePolicyStyleValue, "auto line");
 	}
 }

--- a/crates/css_ast/src/values/grid/impls.rs
+++ b/crates/css_ast/src/values/grid/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	pub fn size_test() {
@@ -40,8 +40,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, GridAutoFlowStyleValue, "dense");
 		assert_parse!(CssAtomSet::ATOMS, GridAutoFlowStyleValue, "row dense");
 		assert_parse!(CssAtomSet::ATOMS, GridAutoFlowStyleValue, "column dense");
-		assert_parse_error!(CssAtomSet::ATOMS, GridAutoFlowStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, GridAutoFlowStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, GridAutoFlowStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, GridAutoFlowStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, GridAutoFlowStyleValue, "row column");
 	}
 }

--- a/crates/css_ast/src/values/image_animation/impls.rs
+++ b/crates/css_ast/src/values/image_animation/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -19,7 +19,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ImageAnimationStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ImageAnimationStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, ImageAnimationStyleValue, "normal paused");
 	}
 }

--- a/crates/css_ast/src/values/images/impls.rs
+++ b/crates/css_ast/src/values/images/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -28,10 +28,10 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ImageRenderingStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ImageRenderingStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, ImageRenderingStyleValue, "high-quality crisp-edges");
 
-		assert_parse_error!(CssAtomSet::ATOMS, ObjectPositionStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ObjectPositionStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, ObjectPositionStyleValue, "1px 2px 3px");
 		assert_parse_error!(CssAtomSet::ATOMS, ObjectPositionStyleValue, "left right");
 	}
@@ -43,8 +43,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ImageOrientationStyleValue, "90deg");
 		assert_parse!(CssAtomSet::ATOMS, ImageOrientationStyleValue, "flip");
 		assert_parse!(CssAtomSet::ATOMS, ImageOrientationStyleValue, "90deg flip");
-		assert_parse_error!(CssAtomSet::ATOMS, ImageOrientationStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ImageOrientationStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ImageOrientationStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ImageOrientationStyleValue, "auto");
 	}
 
 	#[test]
@@ -56,8 +56,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ObjectFitStyleValue, "scale-down");
 		assert_parse!(CssAtomSet::ATOMS, ObjectFitStyleValue, "contain scale-down");
 		assert_parse!(CssAtomSet::ATOMS, ObjectFitStyleValue, "cover scale-down");
-		assert_parse_error!(CssAtomSet::ATOMS, ObjectFitStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ObjectFitStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ObjectFitStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ObjectFitStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, ObjectFitStyleValue, "contain cover");
 	}
 }

--- a/crates/css_ast/src/values/inline/impls.rs
+++ b/crates/css_ast/src/values/inline/impls.rs
@@ -33,7 +33,7 @@ mod tests {
 
 	#[test]
 	fn test_vertical_align() {
-		use css_parse::assert_parse_error;
+		use css_parse::{assert_parse_error, assert_peek_false};
 		// [ first | last ] || <'alignment-baseline'> || <'baseline-shift'>
 		assert_parse!(CssAtomSet::ATOMS, VerticalAlignStyleValue, "first");
 		assert_parse!(CssAtomSet::ATOMS, VerticalAlignStyleValue, "last");
@@ -41,7 +41,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, VerticalAlignStyleValue, "sub");
 		assert_parse!(CssAtomSet::ATOMS, VerticalAlignStyleValue, "10px");
 		assert_parse!(CssAtomSet::ATOMS, VerticalAlignStyleValue, "first baseline");
-		assert_parse_error!(CssAtomSet::ATOMS, VerticalAlignStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, VerticalAlignStyleValue, "");
 		assert_parse_error!(CssAtomSet::ATOMS, VerticalAlignStyleValue, "first last");
 	}
 }

--- a/crates/css_ast/src/values/line_grid/impls.rs
+++ b/crates/css_ast/src/values/line_grid/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -28,12 +28,12 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BoxSnapStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BoxSnapStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, BoxSnapStyleValue, "none center");
-		assert_parse_error!(CssAtomSet::ATOMS, LineGridStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, LineGridStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, LineGridStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, LineGridStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, LineGridStyleValue, "match-parent create");
-		assert_parse_error!(CssAtomSet::ATOMS, LineSnapStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, LineSnapStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, LineSnapStyleValue, "none baseline");
 	}
 }

--- a/crates/css_ast/src/values/lists/impls.rs
+++ b/crates/css_ast/src/values/lists/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -25,7 +25,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, CounterResetStyleValue, "reversed(foo)");
 		assert_parse!(CssAtomSet::ATOMS, CounterResetStyleValue, "reversed(foo) 3");
 		assert_parse!(CssAtomSet::ATOMS, CounterResetStyleValue, "my-counter reversed(foo)");
-		assert_parse_error!(CssAtomSet::ATOMS, CounterResetStyleValue, "123");
+		assert_peek_false!(CssAtomSet::ATOMS, CounterResetStyleValue, "123");
 	}
 
 	#[test]
@@ -38,7 +38,7 @@ mod tests {
 
 	#[test]
 	fn test_counter_increment_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, CounterIncrementStyleValue, "123");
+		assert_peek_false!(CssAtomSet::ATOMS, CounterIncrementStyleValue, "123");
 	}
 
 	#[test]
@@ -51,6 +51,6 @@ mod tests {
 
 	#[test]
 	fn test_counter_set_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, CounterSetStyleValue, "123");
+		assert_peek_false!(CssAtomSet::ATOMS, CounterSetStyleValue, "123");
 	}
 }

--- a/crates/css_ast/src/values/logical/impls.rs
+++ b/crates/css_ast/src/values/logical/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -37,10 +37,10 @@ mod tests {
 
 	#[test]
 	fn test_block_size_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BlockSizeStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockSizeStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, BlockSizeStyleValue, "-10px");
 		assert_parse_error!(CssAtomSet::ATOMS, BlockSizeStyleValue, "-20%");
-		assert_parse_error!(CssAtomSet::ATOMS, BlockSizeStyleValue, "60");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockSizeStyleValue, "60");
 		assert_parse_error!(CssAtomSet::ATOMS, BlockSizeStyleValue, "10px 20%");
 	}
 
@@ -55,9 +55,9 @@ mod tests {
 
 	#[test]
 	fn test_inline_size_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, InlineSizeStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, InlineSizeStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, InlineSizeStyleValue, "-10px");
-		assert_parse_error!(CssAtomSet::ATOMS, InlineSizeStyleValue, "60");
+		assert_peek_false!(CssAtomSet::ATOMS, InlineSizeStyleValue, "60");
 		assert_parse_error!(CssAtomSet::ATOMS, InlineSizeStyleValue, "10px 20%");
 	}
 
@@ -93,8 +93,8 @@ mod tests {
 
 	#[test]
 	fn test_margin_block_start_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MarginBlockStartStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, MarginBlockStartStyleValue, "10");
+		assert_peek_false!(CssAtomSet::ATOMS, MarginBlockStartStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, MarginBlockStartStyleValue, "10");
 	}
 
 	#[test]
@@ -121,7 +121,7 @@ mod tests {
 
 	#[test]
 	fn test_margin_block_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MarginBlockStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, MarginBlockStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, MarginBlockStyleValue, "10px auto 20px");
 	}
 
@@ -138,10 +138,10 @@ mod tests {
 
 	#[test]
 	fn test_padding_block_start_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockStartStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, PaddingBlockStartStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockStartStyleValue, "-10px");
-		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockStartStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockStartStyleValue, "10");
+		assert_peek_false!(CssAtomSet::ATOMS, PaddingBlockStartStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, PaddingBlockStartStyleValue, "10");
 	}
 
 	#[test]
@@ -152,7 +152,7 @@ mod tests {
 
 	#[test]
 	fn test_padding_block_end_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockEndStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, PaddingBlockEndStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockEndStyleValue, "-10px");
 		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockEndStyleValue, "1px, 2px");
 	}
@@ -176,9 +176,9 @@ mod tests {
 
 	#[test]
 	fn test_padding_block_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, PaddingBlockStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockStyleValue, "1px 2px 3px");
-		assert_parse_error!(CssAtomSet::ATOMS, PaddingBlockStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, PaddingBlockStyleValue, "auto");
 	}
 
 	#[test]
@@ -188,7 +188,7 @@ mod tests {
 
 	#[test]
 	fn test_padding_inline_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, PaddingInlineStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, PaddingInlineStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, PaddingInlineStyleValue, "10px auto 20px");
 	}
 }

--- a/crates/css_ast/src/values/masking/impls.rs
+++ b/crates/css_ast/src/values/masking/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -53,24 +53,24 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ClipStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ClipStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ClipRuleStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ClipRuleStyleValue, "1");
 		assert_parse_error!(CssAtomSet::ATOMS, ClipStyleValue, "rect(10px)");
-		assert_parse_error!(CssAtomSet::ATOMS, ClipRuleStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, ClipRuleStyleValue, "1");
 
-		assert_parse_error!(CssAtomSet::ATOMS, MaskBorderModeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, MaskBorderModeStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, MaskBorderModeStyleValue, "luminance alpha");
 
-		assert_parse_error!(CssAtomSet::ATOMS, MaskTypeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, MaskTypeStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, MaskTypeStyleValue, "luminance alpha");
 
-		assert_parse_error!(CssAtomSet::ATOMS, MaskRepeatStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, MaskRepeatStyleValue, "repeat-z");
+		assert_peek_false!(CssAtomSet::ATOMS, MaskRepeatStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, MaskRepeatStyleValue, "repeat-z");
 
 		assert_parse_error!(CssAtomSet::ATOMS, MaskSizeStyleValue, "-1px");
 		assert_parse_error!(CssAtomSet::ATOMS, MaskSizeStyleValue, "1px 2px 3px");
 
-		assert_parse_error!(CssAtomSet::ATOMS, MaskPositionStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, MaskPositionStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, MaskPositionStyleValue, "1px 2px 3px");
 		assert_parse_error!(CssAtomSet::ATOMS, MaskPositionStyleValue, "left right");
 	}

--- a/crates/css_ast/src/values/motion/impls.rs
+++ b/crates/css_ast/src/values/motion/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -38,8 +38,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, OffsetRotateStyleValue, "45deg");
 		assert_parse!(CssAtomSet::ATOMS, OffsetRotateStyleValue, "auto 45deg");
 		assert_parse!(CssAtomSet::ATOMS, OffsetRotateStyleValue, "reverse 90deg");
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetRotateStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetRotateStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetRotateStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetRotateStyleValue, "none");
 	}
 
 	#[test]
@@ -56,16 +56,16 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetAnchorStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetAnchorStyleValue, "30deg");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetAnchorStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetAnchorStyleValue, "30deg");
 
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetDistanceStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetDistanceStyleValue, "30deg");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetDistanceStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetDistanceStyleValue, "30deg");
 
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetPathStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetPathStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetPathStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetPathStyleValue, "auto");
 
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetPositionStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, OffsetPositionStyleValue, "30deg");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetPositionStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, OffsetPositionStyleValue, "30deg");
 	}
 }

--- a/crates/css_ast/src/values/moz.rs
+++ b/crates/css_ast/src/values/moz.rs
@@ -155,7 +155,7 @@ pub struct MozFilterStyleValue<'a>;
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn test_moz_column_gap_parses() {
@@ -166,7 +166,7 @@ mod tests {
 
 	#[test]
 	fn test_moz_column_gap_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MozColumnGapStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MozColumnGapStyleValue, "invalid");
 	}
 
 	#[test]
@@ -189,7 +189,7 @@ mod tests {
 
 	#[test]
 	fn test_moz_user_select_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MozUserSelectStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MozUserSelectStyleValue, "invalid");
 	}
 
 	#[test]
@@ -200,7 +200,7 @@ mod tests {
 
 	#[test]
 	fn test_moz_appearance_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MozAppearanceStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MozAppearanceStyleValue, "invalid");
 	}
 
 	#[test]
@@ -211,7 +211,7 @@ mod tests {
 
 	#[test]
 	fn test_moz_osx_font_smoothing_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MozOsxFontSmoothingStyleValue, "antialiased");
+		assert_peek_false!(CssAtomSet::ATOMS, MozOsxFontSmoothingStyleValue, "antialiased");
 	}
 
 	#[test]
@@ -233,7 +233,7 @@ mod tests {
 
 	#[test]
 	fn test_moz_box_sizing_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MozBoxSizingStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MozBoxSizingStyleValue, "invalid");
 	}
 
 	#[test]
@@ -245,6 +245,6 @@ mod tests {
 
 	#[test]
 	fn test_moz_filter_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MozFilterStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MozFilterStyleValue, "invalid");
 	}
 }

--- a/crates/css_ast/src/values/ms.rs
+++ b/crates/css_ast/src/values/ms.rs
@@ -473,7 +473,7 @@ pub struct MsTransitionStyleValue<'a>;
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn test_ms_interpolation_mode_parses() {
@@ -483,8 +483,8 @@ mod tests {
 
 	#[test]
 	fn test_ms_interpolation_mode_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsInterpolationModeStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, MsInterpolationModeStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsInterpolationModeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, MsInterpolationModeStyleValue, "invalid");
 	}
 
 	#[test]
@@ -495,7 +495,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_box_sizing_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsBoxSizingStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsBoxSizingStyleValue, "invalid");
 	}
 
 	#[test]
@@ -508,7 +508,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_overflow_style_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsOverflowStyleStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsOverflowStyleStyleValue, "invalid");
 	}
 
 	#[test]
@@ -522,7 +522,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_touch_action_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsTouchActionStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsTouchActionStyleValue, "invalid");
 	}
 
 	#[test]
@@ -534,7 +534,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_user_select_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsUserSelectStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsUserSelectStyleValue, "invalid");
 	}
 
 	#[test]
@@ -546,7 +546,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_text_size_adjust_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsTextSizeAdjustStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsTextSizeAdjustStyleValue, "invalid");
 	}
 
 	#[test]
@@ -559,7 +559,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_flex_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsFlexStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsFlexStyleValue, "invalid");
 	}
 
 	#[test]
@@ -579,7 +579,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_flex_direction_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsFlexDirectionStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsFlexDirectionStyleValue, "invalid");
 	}
 
 	#[test]
@@ -591,7 +591,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_flex_wrap_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsFlexWrapStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsFlexWrapStyleValue, "invalid");
 	}
 
 	#[test]
@@ -605,7 +605,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_flex_pack_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsFlexPackStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsFlexPackStyleValue, "invalid");
 	}
 
 	#[test]
@@ -619,7 +619,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_flex_align_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsFlexAlignStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsFlexAlignStyleValue, "invalid");
 	}
 
 	#[test]
@@ -634,7 +634,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_flex_item_align_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsFlexItemAlignStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsFlexItemAlignStyleValue, "invalid");
 	}
 
 	#[test]
@@ -649,7 +649,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_flex_line_pack_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsFlexLinePackStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsFlexLinePackStyleValue, "invalid");
 	}
 
 	#[test]
@@ -661,7 +661,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_transform_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsTransformStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsTransformStyleValue, "invalid");
 	}
 
 	#[test]
@@ -677,7 +677,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_filter_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsFilterStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsFilterStyleValue, "invalid");
 	}
 
 	#[test]
@@ -689,7 +689,7 @@ mod tests {
 
 	#[test]
 	fn test_ms_word_break_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, MsWordBreakStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, MsWordBreakStyleValue, "invalid");
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/multicol/impls.rs
+++ b/crates/css_ast/src/values/multicol/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -38,26 +38,26 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ColumnsStyleValue, "10px");
 		assert_parse!(CssAtomSet::ATOMS, ColumnsStyleValue, "3");
 		assert_parse!(CssAtomSet::ATOMS, ColumnsStyleValue, "10px 3");
-		assert_parse_error!(CssAtomSet::ATOMS, ColumnsStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ColumnsStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ColumnsStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ColumnsStyleValue, "none");
 	}
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ColumnCountStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, ColumnCountStyleValue, "2.5");
+		assert_peek_false!(CssAtomSet::ATOMS, ColumnCountStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ColumnCountStyleValue, "2.5");
 		assert_parse_error!(CssAtomSet::ATOMS, ColumnCountStyleValue, "-1");
 		assert_parse_error!(CssAtomSet::ATOMS, ColumnCountStyleValue, "0");
 		assert_parse_error!(CssAtomSet::ATOMS, ColumnCountStyleValue, "1 234");
 
-		assert_parse_error!(CssAtomSet::ATOMS, ColumnFillStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ColumnFillStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, ColumnFillStyleValue, "auto balance");
 
 		assert_parse_error!(CssAtomSet::ATOMS, ColumnSpanStyleValue, "none all");
 
-		assert_parse_error!(CssAtomSet::ATOMS, ColumnWidthStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, ColumnWidthStyleValue, "10");
+		assert_peek_false!(CssAtomSet::ATOMS, ColumnWidthStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ColumnWidthStyleValue, "10");
 		assert_parse_error!(CssAtomSet::ATOMS, ColumnWidthStyleValue, "-20px");
-		assert_parse_error!(CssAtomSet::ATOMS, ColumnWidthStyleValue, "30%");
+		assert_peek_false!(CssAtomSet::ATOMS, ColumnWidthStyleValue, "30%");
 	}
 }

--- a/crates/css_ast/src/values/nav/impls.rs
+++ b/crates/css_ast/src/values/nav/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -24,11 +24,11 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, SpatialNavigationActionStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, SpatialNavigationActionStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, SpatialNavigationActionStyleValue, "auto focus");
-		assert_parse_error!(CssAtomSet::ATOMS, SpatialNavigationContainStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, SpatialNavigationContainStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, SpatialNavigationContainStyleValue, "auto contain");
-		assert_parse_error!(CssAtomSet::ATOMS, SpatialNavigationFunctionStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, SpatialNavigationFunctionStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, SpatialNavigationFunctionStyleValue, "normal grid");
 	}
 }

--- a/crates/css_ast/src/values/o.rs
+++ b/crates/css_ast/src/values/o.rs
@@ -63,7 +63,7 @@ pub struct OFilterStyleValue<'a>;
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_peek_false};
 
 	#[test]
 	fn test_o_object_fit_parses() {
@@ -76,7 +76,7 @@ mod tests {
 
 	#[test]
 	fn test_o_object_fit_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, OObjectFitStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, OObjectFitStyleValue, "invalid");
 	}
 
 	#[test]
@@ -87,7 +87,7 @@ mod tests {
 
 	#[test]
 	fn test_o_box_sizing_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, OBoxSizingStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, OBoxSizingStyleValue, "invalid");
 	}
 
 	#[test]
@@ -99,6 +99,6 @@ mod tests {
 
 	#[test]
 	fn test_o_filter_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, OFilterStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, OFilterStyleValue, "invalid");
 	}
 }

--- a/crates/css_ast/src/values/overflow/impls.rs
+++ b/crates/css_ast/src/values/overflow/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -39,8 +39,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ScrollbarGutterStyleValue, "auto");
 		assert_parse!(CssAtomSet::ATOMS, ScrollbarGutterStyleValue, "stable");
 		assert_parse!(CssAtomSet::ATOMS, ScrollbarGutterStyleValue, "stable both-edges");
-		assert_parse_error!(CssAtomSet::ATOMS, ScrollbarGutterStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ScrollbarGutterStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, ScrollbarGutterStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ScrollbarGutterStyleValue, "1px");
 	}
 
 	#[test]
@@ -49,8 +49,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ScrollMarkerGroupStyleValue, "before");
 		assert_parse!(CssAtomSet::ATOMS, ScrollMarkerGroupStyleValue, "after");
 		assert_parse!(CssAtomSet::ATOMS, ScrollMarkerGroupStyleValue, "before links");
-		assert_parse_error!(CssAtomSet::ATOMS, ScrollMarkerGroupStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ScrollMarkerGroupStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, ScrollMarkerGroupStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ScrollMarkerGroupStyleValue, "1px");
 	}
 
 	#[test]
@@ -62,8 +62,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, LineClampStyleValue, "3 -webkit-legacy");
 		assert_parse!(CssAtomSet::ATOMS, LineClampStyleValue, "auto -webkit-legacy");
 		assert_parse!(CssAtomSet::ATOMS, LineClampStyleValue, "3 auto -webkit-legacy");
-		assert_parse_error!(CssAtomSet::ATOMS, LineClampStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, LineClampStyleValue, "-webkit-legacy");
+		assert_peek_false!(CssAtomSet::ATOMS, LineClampStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, LineClampStyleValue, "-webkit-legacy");
 		assert_parse_error!(CssAtomSet::ATOMS, LineClampStyleValue, "0");
 	}
 
@@ -83,7 +83,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextOverflowStyleValue, "clip clip");
 		assert_parse!(CssAtomSet::ATOMS, TextOverflowStyleValue, "\"...\" ellipsis");
 		assert_parse!(CssAtomSet::ATOMS, TextOverflowStyleValue, "fade");
-		assert_parse_error!(CssAtomSet::ATOMS, TextOverflowStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TextOverflowStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, TextOverflowStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextOverflowStyleValue, "1px");
 	}
 }

--- a/crates/css_ast/src/values/page/impls.rs
+++ b/crates/css_ast/src/values/page/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -19,7 +19,7 @@ mod tests {
 	#[test]
 	fn test_page_errors() {
 		assert_parse_error!(CssAtomSet::ATOMS, PageStyleValue, "not valid");
-		assert_parse_error!(CssAtomSet::ATOMS, PageStyleValue, "123px");
-		assert_parse_error!(CssAtomSet::ATOMS, PageStyleValue, "default");
+		assert_peek_false!(CssAtomSet::ATOMS, PageStyleValue, "123px");
+		assert_peek_false!(CssAtomSet::ATOMS, PageStyleValue, "default");
 	}
 }

--- a/crates/css_ast/src/values/pointer_animations/impls.rs
+++ b/crates/css_ast/src/values/pointer_animations/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -28,9 +28,9 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, PointerTimelineAxisStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, PointerTimelineAxisStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, PointerTimelineAxisStyleValue, "block inline");
-		assert_parse_error!(CssAtomSet::ATOMS, PointerTimelineNameStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, PointerTimelineStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, PointerTimelineNameStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, PointerTimelineStyleValue, "auto");
 	}
 }

--- a/crates/css_ast/src/values/pointer_events/impls.rs
+++ b/crates/css_ast/src/values/pointer_events/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -22,7 +22,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TouchActionStyleValue, "1px");
-		assert_parse_error!(CssAtomSet::ATOMS, TouchActionStyleValue, "any");
+		assert_peek_false!(CssAtomSet::ATOMS, TouchActionStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, TouchActionStyleValue, "any");
 	}
 }

--- a/crates/css_ast/src/values/regions/impls.rs
+++ b/crates/css_ast/src/values/regions/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -31,7 +31,7 @@ mod tests {
 		assert_parse_error!(CssAtomSet::ATOMS, FlowFromStyleValue, "none myflow");
 		assert_parse_error!(CssAtomSet::ATOMS, FlowIntoStyleValue, "element myflow");
 		assert_parse_error!(CssAtomSet::ATOMS, FlowIntoStyleValue, "content myflow");
-		assert_parse_error!(CssAtomSet::ATOMS, RegionFragmentStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, RegionFragmentStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, RegionFragmentStyleValue, "auto break");
 	}
 }

--- a/crates/css_ast/src/values/rhythm/impls.rs
+++ b/crates/css_ast/src/values/rhythm/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -23,11 +23,11 @@ mod tests {
 
 	#[test]
 	fn test_block_step_size_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepSizeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepSizeStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, BlockStepSizeStyleValue, "-1px");
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepSizeStyleValue, "min-content");
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepSizeStyleValue, "10%");
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepSizeStyleValue, "20");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepSizeStyleValue, "min-content");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepSizeStyleValue, "10%");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepSizeStyleValue, "20");
 	}
 
 	#[test]
@@ -42,8 +42,8 @@ mod tests {
 	fn test_block_step_align_errors() {
 		assert_parse_error!(CssAtomSet::ATOMS, BlockStepAlignStyleValue, "auto auto");
 		assert_parse_error!(CssAtomSet::ATOMS, BlockStepAlignStyleValue, "start end");
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepAlignStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepAlignStyleValue, "-1px");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepAlignStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepAlignStyleValue, "-1px");
 	}
 
 	#[test]
@@ -55,8 +55,8 @@ mod tests {
 
 	#[test]
 	fn test_block_step_round_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepRoundStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepRoundStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepRoundStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepRoundStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, BlockStepRoundStyleValue, "up down");
 	}
 
@@ -69,9 +69,9 @@ mod tests {
 
 	#[test]
 	fn test_block_step_insert_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepInsertStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepInsertStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, BlockStepInsertStyleValue, "border-box");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepInsertStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepInsertStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, BlockStepInsertStyleValue, "border-box");
 		assert_parse_error!(CssAtomSet::ATOMS, BlockStepInsertStyleValue, "margin-box padding-box");
 	}
 
@@ -83,9 +83,9 @@ mod tests {
 
 	#[test]
 	fn test_line_height_step_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, LineHeightStepStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, LineHeightStepStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, LineHeightStepStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, LineHeightStepStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, LineHeightStepStyleValue, "-1px");
-		assert_parse_error!(CssAtomSet::ATOMS, LineHeightStepStyleValue, "10%");
+		assert_peek_false!(CssAtomSet::ATOMS, LineHeightStepStyleValue, "10%");
 	}
 }

--- a/crates/css_ast/src/values/round_display/impls.rs
+++ b/crates/css_ast/src/values/round_display/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -18,7 +18,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BorderBoundaryStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderBoundaryStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, BorderBoundaryStyleValue, "none parent");
 	}
 }

--- a/crates/css_ast/src/values/ruby/impls.rs
+++ b/crates/css_ast/src/values/ruby/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -22,9 +22,9 @@ mod tests {
 
 	#[test]
 	fn test_ruby_align_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, RubyAlignStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, RubyAlignStyleValue, "left");
-		assert_parse_error!(CssAtomSet::ATOMS, RubyAlignStyleValue, "10px");
+		assert_peek_false!(CssAtomSet::ATOMS, RubyAlignStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, RubyAlignStyleValue, "left");
+		assert_peek_false!(CssAtomSet::ATOMS, RubyAlignStyleValue, "10px");
 		assert_parse_error!(CssAtomSet::ATOMS, RubyAlignStyleValue, "center start");
 	}
 
@@ -37,9 +37,9 @@ mod tests {
 
 	#[test]
 	fn test_ruby_merge_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, RubyMergeStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, RubyMergeStyleValue, "collapse");
-		assert_parse_error!(CssAtomSet::ATOMS, RubyMergeStyleValue, "10px");
+		assert_peek_false!(CssAtomSet::ATOMS, RubyMergeStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, RubyMergeStyleValue, "collapse");
+		assert_peek_false!(CssAtomSet::ATOMS, RubyMergeStyleValue, "10px");
 		assert_parse_error!(CssAtomSet::ATOMS, RubyMergeStyleValue, "merge separate");
 	}
 
@@ -53,7 +53,7 @@ mod tests {
 	#[test]
 	fn test_ruby_overhang_errors() {
 		assert_parse_error!(CssAtomSet::ATOMS, RubyOverhangStyleValue, "auto none");
-		assert_parse_error!(CssAtomSet::ATOMS, RubyOverhangStyleValue, "simple");
+		assert_peek_false!(CssAtomSet::ATOMS, RubyOverhangStyleValue, "simple");
 		assert_parse_error!(CssAtomSet::ATOMS, RubyOverhangStyleValue, "auto spaces");
 	}
 
@@ -65,8 +65,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, RubyPositionStyleValue, "inter-character");
 		assert_parse!(CssAtomSet::ATOMS, RubyPositionStyleValue, "alternate over");
 		assert_parse!(CssAtomSet::ATOMS, RubyPositionStyleValue, "alternate under");
-		assert_parse_error!(CssAtomSet::ATOMS, RubyPositionStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, RubyPositionStyleValue, "left");
+		assert_peek_false!(CssAtomSet::ATOMS, RubyPositionStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, RubyPositionStyleValue, "left");
 		assert_parse_error!(CssAtomSet::ATOMS, RubyPositionStyleValue, "over under");
 	}
 }

--- a/crates/css_ast/src/values/scroll_anchoring/impls.rs
+++ b/crates/css_ast/src/values/scroll_anchoring/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -17,7 +17,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, OverflowAnchorStyleValue, "all");
+		assert_peek_false!(CssAtomSet::ATOMS, OverflowAnchorStyleValue, "all");
 		assert_parse_error!(CssAtomSet::ATOMS, OverflowAnchorStyleValue, "auto none");
 	}
 }

--- a/crates/css_ast/src/values/scroll_animations/impls.rs
+++ b/crates/css_ast/src/values/scroll_animations/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -36,8 +36,8 @@ mod tests {
 
 	#[test]
 	fn test_animation_range_start_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationRangeStartStyleValue, "peek 50%");
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationRangeStartStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationRangeStartStyleValue, "peek 50%");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationRangeStartStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationRangeStartStyleValue, "50% contain");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationRangeStartStyleValue, "normal 10px");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationRangeStartStyleValue, "contain contain");
@@ -57,9 +57,9 @@ mod tests {
 
 	#[test]
 	fn test_animation_range_end_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationRangeEndStyleValue, "infinite");
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationRangeEndStyleValue, "peek 50%");
-		assert_parse_error!(CssAtomSet::ATOMS, AnimationRangeEndStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationRangeEndStyleValue, "infinite");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationRangeEndStyleValue, "peek 50%");
+		assert_peek_false!(CssAtomSet::ATOMS, AnimationRangeEndStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, AnimationRangeEndStyleValue, "normal 10px");
 	}
 
@@ -73,8 +73,8 @@ mod tests {
 
 	#[test]
 	fn test_scroll_timeline_axis_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ScrollTimelineAxisStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, ScrollTimelineAxisStyleValue, "horizontal");
+		assert_peek_false!(CssAtomSet::ATOMS, ScrollTimelineAxisStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ScrollTimelineAxisStyleValue, "horizontal");
 		assert_parse_error!(CssAtomSet::ATOMS, ScrollTimelineAxisStyleValue, "block inline");
 	}
 
@@ -87,8 +87,8 @@ mod tests {
 
 	#[test]
 	fn test_scroll_timeline_name_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ScrollTimelineNameStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, ScrollTimelineNameStyleValue, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, ScrollTimelineNameStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ScrollTimelineNameStyleValue, "foo");
 	}
 
 	#[test]
@@ -115,7 +115,7 @@ mod tests {
 
 	#[test]
 	fn test_timeline_scope_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TimelineScopeStyleValue, "foo");
-		assert_parse_error!(CssAtomSet::ATOMS, TimelineScopeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, TimelineScopeStyleValue, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, TimelineScopeStyleValue, "auto");
 	}
 }

--- a/crates/css_ast/src/values/shapes/impls.rs
+++ b/crates/css_ast/src/values/shapes/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -30,8 +30,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ShapeInsideStyleValue, "outside-shape");
 		assert_parse!(CssAtomSet::ATOMS, ShapeInsideStyleValue, "display");
 		assert_parse!(CssAtomSet::ATOMS, ShapeInsideStyleValue, "url(\"shape.svg\")");
-		assert_parse_error!(CssAtomSet::ATOMS, ShapeInsideStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ShapeInsideStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ShapeInsideStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ShapeInsideStyleValue, "none");
 	}
 
 	#[test]
@@ -41,16 +41,16 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ShapeOutsideStyleValue, "content-box");
 		assert_parse!(CssAtomSet::ATOMS, ShapeOutsideStyleValue, "border-box");
 		assert_parse!(CssAtomSet::ATOMS, ShapeOutsideStyleValue, "url(\"shape.svg\")");
-		assert_parse_error!(CssAtomSet::ATOMS, ShapeOutsideStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, ShapeOutsideStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ShapeOutsideStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ShapeOutsideStyleValue, "auto");
 	}
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ShapeImageThresholdStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, ShapeImageThresholdStyleValue, "10px");
+		assert_peek_false!(CssAtomSet::ATOMS, ShapeImageThresholdStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, ShapeImageThresholdStyleValue, "10px");
 
-		assert_parse_error!(CssAtomSet::ATOMS, ShapeMarginStyleValue, "none");
-		assert_parse_error!(CssAtomSet::ATOMS, ShapeMarginStyleValue, "10");
+		assert_peek_false!(CssAtomSet::ATOMS, ShapeMarginStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, ShapeMarginStyleValue, "10");
 	}
 }

--- a/crates/css_ast/src/values/size_adjust/impls.rs
+++ b/crates/css_ast/src/values/size_adjust/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -20,9 +20,9 @@ mod tests {
 
 	#[test]
 	fn test_text_size_adjust_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TextSizeAdjustStyleValue, "reverse");
-		assert_parse_error!(CssAtomSet::ATOMS, TextSizeAdjustStyleValue, "0");
-		assert_parse_error!(CssAtomSet::ATOMS, TextSizeAdjustStyleValue, "10px");
+		assert_peek_false!(CssAtomSet::ATOMS, TextSizeAdjustStyleValue, "reverse");
+		assert_peek_false!(CssAtomSet::ATOMS, TextSizeAdjustStyleValue, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, TextSizeAdjustStyleValue, "10px");
 		assert_parse_error!(CssAtomSet::ATOMS, TextSizeAdjustStyleValue, "-100%");
 	}
 }

--- a/crates/css_ast/src/values/sizing/impls.rs
+++ b/crates/css_ast/src/values/sizing/impls.rs
@@ -16,7 +16,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -48,7 +48,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, ContainIntrinsicSizeStyleValue, "none none");
 		assert_parse!(CssAtomSet::ATOMS, ContainIntrinsicSizeStyleValue, "auto none 100px");
 		assert_parse_error!(CssAtomSet::ATOMS, ContainIntrinsicWidthStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, ContainIntrinsicWidthStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, ContainIntrinsicWidthStyleValue, "");
 	}
 
 	#[test]
@@ -57,8 +57,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, MinIntrinsicSizingStyleValue, "zero-if-scroll");
 		assert_parse!(CssAtomSet::ATOMS, MinIntrinsicSizingStyleValue, "zero-if-extrinsic");
 		assert_parse!(CssAtomSet::ATOMS, MinIntrinsicSizingStyleValue, "zero-if-scroll zero-if-extrinsic");
-		assert_parse_error!(CssAtomSet::ATOMS, MinIntrinsicSizingStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, MinIntrinsicSizingStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, MinIntrinsicSizingStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, MinIntrinsicSizingStyleValue, "auto");
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/speech/impls.rs
+++ b/crates/css_ast/src/values/speech/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	pub fn size_test() {
@@ -37,7 +37,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, VoiceFamilyStyleValue, "Alice");
 		assert_parse!(CssAtomSet::ATOMS, VoiceFamilyStyleValue, "\"Alice\"");
 		assert_parse!(CssAtomSet::ATOMS, VoiceFamilyStyleValue, "Alice,male");
-		assert_parse_error!(CssAtomSet::ATOMS, VoiceFamilyStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, VoiceFamilyStyleValue, "");
 	}
 
 	#[test]
@@ -50,8 +50,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, VoiceVolumeStyleValue, "x-loud");
 		assert_parse!(CssAtomSet::ATOMS, VoiceVolumeStyleValue, "soft 6db");
 		assert_parse!(CssAtomSet::ATOMS, VoiceVolumeStyleValue, "loud -3db");
-		assert_parse_error!(CssAtomSet::ATOMS, VoiceVolumeStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, VoiceVolumeStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, VoiceVolumeStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, VoiceVolumeStyleValue, "1px");
 	}
 
 	#[test]
@@ -64,8 +64,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, VoiceRateStyleValue, "x-fast");
 		assert_parse!(CssAtomSet::ATOMS, VoiceRateStyleValue, "50%");
 		assert_parse!(CssAtomSet::ATOMS, VoiceRateStyleValue, "normal 50%");
-		assert_parse_error!(CssAtomSet::ATOMS, VoiceRateStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, VoiceRateStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, VoiceRateStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, VoiceRateStyleValue, "1px");
 	}
 
 	#[test]

--- a/crates/css_ast/src/values/svg_painting/impls.rs
+++ b/crates/css_ast/src/values/svg_painting/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -36,8 +36,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, ColorInterpolationStyleValue, "red");
+		assert_peek_false!(CssAtomSet::ATOMS, ColorInterpolationStyleValue, "red");
+		assert_peek_false!(CssAtomSet::ATOMS, ShapeRenderingStyleValue, "crisp-edges");
 		assert_parse_error!(CssAtomSet::ATOMS, PaintOrderStyleValue, "fill fill");
-		assert_parse_error!(CssAtomSet::ATOMS, ShapeRenderingStyleValue, "crisp-edges");
 	}
 }

--- a/crates/css_ast/src/values/tables/impls.rs
+++ b/crates/css_ast/src/values/tables/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -33,22 +33,22 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, BorderCollapseStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderCollapseStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, BorderCollapseStyleValue, "separate collapse");
 
-		assert_parse_error!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "10%");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "10%");
 		assert_parse_error!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "-20px");
-		assert_parse_error!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "30");
+		assert_peek_false!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "30");
 		assert_parse_error!(CssAtomSet::ATOMS, BorderSpacingStyleValue, "40px 50px 60px");
 
-		assert_parse_error!(CssAtomSet::ATOMS, CaptionSideStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, CaptionSideStyleValue, "left");
+		assert_peek_false!(CssAtomSet::ATOMS, CaptionSideStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, CaptionSideStyleValue, "left");
 		assert_parse_error!(CssAtomSet::ATOMS, CaptionSideStyleValue, "top bottom");
 
-		assert_parse_error!(CssAtomSet::ATOMS, EmptyCellsStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, EmptyCellsStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, EmptyCellsStyleValue, "show hide");
 
-		assert_parse_error!(CssAtomSet::ATOMS, TableLayoutStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, TableLayoutStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, TableLayoutStyleValue, "auto fixed");
 	}
 }

--- a/crates/css_ast/src/values/text/impls.rs
+++ b/crates/css_ast/src/values/text/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -64,8 +64,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextTransformStyleValue, "math-auto");
 		assert_parse!(CssAtomSet::ATOMS, TextTransformStyleValue, "capitalize full-width");
 		assert_parse!(CssAtomSet::ATOMS, TextTransformStyleValue, "full-width full-size-kana");
-		assert_parse_error!(CssAtomSet::ATOMS, TextTransformStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TextTransformStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, TextTransformStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextTransformStyleValue, "1px");
 	}
 
 	#[test]
@@ -77,8 +77,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, HangingPunctuationStyleValue, "allow-end");
 		assert_parse!(CssAtomSet::ATOMS, HangingPunctuationStyleValue, "first last");
 		assert_parse!(CssAtomSet::ATOMS, HangingPunctuationStyleValue, "first force-end last");
-		assert_parse_error!(CssAtomSet::ATOMS, HangingPunctuationStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, HangingPunctuationStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, HangingPunctuationStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, HangingPunctuationStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, HangingPunctuationStyleValue, "force-end allow-end");
 	}
 
@@ -92,8 +92,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextJustifyStyleValue, "no-compress");
 		assert_parse!(CssAtomSet::ATOMS, TextJustifyStyleValue, "auto no-compress");
 		assert_parse!(CssAtomSet::ATOMS, TextJustifyStyleValue, "inter-word no-compress");
-		assert_parse_error!(CssAtomSet::ATOMS, TextJustifyStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TextJustifyStyleValue, "left");
+		assert_peek_false!(CssAtomSet::ATOMS, TextJustifyStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextJustifyStyleValue, "left");
 	}
 
 	#[test]
@@ -103,7 +103,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextIndentStyleValue, "1em hanging");
 		assert_parse!(CssAtomSet::ATOMS, TextIndentStyleValue, "1em each-line");
 		assert_parse!(CssAtomSet::ATOMS, TextIndentStyleValue, "1em hanging each-line");
-		assert_parse_error!(CssAtomSet::ATOMS, TextIndentStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextIndentStyleValue, "");
 		assert_parse_error!(CssAtomSet::ATOMS, TextIndentStyleValue, "hanging");
 	}
 
@@ -118,8 +118,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, WhiteSpaceStyleValue, "wrap");
 		assert_parse!(CssAtomSet::ATOMS, WhiteSpaceStyleValue, "nowrap");
 		assert_parse!(CssAtomSet::ATOMS, WhiteSpaceStyleValue, "preserve nowrap");
-		assert_parse_error!(CssAtomSet::ATOMS, WhiteSpaceStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, WhiteSpaceStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, WhiteSpaceStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, WhiteSpaceStyleValue, "1px");
 	}
 
 	#[test]
@@ -130,8 +130,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, WhiteSpaceTrimStyleValue, "discard-inner");
 		assert_parse!(CssAtomSet::ATOMS, WhiteSpaceTrimStyleValue, "discard-before discard-after");
 		assert_parse!(CssAtomSet::ATOMS, WhiteSpaceTrimStyleValue, "discard-before discard-after discard-inner");
-		assert_parse_error!(CssAtomSet::ATOMS, WhiteSpaceTrimStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, WhiteSpaceTrimStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, WhiteSpaceTrimStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, WhiteSpaceTrimStyleValue, "auto");
 	}
 
 	#[test]
@@ -141,8 +141,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, WordSpaceTransformStyleValue, "ideographic-space");
 		assert_parse!(CssAtomSet::ATOMS, WordSpaceTransformStyleValue, "space auto-phrase");
 		assert_parse!(CssAtomSet::ATOMS, WordSpaceTransformStyleValue, "ideographic-space auto-phrase");
-		assert_parse_error!(CssAtomSet::ATOMS, WordSpaceTransformStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, WordSpaceTransformStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, WordSpaceTransformStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, WordSpaceTransformStyleValue, "auto");
 	}
 
 	#[test]
@@ -152,7 +152,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, HyphenateLimitCharsStyleValue, "auto 3");
 		assert_parse!(CssAtomSet::ATOMS, HyphenateLimitCharsStyleValue, "5 2 2");
 		assert_parse!(CssAtomSet::ATOMS, HyphenateLimitCharsStyleValue, "auto auto auto");
-		assert_parse_error!(CssAtomSet::ATOMS, HyphenateLimitCharsStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, HyphenateLimitCharsStyleValue, "");
 		assert_parse_error!(CssAtomSet::ATOMS, HyphenateLimitCharsStyleValue, "5 2 2 2");
 	}
 }

--- a/crates/css_ast/src/values/text_decor/impls.rs
+++ b/crates/css_ast/src/values/text_decor/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	pub fn size_test() {
@@ -35,8 +35,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "from-font left");
 		assert_parse!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "left");
 		assert_parse!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "right");
-		assert_parse_error!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "1px");
+		assert_peek_false!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextUnderlinePositionStyleValue, "1px");
 	}
 
 	#[test]
@@ -50,8 +50,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextEmphasisStyleStyleValue, "triangle");
 		assert_parse!(CssAtomSet::ATOMS, TextEmphasisStyleStyleValue, "sesame");
 		assert_parse!(CssAtomSet::ATOMS, TextEmphasisStyleStyleValue, "filled dot");
-		assert_parse_error!(CssAtomSet::ATOMS, TextEmphasisStyleStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TextEmphasisStyleStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, TextEmphasisStyleStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextEmphasisStyleStyleValue, "auto");
 	}
 
 	#[test]
@@ -63,8 +63,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextEmphasisStyleValue, "#ff0000");
 		assert_parse!(CssAtomSet::ATOMS, TextEmphasisStyleValue, "filled red");
 		assert_parse!(CssAtomSet::ATOMS, TextEmphasisStyleValue, "dot blue");
-		assert_parse_error!(CssAtomSet::ATOMS, TextEmphasisStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TextEmphasisStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, TextEmphasisStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextEmphasisStyleValue, "invalid");
 	}
 
 	#[test]
@@ -77,7 +77,7 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationLineStyleValue, "underline line-through overline");
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationLineStyleValue, "spelling-error");
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationLineStyleValue, "grammar-error");
-		assert_parse_error!(CssAtomSet::ATOMS, TextDecorationLineStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextDecorationLineStyleValue, "");
 		assert_parse_error!(CssAtomSet::ATOMS, TextDecorationLineStyleValue, "none underline");
 	}
 
@@ -90,8 +90,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationSkipSelfStyleValue, "skip-overline");
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationSkipSelfStyleValue, "skip-line-through");
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationSkipSelfStyleValue, "skip-underline skip-overline");
-		assert_parse_error!(CssAtomSet::ATOMS, TextDecorationSkipSelfStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TextDecorationSkipSelfStyleValue, "left");
+		assert_peek_false!(CssAtomSet::ATOMS, TextDecorationSkipSelfStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextDecorationSkipSelfStyleValue, "left");
 	}
 
 	#[test]
@@ -101,8 +101,8 @@ mod tests {
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationSkipSpacesStyleValue, "start");
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationSkipSpacesStyleValue, "end");
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationSkipSpacesStyleValue, "start end");
-		assert_parse_error!(CssAtomSet::ATOMS, TextDecorationSkipSpacesStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TextDecorationSkipSpacesStyleValue, "left");
+		assert_peek_false!(CssAtomSet::ATOMS, TextDecorationSkipSpacesStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextDecorationSkipSpacesStyleValue, "left");
 	}
 
 	#[test]
@@ -119,8 +119,8 @@ mod tests {
 		// order should not matter (|| combinator)
 		assert_parse!(CssAtomSet::ATOMS, TextDecorationStyleValue, "red underline");
 		// errors
-		assert_parse_error!(CssAtomSet::ATOMS, TextDecorationStyleValue, "");
-		assert_parse_error!(CssAtomSet::ATOMS, TextDecorationStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, TextDecorationStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextDecorationStyleValue, "invalid");
 	}
 
 	#[test]
@@ -139,10 +139,10 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TextEmphasisSkipStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, TextEmphasisSkipStyleValue, "");
 		assert_parse_error!(CssAtomSet::ATOMS, TextEmphasisSkipStyleValue, "spaces spaces");
 		assert_parse_error!(CssAtomSet::ATOMS, TextEmphasisSkipStyleValue, "punctuation punctuation");
-		assert_parse_error!(CssAtomSet::ATOMS, TextEmphasisSkipStyleValue, "foo");
+		assert_peek_false!(CssAtomSet::ATOMS, TextEmphasisSkipStyleValue, "foo");
 		assert_parse_error!(CssAtomSet::ATOMS, TextEmphasisSkipStyleValue, "punctuation bar narrow");
 	}
 }

--- a/crates/css_ast/src/values/transforms/impls.rs
+++ b/crates/css_ast/src/values/transforms/impls.rs
@@ -18,7 +18,7 @@ impl<'a> Parse<'a> for TransformOriginStyleValue {
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -50,7 +50,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TransformStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, TransformStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, ScaleStyleValue, "none none");
 	}
 
@@ -100,10 +100,10 @@ mod tests {
 
 	#[test]
 	fn test_transform_origin_errors() {
+		assert_peek_false!(CssAtomSet::ATOMS, TransformOriginStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, TransformOriginStyleValue, "top top");
 		assert_parse_error!(CssAtomSet::ATOMS, TransformOriginStyleValue, "left left");
 		assert_parse_error!(CssAtomSet::ATOMS, TransformOriginStyleValue, "left top 50%");
-		assert_parse_error!(CssAtomSet::ATOMS, TransformOriginStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, TransformOriginStyleValue, "left top 0px extra");
 	}
 }

--- a/crates/css_ast/src/values/transitions/impls.rs
+++ b/crates/css_ast/src/values/transitions/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -24,9 +24,9 @@ mod tests {
 
 	#[test]
 	fn test_transition_delay_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionDelayStyleValue, "0");
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionDelayStyleValue, "0px");
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionDelayStyleValue, "infinite");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionDelayStyleValue, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionDelayStyleValue, "0px");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionDelayStyleValue, "infinite");
 		assert_parse_error!(CssAtomSet::ATOMS, TransitionDelayStyleValue, "1s 2s 3s");
 	}
 
@@ -40,12 +40,12 @@ mod tests {
 
 	#[test]
 	fn test_transition_duration_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "0");
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "0px");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "0");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "0px");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "infinite");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "auto");
 		assert_parse_error!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "-3s");
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "infinite");
 		assert_parse_error!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "1s 2s");
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionDurationStyleValue, "auto");
 	}
 
 	#[test]
@@ -60,7 +60,7 @@ mod tests {
 
 	#[test]
 	fn test_transition_property_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionPropertyStyleValue, "12");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionPropertyStyleValue, "12");
 		assert_parse_error!(CssAtomSet::ATOMS, TransitionPropertyStyleValue, "opacity color");
 	}
 
@@ -92,8 +92,8 @@ mod tests {
 
 	#[test]
 	fn test_transition_behavior_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionBehaviorStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, TransitionBehaviorStyleValue, "discrete");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionBehaviorStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, TransitionBehaviorStyleValue, "discrete");
 		assert_parse_error!(CssAtomSet::ATOMS, TransitionBehaviorStyleValue, "allow-discrete normal");
 	}
 }

--- a/crates/css_ast/src/values/values/impls.rs
+++ b/crates/css_ast/src/values/values/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -16,9 +16,13 @@ mod tests {
 	}
 
 	#[test]
+	fn test_peek() {
+		assert_peek_false!(CssAtomSet::ATOMS, InterpolateSizeStyleValue, "auto");
+		assert_peek_false!(CssAtomSet::ATOMS, InterpolateSizeStyleValue, "none");
+	}
+
+	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, InterpolateSizeStyleValue, "auto");
-		assert_parse_error!(CssAtomSet::ATOMS, InterpolateSizeStyleValue, "none");
 		assert_parse_error!(CssAtomSet::ATOMS, InterpolateSizeStyleValue, "numeric-only allow-keywords");
 	}
 }

--- a/crates/css_ast/src/values/viewport/impls.rs
+++ b/crates/css_ast/src/values/viewport/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	pub fn size_test() {
@@ -18,10 +18,14 @@ mod tests {
 	}
 
 	#[test]
+	fn test_peek() {
+		assert_peek_false!(CssAtomSet::ATOMS, ZoomStyleValue, "smaller");
+	}
+
+	#[test]
 	fn test_errors() {
 		assert_parse_error!(CssAtomSet::ATOMS, ZoomStyleValue, "-100%");
 		assert_parse_error!(CssAtomSet::ATOMS, ZoomStyleValue, "-10");
-		assert_parse_error!(CssAtomSet::ATOMS, ZoomStyleValue, "smaller");
 		assert_parse_error!(CssAtomSet::ATOMS, ZoomStyleValue, "10 10%");
 		assert_parse_error!(CssAtomSet::ATOMS, ZoomStyleValue, "10% 10");
 	}

--- a/crates/css_ast/src/values/webkit.rs
+++ b/crates/css_ast/src/values/webkit.rs
@@ -1232,7 +1232,7 @@ pub struct WebkitPerspectiveStyleValue;
 mod tests {
 	use super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -1250,7 +1250,7 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitFilterStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitFilterStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1287,7 +1287,7 @@ mod tests {
 
 	#[test]
 	fn test_flex_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitFlexStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitFlexStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1304,7 +1304,7 @@ mod tests {
 
 	#[test]
 	fn test_order_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitOrderStyleValue, "none");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitOrderStyleValue, "none");
 	}
 
 	#[test]
@@ -1322,7 +1322,7 @@ mod tests {
 
 	#[test]
 	fn test_appearance_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitAppearanceStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitAppearanceStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1339,7 +1339,7 @@ mod tests {
 
 	#[test]
 	fn test_transform_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitTransformStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitTransformStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1357,7 +1357,7 @@ mod tests {
 
 	#[test]
 	fn test_font_smoothing_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitFontSmoothingStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitFontSmoothingStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1374,7 +1374,7 @@ mod tests {
 
 	#[test]
 	fn test_text_size_adjust_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitTextSizeAdjustStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitTextSizeAdjustStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1393,7 +1393,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_delay_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitAnimationDelayStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitAnimationDelayStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1413,7 +1413,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_duration_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitAnimationDurationStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitAnimationDurationStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1433,7 +1433,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_fill_mode_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitAnimationFillModeStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitAnimationFillModeStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1453,7 +1453,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_iteration_count_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitAnimationIterationCountStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitAnimationIterationCountStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1472,7 +1472,8 @@ mod tests {
 
 	#[test]
 	fn test_animation_name_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitAnimationNameStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitAnimationNameStyleValue, "");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitAnimationNameStyleValue, "1px");
 	}
 
 	#[test]
@@ -1493,7 +1494,7 @@ mod tests {
 
 	#[test]
 	fn test_animation_timing_function_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitAnimationTimingFunctionStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitAnimationTimingFunctionStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1512,7 +1513,7 @@ mod tests {
 
 	#[test]
 	fn test_backface_visibility_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitBackfaceVisibilityStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitBackfaceVisibilityStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1532,7 +1533,7 @@ mod tests {
 
 	#[test]
 	fn test_tap_highlight_color_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitTapHighlightColorStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitTapHighlightColorStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1552,7 +1553,7 @@ mod tests {
 
 	#[test]
 	fn test_transition_duration_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitTransitionDurationStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitTransitionDurationStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1572,7 +1573,7 @@ mod tests {
 
 	#[test]
 	fn test_transition_timing_function_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitTransitionTimingFunctionStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitTransitionTimingFunctionStyleValue, "invalid");
 	}
 
 	#[test]
@@ -1583,6 +1584,6 @@ mod tests {
 
 	#[test]
 	fn test_webkit_perspective_errors() {
-		assert_parse_error!(CssAtomSet::ATOMS, WebkitPerspectiveStyleValue, "invalid");
+		assert_peek_false!(CssAtomSet::ATOMS, WebkitPerspectiveStyleValue, "invalid");
 	}
 }

--- a/crates/css_ast/src/values/will_change/impls.rs
+++ b/crates/css_ast/src/values/will_change/impls.rs
@@ -2,7 +2,7 @@
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn test_writes() {
@@ -13,10 +13,14 @@ mod tests {
 	}
 
 	#[test]
+	fn test_peek() {
+		assert_peek_false!(CssAtomSet::ATOMS, WillChangeStyleValue, ""); // must be at-least-one
+		assert_peek_false!(CssAtomSet::ATOMS, WillChangeStyleValue, "0px 3px"); // dimensions not idents
+	}
+
+	#[test]
 	fn test_errors() {
 		assert_parse_error!(CssAtomSet::ATOMS, WillChangeStyleValue, "auto auto"); // two autos is illegal
-		assert_parse_error!(CssAtomSet::ATOMS, WillChangeStyleValue, ""); // must be at-least-one
 		assert_parse_error!(CssAtomSet::ATOMS, WillChangeStyleValue, "transform filter"); // no commas
-		assert_parse_error!(CssAtomSet::ATOMS, WillChangeStyleValue, "0px 3px"); // dimensions not idents
 	}
 }

--- a/crates/css_ast/src/values/writing_modes/impls.rs
+++ b/crates/css_ast/src/values/writing_modes/impls.rs
@@ -42,7 +42,7 @@ impl<'a> Parse<'a> for GlyphOrientationVerticalStyleValue {
 mod tests {
 	use super::super::*;
 	use crate::CssAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn size_test() {
@@ -68,10 +68,13 @@ mod tests {
 	}
 
 	#[test]
+	fn test_peek() {
+		assert_peek_false!(CssAtomSet::ATOMS, GlyphOrientationVerticalStyleValue, "128");
+		assert_peek_false!(CssAtomSet::ATOMS, GlyphOrientationVerticalStyleValue, "50deg");
+	}
+
+	#[test]
 	fn test_parse_error() {
-		assert_parse_error!(CssAtomSet::ATOMS, GlyphOrientationVerticalStyleValue, "128");
-		assert_parse_error!(CssAtomSet::ATOMS, GlyphOrientationVerticalStyleValue, "50deg");
-		assert_parse_error!(CssAtomSet::ATOMS, GlyphOrientationVerticalStyleValue, "50deg");
 		assert_parse_error!(CssAtomSet::ATOMS, TextCombineUprightStyleValue, "digits 1");
 		assert_parse_error!(CssAtomSet::ATOMS, TextCombineUprightStyleValue, "digits 2 2");
 		assert_parse_error!(CssAtomSet::ATOMS, TextCombineUprightStyleValue, "digits 5");

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -259672,6 +259673,11 @@ StyleSheet(
               len: 1,
             ))),
           ),
+          Whitespace(Cursor(
+            kind: "Whitespace",
+            offset: SourceOffset(200345),
+            len: 1,
+          )),
         ],
       ),
       block: ComponentValues(

--- a/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/popular_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -10609,6 +10610,11 @@ StyleSheet(
                       len: 1,
                     ))),
                   ),
+                  Whitespace(Cursor(
+                    kind: "Whitespace",
+                    offset: SourceOffset(7436),
+                    len: 1,
+                  )),
                 ],
               ),
               block: ComponentValues(
@@ -32827,6 +32833,11 @@ StyleSheet(
                       len: 1,
                     ))),
                   ),
+                  Whitespace(Cursor(
+                    kind: "Whitespace",
+                    offset: SourceOffset(21880),
+                    len: 1,
+                  )),
                 ],
               ),
               block: ComponentValues(
@@ -34423,6 +34434,11 @@ StyleSheet(
                       len: 1,
                     ))),
                   ),
+                  Whitespace(Cursor(
+                    kind: "Whitespace",
+                    offset: SourceOffset(23232),
+                    len: 1,
+                  )),
                 ],
               ),
               block: ComponentValues(
@@ -35193,6 +35209,11 @@ StyleSheet(
                                   kind: "Dimension",
                                   offset: SourceOffset(23846),
                                   len: 2,
+                                )),
+                                Whitespace(Cursor(
+                                  kind: "Whitespace",
+                                  offset: SourceOffset(23848),
+                                  len: 1,
                                 )),
                               ],
                             ),
@@ -59727,6 +59748,11 @@ StyleSheet(
                                   len: 1,
                                 ))),
                               ),
+                              Whitespace(Cursor(
+                                kind: "Whitespace",
+                                offset: SourceOffset(41167),
+                                len: 1,
+                              )),
                             ],
                           ),
                           close: RightParen(Cursor(
@@ -59766,6 +59792,11 @@ StyleSheet(
                             len: 1,
                           )),
                         ),
+                        Whitespace(Cursor(
+                          kind: "Whitespace",
+                          offset: SourceOffset(41189),
+                          len: 1,
+                        )),
                       ],
                     ),
                     close: RightParen(Cursor(
@@ -60564,6 +60595,11 @@ StyleSheet(
                       len: 1,
                     ))),
                   ),
+                  Whitespace(Cursor(
+                    kind: "Whitespace",
+                    offset: SourceOffset(41622),
+                    len: 1,
+                  )),
                 ],
               ),
               block: ComponentValues(
@@ -73533,6 +73569,11 @@ StyleSheet(
                   Semicolon(Cursor(
                     kind: "Semicolon",
                     offset: SourceOffset(50341),
+                    len: 1,
+                  )),
+                  Whitespace(Cursor(
+                    kind: "Whitespace",
+                    offset: SourceOffset(50342),
                     len: 1,
                   )),
                 ],

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_brackets.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_brackets.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -1316,6 +1317,11 @@ StyleSheet(
               len: 1,
             ))),
           ),
+          Whitespace(Cursor(
+            kind: "Whitespace",
+            offset: SourceOffset(507),
+            len: 1,
+          )),
         ],
       ),
       block: ComponentValues(

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_decls.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_decls.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -323,6 +324,11 @@ StyleSheet(
               len: 1,
             ))),
           ),
+          Whitespace(Cursor(
+            kind: "Whitespace",
+            offset: SourceOffset(200),
+            len: 1,
+          )),
         ],
       ),
       block: ComponentValues(

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_rules.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_atrule_rules.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -209,6 +210,11 @@ StyleSheet(
                     len: 1,
                   ))),
                 ),
+                Whitespace(Cursor(
+                  kind: "Whitespace",
+                  offset: SourceOffset(168),
+                  len: 1,
+                )),
               ],
             ),
             block: ComponentValues(
@@ -354,6 +360,11 @@ StyleSheet(
               len: 1,
             ))),
           ),
+          Whitespace(Cursor(
+            kind: "Whitespace",
+            offset: SourceOffset(257),
+            len: 1,
+          )),
         ],
       ),
       block: ComponentValues(

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_extends.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_extends.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -143,6 +144,11 @@ StyleSheet(
                   len: 1,
                 ))),
               ),
+              Whitespace(Cursor(
+                kind: "Whitespace",
+                offset: SourceOffset(56),
+                len: 1,
+              )),
             ],
           ),
         ],

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_inside.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_inside.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -40,6 +41,11 @@ StyleSheet(
                     kind: "String",
                     offset: SourceOffset(12),
                     len: 7,
+                  )),
+                  Whitespace(Cursor(
+                    kind: "Whitespace",
+                    offset: SourceOffset(19),
+                    len: 1,
                   )),
                 ],
               ),

--- a/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_rule_at.snap
+++ b/crates/css_ast/tests/snapshots/postcss_snapshots__postcss_rule_at.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/css_ast/tests/postcss_snapshots.rs
 expression: result.output.unwrap()
+snapshot_kind: text
 ---
 StyleSheet(
   rules: [
@@ -158,6 +159,11 @@ StyleSheet(
                       len: 1,
                     ))),
                   ),
+                  Whitespace(Cursor(
+                    kind: "Whitespace",
+                    offset: SourceOffset(91),
+                    len: 1,
+                  )),
                 ],
               ),
               block: ComponentValues(

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -254,6 +254,11 @@
 //!   colon: T![Colon],
 //!   dimension: T![Dimension],
 //! }
+//!
+//! impl<'a> Peek<'a> for MyProperty {
+//!   const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Ident]);
+//! }
+//!
 //! impl<'a> Parse<'a> for MyProperty {
 //!   fn parse<I>(p: &mut Parser<'a, I>) -> Result<Self>
 //!   where

--- a/crates/css_parse/src/macros/pseudo_class.rs
+++ b/crates/css_parse/src/macros/pseudo_class.rs
@@ -40,14 +40,14 @@
 /// // Matches are case insensitive
 /// assert_parse!(MyAtomSet::ATOMS, MyPseudoClass, ":BaR");
 ///
-/// // Words that do not match will fail to parse.
-/// assert_parse_error!(MyAtomSet::ATOMS, MyPseudoClass, ":bing");
+/// // Words that do not match will fail to Peek.
+/// assert_peek_false!(MyAtomSet::ATOMS, MyPseudoClass, ":bing");
 ///
 /// // The `:` is also required
-/// assert_parse_error!(MyAtomSet::ATOMS, MyPseudoClass, "baz");
+/// assert_peek_false!(MyAtomSet::ATOMS, MyPseudoClass, "baz");
 ///
 /// // Any tokens between the `:` and ident result in a parse error:
-/// assert_parse_error!(MyAtomSet::ATOMS, MyPseudoClass, ": foo");
+/// assert_peek_false!(MyAtomSet::ATOMS, MyPseudoClass, ": foo");
 /// ```
 #[macro_export]
 macro_rules! pseudo_class {

--- a/crates/css_parse/src/macros/pseudo_element.rs
+++ b/crates/css_parse/src/macros/pseudo_element.rs
@@ -40,8 +40,8 @@
 /// // The result will be one of the variants in the enum, matching the keyword.
 /// assert_parse!(MyAtomSet::ATOMS, MyPseudoElement, "::bar");
 ///
-/// // Words that do not match will fail to parse.
-/// assert_parse_error!(MyAtomSet::ATOMS, MyPseudoElement, "::bing");
+/// // Words that do not match will fail to Peek.
+/// assert_peek_false!(MyAtomSet::ATOMS, MyPseudoElement, "::bing");
 /// ```
 #[macro_export]
 macro_rules! pseudo_element {

--- a/crates/css_parse/src/syntax/component_value.rs
+++ b/crates/css_parse/src/syntax/component_value.rs
@@ -45,6 +45,13 @@ impl<'a> Peek<'a> for ComponentValue<'a> {
 		Kind::LeftParen,
 		Kind::LeftSquare,
 	]);
+	#[inline(always)]
+	fn peek<Iter>(p: &Parser<'a, Iter>, c: Cursor) -> bool
+	where
+		Iter: Iterator<Item = Cursor> + Clone,
+	{
+		c == Self::PEEK_KINDSET || <T![' ']>::peek(p, c)
+	}
 }
 
 // https://drafts.csswg.org/css-syntax-3/#consume-component-value

--- a/crates/css_parse/src/syntax/either.rs
+++ b/crates/css_parse/src/syntax/either.rs
@@ -108,7 +108,7 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{T, assert_parse, assert_parse_error};
+	use crate::{T, assert_parse, assert_parse_error, assert_peek_false};
 	use css_lexer::EmptyAtomSet;
 
 	type IdentOrNumber = Either<T![Ident], T![Number]>;
@@ -127,8 +127,8 @@ mod tests {
 
 	#[test]
 	fn test_errors() {
-		assert_parse_error!(EmptyAtomSet::ATOMS, IdentOrNumber, "");
-		assert_parse_error!(EmptyAtomSet::ATOMS, IdentOrNumber, "foo(");
+		assert_peek_false!(EmptyAtomSet::ATOMS, IdentOrNumber, "");
+		assert_peek_false!(EmptyAtomSet::ATOMS, IdentOrNumber, "foo(");
 		assert_parse_error!(EmptyAtomSet::ATOMS, IdentOrNumber, "auto auto");
 		assert_parse_error!(EmptyAtomSet::ATOMS, IdentOrNumber, "1 1");
 	}

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -16,7 +16,7 @@
 /// ```
 /// use css_parse::*;
 /// use csskit_derives::*;
-/// #[derive(Parse, ToCursors, Debug)]
+/// #[derive(Peek, Parse, ToCursors, Debug)]
 /// enum IdentOrNumber {
 ///     Ident(T![Ident]),
 ///     Number(T![Number]),
@@ -81,6 +81,9 @@ macro_rules! assert_parse {
 			let bump = ::bumpalo::Bump::default();
 			let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
 			let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
+			if !parser.peek::<$ty>() {
+				panic!("\n\nParse failed because Type didn't peek!\n\n   parser input: {:?}\n", source_text);
+			}
 			let result = parser.parse_entirely::<$ty>().with_trivia();
 			if !result.errors.is_empty() {
 				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
@@ -119,7 +122,7 @@ pub(crate) use assert_parse;
 ///
 /// ```
 /// use css_parse::*;
-/// assert_parse_error!(EmptyAtomSet::ATOMS, T![Ident], "1");
+/// assert_parse_error!(EmptyAtomSet::ATOMS, T![Ident], "one two");
 /// ```
 #[macro_export]
 macro_rules! assert_parse_error {
@@ -128,6 +131,9 @@ macro_rules! assert_parse_error {
 		let bump = ::bumpalo::Bump::default();
 		let lexer = css_lexer::Lexer::new(&$atomset, source_text);
 		let mut parser = $crate::Parser::new(&bump, source_text, lexer);
+		if !parser.peek::<$ty>() {
+			panic!("\n\n.\n\nPeek returned false, please don't use `assert_parse_error` - use `assert_peek_false` instead: {:?}", source_text);
+		}
 		let result = parser.parse::<$ty>();
 		if parser.at_end() {
 			if let Ok(result) = result {

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -124,6 +124,15 @@ macro_rules! boolean_feature {
 			Bare($crate::T!['('], $crate::T![Ident], $crate::T![')']),
 		}
 
+		impl<'a> $crate::Peek<'a> for $feature {
+			fn peek<Iter>(p: &$crate::Parser<'a, Iter>, c: $crate::Cursor) -> bool
+			where
+				Iter: Iterator<Item = $crate::Cursor> + Clone,
+			{
+				c == $crate::Kind::LeftParen && p.peek_n(2) == $crate::Kind::Ident
+			}
+		}
+
 		impl<'a> $crate::Parse<'a> for $feature {
 			fn parse<I>(p: &mut $crate::Parser<'a, I>) -> $crate::Result<Self>
 			where

--- a/crates/css_parse/src/traits/discrete_feature.rs
+++ b/crates/css_parse/src/traits/discrete_feature.rs
@@ -113,6 +113,15 @@ macro_rules! discrete_feature {
 			Bare($crate::T!['('], $crate::T![Ident], $crate::T![')']),
 		}
 
+		impl<'a> $crate::Peek<'a> for $feature {
+			fn peek<Iter>(p: &$crate::Parser<'a, Iter>, c: $crate::Cursor) -> bool
+			where
+				Iter: Iterator<Item = $crate::Cursor> + Clone,
+			{
+				c == $crate::Kind::LeftParen && p.peek_n(2) == $crate::Kind::Ident
+			}
+		}
+
 		impl<'a> $crate::Parse<'a> for $feature {
 			fn parse<I>(p: &mut $crate::Parser<'a, I>) -> $crate::Result<Self>
 			where

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -291,6 +291,15 @@ macro_rules! ranged_feature {
 			Exact($crate::T!['('], T![Ident], $crate::T![:], $value, $crate::T![')']),
 		}
 
+		impl<'a> $crate::Peek<'a> for $feature {
+			fn peek<Iter>(p: &$crate::Parser<'a, Iter>, c: $crate::Cursor) -> bool
+			where
+				Iter: Iterator<Item = $crate::Cursor> + Clone,
+			{
+				c == $crate::Kind::LeftParen && p.peek_n(2) == $crate::KindSet::new(&[$crate::Kind::Ident, $crate::Kind::Number, $crate::Kind::Dimension])
+			}
+		}
+
 		impl<'a> $crate::Parse<'a> for $feature {
 			fn parse<I>(p: &mut $crate::Parser<'a, I>) -> $crate::Result<Self>
 			where

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -861,7 +861,7 @@ impl QuerySizePseudo {
 mod tests {
 	use super::{QueryCompoundSelector, QuerySelectorList};
 	use crate::CsskitAtomSet;
-	use css_parse::{assert_parse, assert_parse_error};
+	use css_parse::{assert_parse, assert_parse_error, assert_peek_false};
 
 	#[test]
 	fn test_parse_simple_type() {
@@ -960,7 +960,7 @@ mod tests {
 
 	#[test]
 	fn test_parse_class_unsupported() {
-		assert_parse_error!(CsskitAtomSet::ATOMS, QueryCompoundSelector, ".foo");
+		assert_peek_false!(CsskitAtomSet::ATOMS, QueryCompoundSelector, ".foo");
 	}
 
 	#[test]

--- a/crates/csskit_ast/src/sheet.rs
+++ b/crates/csskit_ast/src/sheet.rs
@@ -12,7 +12,7 @@ use crate::stat_rule::StatRule;
 use crate::when_rule::WhenRule;
 
 /// A stats stylesheet containing rules for collecting statistics and diagnostics.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Peek, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Sheet<'a> {
 	pub rules: Vec<'a, Rule<'a>>,
 }


### PR DESCRIPTION
Many of our AST types do not implement Peek, which can cause some issues. We
also don't actually test Peek in any direct way, it effectively becomes an
optimisation rather than a formal part of the Parse/Peek combination; that is to
say impls could instead parse and rewind over peeking which would be bad.

This change does a few things to help with this:

 - It introduces changes to `assert_parse` to ensure `peek()` must return true
   before trying to Parse. This gives developers a hint that they haven't
	 implemented Peek, or haven't implemented it properly.
 - It introduces `assert_peek_false!` which simply checks a given string should
   return `false` from `::peek()`.
 - It introduces changes to `assert_parse_error` to ensure if `peek()` returns
   `false`, if it does, the test fails and it encourages transitioning to
   `assert_peek_false`. This gives us better visibility on what fails due to a
   Peek vs a Parse.
