### PR TITLE
Release v0.0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## [0.0.27] - 2026-07-04
+
+### Other Changes
+- Fuzz: minimize corpus, and do so on nightly fuzz build (#1257) ([#1257](https://github.com/csskit/csskit/pull/1257))
+- CI: Ensure benches build (#1259) ([#1259](https://github.com/csskit/csskit/pull/1259))
+
+
+### Css_ast
+- css_ast/css_parse: Improve peeking robustness. (#1238) ([#1238](https://github.com/csskit/csskit/pull/1238))
+- Regenerate css_ast/src/values from csswg drafts (#1242) ([#1242](https://github.com/csskit/csskit/pull/1242))
+- Regenerate css_ast/src/values from csswg drafts (#1254) ([#1254](https://github.com/csskit/csskit/pull/1254))
+- fuzz: new parser findings 2026-06-19 (#1232) ([#1232](https://github.com/csskit/csskit/pull/1232))
+- css_ast: Refactor assert_specificity to use closure pattern (#1261) ([#1261](https://github.com/csskit/csskit/pull/1261))
+- css_ast: derive(ToSpan) on WebkitFunctionalPseudoClass (#1262) ([#1262](https://github.com/csskit/csskit/pull/1262))
+- Implement "VisitFlow" (#1263) ([#1263](https://github.com/csskit/csskit/pull/1263))
+
+
+### Css_parse
+- fuzz: new parser findings 2026-07-01 (#1260) ([#1260](https://github.com/csskit/csskit/pull/1260))
+
+
+### Csskit
+- chore(deps): update dependencies (patch) (#1243) ([#1243](https://github.com/csskit/csskit/pull/1243))
+
+
+### Csskit_derives
+- chore(deps): update rust crate itertools to 0.15.0 (#1246) ([#1246](https://github.com/csskit/csskit/pull/1246))
+
+
+### Csskit_vscode
+- chore(deps): update dependencies to v1.68.0 (#1247) ([#1247](https://github.com/csskit/csskit/pull/1247))
+- fix(deps): update dependencies (patch) (#1255) ([#1255](https://github.com/csskit/csskit/pull/1255))
+
 ## [0.0.26] - 2026-06-20
 
 ### Other Changes
@@ -22,6 +55,7 @@
 - csskit_wasm/csskit(node): Provide csskit library functions in csskit package (#1234) ([#1234](https://github.com/csskit/csskit/pull/1234))
 - csskit(node): manage wasm-opt with mise (#1235) ([#1235](https://github.com/csskit/csskit/pull/1235))
 - csskit(node): Move build script to Mise (#1237) ([#1237](https://github.com/csskit/csskit/pull/1237))
+- Release v0.0.26 (#1224) ([#1224](https://github.com/csskit/csskit/pull/1224))
 
 ## [0.0.25] - 2026-06-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 exclude = ["packages/csskit_zed"]
 
 [workspace.package]
-version = "0.0.26"  # @release
+version = "0.0.27"  # @release
 authors = ["Keith Cirkel (https://keithcirkel.co.uk)"]
 edition = "2024"
 description = "Refreshing CSS!"
@@ -14,24 +14,24 @@ license = "MIT"
 keywords = ["CSS", "parser"]
 
 [workspace.dependencies]
-chromashift = { path = "crates/chromashift", version = "0.0.26" }  # @release
-css_ast = { path = "crates/css_ast", version = "0.0.26" }  # @release
-css_feature_data = { path = "crates/css_feature_data", version = "0.0.26" }  # @release
-css_lexer = { path = "crates/css_lexer", version = "0.0.26" }  # @release
-css_parse = { path = "crates/css_parse", version = "0.0.26" }  # @release
-css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.26" }  # @release
+chromashift = { path = "crates/chromashift", version = "0.0.27" }  # @release
+css_ast = { path = "crates/css_ast", version = "0.0.27" }  # @release
+css_feature_data = { path = "crates/css_feature_data", version = "0.0.27" }  # @release
+css_lexer = { path = "crates/css_lexer", version = "0.0.27" }  # @release
+css_parse = { path = "crates/css_parse", version = "0.0.27" }  # @release
+css_value_definition_parser = { path = "crates/css_value_definition_parser", version = "0.0.27" }  # @release
 # Local packages
-csskit = { path = "crates/csskit", version = "0.0.26" }  # @release
-csskit_ast = { path = "crates/csskit_ast", version = "0.0.26" }  # @release
-csskit_derives = { path = "crates/csskit_derives", version = "0.0.26" }  # @release
-csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.26" }  # @release
-csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.26" }  # @release
-csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.26" }  # @release
-csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.26" }  # @release
+csskit = { path = "crates/csskit", version = "0.0.27" }  # @release
+csskit_ast = { path = "crates/csskit_ast", version = "0.0.27" }  # @release
+csskit_derives = { path = "crates/csskit_derives", version = "0.0.27" }  # @release
+csskit_highlight = { path = "crates/csskit_highlight", version = "0.0.27" }  # @release
+csskit_lsp = { path = "crates/csskit_lsp", version = "0.0.27" }  # @release
+csskit_proc_macro = { path = "crates/csskit_proc_macro", version = "0.0.27" }  # @release
+csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.27" }  # @release
 csskit_spec_generator = { path = "crates/csskit_spec_generator", version = "0.0.0" }
-csskit_transform = { path = "crates/csskit_transform", version = "0.0.26" }  # @release
-derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.26" }  # @release
-visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.26" }  # @release
+csskit_transform = { path = "crates/csskit_transform", version = "0.0.27" }  # @release
+derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.27" }  # @release
+visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.27" }  # @release
 
 # Memory
 allocator-api2 = { version = "0.2.21" }  # Held back for bumpalo (https://github.com/fitzgen/bumpalo/pull/288)

--- a/packages/csskit-darwin-arm64/package.json
+++ b/packages/csskit-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-arm64",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "description": "Refreshing CSS - macOS arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-darwin-x64/package.json
+++ b/packages/csskit-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-darwin-x64",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "description": "Refreshing CSS - macOS x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-arm64/package.json
+++ b/packages/csskit-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-arm64",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "description": "Refreshing CSS - Linux arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-linux-x64/package.json
+++ b/packages/csskit-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-linux-x64",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "description": "Refreshing CSS - Linux x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-arm64/package.json
+++ b/packages/csskit-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-arm64",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "description": "Refreshing CSS - Windows arm64 binary",
     "keywords": [
         "css",

--- a/packages/csskit-win32-x64/package.json
+++ b/packages/csskit-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
     "name": "csskit-win32-x64",
-    "version": "0.0.26",
+    "version": "0.0.27",
     "description": "Refreshing CSS - Windows x64 binary",
     "keywords": [
         "css",

--- a/packages/csskit/package-lock.json
+++ b/packages/csskit/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "csskit",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "csskit",
-			"version": "0.0.26",
+			"version": "0.0.27",
 			"license": "MIT",
 			"dependencies": {
 				"csskit-darwin-arm64": "^0.0.26",

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -1,39 +1,39 @@
 {
-	"name": "csskit",
-	"version": "0.0.26",
-	"description": "Refreshing CSS",
-	"keywords": [],
-	"repository": "https://github.com/csskit/csskit",
-	"funding": {
-		"url": "https://github.com/sponsors/keithamus"
-	},
-	"license": "MIT",
-	"author": "Keith Cirkel (https://keithcirkel.co.uk)",
-	"exports": {
-		".": "./index.js",
-		"./bundler": "./bundle/csskit_wasm.js",
-		"./wasm": "./bundle/csskit_wasm_bg.wasm",
-		"./bin/csskit": "./bin/csskit"
-	},
-	"main": "./index.js",
-	"bin": "./bin/csskit",
-	"files": [
-		"./bin",
-		"./index.js",
-		"./index.d.ts",
-		"./csskit_wasm_bg.wasm",
-		"./csskit_wasm_bg.wasm.d.ts",
-		"./bundle"
-	],
-	"optionalDependencies": {
-		"csskit-darwin-arm64": "0.0.26",
-		"csskit-darwin-x64": "0.0.26",
-		"csskit-linux-arm64": "0.0.26",
-		"csskit-linux-x64": "0.0.26",
-		"csskit-win32-arm64": "0.0.26",
-		"csskit-win32-x64": "0.0.26"
-	},
-	"allowScripts": {
-		"wasm-opt@1.4.0": true
-	}
+    "name": "csskit",
+    "version": "0.0.27",
+    "description": "Refreshing CSS",
+    "keywords": [],
+    "repository": "https://github.com/csskit/csskit",
+    "funding": {
+        "url": "https://github.com/sponsors/keithamus"
+    },
+    "license": "MIT",
+    "author": "Keith Cirkel (https://keithcirkel.co.uk)",
+    "exports": {
+        ".": "./index.js",
+        "./bundler": "./bundle/csskit_wasm.js",
+        "./wasm": "./bundle/csskit_wasm_bg.wasm",
+        "./bin/csskit": "./bin/csskit"
+    },
+    "main": "./index.js",
+    "bin": "./bin/csskit",
+    "files": [
+        "./bin",
+        "./index.js",
+        "./index.d.ts",
+        "./csskit_wasm_bg.wasm",
+        "./csskit_wasm_bg.wasm.d.ts",
+        "./bundle"
+    ],
+    "optionalDependencies": {
+        "csskit-darwin-arm64": "0.0.27",
+        "csskit-darwin-x64": "0.0.27",
+        "csskit-linux-arm64": "0.0.27",
+        "csskit-linux-x64": "0.0.27",
+        "csskit-win32-arm64": "0.0.27",
+        "csskit-win32-x64": "0.0.27"
+    },
+    "allowScripts": {
+        "wasm-opt@1.4.0": true
+    }
 }


### PR DESCRIPTION
## [0.0.27] - 2026-07-04

### Other Changes
- Fuzz: minimize corpus, and do so on nightly fuzz build (#1257) ([#1257](https://github.com/csskit/csskit/pull/1257))
- CI: Ensure benches build (#1259) ([#1259](https://github.com/csskit/csskit/pull/1259))


### Css_ast
- css_ast/css_parse: Improve peeking robustness. (#1238) ([#1238](https://github.com/csskit/csskit/pull/1238))
- Regenerate css_ast/src/values from csswg drafts (#1242) ([#1242](https://github.com/csskit/csskit/pull/1242))
- Regenerate css_ast/src/values from csswg drafts (#1254) ([#1254](https://github.com/csskit/csskit/pull/1254))
- fuzz: new parser findings 2026-06-19 (#1232) ([#1232](https://github.com/csskit/csskit/pull/1232))
- css_ast: Refactor assert_specificity to use closure pattern (#1261) ([#1261](https://github.com/csskit/csskit/pull/1261))
- css_ast: derive(ToSpan) on WebkitFunctionalPseudoClass (#1262) ([#1262](https://github.com/csskit/csskit/pull/1262))
- Implement "VisitFlow" (#1263) ([#1263](https://github.com/csskit/csskit/pull/1263))


### Css_parse
- fuzz: new parser findings 2026-07-01 (#1260) ([#1260](https://github.com/csskit/csskit/pull/1260))


### Csskit
- chore(deps): update dependencies (patch) (#1243) ([#1243](https://github.com/csskit/csskit/pull/1243))


### Csskit_derives
- chore(deps): update rust crate itertools to 0.15.0 (#1246) ([#1246](https://github.com/csskit/csskit/pull/1246))


### Csskit_vscode
- chore(deps): update dependencies to v1.68.0 (#1247) ([#1247](https://github.com/csskit/csskit/pull/1247))
- fix(deps): update dependencies (patch) (#1255) ([#1255](https://github.com/csskit/csskit/pull/1255))