### PR TITLE
css_lexer/csskit: Implement LineIndex, precomputing line offsets

### DIFF
--- a/crates/css_lexer/src/lib.rs
+++ b/crates/css_lexer/src/lib.rs
@@ -114,7 +114,7 @@ pub use pairwise::PairWise;
 pub use quote_style::QuoteStyle;
 pub use source_cursor::SourceCursor;
 pub use source_offset::SourceOffset;
-pub use span::{Span, ToSpan};
+pub use span::{LineIndex, Span, ToSpan};
 pub use token::Token;
 pub use whitespace_style::Whitespace;
 

--- a/crates/css_lexer/src/span.rs
+++ b/crates/css_lexer/src/span.rs
@@ -88,6 +88,63 @@ impl Span {
 	}
 }
 
+/// Precomputed line-start offsets for a source string, enabling O(log lines) line/column lookup.
+///
+/// Building the index is a single linear pass over the source; each subsequent [`LineIndex::line_and_column`] is a
+/// binary search plus a per-line character count. Prefer this over [`Span::line_and_column`] whenever
+/// resolving more than a couple of spans against one source.
+#[derive(Debug, Clone)]
+pub struct LineIndex<'a> {
+	source: &'a str,
+	/// Byte offset of the start of each line. Always begins with 0.
+	#[cfg(feature = "bumpalo")]
+	line_starts: bumpalo::collections::Vec<'a, u32>,
+	#[cfg(not(feature = "bumpalo"))]
+	line_starts: Vec<u32>,
+}
+
+impl<'a> LineIndex<'a> {
+	/// Build a line index for `source` in a single pass.
+	#[cfg(not(feature = "bumpalo"))]
+	pub fn new(source: &'a str) -> Self {
+		let mut line_starts = Vec::with_capacity(source.len() / 32 + 1);
+		line_starts.push(0);
+		for (i, b) in source.bytes().enumerate() {
+			if b == b'\n' {
+				line_starts.push(i as u32 + 1);
+			}
+		}
+		Self { source, line_starts }
+	}
+
+	/// Build a line index for `source` in a single pass, allocating the backing table in `bump`.
+	#[cfg(feature = "bumpalo")]
+	pub fn new_in(source: &'a str, bump: &'a bumpalo::Bump) -> Self {
+		let mut line_starts = bumpalo::collections::Vec::with_capacity_in(source.len() / 32 + 1, bump);
+		line_starts.push(0);
+		for (i, b) in source.bytes().enumerate() {
+			if b == b'\n' {
+				line_starts.push(i as u32 + 1);
+			}
+		}
+		Self { source, line_starts }
+	}
+
+	/// Returns the zero-based `(line, column)` of the span's start, where column counts Unicode
+	/// scalar values from the line start. Matches [`Span::line_and_column`] exactly.
+	pub fn line_and_column(&self, span: Span) -> (u32, u32) {
+		let line_starts = &self.line_starts[..];
+		let offset = span.start().0;
+		// Largest line whose start is <= offset.
+		let line = line_starts.partition_point(|&start| start <= offset) - 1;
+		let line_start = line_starts[line] as usize;
+		let end = (offset as usize).min(self.source.len());
+		// Count characters (not bytes) within the line up to the offset.
+		let column = self.source[line_start..end].chars().count() as u32;
+		(line as u32, column)
+	}
+}
+
 /// Extends this [Span], ensuring that the resulting new [Span] is broader than both this and the given [Span].
 /// In other words the resulting span will always [Span::contains()] both [Spans][Span].
 impl Add for Span {
@@ -228,5 +285,44 @@ mod test {
 		vec.push(Span::new(SourceOffset(3), SourceOffset(10)));
 		vec.push(Span::new(SourceOffset(13), SourceOffset(15)));
 		assert_eq!(vec.to_span(), Span::new(SourceOffset(3), SourceOffset(15)));
+	}
+
+	#[cfg(feature = "bumpalo")]
+	fn line_index<'a>(bump: &'a bumpalo::Bump, source: &'a str) -> LineIndex<'a> {
+		LineIndex::new_in(source, bump)
+	}
+	#[cfg(not(feature = "bumpalo"))]
+	fn line_index<'a>(_bump: &'a (), source: &'a str) -> LineIndex<'a> {
+		LineIndex::new(source)
+	}
+
+	#[test]
+	fn line_index_matches_scan() {
+		#[cfg(feature = "bumpalo")]
+		let bump = bumpalo::Bump::new();
+		#[cfg(not(feature = "bumpalo"))]
+		let bump = ();
+		// Includes a multibyte char (é = 2 bytes) so column-by-char and byte offsets diverge.
+		let source = "a\nbc\n\ndéf\nghi";
+		let index = line_index(&bump, source);
+		for offset in 0..=source.len() as u32 {
+			// Only test offsets on char boundaries, as spans always land on them.
+			if !source.is_char_boundary(offset as usize) {
+				continue;
+			}
+			let span = Span::new(SourceOffset(offset), SourceOffset(offset));
+			assert_eq!(index.line_and_column(span), span.line_and_column(source), "offset {offset}");
+		}
+	}
+
+	#[test]
+	fn line_index_empty_source() {
+		#[cfg(feature = "bumpalo")]
+		let bump = bumpalo::Bump::new();
+		#[cfg(not(feature = "bumpalo"))]
+		let bump = ();
+		let index = line_index(&bump, "");
+		let span = Span::new(SourceOffset(0), SourceOffset(0));
+		assert_eq!(index.line_and_column(span), (0, 0));
 	}
 }

