### PR TITLE
Implement "VisitFlow"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Build
-        run: set -euo pipefail; for d in crates/*/; do cargo build -p $(basename $d); done
+        run: set -euo pipefail; for d in crates/*/; do pkg=$(cargo metadata --no-deps --manifest-path $d/Cargo.toml --format-version 1 2>/dev/null | jq -r '.packages[0].name'); cargo build -p $pkg; done
 
   build_benches:
     name: Build benches

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "smallvec",
  "syn",
  "thiserror 2.0.18",
+ "visit-flow",
 ]
 
 [[package]]
@@ -763,6 +764,7 @@ dependencies = [
  "strsim",
  "tracing",
  "tracing-subscriber",
+ "visit-flow",
 ]
 
 [[package]]
@@ -782,6 +784,7 @@ dependencies = [
  "miette",
  "pprof",
  "smallvec",
+ "visit-flow",
 ]
 
 [[package]]
@@ -816,6 +819,7 @@ dependencies = [
  "owo-colors",
  "similar 3.1.1",
  "strum",
+ "visit-flow",
 ]
 
 [[package]]
@@ -920,6 +924,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar 3.1.1",
+ "visit-flow",
 ]
 
 [[package]]
@@ -3625,6 +3630,10 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visit-flow"
+version = "0.0.26"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.26
 csskit_spec_generator = { path = "crates/csskit_spec_generator", version = "0.0.0" }
 csskit_transform = { path = "crates/csskit_transform", version = "0.0.26" }  # @release
 derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.26" }  # @release
+visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.26" }  # @release
 
 # Memory
 allocator-api2 = { version = "0.2.21" }  # Held back for bumpalo (https://github.com/fitzgen/bumpalo/pull/288)

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 [dependencies]
 css_parse = { workspace = true }                         # @release
 css_lexer = { workspace = true }                         # @release
+visit_flow = { workspace = true }                        # @release
 csskit_proc_macro = { workspace = true }                 # @release
 csskit_derives = { workspace = true }                    # @release
 derive_atom_set = { workspace = true }                   # @release

--- a/crates/css_ast/src/selector/mod.rs
+++ b/crates/css_ast/src/selector/mod.rs
@@ -363,4 +363,59 @@ mod tests {
 		assert_specificity!("table tr:not(:first-child):hover td:nth-child(2n+1)", 0, 3, 3);
 		assert_specificity!("input[type='checkbox'][checked]:indeterminate + label", 0, 3, 2);
 	}
+
+	#[test]
+	#[cfg(feature = "visitable")]
+	fn visit_flow_baseline() {
+		use crate::test_helpers::{ControlFlowTestVisitor, assert_visit_flow};
+		assert_visit_flow!(
+			".foo, #bar", SelectorList, ControlFlowTestVisitor::new(),
+			entered: [SelectorList, CompoundSelector, Class, CompoundSelector, Id],
+			exited: [Class, CompoundSelector, Id, CompoundSelector, SelectorList],
+		);
+	}
+
+	#[test]
+	#[cfg(feature = "visitable")]
+	fn visit_flow_stop() {
+		use crate::test_helpers::{ControlFlowTestVisitor, assert_visit_flow};
+		use visit_flow::{VisitBreak, VisitFlow, VisitFlowExt};
+		assert_visit_flow!(
+			".foo, #bar", SelectorList,
+			ControlFlowTestVisitor::with_callback(|id| {
+				if id == NodeId::CompoundSelector { VisitFlow::STOP } else { VisitFlow::DESCEND }
+			}),
+			entered: [SelectorList, CompoundSelector],
+			exited: [],
+			result: VisitFlow::Break(VisitBreak::Stop),
+		);
+	}
+
+	#[test]
+	#[cfg(feature = "visitable")]
+	fn visit_flow_skip_children() {
+		use crate::test_helpers::{ControlFlowTestVisitor, assert_visit_flow};
+		use visit_flow::{VisitFlow, VisitFlowExt};
+		assert_visit_flow!(
+			".foo, #bar", SelectorList,
+			ControlFlowTestVisitor::with_callback(|id| {
+				if id == NodeId::CompoundSelector { VisitFlow::SKIP_CHILDREN } else { VisitFlow::DESCEND }
+			}),
+			entered: [SelectorList, CompoundSelector, CompoundSelector],
+			exited: [CompoundSelector, CompoundSelector, SelectorList],
+		);
+	}
+
+	#[test]
+	#[cfg(feature = "visitable")]
+	fn visit_flow_filter() {
+		use crate::test_helpers::{ControlFlowTestVisitor, assert_visit_flow};
+		use css_lexer::{SourceOffset, Span};
+		assert_visit_flow!(
+			".foo, #bar", SelectorList,
+			ControlFlowTestVisitor::with_span_filter(Span::new(SourceOffset(0), SourceOffset(4))),
+			entered: [SelectorList, CompoundSelector, Class],
+			exited: [Class, CompoundSelector, SelectorList],
+		);
+	}
 }

--- a/crates/css_ast/src/test_helpers.rs
+++ b/crates/css_ast/src/test_helpers.rs
@@ -107,6 +107,35 @@ macro_rules! assert_visits {
 	}};
 }
 
+/// Parse `$source` as `$ty`, run a [`ControlFlowTestVisitor`] over it, and assert the
+/// `entered`/`exited` node sequences (and optionally the resulting [`VisitFlow`]).
+///
+/// Node names are bare idents; the macro prefixes them with `NodeId::`. The visitor is
+/// configured with either `descend` (no control flow), a `callback: |id| ...` returning
+/// a [`VisitFlow`], or a `span_filter: <Span>`.
+#[cfg(feature = "visitable")]
+macro_rules! assert_visit_flow {
+	($source:expr, $ty:ty, $visitor:expr,
+		entered: [$($enter:ident),* $(,)?],
+		exited: [$($exit:ident),* $(,)?]
+		$(, result: $result:pat)? $(,)?
+	) => {{
+		use $crate::Visitable;
+		use $crate::NodeId;
+		let bump = bumpalo::Bump::new();
+		let lexer = css_lexer::Lexer::new(&$crate::CssAtomSet::ATOMS, $source);
+		let mut parser = css_parse::Parser::new(&bump, $source, lexer);
+		let parsed = parser.parse_entirely::<$ty>().output.expect("parse failed");
+		let mut v = $visitor;
+		let _result = parsed.accept(&mut v);
+		assert_eq!(v.entered(), vec![$(NodeId::$enter),*], "entered mismatch for {:?}", $source);
+		assert_eq!(v.exited(), vec![$(NodeId::$exit),*], "exited mismatch for {:?}", $source);
+		$(assert!(matches!(_result, $result), "result mismatch for {:?}: got {:?}", $source, _result);)?
+	}};
+}
+#[cfg(feature = "visitable")]
+pub(crate) use assert_visit_flow;
+
 #[cfg(feature = "css_feature_data")]
 #[macro_export]
 macro_rules! assert_feature_id {
@@ -124,6 +153,71 @@ macro_rules! assert_feature_id {
 		}
 		assert_eq!(result.output.unwrap().to_css_feature().unwrap().id, $id);
 	}};
+}
+
+/// A visitor for testing `VisitFlow` control: `Stop`, `SkipChildren`, and span filtering.
+///
+/// Records enter/exit events for every queryable node visited. The `on_visit` callback
+/// controls what `VisitFlow` is returned from `enter_node`, allowing tests to
+/// simulate early termination or child-skipping without writing a bespoke visitor each time.
+#[cfg(feature = "visitable")]
+use visit_flow::{VisitFlow, VisitFlowExt};
+
+#[cfg(feature = "visitable")]
+pub(crate) struct ControlFlowTestVisitor {
+	pub events: Vec<(bool, crate::NodeId)>, // (is_enter, node_id)
+	span_filter: Option<css_lexer::Span>,
+	on_visit: Box<dyn Fn(crate::NodeId) -> VisitFlow>,
+}
+
+#[cfg(feature = "visitable")]
+impl ControlFlowTestVisitor {
+	/// Records all nodes without any control flow.
+	pub fn new() -> Self {
+		Self::with_callback(|_| VisitFlow::DESCEND)
+	}
+
+	pub fn with_callback(on_visit: impl Fn(crate::NodeId) -> VisitFlow + 'static) -> Self {
+		Self { events: Vec::new(), span_filter: None, on_visit: Box::new(on_visit) }
+	}
+
+	/// Only visit nodes whose span overlaps `span`.
+	pub fn with_span_filter(span: css_lexer::Span) -> Self {
+		Self { events: Vec::new(), span_filter: Some(span), on_visit: Box::new(|_| VisitFlow::DESCEND) }
+	}
+
+	pub fn entered(&self) -> Vec<crate::NodeId> {
+		self.events.iter().filter_map(|(enter, id)| enter.then_some(*id)).collect()
+	}
+
+	pub fn exited(&self) -> Vec<crate::NodeId> {
+		self.events.iter().filter_map(|(enter, id)| (!enter).then_some(*id)).collect()
+	}
+}
+
+#[cfg(feature = "visitable")]
+impl crate::Visit for ControlFlowTestVisitor {
+	fn consider_node(&self, node: crate::VisitNode) -> VisitFlow {
+		if let Some(filter_span) = self.span_filter {
+			let span = node.span;
+			// Prune if no overlap: span must share at least one byte with filter_span.
+			if span.start() >= filter_span.end() || filter_span.start() >= span.end() {
+				return VisitFlow::SKIP_CHILDREN;
+			}
+		}
+		VisitFlow::DESCEND
+	}
+
+	fn enter_node(&mut self, node: crate::VisitNode) -> VisitFlow {
+		let node_id = node.node_id.unwrap();
+		self.events.push((true, node_id));
+		(self.on_visit)(node_id)
+	}
+
+	fn exit_node(&mut self, query: crate::VisitNode) -> VisitFlow {
+		self.events.push((false, query.node_id.unwrap()));
+		VisitFlow::DESCEND
+	}
 }
 
 #[cfg(all(test, feature = "visitable"))]

--- a/crates/css_ast/src/visit/mod.rs
+++ b/crates/css_ast/src/visit/mod.rs
@@ -7,8 +7,19 @@ use bumpalo::collections::Vec;
 use css_parse::{
 	Block, BumpBox, CommaSeparated, Comparison, ComponentValues, Cursor, Declaration, DeclarationGroup,
 	DeclarationList, DeclarationOrBad, DeclarationValue, Either, NoBlockAllowed, NodeMetadata, NodeWithMetadata,
-	Optionals2, Optionals3, Optionals4, Optionals5, QualifiedRule, RuleList, syntax::BadDeclaration, token_macros,
+	Optionals2, Optionals3, Optionals4, Optionals5, QualifiedRule, RuleList, ToSpan, syntax::BadDeclaration,
+	token_macros,
 };
