### PR TITLE
csskit_derives: Add peek(skip) attribute

### DIFF
--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -61,7 +61,9 @@ pub struct SupportsRuleBlock<'a>(#[metadata(delegate)] pub RuleList<'a, Rule<'a>
 pub enum SupportsCondition<'a> {
 	Is(SupportsFeature<'a>),
 	Not(#[atom(CssAtomSet::Not)] T![Ident], SupportsFeature<'a>),
+	#[peek(skip)]
 	And(Vec<'a, (SupportsFeature<'a>, Option<T![Ident]>)>),
+	#[peek(skip)]
 	Or(Vec<'a, (SupportsFeature<'a>, Option<T![Ident]>)>),
 }
 

--- a/crates/csskit_derives/src/attributes.rs
+++ b/crates/csskit_derives/src/attributes.rs
@@ -70,6 +70,25 @@ impl ToTokens for Atom {
 	}
 }
 
+pub fn extract_peek_skip(attrs: &[Attribute]) -> bool {
+	for attr in attrs.iter().filter(|a| a.path().is_ident("peek")) {
+		if let Meta::List(meta) = &attr.meta {
+			let mut skip = false;
+			meta.parse_nested_meta(|nested| {
+				if nested.path.is_ident("skip") {
+					skip = true;
+				}
+				Ok(())
+			})
+			.ok();
+			if skip {
+				return true;
+			}
+		}
+	}
+	false
+}
+
 pub fn extract_atom(attrs: &[Attribute]) -> Result<Option<Atom>> {
 	let Some(attr) = attrs.iter().find(|a| a.path().is_ident("atom")) else {
 		return Ok(None);

--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -1,6 +1,6 @@
 use crate::{
 	FieldsExt, WhereCollector,
-	attributes::{Atom, extract_atom, extract_field_parse_mode},
+	attributes::{Atom, extract_atom, extract_field_parse_mode, extract_peek_skip},
 	ensure_lifetime_a,
 	field_view::option_inner,
 };
@@ -60,6 +60,9 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 			let parse_mode = extract_field_parse_mode(&input.attrs)?;
 			let mut checks: Vec<TokenStream> = vec![];
 			for (view, syn_field) in fields.views().into_iter().zip(fields.iter()) {
+				if extract_peek_skip(&syn_field.attrs) {
+					continue;
+				}
 				let atom = extract_atom(&syn_field.attrs)?;
 				let atoms = atom.map(|a| vec![a]).unwrap_or_default();
 				let peek_ty = option_inner(view.ty).unwrap_or(view.ty);
@@ -111,9 +114,15 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 			};
 
 			for variant in variants.iter() {
+				if extract_peek_skip(&variant.attrs) {
+					continue;
+				}
 				let views = variant.fields.views();
 				let parse_mode = extract_field_parse_mode(&variant.attrs)?;
 				for (view, syn_field) in views.iter().zip(variant.fields.iter()) {
+					if extract_peek_skip(&syn_field.attrs) {
+						continue;
+					}
 					let atom = match extract_atom(&variant.attrs)? {
 						Some(a) => Some(a),
 						None => extract_atom(&syn_field.attrs)?,

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_skip_variant.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_enum_skip_variant.snap
@@ -1,0 +1,15 @@
+---
+source: crates/csskit_derives/src/test/test_peek.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for Foo {
+    #[inline(always)]
+    fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use ::css_parse::Peek;
+        <T>::peek(p, c)
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_skip_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_skip_field.snap
@@ -1,0 +1,10 @@
+---
+source: crates/csskit_derives/src/test/test_peek.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for Foo {
+    const PEEK_KINDSET: ::css_lexer::KindSet = ::css_lexer::KindSet::new(
+        &[::css_lexer::Kind::Ident],
+    );
+}

--- a/crates/csskit_derives/src/test/test_peek.rs
+++ b/crates/csskit_derives/src/test/test_peek.rs
@@ -189,6 +189,31 @@ fn peek_enum_with_multiple_identical_types() {
 }
 
 #[test]
+fn peek_enum_skip_variant() {
+	let data = to_deriveinput! {
+		enum Foo {
+			One(T),
+			#[peek(skip)]
+			Many(CommaSeparated<T>),
+		}
+	};
+	assert_peek_snapshot!(data, "peek_enum_skip_variant");
+}
+
+#[test]
+fn peek_struct_skip_field() {
+	let data = to_deriveinput! {
+		#[parse(all_must_occur)]
+		struct Foo {
+			keyword: Ident,
+			#[peek(skip)]
+			rest: Percentage,
+		}
+	};
+	assert_peek_snapshot!(data, "peek_struct_skip_field");
+}
+
+#[test]
 fn peek_enum_with_option_variants() {
 	let data = to_deriveinput! {
 		enum Foo {


### PR DESCRIPTION
Some derive(Peek) calls end up peeking duplicate effective tokens, for example a
generic which also wraps a container generic, e.g.
`Foo<T> { One(T), Many(CommaSeparated<T>) }` would peek `T || CommaSeparated<T>`
which is effectively the same as peeking just `T` (as `CommaSeparated` just
peeks `T` also). This makes `derive(Peek)` leaky, as if we want to optimise a
peek we have to manually implement instead.

This change introduces `peek(skip)` as a variant/field attribute, allowing
`derive(Peek)` to ignore certain fields, this allows us to optimise without
having to drop to a manual impl.