--- a/crates/csskit/src/commands/check.rs
+++ b/crates/csskit/src/commands/check.rs
@@ -9,7 +9,7 @@ use crate::{
 use bumpalo::Bump;
 use clap::Args;
 use css_ast::CssAtomSet;
-use css_lexer::{DynAtomSet, Lexer, RegisteredAtomSet};
+use css_lexer::{DynAtomSet, Lexer, LineIndex, RegisteredAtomSet};
 use css_parse::Parser;
 use csskit_ast::{Collector, CsskitAtomSet, ResolvedDiagnosticLevel, StatType, sheet::Sheet};
 use csskit_highlight::CssHighlighter;
@@ -177,6 +177,7 @@ impl Check {
 
 			let mut file_failed = false;
 			let mut file_diagnostics: Vec<DiagnosticData> = Vec::new();
+			let line_index = matches!(format, OutputFormat::Json).then(|| LineIndex::new_in(&css_source, &bump));
 
 			for diagnostic in collector.diagnostics(&css_source) {
 				let is_error = matches!(diagnostic.severity, ResolvedDiagnosticLevel::Error);
@@ -190,10 +191,14 @@ impl Check {
 
 				match format {
 					OutputFormat::Json => {
+						let location = line_index
+							.as_ref()
+							.map(|index| Location::from_span(diagnostic.span, index))
+							.expect("line index is built for JSON output");
 						file_diagnostics.push(DiagnosticData {
 							severity: diagnostic.severity.to_string(),
 							message: diagnostic.message.clone(),
-							location: Location::from_span(diagnostic.span, &css_source),
+							location,
 						});
 					}
 					OutputFormat::Text => {

--- a/crates/csskit/src/commands/colors.rs
+++ b/crates/csskit/src/commands/colors.rs
@@ -8,7 +8,7 @@ use bumpalo::Bump;
 use chromashift::*;
 use clap::Args;
 use css_ast::{Color as ASTColor, CssAtomSet, StyleSheet, ToChromashift, Visitable};
-use css_lexer::Lexer;
+use css_lexer::{Lexer, LineIndex};
 use css_parse::{Diagnostic, Parser, Span, ToSpan};
 use itertools::Itertools;
 use serde::Serialize;
@@ -408,9 +408,18 @@ impl Extract for ColorCommand {
 		// Unreachable: parse_and_extract_file is fully overridden.
 	}
 
-	fn render_text(&self, _ctx: &ColorContext, file: &str, src: &str, span: Span, row: &ColorData, color: bool) {
+	fn render_text(
+		&self,
+		_ctx: &ColorContext,
+		file: &str,
+		_src: &str,
+		index: &LineIndex,
+		span: Span,
+		row: &ColorData,
+		color: bool,
+	) {
 		let lc = if file != "<content>" && file != "-" {
-			let (line, col) = span.line_and_column(src);
+			let (line, col) = index.line_and_column(span);
 			Some((file, line, col))
 		} else {
 			None

--- a/crates/csskit/src/commands/extract.rs
+++ b/crates/csskit/src/commands/extract.rs
@@ -2,7 +2,7 @@ use crate::{CliResult, GlobalConfig, InputArgs};
 use bumpalo::Bump;
 use clap::ValueEnum;
 use css_ast::{CssAtomSet, StyleSheet};
-use css_lexer::{Lexer, Span};
+use css_lexer::{Lexer, LineIndex, Span};
 use css_parse::Parser;
 use serde::Serialize;
 use std::io::Read;
@@ -17,8 +17,8 @@ pub struct Location {
 }
 
 impl Location {
-	pub fn from_span(span: Span, src: &str) -> Self {
-		let (line, col) = span.line_and_column(src);
+	pub fn from_span(span: Span, index: &LineIndex) -> Self {
+		let (line, col) = index.line_and_column(span);
 		Self { line: line + 1, column: col + 1, start: usize::from(span.start()), end: usize::from(span.end()) }
 	}
 }
@@ -116,7 +116,17 @@ pub trait Extract: Sized {
 	fn extract<'a>(&self, stylesheet: &StyleSheet<'a>, src: &str, out: &mut Vec<(Span, Self::Row)>);
 
 	/// Format one row for text output.
-	fn render_text(&self, ctx: &Self::FileContext, file: &str, src: &str, span: Span, row: &Self::Row, color: bool);
+	#[allow(clippy::too_many_arguments)]
+	fn render_text(
+		&self,
+		ctx: &Self::FileContext,
+		file: &str,
+		src: &str,
+		index: &LineIndex,
+		span: Span,
+		row: &Self::Row,
+		color: bool,
+	);
 
 	/// Build the per-file context from the parsed stylesheet and source.
 	fn build_context<'a>(&self, _stylesheet: &StyleSheet<'a>, _src: &str) -> Self::FileContext {
@@ -225,15 +235,17 @@ pub trait Extract: Sized {
 								}
 							}
 							self.render_file_preamble(filename, rows.len(), config.colors());
+							let index = LineIndex::new_in(&src, &bump);
 							for (span, row) in &rows {
-								self.render_text(&ctx, filename, &src, *span, row, config.colors());
+								self.render_text(&ctx, filename, &src, &index, *span, row, config.colors());
 							}
 						}
 					}
 					OutputFormat::Json => {
+						let index = LineIndex::new_in(&src, &bump);
 						let records = rows
 							.into_iter()
-							.map(|(span, data)| Record { location: Location::from_span(span, &src), data })
+							.map(|(span, data)| Record { location: Location::from_span(span, &index), data })
 							.collect();
 						envelopes.push(FileEnvelope::ok(filename, records));
 					}

--- a/crates/csskit/src/commands/find.rs
+++ b/crates/csskit/src/commands/find.rs
@@ -6,7 +6,7 @@ use crate::{
 use bumpalo::Bump;
 use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet, Visitable, visit::NodeId};
-use css_lexer::{Cursor, Lexer, SourceOffset, Span};
+use css_lexer::{Cursor, Lexer, LineIndex, SourceOffset, Span};
 use css_parse::{NodeWithMetadata, Parser, SourceCursor, SourceCursorSink};
 use csskit_ast::{CsskitAtomSet, QuerySelectorList, SelectorMatcher};
 use csskit_highlight::{AnsiHighlightCursorStream, DefaultAnsiTheme, TokenHighlighter};
@@ -173,8 +173,17 @@ impl Extract for Find {
 		}
 	}
 
-	fn render_text(&self, ctx: &TokenHighlighter, _file: &str, src: &str, span: Span, _row: &FindData, color: bool) {
-		let (line, col) = span.line_and_column(src);
+	fn render_text(
+		&self,
+		ctx: &TokenHighlighter,
+		_file: &str,
+		src: &str,
+		index: &LineIndex,
+		span: Span,
+		_row: &FindData,
+		color: bool,
+	) {
+		let (line, col) = index.line_and_column(span);
 		let (start, end) = line_bounds(src, span.start().into());
 
 		if color {

--- a/crates/csskit/src/commands/specificity.rs
+++ b/crates/csskit/src/commands/specificity.rs
@@ -4,7 +4,7 @@ use bumpalo::Bump;
 use clap::Args;
 use css_ast::specificity::ToSpecificity;
 use css_ast::{CssAtomSet, SelectorList, StyleRule, StyleSheet, Visit, Visitable, visitor};
-use css_lexer::{Lexer, Span};
+use css_lexer::{Lexer, LineIndex, Span};
 use css_parse::{Parser, ToSpan};
 use serde::Serialize;
 
@@ -81,7 +81,16 @@ impl Extract for Specificity {
 		let _ = stylesheet.accept(&mut visitor);
 	}
 
-	fn render_text(&self, _ctx: &(), _file: &str, _src: &str, _span: Span, row: &Self::Row, _color: bool) {
+	fn render_text(
+		&self,
+		_ctx: &(),
+		_file: &str,
+		_src: &str,
+		_index: &LineIndex,
+		_span: Span,
+		row: &Self::Row,
+		_color: bool,
+	) {
 		println!("{} ({},{},{})", row.selector, row.a, row.b, row.c);
 	}
 }

--- a/crates/csskit_lsp/src/service.rs
+++ b/crates/csskit_lsp/src/service.rs
@@ -1,7 +1,7 @@
 use bumpalo::Bump;
 use crossbeam_channel::{Receiver, Sender, bounded};
 use css_ast::{CssAtomSet, StyleSheet, Visitable};
-use css_lexer::Lexer;
+use css_lexer::{Lexer, LineIndex};
 use css_parse::{Parser, ParserReturn};
 use csskit_highlight::{Highlight, SemanticKind, SemanticModifier, TokenHighlighter};
 use dashmap::DashMap;
@@ -85,12 +85,13 @@ impl File {
 									let _ = stylesheet.accept(&mut highlighter);
 									let mut current_line = 0;
 									let mut current_start = 0;
+									let index_bump = Bump::new();
+									let line_index = LineIndex::new_in(&string, &index_bump);
 									let data = highlighter
 										.highlights()
 										.sorted_by(|a, b| Ord::cmp(&a.span(), &b.span()))
 										.map(|h| {
-											// TODO: figure out a more efficient way to get line/col
-											let (line, start) = h.span().line_and_column(&string);
+											let (line, start) = line_index.line_and_column(h.span());
 											let delta_line: Line = line - current_line;
 											current_line = line;
 											let delta_start: Col =


### PR DESCRIPTION
We defer computing line offsets until they're needed, however this can lead to
quadratic behaviour when multiple rules end up needing to lookup the same line
again and again, for example `csskit find '*'` or something. This slows down a
lot of operations.

This change introduces LineIndex to css_lexer, a simple struct which reads
source and precomputes all line offsets, so that they can be looked up far more
quickly than reading byte-for-byte.