+use visit_flow::{VisitFlow, try_visit};
+
+/// The `#[visitor]` attribute: observer methods without a return type
+/// auto-descend. Re-exported so visitor consumers need only depend on `css_ast`.
+pub use csskit_derives::visitor;
+pub use visit_flow::{VisitAction, VisitBreak, VisitFlowExt};
+
+mod visit_node;
+pub(crate) use visit_node::QueryNodeData;
+pub use visit_node::VisitNode;
 
 use crate::*;
 
@@ -38,28 +49,60 @@ macro_rules! visit_trait {
 		$name: ident$(<$($gen:tt),+>)?($obj: ty),
 	)+ ) => {
 		pub trait Visit: Sized {
-			/// Generic method for visiting queryable nodes. Override this to handle all queryable nodes uniformly.
-			/// Individual visit methods will delegate to this by default.
-			fn visit_queryable_node<T: QueryableNode>(&mut self, _node: &T) {}
+			/// Called before entering a node.
+			///
+			/// Return [`VisitFlow::SKIP_CHILDREN`] to prune the node and its entire subtree (it is
+			/// never entered). Return [`VisitFlow::STOP`] to halt the whole traversal. Default
+			/// considers everything.
+			fn consider_node(&self, _node: VisitNode) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
 
-			/// Generic method for exiting queryable nodes. Override this to handle all queryable nodes uniformly.
-			/// Individual exit methods will delegate to this by default.
-			fn exit_queryable_node<T: QueryableNode>(&mut self, _node: &T) {}
+			/// Called on entry to every queryable node. Override to handle all queryable nodes uniformly.
+			///
+			/// Receives a [`VisitNode`]; per-node metadata and properties are available lazily via
+			/// its methods. Return [`VisitFlow::SKIP_CHILDREN`] to skip the typed `visit_*` call and children.
+			fn enter_node(&mut self, _node: VisitNode) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
 
-			fn visit_declaration<'a, T: DeclarationValue<'a, CssMetadata> + QueryableNode>(&mut self, _rule: &Declaration<'a, T, CssMetadata>) {}
-			fn exit_declaration<'a, T: DeclarationValue<'a, CssMetadata> + QueryableNode>(&mut self, _rule: &Declaration<'a, T, CssMetadata>) {}
+			/// Called on exit from every queryable node.
+			fn exit_node(&mut self, _node: VisitNode) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
 
-			fn visit_feature<T: FeatureMetadata + QueryableNode>(&mut self, _node: &T) {}
-			fn exit_feature<T: FeatureMetadata + QueryableNode>(&mut self, _node: &T) {}
+			fn enter_declaration<'a, T: DeclarationValue<'a, CssMetadata>>(&mut self, _rule: &Declaration<'a, T, CssMetadata>, _node: VisitNode) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
+			fn exit_declaration<'a, T: DeclarationValue<'a, CssMetadata>>(&mut self, _rule: &Declaration<'a, T, CssMetadata>, _node: VisitNode) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
+			fn visit_bad_declaration<'a>(&mut self, _rule: &BadDeclaration<'a>) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
+			fn exit_bad_declaration<'a>(&mut self, _rule: &BadDeclaration<'a>) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
+			fn visit_string(&mut self, _str: &token_macros::String) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
+			fn exit_string(&mut self, _str: &token_macros::String) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
+			fn visit_comparison(&mut self, _comparison: &Comparison) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
+			fn exit_comparison(&mut self, _comparison: &Comparison) -> VisitFlow {
+				VisitFlow::DESCEND
+			}
 
-			fn visit_bad_declaration<'a>(&mut self, _rule: &BadDeclaration<'a>) {}
-			fn exit_bad_declaration<'a>(&mut self, _rule: &BadDeclaration<'a>) {}
-			fn visit_string(&mut self, _str: &token_macros::String) {}
-			fn exit_string(&mut self, _str: &token_macros::String) {}
-			fn visit_comparison(&mut self, _comparison: &Comparison) {}
-			fn exit_comparison(&mut self, _comparison: &Comparison) {}
+			fn visit_feature<T: FeatureMetadata>(&mut self, _node: &T) {}
+			fn exit_feature<T: FeatureMetadata>(&mut self, _node: &T) {}
+
 			$(
-				fn $name$(<$($gen),+>)?(&mut self, _rule: &$obj) {}
+				fn $name$(<$($gen),+>)?(&mut self, _rule: &$obj) -> VisitFlow {
+					VisitFlow::DESCEND
+				}
 			)+
 		}
 	}
@@ -71,21 +114,17 @@ pub trait VisitableMut {
 }
 
 pub trait Visitable {
-	fn accept<V: Visit>(&self, v: &mut V);
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow;
 }
 
 /// Marker trait for AST nodes that can be queried with selectors.
 ///
-/// This trait extends `Visitable` and adds a unique identifier for the node type.
-/// It is automatically implemented by `#[derive(Visitable)]` for all nodes that
-/// are not marked with `#[visit(skip)]` or `#[visit(children)]`.
-pub trait QueryableNode: Visitable + NodeWithMetadata<CssMetadata> + ToSpan {
+/// Implemented by `#[derive(Visitable)]` for queryable nodes, and manually for nodes
+/// with `get_property` overrides (named at-rules, declarations).
+/// Not part of the `Visit` public API - visitors receive a [`VisitNode`] instead.
+pub(crate) trait QueryableNode: ToSpan + NodeWithMetadata<CssMetadata> {
 	/// Unique identifier for this node type.
 	const NODE_ID: NodeId;
-
-	fn node_id(&self) -> NodeId {
-		Self::NODE_ID
-	}
 
 	/// Returns a cursor for the given property kind, if the node has that property.
 	/// Used by attribute selectors to extract values from nodes.
@@ -94,6 +133,30 @@ pub trait QueryableNode: Visitable + NodeWithMetadata<CssMetadata> + ToSpan {
 	/// name for declarations, animation name for `@keyframes`).
 	fn get_property(&self, _kind: PropertyKind) -> Option<Cursor> {
 		None
+	}
+
+	/// Builds the [`VisitNode`] passed to every `Visit` callback for this node.
+	///
+	/// `subtree_metadata` (eager) uses `metadata()` (self + subtree) so the prune gate can
+	/// reject whole subtrees; `self_metadata`/properties are deferred to `&dyn` accessors so
+	/// they only cost anything when a visitor actually reads them.
+	fn visit_node(&self) -> VisitNode<'_>
+	where
+		Self: Sized,
+	{
+		VisitNode::new(self.to_span(), Self::NODE_ID, self.metadata(), self)
+	}
+}
+
+/// Blanket bridge so any [`QueryableNode`] can be held as a `&dyn` in [`VisitNode`].
+impl<T: QueryableNode> QueryNodeData for T {
+	#[inline]
+	fn self_metadata(&self) -> CssMetadata {
+		NodeWithMetadata::self_metadata(self)
+	}
+	#[inline]
+	fn get_property(&self, kind: PropertyKind) -> Option<Cursor> {
+		QueryableNode::get_property(self, kind)
 	}
 }
 
@@ -116,9 +179,10 @@ macro_rules! impl_optionals {
 		{
 			#[allow(non_snake_case)]
 			#[allow(unused)]
-			fn accept<VI: Visit>(&self, v: &mut VI) {
+			fn accept<VI: Visit>(&self, v: &mut VI) -> VisitFlow {
 				let $N($($T),+) = self;
-				$($T.accept(v);)+;
+				$(try_visit!($T.accept(v));)+;
+				VisitFlow::DESCEND
 			}
 		}
 
@@ -142,7 +206,9 @@ impl_optionals!(Optionals4, T, U, V, W);
 impl_optionals!(Optionals5, T, U, V, W, X);
 
 impl Visitable for token_macros::Ident {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::Ident {
@@ -150,7 +216,9 @@ impl VisitableMut for token_macros::Ident {
 }
 
 impl Visitable for token_macros::Function {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::Function {
@@ -158,7 +226,9 @@ impl VisitableMut for token_macros::Function {
 }
 
 impl Visitable for token_macros::Comma {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::Comma {
@@ -166,7 +236,9 @@ impl VisitableMut for token_macros::Comma {
 }
 
 impl Visitable for token_macros::LeftParen {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::LeftParen {
@@ -174,7 +246,9 @@ impl VisitableMut for token_macros::LeftParen {
 }
 
 impl Visitable for token_macros::RightParen {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::RightParen {
@@ -182,7 +256,9 @@ impl VisitableMut for token_macros::RightParen {
 }
 
 impl Visitable for token_macros::Colon {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::Colon {
@@ -190,9 +266,10 @@ impl VisitableMut for token_macros::Colon {
 }
 
 impl Visitable for Comparison {
-	fn accept<V: Visit>(&self, v: &mut V) {
-		v.visit_comparison(self);
-		v.exit_comparison(self);
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
+		try_visit!(v.visit_comparison(self));
+		try_visit!(v.exit_comparison(self));
+		VisitFlow::DESCEND
 	}
 }
 
@@ -204,7 +281,9 @@ impl VisitableMut for Comparison {
 }
 
 impl Visitable for token_macros::delim::Dash {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::delim::Dash {
@@ -212,7 +291,9 @@ impl VisitableMut for token_macros::delim::Dash {
 }
 
 impl Visitable for token_macros::delim::Slash {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::delim::Slash {
@@ -220,7 +301,9 @@ impl VisitableMut for token_macros::delim::Slash {
 }
 
 impl Visitable for token_macros::Number {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::Number {
@@ -228,7 +311,9 @@ impl VisitableMut for token_macros::Number {
 }
 
 impl Visitable for token_macros::Any {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl VisitableMut for token_macros::Any {
@@ -236,9 +321,10 @@ impl VisitableMut for token_macros::Any {
 }
 
 impl Visitable for token_macros::String {
-	fn accept<V: Visit>(&self, v: &mut V) {
-		v.visit_string(self);
-		v.exit_string(self);
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
+		try_visit!(v.visit_string(self));
+		try_visit!(v.exit_string(self));
+		VisitFlow::DESCEND
 	}
 }
 
@@ -253,10 +339,11 @@ impl<T> Visitable for Option<T>
 where
 	T: Visitable,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
 		if let Some(node) = self {
-			node.accept(v)
+			try_visit!(node.accept(v));
 		}
+		VisitFlow::DESCEND
 	}
 }
 
@@ -267,7 +354,7 @@ impl<'a, T: VisitableMut> VisitableMut for BumpBox<'a, T> {
 }
 
 impl<'a, T: Visitable> Visitable for BumpBox<'a, T> {
-	fn accept<V: Visit>(&self, v: &mut V) {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
 		(**self).accept(v)
 	}
 }
@@ -287,10 +374,11 @@ impl<'a, T, const MIN: usize> Visitable for CommaSeparated<'a, T, MIN>
 where
 	T: Visitable + Peek<'a> + Parse<'a> + ToCursors + ToSpan,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
 		for (node, _) in self {
-			node.accept(v)
+			try_visit!(node.accept(v));
 		}
+		VisitFlow::DESCEND
 	}
 }
 
@@ -312,7 +400,7 @@ where
 	Left: Visitable,
 	Right: Visitable,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
 		match self {
 			Self::Left(t) => t.accept(v),
 			Self::Right(t) => t.accept(v),
@@ -337,15 +425,18 @@ where
 {
 	const NODE_ID: NodeId = NodeId::StyleValue;
 
-	fn node_id(&self) -> NodeId {
-		T::NODE_ID
-	}
-
 	fn get_property(&self, kind: PropertyKind) -> Option<Cursor> {
 		match kind {
 			PropertyKind::Name => Some(self.name.into()),
 			_ => None,
 		}
+	}
+
+	fn visit_node(&self) -> VisitNode<'_> {
+		// Use T::NODE_ID so each declaration type has its own identity.
+		// Use metadata() (aggregated) for the eager subtree facts; self_metadata/properties
+		// stay deferred via the &dyn.
+		VisitNode::new(self.to_span(), T::NODE_ID, self.metadata(), self)
 	}
 }
 
@@ -353,12 +444,19 @@ impl<'a, T> Visitable for Declaration<'a, T, CssMetadata>
 where
 	T: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
-		v.visit_queryable_node(self);
-		v.visit_declaration::<T>(self);
-		self.value.accept(v);
-		v.exit_declaration::<T>(self);
-		v.exit_queryable_node(self);
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
+		let node = self.visit_node();
+		if let visit_flow::VisitAction::SkipChildren = try_visit!(v.consider_node(node)) {
+			return VisitFlow::DESCEND;
+		}
+		if let visit_flow::VisitAction::Descend = visit_flow::try_visit!(v.enter_node(node)) {
+			if let visit_flow::VisitAction::Descend = visit_flow::try_visit!(v.enter_declaration::<T>(self, node)) {
+				try_visit!(self.value.accept(v));
+			}
+			try_visit!(v.exit_declaration::<T>(self, node));
+		}
+		try_visit!(v.exit_node(node));
+		VisitFlow::DESCEND
 	}
 }
 
@@ -377,10 +475,11 @@ impl<'a, T> Visitable for DeclarationList<'a, T, CssMetadata>
 where
 	T: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
 		for declaration in &self.declarations {
-			declaration.accept(v);
+			try_visit!(declaration.accept(v));
 		}
+		VisitFlow::DESCEND
 	}
 }
 
@@ -399,8 +498,8 @@ where
 	T: Visitable + Parse<'a> + ToCursors + ToSpan + NodeWithMetadata<M>,
 	M: NodeMetadata,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
-		self.rules.accept(v);
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
+		self.rules.accept(v)
 	}
 }
 
@@ -424,9 +523,9 @@ where
 	R: Visitable + Parse<'a> + ToCursors + ToSpan,
 	Block<'a, D, R, CssMetadata>: Parse<'a> + ToCursors + ToSpan,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
-		self.prelude.accept(v);
-		self.block.accept(v);
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
+		try_visit!(self.prelude.accept(v));
+		self.block.accept(v)
 	}
 }
 
@@ -450,13 +549,14 @@ where
 	D: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 	R: Visitable + Parse<'a> + ToCursors + ToSpan,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
 		for declaration in &self.declarations {
-			declaration.accept(v);
+			try_visit!(declaration.accept(v));
 		}
 		for rule in &self.rules {
-			rule.accept(v);
+			try_visit!(rule.accept(v));
 		}
+		VisitFlow::DESCEND
 	}
 }
 
@@ -475,10 +575,11 @@ impl<'a, T> Visitable for Vec<'a, T>
 where
 	T: Visitable,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
 		for node in self {
-			node.accept(v)
+			try_visit!(node.accept(v));
 		}
+		VisitFlow::DESCEND
 	}
 }
 
@@ -490,9 +591,10 @@ impl<'a> VisitableMut for BadDeclaration<'a> {
 }
 
 impl<'a> Visitable for BadDeclaration<'a> {
-	fn accept<V: Visit>(&self, v: &mut V) {
-		v.visit_bad_declaration(self);
-		v.exit_bad_declaration(self);
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
+		try_visit!(v.visit_bad_declaration(self));
+		try_visit!(v.exit_bad_declaration(self));
+		VisitFlow::DESCEND
 	}
 }
 
@@ -501,7 +603,9 @@ impl<'a> VisitableMut for ComponentValues<'a> {
 }
 
 impl<'a> Visitable for ComponentValues<'a> {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl<D, M> VisitableMut for NoBlockAllowed<D, M> {
@@ -509,7 +613,9 @@ impl<D, M> VisitableMut for NoBlockAllowed<D, M> {
 }
 
 impl<D, M> Visitable for NoBlockAllowed<D, M> {
-	fn accept<V: Visit>(&self, _: &mut V) {}
+	fn accept<V: Visit>(&self, _: &mut V) -> VisitFlow {
+		VisitFlow::DESCEND
+	}
 }
 
 impl<'a, D> VisitableMut for DeclarationGroup<'a, D, CssMetadata>
@@ -527,10 +633,11 @@ impl<'a, D> Visitable for DeclarationGroup<'a, D, CssMetadata>
 where
 	D: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
 		for declaration in &self.declarations {
-			declaration.accept(v)
+			try_visit!(declaration.accept(v));
 		}
+		VisitFlow::DESCEND
 	}
 }
 
@@ -550,7 +657,7 @@ impl<'a, D> Visitable for DeclarationOrBad<'a, D, CssMetadata>
 where
 	D: Visitable + DeclarationValue<'a, CssMetadata> + QueryableNode,
 {
-	fn accept<V: Visit>(&self, v: &mut V) {
+	fn accept<V: Visit>(&self, v: &mut V) -> VisitFlow {
 		match self {
 			Self::Declaration(d) => d.accept(v),
 			Self::Bad(b) => b.accept(v),
@@ -588,15 +695,16 @@ impl_tuple_mut!(T, U, V, W, X, Y, Z, A, B, C, D, E);
 
 macro_rules! impl_tuple {
     ($($T:ident),*) => {
-				impl<$($T),*> Visitable for ($($T),*)
+			impl<$($T),*> Visitable for ($($T),*)
         where
             $($T: Visitable,)*
         {
             #[allow(non_snake_case)]
             #[allow(unused)]
-						fn accept<VI: Visit>(&self, v: &mut VI) {
+					fn accept<VI: Visit>(&self, v: &mut VI) -> VisitFlow {
                 let ($($T),*) = self;
-                $($T.accept(v);)*
+                $(try_visit!($T.accept(v));)*
+                VisitFlow::DESCEND
             }
         }
     };

--- a/crates/css_ast/src/visit/visit_node.rs
+++ b/crates/css_ast/src/visit/visit_node.rs
@@ -1,0 +1,59 @@
+use css_lexer::Span;
+use css_parse::Cursor;
+
+use crate::{CssMetadata, PropertyKind};
+
+use super::NodeId;
+
+pub(crate) trait QueryNodeData {
+	/// Metadata for *this node only* (no subtree aggregation).
+	fn self_metadata(&self) -> CssMetadata;
+	/// Returns a cursor for the given property kind, if the node has that property.
+	fn get_property(&self, kind: PropertyKind) -> Option<Cursor>;
+}
+
+/// The single node view passed to every [`Visit`](super::Visit) callback.
+#[derive(Clone, Copy)]
+pub struct VisitNode<'n> {
+	pub span: Span,
+	pub node_id: Option<NodeId>,
+	subtree_metadata: CssMetadata,
+	source: Option<&'n dyn QueryNodeData>,
+}
+
+impl<'n> VisitNode<'n> {
+	/// Construct for a queryable node. For Nodes without `NodeId` or meta see [VisitNode::new_transparent].
+	#[inline]
+	pub(crate) fn new(
+		span: Span,
+		node_id: NodeId,
+		subtree_metadata: CssMetadata,
+		source: &'n dyn QueryNodeData,
+	) -> Self {
+		Self { span, node_id: Some(node_id), subtree_metadata, source: Some(source) }
+	}
+
+	/// Construct for a "transparent node" (no `NodeId`, no meta).
+	#[inline]
+	pub fn new_transparent(span: Span) -> Self {
+		Self { span, node_id: None, subtree_metadata: CssMetadata::default(), source: None }
+	}
+
+	/// Aggregated metadata for this node *and its entire subtree*.
+	#[inline]
+	pub fn subtree_metadata(&self) -> CssMetadata {
+		self.subtree_metadata
+	}
+
+	/// Metadata for *this node only* (no subtree aggregation).
+	#[inline]
+	pub fn self_metadata(&self) -> CssMetadata {
+		self.source.map(QueryNodeData::self_metadata).unwrap_or_default()
+	}
+
+	/// Retrieve a named property from this node, if present.
+	#[inline]
+	pub fn property(&self, kind: PropertyKind) -> Option<Cursor> {
+		self.source.and_then(|s| s.get_property(kind))
+	}
+}

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 css_lexer = { workspace = true } # @release
 css_ast = { workspace = true, features = ["chromashift", "visitable", "miette"] } # @release
 css_parse = { workspace = true, features = ["miette", "egg"] } # @release
+visit_flow = { workspace = true }                              # @release
 csskit_ast = { workspace = true, features = ["miette"] } # @release
 csskit_lsp = { workspace = true } # @release
 csskit_highlight = { workspace = true, features = ["miette"] } # @release

--- a/crates/csskit/src/commands/colors.rs
+++ b/crates/csskit/src/commands/colors.rs
@@ -22,7 +22,7 @@ fn extract_colors(src: &str, bump: &Bump) -> Result<Vec<(Color, Span)>, Vec<Diag
 	let mut parser = Parser::new(bump, src, lexer);
 	let result = parser.parse_entirely::<bumpalo::collections::Vec<ASTColor>>();
 	if let Some(output) = result.output.filter(|_| result.errors.is_empty()) {
-		output.accept(&mut visitor);
+		let _ = output.accept(&mut visitor);
 		return Ok(visitor.colors);
 	}
 
@@ -31,7 +31,7 @@ fn extract_colors(src: &str, bump: &Bump) -> Result<Vec<(Color, Span)>, Vec<Diag
 	let mut parser = Parser::new(bump, src, lexer);
 	let result = parser.parse_entirely::<StyleSheet>();
 	if let Some(stylesheet) = result.output {
-		stylesheet.accept(&mut visitor);
+		let _ = stylesheet.accept(&mut visitor);
 		Ok(visitor.colors)
 	} else {
 		Err(result.errors.to_vec())
@@ -49,6 +49,7 @@ impl ColorExtractor {
 	}
 }
 
+#[css_ast::visitor]
 impl css_ast::Visit for ColorExtractor {
 	fn visit_color(&mut self, color: &ASTColor) {
 		if let Some(raw_color) = color.to_chromashift() {

--- a/crates/csskit/src/commands/find.rs
+++ b/crates/csskit/src/commands/find.rs
@@ -158,7 +158,7 @@ impl Extract for Find {
 
 	fn build_context<'a>(&self, stylesheet: &StyleSheet<'a>, _src: &str) -> TokenHighlighter {
 		let mut highlighter = TokenHighlighter::new();
-		stylesheet.accept(&mut highlighter);
+		let _ = stylesheet.accept(&mut highlighter);
 		highlighter
 	}
 

--- a/crates/csskit/src/commands/fmt.rs
+++ b/crates/csskit/src/commands/fmt.rs
@@ -53,7 +53,7 @@ impl Fmt {
 				let mut str = String::new();
 				if color {
 					let mut highlighter = TokenHighlighter::new();
-					stylesheet.accept(&mut highlighter);
+					let _ = stylesheet.accept(&mut highlighter);
 					let ansi = AnsiHighlightCursorStream::new(&mut str, &highlighter, DefaultAnsiTheme);
 					let mut stream = CursorPrettyWriteSink::new(source_text, ansi, *expand_tab, quotes);
 					result.to_cursors(&mut stream);

--- a/crates/csskit/src/commands/min.rs
+++ b/crates/csskit/src/commands/min.rs
@@ -51,7 +51,7 @@ impl Min {
 				let mut str = String::new();
 				if color {
 					let mut highlighter = TokenHighlighter::new();
-					stylesheet.accept(&mut highlighter);
+					let _ = stylesheet.accept(&mut highlighter);
 					let ansi = AnsiHighlightCursorStream::new(&mut str, &highlighter, DefaultAnsiTheme);
 					{
 						let mut stream = CursorOverlaySink::new(

--- a/crates/csskit/src/commands/specificity.rs
+++ b/crates/csskit/src/commands/specificity.rs
@@ -3,7 +3,7 @@ use crate::commands::{Extract, OutputFormat};
 use bumpalo::Bump;
 use clap::Args;
 use css_ast::specificity::ToSpecificity;
-use css_ast::{CssAtomSet, SelectorList, StyleRule, StyleSheet, Visit, Visitable};
+use css_ast::{CssAtomSet, SelectorList, StyleRule, StyleSheet, Visit, Visitable, visitor};
 use css_lexer::{Lexer, Span};
 use css_parse::{Parser, ToSpan};
 use serde::Serialize;
@@ -36,6 +36,7 @@ impl<'a, 'out> SpecificityVisitor<'a, 'out> {
 	}
 }
 
+#[visitor]
 impl<'src, 'out> Visit for SpecificityVisitor<'src, 'out> {
 	fn visit_style_rule<'a>(&mut self, rule: &StyleRule<'a>) {
 		extract_selector_list(&rule.rule.prelude, self.source, self.out);
@@ -77,7 +78,7 @@ impl Extract for Specificity {
 
 	fn extract<'a>(&self, stylesheet: &StyleSheet<'a>, src: &str, out: &mut Vec<(Span, Self::Row)>) {
 		let mut visitor = SpecificityVisitor::new(src, out);
-		stylesheet.accept(&mut visitor);
+		let _ = stylesheet.accept(&mut visitor);
 	}
 
 	fn render_text(&self, _ctx: &(), _file: &str, _src: &str, _span: Span, row: &Self::Row, _color: bool) {

--- a/crates/csskit/src/commands/tree.rs
+++ b/crates/csskit/src/commands/tree.rs
@@ -2,7 +2,8 @@ use std::io::Read;
 
 use bumpalo::Bump;
 use clap::Args;
-use css_ast::visit::{QueryableNode, Visit, Visitable};
+use css_ast::VisitNode;
+use css_ast::visit::{Visit, Visitable, visitor};
 use css_ast::{CssAtomSet, PROPERTY_KIND_VARIANTS, PropertyKind, StyleSheet};
 use css_lexer::Lexer;
 use css_parse::{Cursor, Parser, ToSpan};
@@ -43,16 +44,17 @@ impl<'a> CollectionVisitor<'a> {
 		Self { source, nodes: Vec::new(), depth: 0 }
 	}
 
-	fn build_display<T: QueryableNode>(&self, node: &T) -> String {
-		let meta = node.self_metadata();
-		let mut display = node.node_id().tag_name().to_string();
+	fn build_display(&self, query: &VisitNode) -> String {
+		let meta = query.self_metadata();
+		let meta = &meta;
+		let mut display = query.node_id.expect("tree output only displays queryable nodes").tag_name().to_string();
 
 		// Attributes
 		for &kind in PROPERTY_KIND_VARIANTS {
 			if !meta.property_kinds.contains(kind) {
 				continue;
 			}
-			if let Some(cursor) = node.get_property(kind) {
+			if let Some(cursor) = query.property(kind) {
 				let value = self.cursor_to_str(cursor);
 				let attr_name = match kind {
 					PropertyKind::Name => "name",
@@ -63,11 +65,11 @@ impl<'a> CollectionVisitor<'a> {
 		}
 
 		// Pseudos
-		for name in QueryPseudoClass::matching_metadata_pseudos(&meta) {
+		for name in QueryPseudoClass::matching_metadata_pseudos(meta) {
 			display.push(':');
 			display.push_str(name);
 		}
-		if let Some(size) = QueryFunctionalPseudoClass::matching_size(&meta) {
+		if let Some(size) = QueryFunctionalPseudoClass::matching_size(meta) {
 			display.push_str(&format!(":size({})", size));
 		}
 
@@ -112,15 +114,16 @@ impl<'a> CollectionVisitor<'a> {
 	}
 }
 
+#[visitor]
 impl<'a> Visit for CollectionVisitor<'a> {
-	fn visit_queryable_node<T: QueryableNode>(&mut self, node: &T) {
-		let display = self.build_display(node);
+	fn enter_node(&mut self, query: VisitNode) {
+		let display = self.build_display(&query);
 		let node_info = NodeInfo { display, depth: self.depth, child_start_idx: self.nodes.len() + 1 };
 		self.nodes.push(node_info);
 		self.depth += 1;
 	}
 
-	fn exit_queryable_node<T: QueryableNode>(&mut self, _node: &T) {
+	fn exit_node(&mut self, _query: VisitNode) {
 		self.depth -= 1;
 	}
 }
@@ -146,7 +149,7 @@ impl Tree {
 
 			// Collect all nodes
 			let mut visitor = CollectionVisitor::new(&src);
-			stylesheet.accept(&mut visitor);
+			let _ = stylesheet.accept(&mut visitor);
 
 			// Print root
 			if let Some(root) = visitor.nodes.first() {

--- a/crates/csskit_ast/Cargo.toml
+++ b/crates/csskit_ast/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 bitmask-enum = { workspace = true }
 css_lexer = { workspace = true, features = ["dynamic-atoms"] } # @release
 css_parse = { workspace = true } # @release
+visit_flow = { workspace = true } # @release
 css_ast = { workspace = true, features = ["visitable"] } # @release
 csskit_derives = { workspace = true } # @release
 derive_atom_set = { workspace = true } # @release

--- a/crates/csskit_ast/src/selector/matcher/buckets.rs
+++ b/crates/csskit_ast/src/selector/matcher/buckets.rs
@@ -1,6 +1,6 @@
 use super::NodeData;
 use crate::{QueryCompoundSelector, SelectorRequirements, SelectorStructure};
-use css_ast::{CssMetadata, PropertyKind, visit::NodeId};
+use css_ast::{AtRuleId, CssMetadata, NodeKinds, PropertyKind, visit::NodeId};
 use std::collections::HashMap;
 
 /// Type for requirement check functions used in bucketing.
@@ -18,8 +18,21 @@ pub(crate) struct SelectorBuckets<'a, 'b> {
 	other: Vec<&'a QueryCompoundSelector<'b>>,
 	/// Aggregated requirements across all selectors for quick filtering.
 	all_requirements: SelectorRequirements,
-	/// Aggregated structure flags.
-	all_structure: SelectorStructure,
+	/// True if any type-bucketed selector targets `StyleRule` nodes; checked by `subtree_can_match`
+	/// against `CssMetadata::node_kinds`.
+	wants_style_rule: bool,
+	/// Union of `AtRuleId`s that type-bucketed selectors target; checked by `subtree_can_match`
+	/// against `CssMetadata::used_at_rules`.
+	wanted_at_rules: AtRuleId,
+	/// Union of attribute property kinds any selector targets; checked by `subtree_can_match`
+	/// against `CssMetadata::property_kinds`.
+	wanted_attributes: PropertyKind,
+	/// True when subtree pruning is unsafe (a selector has a combinator, pseudo-class, or
+	/// functional pseudo-class - ancestors/siblings/inner targets must stay reachable) or
+	/// unnecessary (a selector has no closed-domain aggregate to prune against - declarations,
+	/// functions, value types, or the wildcard/complex catch-all bucket). When set,
+	/// `subtree_can_match` always returns `true`.
+	has_unconstrained: bool,
 }
 
 impl<'a, 'b> SelectorBuckets<'a, 'b> {
@@ -30,7 +43,10 @@ impl<'a, 'b> SelectorBuckets<'a, 'b> {
 			by_pseudo: HashMap::new(),
 			other: Vec::new(),
 			all_requirements: SelectorRequirements::none(),
-			all_structure: SelectorStructure::none(),
+			wants_style_rule: false,
+			wanted_at_rules: AtRuleId::none(),
+			wanted_attributes: PropertyKind::none(),
+			has_unconstrained: false,
 		};
 
 		for &selector in selectors {
@@ -43,16 +59,29 @@ impl<'a, 'b> SelectorBuckets<'a, 'b> {
 	fn add_selector(&mut self, selector: &'a QueryCompoundSelector<'b>) {
 		let meta = selector.metadata();
 		self.all_requirements |= meta.self_requirements;
-		self.all_structure |= meta.structure;
+
+		let unsafe_structure =
+			SelectorStructure::HasCombinator | SelectorStructure::HasPseudo | SelectorStructure::HasFunctionalPseudo;
+		if meta.structure.intersects(unsafe_structure) {
+			self.has_unconstrained = true;
+		}
 
 		if let Some(type_id) = meta.rightmost_type_id {
 			self.by_type.entry(type_id).or_default().push(selector);
+			if type_id == NodeId::StyleRule {
+				self.wants_style_rule = true;
+			} else if let Some(at_rule_id) = type_id.to_at_rule_id() {
+				self.wanted_at_rules |= at_rule_id;
+			} else {
+				self.has_unconstrained = true;
+			}
 			return;
 		}
 
 		// Use self_attribute_filter for bucketing - excludes :has() inner requirements
 		if !meta.self_attribute_filter.is_none() {
 			self.by_attribute.entry(meta.self_attribute_filter).or_default().push(selector);
+			self.wanted_attributes |= meta.self_attribute_filter;
 			return;
 		}
 
@@ -76,6 +105,7 @@ impl<'a, 'b> SelectorBuckets<'a, 'b> {
 			}
 		}
 		self.other.push(selector);
+		self.has_unconstrained = true;
 	}
 
 	/// Returns an iterator over selectors that might match the given node.
@@ -107,5 +137,26 @@ impl<'a, 'b> SelectorBuckets<'a, 'b> {
 			.filter(move |(req, check_fn)| check_fn(&node.metadata) && self.all_requirements.contains(*req))
 			.filter_map(move |(req, _)| self.by_pseudo.get(req))
 			.flat_map(|v| v.iter())
+	}
+
+	/// Returns `false` if the subtree rooted at a node with `subtree_meta` provably
+	/// contains no node that could match any live selector's rightmost component.
+	///
+	/// `subtree_meta` must be the aggregated metadata for the node (self + descendants).
+	#[inline]
+	pub(crate) fn subtree_can_match(&self, subtree_meta: &CssMetadata) -> bool {
+		if self.has_unconstrained {
+			return true;
+		}
+		if self.wants_style_rule && subtree_meta.node_kinds.contains(NodeKinds::StyleRule) {
+			return true;
+		}
+		if !self.wanted_at_rules.is_none() && subtree_meta.used_at_rules.intersects(self.wanted_at_rules) {
+			return true;
+		}
+		if !self.wanted_attributes.is_none() && subtree_meta.property_kinds.intersects(self.wanted_attributes) {
+			return true;
+		}
+		false
 	}
 }

--- a/crates/csskit_ast/src/selector/matcher/node_collector.rs
+++ b/crates/csskit_ast/src/selector/matcher/node_collector.rs
@@ -1,7 +1,9 @@
-use super::NodeData;
-use css_ast::visit::{NodeId, QueryableNode, Visit};
+use super::{NodeData, SelectorBuckets};
+use css_ast::VisitNode;
+use css_ast::visit::{NodeId, Visit, visitor};
 use smallvec::SmallVec;
 use std::collections::HashMap;
+use visit_flow::{VisitFlow, VisitFlowExt};
 
 /// Sibling position data, computed lazily only when needed.
 #[derive(Clone, Copy, Default)]
@@ -31,16 +33,18 @@ pub(crate) struct TreeNode {
 }
 
 /// Collector visitor for building the node tree.
-pub(crate) struct NodeCollector {
+pub(crate) struct NodeCollector<'x, 'a, 'b> {
 	/// All collected nodes.
 	nodes: Vec<TreeNode>,
 	/// Stack of (node_index, children_nested) for tracking parent during traversal.
 	stack: Vec<(usize, bool)>,
+	/// Bucketed selectors, consulted to skip subtrees that can't contain any match.
+	buckets: &'x SelectorBuckets<'a, 'b>,
 }
 
-impl NodeCollector {
-	pub fn new() -> Self {
-		Self { nodes: Vec::new(), stack: Vec::new() }
+impl<'x, 'a, 'b> NodeCollector<'x, 'a, 'b> {
+	pub fn new(buckets: &'x SelectorBuckets<'a, 'b>) -> Self {
+		Self { nodes: Vec::new(), stack: Vec::new(), buckets }
 	}
 
 	pub fn finalize(mut self, needs_type_tracking: bool) -> Vec<TreeNode> {
@@ -90,16 +94,26 @@ impl NodeCollector {
 	}
 }
 
-impl Visit for NodeCollector {
-	fn visit_queryable_node<T: QueryableNode>(&mut self, node: &T) {
-		let node_id = node.node_id();
+#[visitor]
+impl<'x, 'a, 'b> Visit for NodeCollector<'x, 'a, 'b> {
+	fn consider_node(&self, node: VisitNode) -> VisitFlow {
+		// Only prune queryable nodes (which carry aggregated subtree metadata).
+		// Transparent nodes use VisitNode::new_transparent with empty metadata,
+		// so we can't make any pruning decision from it.
+		if node.node_id.is_some() && !self.buckets.subtree_can_match(&node.subtree_metadata()) {
+			return VisitFlow::SKIP_CHILDREN;
+		}
+		VisitFlow::DESCEND
+	}
+
+	fn enter_node(&mut self, query: VisitNode) {
+		let node_id = query.node_id.expect("NodeCollector only visits queryable nodes");
 
 		let (parent_idx, parent_children_nested) =
 			self.stack.last().map(|&(idx, nested)| (Some(idx), nested)).unwrap_or((None, false));
 
-		let node_data = NodeData::from_node(node);
+		let node_data = NodeData::from_query(query);
 		let node_idx = self.nodes.len();
-
 		let is_nested = parent_children_nested;
 
 		self.nodes.push(TreeNode {
@@ -119,7 +133,7 @@ impl Visit for NodeCollector {
 		self.stack.push((node_idx, children_nested));
 	}
 
-	fn exit_queryable_node<T: QueryableNode>(&mut self, _: &T) {
+	fn exit_node(&mut self, _query: VisitNode) {
 		self.stack.pop();
 	}
 }

--- a/crates/csskit_ast/src/selector/matcher/node_data.rs
+++ b/crates/csskit_ast/src/selector/matcher/node_data.rs
@@ -1,6 +1,7 @@
 use super::PropertyValues;
 use css_ast::CssMetadata;
-use css_ast::visit::{NodeId, QueryableNode};
+use css_ast::VisitNode;
+use css_ast::visit::NodeId;
 use css_lexer::Span;
 
 /// Node-specific data captured during visit (independent of sibling position).
@@ -14,12 +15,8 @@ pub(crate) struct NodeData {
 
 impl NodeData {
 	#[inline]
-	pub(crate) fn from_node<T: QueryableNode>(node: &T) -> Self {
-		Self {
-			node_id: node.node_id(),
-			span: node.to_span(),
-			metadata: node.self_metadata(),
-			properties: PropertyValues::from_node(node),
-		}
+	pub(crate) fn from_query(node: VisitNode) -> Self {
+		let node_id = node.node_id.expect("NodeData only stores queryable nodes");
+		Self { node_id, span: node.span, metadata: node.self_metadata(), properties: PropertyValues::from_query(&node) }
 	}
 }

--- a/crates/csskit_ast/src/selector/matcher/property_values.rs
+++ b/crates/csskit_ast/src/selector/matcher/property_values.rs
@@ -1,5 +1,5 @@
 use crate::QueryAttribute;
-use css_ast::visit::QueryableNode;
+use css_ast::visit::VisitNode;
 use css_ast::{AttributeOperator, CssAtomSet, PropertyKind};
 use css_parse::{AtomSet, Cursor};
 
@@ -12,8 +12,8 @@ pub struct PropertyValues {
 
 impl PropertyValues {
 	#[inline]
-	pub(crate) fn from_node<T: QueryableNode>(node: &T) -> Self {
-		Self { name: node.get_property(PropertyKind::Name) }
+	pub(crate) fn from_query(node: &VisitNode) -> Self {
+		Self { name: node.property(PropertyKind::Name) }
 	}
 
 	#[inline]

--- a/crates/csskit_ast/src/selector/matcher/selector_matcher.rs
+++ b/crates/csskit_ast/src/selector/matcher/selector_matcher.rs
@@ -108,7 +108,7 @@ impl<'a, 'b> SelectorMatcher<'a, 'b> {
 		});
 
 		let buckets = SelectorBuckets::new(&self.selectors);
-		let nodes = self.collect_nodes(root);
+		let nodes = self.collect_nodes(root, &buckets);
 		for (idx, node) in nodes.iter().enumerate() {
 			for selector in buckets.selectors_for_node(&node.data) {
 				if self.matches_selector(selector, idx, &nodes) {
@@ -126,9 +126,13 @@ impl<'a, 'b> SelectorMatcher<'a, 'b> {
 		self.matches.into_iter()
 	}
 
-	fn collect_nodes<T: Visitable + NodeWithMetadata<CssMetadata>>(&self, root: &T) -> Vec<TreeNode> {
-		let mut collector = NodeCollector::new();
-		root.accept(&mut collector);
+	fn collect_nodes<T: Visitable + NodeWithMetadata<CssMetadata>>(
+		&self,
+		root: &T,
+		buckets: &SelectorBuckets<'a, 'b>,
+	) -> Vec<TreeNode> {
+		let mut collector = NodeCollector::new(buckets);
+		let _ = root.accept(&mut collector);
 		collector.finalize(self.needs_type_tracking)
 	}
 

--- a/crates/csskit_derives/Cargo.toml
+++ b/crates/csskit_derives/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 proc-macro = true
 
 [dependencies]
-syn = { workspace = true, features = ["extra-traits", "full", "visit"] }
+syn = { workspace = true, features = ["extra-traits", "full", "visit", "visit-mut"] }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
 itertools = { workspace = true }

--- a/crates/csskit_derives/src/lib.rs
+++ b/crates/csskit_derives/src/lib.rs
@@ -16,6 +16,7 @@ mod semantic_eq;
 mod to_cursors;
 mod to_span;
 mod visitable;
+mod visitor;
 mod where_collector;
 
 use field_view::FieldsExt;
@@ -93,4 +94,10 @@ pub fn derive_declaration_metadata(stream: TokenStream) -> TokenStream {
 #[proc_macro_derive(SemanticEq, attributes(semantic_eq))]
 pub fn derive_semantic_eq(stream: TokenStream) -> TokenStream {
 	run(stream, semantic_eq::derive)
+}
+
+#[proc_macro_attribute]
+pub fn visitor(_attr: TokenStream, item: TokenStream) -> TokenStream {
+	let item = syn::parse_macro_input!(item as syn::ItemImpl);
+	visitor::expand(item).unwrap_or_else(|e| e.into_compile_error()).into()
 }

--- a/crates/csskit_derives/src/test/mod.rs
+++ b/crates/csskit_derives/src/test/mod.rs
@@ -4,6 +4,7 @@ mod test_semantic_eq;
 mod test_to_cursors;
 mod test_to_span;
 mod test_visitable;
+mod test_visitor;
 
 #[macro_export]
 macro_rules! to_deriveinput {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_enum_with_named_struct_variant.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_enum_with_named_struct_variant.snap
@@ -23,20 +23,19 @@ impl crate::VisitableMut for FlexWrap {
 }
 #[automatically_derived]
 impl crate::Visitable for FlexWrap {
-    fn accept<V: crate::Visit>(&self, v: &mut V) {
+    fn accept<V: crate::Visit>(&self, v: &mut V) -> visit_flow::VisitFlow {
         use crate::Visitable;
-        match self {
-            Self::Nowrap(__binding_0) => {
-                __binding_0.accept(v);
-            }
-            Self::Wrap { wrap: __binding_0, balance: __binding_1 } => {
-                __binding_0.accept(v);
-                __binding_1.accept(v);
-            }
-            Self::WrapReverse { wrap_reverse: __binding_0, balance: __binding_1 } => {
-                __binding_0.accept(v);
-                __binding_1.accept(v);
-            }
-        }
+        visit_flow::try_visit!(
+            { match self { Self::Nowrap(__binding_0) => {
+            visit_flow::try_visit!(__binding_0.accept(v)); < visit_flow::VisitFlow as
+            visit_flow::VisitFlowExt > ::DESCEND }, Self::Wrap { wrap : __binding_0,
+            balance : __binding_1 } => { visit_flow::try_visit!(__binding_0.accept(v));
+            visit_flow::try_visit!(__binding_1.accept(v)); < visit_flow::VisitFlow as
+            visit_flow::VisitFlowExt > ::DESCEND }, Self::WrapReverse { wrap_reverse :
+            __binding_0, balance : __binding_1 } => { visit_flow::try_visit!(__binding_0
+            .accept(v)); visit_flow::try_visit!(__binding_1.accept(v)); <
+            visit_flow::VisitFlow as visit_flow::VisitFlowExt > ::DESCEND }, } }
+        );
+        <visit_flow::VisitFlow as visit_flow::VisitFlowExt>::DESCEND
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_tuple_enum.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitable__visitable_tuple_enum.snap
@@ -18,15 +18,15 @@ impl crate::VisitableMut for Display {
 }
 #[automatically_derived]
 impl crate::Visitable for Display {
-    fn accept<V: crate::Visit>(&self, v: &mut V) {
+    fn accept<V: crate::Visit>(&self, v: &mut V) -> visit_flow::VisitFlow {
         use crate::Visitable;
-        match self {
-            Self::Block(__binding_0) => {
-                __binding_0.accept(v);
-            }
-            Self::Inline(__binding_0) => {
-                __binding_0.accept(v);
-            }
-        }
+        visit_flow::try_visit!(
+            { match self { Self::Block(__binding_0) => {
+            visit_flow::try_visit!(__binding_0.accept(v)); < visit_flow::VisitFlow as
+            visit_flow::VisitFlowExt > ::DESCEND }, Self::Inline(__binding_0) => {
+            visit_flow::try_visit!(__binding_0.accept(v)); < visit_flow::VisitFlow as
+            visit_flow::VisitFlowExt > ::DESCEND }, } }
+        );
+        <visit_flow::VisitFlow as visit_flow::VisitFlowExt>::DESCEND
     }
 }

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_bare_return.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_bare_return.snap
@@ -1,0 +1,13 @@
+---
+source: crates/csskit_derives/src/test/test_visitor.rs
+expression: out
+---
+impl Visit for V {
+    fn visit_color(&mut self, c: &Color) -> ::visit_flow::VisitFlow {
+        if c.is_empty() {
+            return <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND;
+        }
+        self.seen.push(c);
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_explicit_return.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_explicit_return.snap
@@ -1,0 +1,9 @@
+---
+source: crates/csskit_derives/src/test/test_visitor.rs
+expression: out
+---
+impl Visit for V {
+    fn consider_node(&self, q: VisitNode) -> VisitFlow {
+        VisitFlow::SKIP_CHILDREN
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_nested_closure.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_nested_closure.snap
@@ -1,0 +1,13 @@
+---
+source: crates/csskit_derives/src/test/test_visitor.rs
+expression: out
+---
+impl Visit for V {
+    fn visit_color(&mut self, c: &Color) -> ::visit_flow::VisitFlow {
+        let f = || {
+            return;
+        };
+        f();
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_observer.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_observer.snap
@@ -1,0 +1,10 @@
+---
+source: crates/csskit_derives/src/test/test_visitor.rs
+expression: out
+---
+impl Visit for V {
+    fn visit_color(&mut self, c: &Color) -> ::visit_flow::VisitFlow {
+        self.seen.push(c);
+        <::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_unit_optout.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_visitor__visitor_unit_optout.snap
@@ -1,0 +1,9 @@
+---
+source: crates/csskit_derives/src/test/test_visitor.rs
+expression: out
+---
+impl VisitMut for V {
+    fn visit_color(&mut self, c: &Color) -> () {
+        self.seen.push(c);
+    }
+}

--- a/crates/csskit_derives/src/test/test_visitor.rs
+++ b/crates/csskit_derives/src/test/test_visitor.rs
@@ -1,0 +1,90 @@
+use crate::visitor;
+use insta::assert_snapshot;
+use quote::quote;
+
+fn expand(tokens: proc_macro2::TokenStream) -> String {
+	let item = syn::parse2::<syn::ItemImpl>(tokens).unwrap();
+	let out = visitor::expand(item).expect("visitor expansion failed");
+	let file = syn::parse2::<syn::File>(out).unwrap();
+	prettyplease::unparse(&file)
+}
+
+#[test]
+fn observer_method_gets_return_type_and_descend_tail() {
+	let out = expand(quote! {
+		impl Visit for V {
+			fn visit_color(&mut self, c: &Color) {
+				self.seen.push(c);
+			}
+		}
+	});
+	assert_snapshot!("visitor_observer", out);
+}
+
+#[test]
+fn explicit_return_type_is_untouched() {
+	let out = expand(quote! {
+		impl Visit for V {
+			fn consider_node(&self, q: VisitNode) -> VisitFlow {
+				VisitFlow::SKIP_CHILDREN
+			}
+		}
+	});
+	assert_snapshot!("visitor_explicit_return", out);
+}
+
+#[test]
+fn bare_return_in_observer_is_rewritten() {
+	let out = expand(quote! {
+		impl Visit for V {
+			fn visit_color(&mut self, c: &Color) {
+				if c.is_empty() {
+					return;
+				}
+				self.seen.push(c);
+			}
+		}
+	});
+	assert_snapshot!("visitor_bare_return", out);
+}
+
+#[test]
+fn return_in_nested_closure_is_not_rewritten() {
+	let out = expand(quote! {
+		impl Visit for V {
+			fn visit_color(&mut self, c: &Color) {
+				let f = || {
+					return;
+				};
+				f();
+			}
+		}
+	});
+	assert_snapshot!("visitor_nested_closure", out);
+}
+
+#[test]
+fn explicit_unit_return_opts_out() {
+	let out = expand(quote! {
+		impl VisitMut for V {
+			fn visit_color(&mut self, c: &Color) -> () {
+				self.seen.push(c);
+			}
+		}
+	});
+	assert_snapshot!("visitor_unit_optout", out);
+}
+
+#[test]
+fn rejects_inherent_impl() {
+	let item = syn::parse2::<syn::ItemImpl>(quote! {
+		impl V {
+			fn visit_color(&mut self, c: &Color) {
+				self.seen.push(c);
+			}
+		}
+	})
+	.unwrap();
+
+	assert!(visitor::expand(item).is_err());
+}

--- a/crates/csskit_derives/src/visitable.rs
+++ b/crates/csskit_derives/src/visitable.rs
@@ -83,7 +83,7 @@ fn has_feature_metadata(attrs: &[Attribute]) -> bool {
 	})
 }
 
-fn make_body(s: &Structure, accept: &syn::Ident, wc: &mut WhereCollector) -> TokenStream {
+fn make_body(s: &Structure, accept: &syn::Ident, wc: &mut WhereCollector, use_try_visit: bool) -> TokenStream {
 	match &s.ast().data {
 		Data::Struct(ds) => {
 			let steps: Vec<TokenStream> = ds
@@ -97,10 +97,18 @@ fn make_body(s: &Structure, accept: &syn::Ident, wc: &mut WhereCollector) -> Tok
 					}
 					wc.add(&syn_field.ty);
 					let m = &view.member;
-					Some(quote! { self.#m.#accept(v); })
+					if use_try_visit {
+						Some(quote! { visit_flow::try_visit!(self.#m.#accept(v)); })
+					} else {
+						Some(quote! { self.#m.#accept(v); })
+					}
 				})
 				.collect();
-			quote! { #(#steps)* }
+			if use_try_visit {
+				quote! { #(#steps)* <visit_flow::VisitFlow as visit_flow::VisitFlowExt>::DESCEND }
+			} else {
+				quote! { #(#steps)* }
+			}
 		}
 		Data::Enum(_) => {
 			let arms: TokenStream = s
@@ -124,13 +132,23 @@ fn make_body(s: &Structure, accept: &syn::Ident, wc: &mut WhereCollector) -> Tok
 									(quote! { #field_name: _ }, quote! {})
 								} else {
 									wc.add(&bi.ast().ty);
-									(quote! { #field_name: #binding }, quote! { #binding.#accept(v) })
+									let call = if use_try_visit {
+										quote! { visit_flow::try_visit!(#binding.#accept(v)) }
+									} else {
+										quote! { #binding.#accept(v) }
+									};
+									(quote! { #field_name: #binding }, call)
 								}
 							} else if skip_field {
 								(quote! { _ }, quote! {})
 							} else {
 								wc.add(&bi.ast().ty);
-								(quote! { #binding }, quote! { #binding.#accept(v) })
+								let call = if use_try_visit {
+									quote! { visit_flow::try_visit!(#binding.#accept(v)) }
+								} else {
+									quote! { #binding.#accept(v) }
+								};
+								(quote! { #binding }, call)
 							}
 						})
 						.unzip();
@@ -142,7 +160,11 @@ fn make_body(s: &Structure, accept: &syn::Ident, wc: &mut WhereCollector) -> Tok
 					} else {
 						quote! { Self::#var_ident(#(#patterns),*) }
 					};
-					quote! { #pattern => { #(#calls;)* }, }
+					if use_try_visit {
+						quote! { #pattern => { #(#calls;)* <visit_flow::VisitFlow as visit_flow::VisitFlowExt>::DESCEND }, }
+					} else {
+						quote! { #pattern => { #(#calls;)* }, }
+					}
 				})
 				.collect();
 			quote! { match self { #arms } }
@@ -166,16 +188,10 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let ident = &input.ident;
 	let (impl_generics, type_generics, _) = input.generics.split_for_impl();
 
-	let (visit, exit) = if style.visit_self() {
+	let (visit_mut, exit_mut) = if style.visit_self() {
 		let visit_method = format_ident!("visit_{}", ident.to_string().to_snake_case());
 		let exit_method = format_ident!("exit_{}", ident.to_string().to_snake_case());
 		(quote! { v.#visit_method(self); }, quote! { v.#exit_method(self); })
-	} else {
-		(quote! {}, quote! {})
-	};
-
-	let (visit_queryable, exit_queryable) = if is_queryable {
-		(quote! { v.visit_queryable_node(self); }, quote! { v.exit_queryable_node(self); })
 	} else {
 		(quote! {}, quote! {})
 	};
@@ -194,11 +210,50 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let (body_mut, body) = if style.visit_children() {
 		let accept_mut = format_ident!("accept_mut");
 		let accept = format_ident!("accept");
-		let b_mut = make_body(&s, &accept_mut, &mut wc);
-		let b = make_body(&s, &accept, &mut wc);
+		let b_mut = make_body(&s, &accept_mut, &mut wc, false);
+		let b = make_body(&s, &accept, &mut wc, true);
 		(b_mut, b)
 	} else {
-		(quote! {}, quote! {})
+		(quote! {}, quote! { <visit_flow::VisitFlow as visit_flow::VisitFlowExt>::DESCEND })
+	};
+
+	let accept_body = if is_queryable {
+		let node_var = quote! { __node };
+		let children_block = if style.visit_self() {
+			let visit_method = format_ident!("visit_{}", ident.to_string().to_snake_case());
+			let exit_method = format_ident!("exit_{}", ident.to_string().to_snake_case());
+			quote! {
+				if let visit_flow::VisitAction::Descend = visit_flow::try_visit!(v.#visit_method(self)) {
+					visit_flow::try_visit!({ #body });
+				}
+				visit_flow::try_visit!(v.#exit_method(self));
+			}
+		} else {
+			quote! { visit_flow::try_visit!({ #body }); }
+		};
+		quote! {
+			let #node_var = crate::QueryableNode::visit_node(self);
+			if let visit_flow::VisitAction::SkipChildren = visit_flow::try_visit!(v.consider_node(#node_var)) {
+				return <visit_flow::VisitFlow as visit_flow::VisitFlowExt>::DESCEND;
+			}
+			#visit_feature
+			if let visit_flow::VisitAction::Descend = visit_flow::try_visit!(v.enter_node(#node_var)) {
+				#children_block
+			}
+			visit_flow::try_visit!(v.exit_node(#node_var));
+			#exit_feature
+		}
+	} else if style.visit_self() {
+		let visit_method = format_ident!("visit_{}", ident.to_string().to_snake_case());
+		let exit_method = format_ident!("exit_{}", ident.to_string().to_snake_case());
+		quote! {
+			if let visit_flow::VisitAction::Descend = visit_flow::try_visit!(v.#visit_method(self)) {
+				visit_flow::try_visit!({ #body });
+			}
+			visit_flow::try_visit!(v.#exit_method(self));
+		}
+	} else {
+		quote! { visit_flow::try_visit!({ #body }); }
 	};
 
 	let where_clause = wc.extend_where_clause(&input.generics, parse_quote! { crate::Visitable });
@@ -222,23 +277,18 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 		impl #impl_generics crate::VisitableMut for #ident #type_generics #mut_where_clause {
 			fn accept_mut<V: crate::VisitMut>(&mut self, v: &mut V) {
 				use crate::VisitableMut;
-				#visit
+				#visit_mut
 				#body_mut
-				#exit
+				#exit_mut
 			}
 		}
 
 		#[automatically_derived]
 		impl #impl_generics crate::Visitable for #ident #type_generics #where_clause {
-			fn accept<V: crate::Visit>(&self, v: &mut V) {
+			fn accept<V: crate::Visit>(&self, v: &mut V) -> visit_flow::VisitFlow {
 				use crate::Visitable;
-				#visit_queryable
-				#visit_feature
-				#visit
-				#body
-				#exit
-				#exit_feature
-				#exit_queryable
+				#accept_body
+				<visit_flow::VisitFlow as visit_flow::VisitFlowExt>::DESCEND
 			}
 		}
 

--- a/crates/csskit_derives/src/visitor.rs
+++ b/crates/csskit_derives/src/visitor.rs
@@ -1,0 +1,79 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+	Expr, ImplItem, ItemImpl, Result, ReturnType, parse_quote,
+	spanned::Spanned,
+	visit_mut::{self, VisitMut},
+};
+
+/// Rewrites bare `return;` into `return VisitFlow::DESCEND` within a method
+/// body, so observer methods can early-out without spelling the flow value.
+///
+/// Does not descend into nested closures or async blocks: their `return`
+/// targets a different (non-`VisitFlow`) context.
+struct ReturnRewriter;
+
+impl VisitMut for ReturnRewriter {
+	fn visit_expr_mut(&mut self, expr: &mut Expr) {
+		match expr {
+			// Don't cross into a different return target.
+			Expr::Closure(_) | Expr::Async(_) => return,
+			Expr::Return(ret) if ret.expr.is_none() => {
+				ret.expr =
+					Some(Box::new(parse_quote!(<::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND)));
+			}
+			_ => {}
+		}
+		visit_mut::visit_expr_mut(self, expr);
+	}
+}
+
+fn trait_name(item: &ItemImpl) -> Result<&syn::Ident> {
+	let Some((_, path, _)) = &item.trait_ else {
+		return Err(syn::Error::new(item.impl_token.span(), "#[visitor] requires an impl Visit block"));
+	};
+	path.segments
+		.last()
+		.map(|segment| &segment.ident)
+		.ok_or_else(|| syn::Error::new(path.span(), "#[visitor] requires an impl Visit block"))
+}
+
+/// Rewrites a `Visit` impl block so observer methods need no
+/// `-> VisitFlow` return type or trailing `VisitFlow::DESCEND`.
+///
+/// For every method that declares **no** return type, the macro:
+/// - sets the return type to `visit_flow::VisitFlow`, and
+/// - appends `visit_flow::VisitFlow::DESCEND` as the trailing expression.
+///
+/// Methods that declare an explicit return type (e.g. `-> VisitFlow`) are left
+/// untouched, so flow-controlling visitors keep full control (return
+/// `VisitFlow::SKIP_CHILDREN` / `VisitFlow::STOP` as normal).
+///
+/// `VisitMut` impls are accepted but left untouched; those trait methods return
+/// `()` and do not participate in `VisitFlow`.
+pub fn expand(item: ItemImpl) -> Result<TokenStream> {
+	let mut item = item;
+	let name = trait_name(&item)?;
+	if name == "VisitMut" {
+		return Ok(quote! { #item });
+	}
+	if name != "Visit" {
+		return Err(syn::Error::new(name.span(), "#[visitor] only supports impl Visit or impl VisitMut"));
+	}
+	for impl_item in &mut item.items {
+		let ImplItem::Fn(method) = impl_item else { continue };
+		// Only rewrite methods with an elided return type. An explicit return
+		// type (including `-> ()`) is an opt-out.
+		if !matches!(method.sig.output, ReturnType::Default) {
+			continue;
+		}
+		method.sig.output = parse_quote!(-> ::visit_flow::VisitFlow);
+		ReturnRewriter.visit_block_mut(&mut method.block);
+		let stmts = &method.block.stmts;
+		method.block = parse_quote!({
+			#(#stmts)*
+			<::visit_flow::VisitFlow as ::visit_flow::VisitFlowExt>::DESCEND
+		});
+	}
+	Ok(quote! { #item })
+}

--- a/crates/csskit_highlight/Cargo.toml
+++ b/crates/csskit_highlight/Cargo.toml
@@ -19,6 +19,7 @@ css_ast = { workspace = true, features = [
 ] } # @release
 css_lexer = { workspace = true } # @release
 css_parse = { workspace = true } # @release
+visit_flow = { workspace = true } # @release
 chromashift = { workspace = true } # @release
 
 bitmask-enum = { workspace = true }

--- a/crates/csskit_highlight/src/css.rs
+++ b/crates/csskit_highlight/src/css.rs
@@ -1,6 +1,6 @@
 use css_ast::{
-	CSSInt, Color, CssMetadata, Declaration, DeclarationValue, NodeId, PropertyRule, QueryableNode, StyleRule,
-	ToChromashift, Visit,
+	CSSInt, Color, CssMetadata, Declaration, DeclarationValue, NodeId, PropertyRule, StyleRule, ToChromashift, Visit,
+	VisitNode, visitor,
 };
 use css_lexer::ToSpan;
 use css_parse::NodeWithMetadata;
@@ -98,15 +98,15 @@ impl From<&CssMetadata> for SemanticModifier {
 	}
 }
 
+#[visitor]
 impl Visit for TokenHighlighter {
-	fn visit_queryable_node<T: QueryableNode>(&mut self, node: &T) {
-		let node_id = node.node_id();
-		let metadata = node.metadata();
-		let modifier = SemanticModifier::from(&metadata);
+	fn enter_node(&mut self, query: VisitNode) {
+		let node_id = query.node_id.unwrap();
+		let modifier = SemanticModifier::from(&query.self_metadata());
 		let kind = SemanticKind::from_node_id(node_id).unwrap_or(SemanticKind::None);
 
 		if !modifier.is_none() || kind != SemanticKind::None {
-			self.insert(node.to_span(), kind, modifier);
+			self.insert(query.span, kind, modifier);
 		}
 	}
 
@@ -119,9 +119,10 @@ impl Visit for TokenHighlighter {
 	}
 
 	// Visit Declarations to mark the name and colon
-	fn visit_declaration<'a, T: DeclarationValue<'a, CssMetadata>>(
+	fn enter_declaration<'a, T: DeclarationValue<'a, CssMetadata>>(
 		&mut self,
 		property: &Declaration<'a, T, CssMetadata>,
+		_query: css_ast::VisitNode,
 	) {
 		let metadata = property.metadata();
 		let modifier = SemanticModifier::from(&metadata);

--- a/crates/csskit_highlight/src/highlight.rs
+++ b/crates/csskit_highlight/src/highlight.rs
@@ -14,7 +14,7 @@ pub struct CssHighlighter {
 impl CssHighlighter {
 	pub fn new(source: String, stylesheet: &StyleSheet) -> Self {
 		let mut token_colors = TokenHighlighter::new();
-		stylesheet.accept(&mut token_colors);
+		let _ = stylesheet.accept(&mut token_colors);
 		Self { source, token_colors }
 	}
 }

--- a/crates/csskit_highlight/src/test_helpers.rs
+++ b/crates/csskit_highlight/src/test_helpers.rs
@@ -108,7 +108,7 @@ macro_rules! assert_highlight {
 		let mut actual = String::new_in(&bump);
 		let mut cursors = HTMLHighlightCursorStream::new($str, &mut actual);
 		let node = result.output.clone().unwrap();
-		node.accept(&mut cursors.highlighter);
+		let _ = node.accept(&mut cursors.highlighter);
 		result.to_cursors(&mut cursors);
 		cursors.finish();
 		::insta::assert_snapshot!($name, actual)

--- a/crates/csskit_lsp/src/service.rs
+++ b/crates/csskit_lsp/src/service.rs
@@ -82,7 +82,7 @@ impl File {
 								let _ = span.enter();
 								let mut highlighter = TokenHighlighter::new();
 								if let Some(stylesheet) = &result.output {
-									stylesheet.accept(&mut highlighter);
+									let _ = stylesheet.accept(&mut highlighter);
 									let mut current_line = 0;
 									let mut current_start = 0;
 									let data = highlighter

--- a/crates/csskit_transform/Cargo.toml
+++ b/crates/csskit_transform/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 [dependencies]
 css_ast = { workspace = true, features = ["visitable", "chromashift"] }
 css_parse = { workspace = true }
+visit_flow = { workspace = true }
 css_lexer = { workspace = true }
 bumpalo = { workspace = true }
 bitmask-enum = { workspace = true }

--- a/crates/csskit_transform/src/lib.rs
+++ b/crates/csskit_transform/src/lib.rs
@@ -7,9 +7,10 @@ pub use transformer::*;
 
 pub(crate) mod prelude {
 	pub(crate) use crate::{CssMinifierFeature, Transform, Transformer};
-	pub(crate) use css_ast::{CssMetadata, Visit};
+	pub(crate) use css_ast::{CssMetadata, Visit, visitor};
 	pub(crate) use css_lexer::ToSpan;
 	pub(crate) use css_parse::NodeWithMetadata;
+	pub(crate) use visit_flow::{VisitFlow, VisitFlowExt};
 }
 
 mod css_minifier;

--- a/crates/csskit_transform/src/reduce_colors.rs
+++ b/crates/csskit_transform/src/reduce_colors.rs
@@ -7,9 +7,6 @@ use css_ast::{
 
 pub struct ReduceColors<'a, 'ctx, N: Visitable + NodeWithMetadata<CssMetadata>> {
 	pub transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>,
-	/// When true, the outer color-mix() is being replaced entirely, so inner
-	/// `visit_color` calls should be suppressed to avoid overlapping edits.
-	replacing_outer: bool,
 }
 
 impl<'a, 'ctx, N> Transform<'a, 'ctx, CssMetadata, N, CssMinifierFeature> for ReduceColors<'a, 'ctx, N>
@@ -21,7 +18,7 @@ where
 	}
 
 	fn new(transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>) -> Self {
-		Self { transformer, replacing_outer: false }
+		Self { transformer }
 	}
 }
 
@@ -168,14 +165,12 @@ impl ToCss for chromashift::Color {
 	}
 }
 
+#[visitor]
 impl<'a, 'ctx, N> Visit for ReduceColors<'a, 'ctx, N>
 where
 	N: Visitable + NodeWithMetadata<CssMetadata>,
 {
 	fn visit_color(&mut self, color: &Color) {
-		if self.replacing_outer {
-			return;
-		}
 		// color-mix() is handled by visit_color_mix_function
 		if let Color::Function(colorfn) = color
 			&& matches!(**colorfn, ColorFunction::ColorMix(_))
@@ -205,7 +200,7 @@ where
 		}
 	}
 
-	fn visit_color_mix_function<'b>(&mut self, mix: &ColorMixFunction<'b>) {
+	fn visit_color_mix_function<'b>(&mut self, mix: &ColorMixFunction<'b>) -> VisitFlow {
 		let outer_span = mix.to_span();
 		let outer_len = outer_span.len() as usize;
 
@@ -236,8 +231,7 @@ where
 				});
 				self.transformer.clear_pending_edits(outer_span);
 				self.transformer.replace_parsed::<Color>(outer_span, &str);
-				self.replacing_outer = true;
-				return;
+				return VisitFlow::SKIP_CHILDREN;
 			}
 		}
 
@@ -254,8 +248,7 @@ where
 					});
 					self.transformer.clear_pending_edits(outer_span);
 					self.transformer.replace_parsed::<Color>(outer_span, &str);
-					self.replacing_outer = true;
-					return;
+					return VisitFlow::SKIP_CHILDREN;
 				}
 			}
 		}
@@ -275,8 +268,7 @@ where
 				&& candidate.len() < outer_len
 			{
 				self.transformer.replace_parsed::<Color>(outer_span, candidate);
-				self.replacing_outer = true;
-				return;
+				return VisitFlow::SKIP_CHILDREN;
 			}
 		}
 
@@ -298,10 +290,7 @@ where
 		{
 			self.transformer.delete(hue_method.to_span());
 		}
-	}
-
-	fn exit_color_mix_function<'b>(&mut self, _mix: &ColorMixFunction<'b>) {
-		self.replacing_outer = false;
+		VisitFlow::DESCEND
 	}
 }
 

--- a/crates/csskit_transform/src/reduce_lengths.rs
+++ b/crates/csskit_transform/src/reduce_lengths.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use css_ast::{DeclarationValue, Length, QueryableNode, UnitlessZeroResolves, Visitable};
+use css_ast::{DeclarationValue, Length, UnitlessZeroResolves, VisitNode, Visitable};
 use css_parse::Declaration;
 use std::cell::Cell;
 
@@ -23,20 +23,23 @@ where
 	}
 }
 
+#[visitor]
 impl<'a, 'ctx, N> Visit for ReduceLengths<'a, 'ctx, N>
 where
 	N: Visitable + NodeWithMetadata<CssMetadata>,
 {
-	fn visit_declaration<'b, T: DeclarationValue<'b, CssMetadata> + QueryableNode>(
+	fn enter_declaration<'b, T: DeclarationValue<'b, CssMetadata>>(
 		&mut self,
 		decl: &Declaration<'b, T, CssMetadata>,
+		_query: VisitNode,
 	) {
 		self.unitless_zero_resolves.set(decl.metadata().unitless_zero_resolves);
 	}
 
-	fn exit_declaration<'b, T: DeclarationValue<'b, CssMetadata> + QueryableNode>(
+	fn exit_declaration<'b, T: DeclarationValue<'b, CssMetadata>>(
 		&mut self,
 		_decl: &Declaration<'b, T, CssMetadata>,
+		_query: VisitNode,
 	) {
 		self.unitless_zero_resolves.set(UnitlessZeroResolves::Length);
 	}

--- a/crates/csskit_transform/src/reduce_time_units.rs
+++ b/crates/csskit_transform/src/reduce_time_units.rs
@@ -18,6 +18,7 @@ where
 	}
 }
 
+#[visitor]
 impl<'a, 'ctx, N> Visit for ReduceTimeUnits<'a, 'ctx, N>
 where
 	N: Visitable + NodeWithMetadata<CssMetadata>,

--- a/crates/csskit_transform/src/reduce_urls.rs
+++ b/crates/csskit_transform/src/reduce_urls.rs
@@ -18,14 +18,14 @@ where
 	}
 }
 
+#[visitor]
 impl<'a, 'ctx, N> Visit for ReduceUrls<'a, 'ctx, N>
 where
 	N: Visitable + NodeWithMetadata<CssMetadata>,
 {
 	fn visit_url_or_string(&mut self, url_or_string: &UrlOrString) {
-		let url = match url_or_string {
-			UrlOrString::Url(url) => url,
-			UrlOrString::String(_) => return,
+		let UrlOrString::Url(url) = url_or_string else {
+			return;
 		};
 		match url {
 			Url::UrlFunction(_, string, _) | Url::SrcFunction(_, string, _) => {

--- a/crates/csskit_transform/src/transformer.rs
+++ b/crates/csskit_transform/src/transformer.rs
@@ -271,7 +271,7 @@ macro_rules! transformer {
 					$(
 						if $variant::may_change(transformer.features, node) {
 							let mut transform = $variant::new(transformer);
-							node.accept(&mut transform);
+							let _ = node.accept(&mut transform);
 						}
 					)+
 				}

--- a/crates/visit_flow/Cargo.toml
+++ b/crates/visit_flow/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "visit-flow"
+version.workspace = true
+authors.workspace = true
+description = "Zero-dependency visitor control-flow primitives: VisitFlow and the try_visit! macro."
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+bench = false
+
+[dependencies]

--- a/crates/visit_flow/src/lib.rs
+++ b/crates/visit_flow/src/lib.rs
@@ -1,0 +1,53 @@
+use std::ops::ControlFlow;
+
+/// Controls whether children are visited after a `visit_*` method returns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisitAction {
+	/// Recurse into children (default).
+	Descend,
+	/// Skip children; `exit_*` is still called.
+	///
+	/// When returned from [`Visit::filter`], this means skip self _and_ children
+	/// (prune the entire subtree). The positional distinction: a visitor returning
+	/// `SkipChildren` from `visit_*` has already seen the node; a filter returning
+	/// it has not.
+	SkipChildren,
+}
+
+/// Controls early termination of the entire traversal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisitBreak {
+	/// Halt immediately; no further visits or exits.
+	Stop,
+}
+
+/// Convenience alias for the visitor control-flow type.
+pub type VisitFlow = ControlFlow<VisitBreak, VisitAction>;
+
+/// Named [`VisitFlow`] values.
+///
+/// `VisitFlow` is a type alias for [`ControlFlow`], so the canonical values are
+/// exposed as associated consts via this extension trait rather than inherent
+/// consts. Bringing the trait into scope lets you write `VisitFlow::DESCEND`,
+/// `VisitFlow::SKIP_CHILDREN`, and `VisitFlow::STOP`.
+pub trait VisitFlowExt {
+	/// Continue traversal and recurse into children.
+	const DESCEND: VisitFlow = ControlFlow::Continue(VisitAction::Descend);
+	/// Continue traversal but skip visiting children (`exit_*` still fires).
+	const SKIP_CHILDREN: VisitFlow = ControlFlow::Continue(VisitAction::SkipChildren);
+	/// Stop traversal immediately.
+	const STOP: VisitFlow = ControlFlow::Break(VisitBreak::Stop);
+}
+
+impl VisitFlowExt for VisitFlow {}
+
+/// Propagates a [`VisitFlow`]: on `Break`, returns early; on `Continue`, yields the [`VisitAction`].
+#[macro_export]
+macro_rules! try_visit {
+	($e:expr) => {
+		match $e {
+			::std::ops::ControlFlow::Continue(action) => action,
+			::std::ops::ControlFlow::Break(r) => return ::std::ops::ControlFlow::Break(r),
+		}
+	};
+}


### PR DESCRIPTION
Currently the AST traversal visitor pattern walks the entire tree, even when it
doesn't strictly need to. This is bad for performance, which is especially
wasteful as we precompute alot of metadata while building the AST. This also
means some code (e.g. reduce_colors) needs to manage its own control flow to
avoid "over reducing" some nodes. Really we should be able to skip descending
into subtrees.

This change refactors the Visit code to return a ControlFlow type, with subtype
enums that control how visitors should descend into the tree. Each visit method
can either break (stop the whole visit flow), skip children (so only the exit_
fires) or descend (the default). This also refactors the various consumers to
take advantage of this new feature, including the selector engine in csskit_ast.
