### PR TITLE
css_parse/csskit_derives: Add semantic_eq(skip) to derive(SemanticEq)

### DIFF
--- a/crates/css_ast/src/functions/attr_function.rs
+++ b/crates/css_ast/src/functions/attr_function.rs
@@ -16,19 +16,25 @@ pub struct AttrFunction<'a> {
 	#[atom(CssAtomSet::Attr)]
 	pub name: T![Function],
 	pub params: AttrFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct AttrFunctionParams<'a>(AttrName, Option<AttrType>, Option<T![,]>, Option<ComponentValues<'a>>);
+pub struct AttrFunctionParams<'a>(
+	AttrName,
+	Option<AttrType>,
+	#[semantic_eq(skip)] Option<T![,]>,
+	Option<ComponentValues<'a>>,
+);
 
 /// ```text,ignore
 /// <attr-name> = [ <ident-token>? '|' ]? <ident-token>
 /// ```
 #[derive(ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct AttrName(pub Option<T![Ident]>, pub Option<T![|]>, pub Option<T![Ident]>);
+pub struct AttrName(pub Option<T![Ident]>, #[semantic_eq(skip)] pub Option<T![|]>, pub Option<T![Ident]>);
 
 impl<'a> Peek<'a> for AttrName {
 	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Ident]);
@@ -67,7 +73,7 @@ impl<'a> Parse<'a> for AttrName {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum AttrType {
 	#[atom(CssAtomSet::Type)]
-	Type(T![Function], Syntax, T![')']),
+	Type(T![Function], Syntax, #[semantic_eq(skip)] T![')']),
 	#[atom(CssAtomSet::RawString)]
 	RawString(T![Ident]),
 	Unit(T![Ident]),

--- a/crates/css_ast/src/functions/calc_size_function.rs
+++ b/crates/css_ast/src/functions/calc_size_function.rs
@@ -17,6 +17,7 @@ pub struct CalcSizeFunction {
 	#[atom(CssAtomSet::CalcSize)]
 	pub name: T![Function],
 	pub params: Todo,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/color_function.rs
+++ b/crates/css_ast/src/functions/color_function.rs
@@ -168,6 +168,7 @@ pub struct ColorFunctionColor {
 	#[atom(CssAtomSet::Color)]
 	pub name: T![Function],
 	pub params: ColorFunctionColorParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -256,7 +257,7 @@ pub struct ColorFunctionColorParams(
 	pub NoneOr<NumberOrPercentage>,
 	pub NoneOr<NumberOrPercentage>,
 	pub NoneOr<NumberOrPercentage>,
-	pub Option<T![/]>,
+	#[semantic_eq(skip)] pub Option<T![/]>,
 	pub Option<NoneOr<NumberOrPercentage>>,
 );
 
@@ -284,6 +285,7 @@ pub struct RgbFunction {
 	#[atom(CssAtomSet::Rgb)]
 	pub name: T![Function],
 	pub params: RgbFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -302,6 +304,7 @@ pub struct RgbaFunction {
 	#[atom(CssAtomSet::Rgba)]
 	pub name: T![Function],
 	pub params: RgbFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -318,9 +321,9 @@ impl crate::ToChromashift for RgbaFunction {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct RgbFunctionParams(
 	pub NoneOr<NumberOrPercentage>,
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub NoneOr<NumberOrPercentage>,
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub NoneOr<NumberOrPercentage>,
 	pub Option<CommaOrSlash>,
 	pub Option<NoneOr<NumberOrPercentage>>,
@@ -385,6 +388,7 @@ pub struct HslFunction {
 	#[atom(CssAtomSet::Hsl)]
 	pub name: T![Function],
 	pub params: HslFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -403,6 +407,7 @@ pub struct HslaFunction {
 	#[atom(CssAtomSet::Hsla)]
 	pub name: T![Function],
 	pub params: HslFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -419,9 +424,9 @@ impl crate::ToChromashift for HslaFunction {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct HslFunctionParams(
 	pub NoneOr<AngleOrNumber>,
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub NoneOr<NumberOrPercentage>,
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub NoneOr<NumberOrPercentage>,
 	pub Option<CommaOrSlash>,
 	pub Option<NoneOr<NumberOrPercentage>>,
@@ -474,6 +479,7 @@ pub struct HwbFunction {
 	#[atom(CssAtomSet::Hwb)]
 	pub name: T![Function],
 	pub params: HwbFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -515,7 +521,7 @@ pub struct HwbFunctionParams(
 	pub NoneOr<AngleOrNumber>,
 	pub NoneOr<NumberOrPercentage>,
 	pub NoneOr<NumberOrPercentage>,
-	pub Option<T![/]>,
+	#[semantic_eq(skip)] pub Option<T![/]>,
 	pub Option<NoneOr<NumberOrPercentage>>,
 );
 
@@ -535,6 +541,7 @@ pub struct LabFunction {
 	#[atom(CssAtomSet::Lab)]
 	pub name: T![Function],
 	pub params: LabFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -576,7 +583,7 @@ pub struct LabFunctionParams(
 	pub NoneOr<NumberOrPercentage>,
 	pub NoneOr<NumberOrPercentage>,
 	pub NoneOr<NumberOrPercentage>,
-	pub Option<T![/]>,
+	#[semantic_eq(skip)] pub Option<T![/]>,
 	pub Option<NoneOr<NumberOrPercentage>>,
 );
 
@@ -596,6 +603,7 @@ pub struct LchFunction {
 	#[atom(CssAtomSet::Lch)]
 	pub name: T![Function],
 	pub params: LchFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -637,7 +645,7 @@ pub struct LchFunctionParams(
 	pub NoneOr<NumberOrPercentage>,
 	pub NoneOr<NumberOrPercentage>,
 	pub NoneOr<AngleOrNumber>,
-	pub Option<T![/]>,
+	#[semantic_eq(skip)] pub Option<T![/]>,
 	pub Option<NoneOr<NumberOrPercentage>>,
 );
 
@@ -657,6 +665,7 @@ pub struct OklabFunction {
 	#[atom(CssAtomSet::Oklab)]
 	pub name: T![Function],
 	pub params: LabFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -706,6 +715,7 @@ pub struct OklchFunction {
 	#[atom(CssAtomSet::Oklch)]
 	pub name: T![Function],
 	pub params: LchFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/color_mix_function.rs
+++ b/crates/css_ast/src/functions/color_mix_function.rs
@@ -16,9 +16,11 @@ pub struct ColorMixFunction<'a> {
 	pub name: T![Function],
 	pub interpolation: Option<ColorInterpolationMethod>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub interpolation_comma: Option<T![,]>,
 	pub parts: CommaSeparated<'a, ColorMixPart<'a>, 1>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/content_function.rs
+++ b/crates/css_ast/src/functions/content_function.rs
@@ -13,6 +13,7 @@ pub struct ContentFunction {
 	#[atom(CssAtomSet::Content)]
 	pub name: T![Function],
 	pub params: Option<ContentKeyword>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/counter_functions.rs
+++ b/crates/css_ast/src/functions/counter_functions.rs
@@ -14,12 +14,13 @@ pub struct CounterFunction<'a> {
 	#[atom(CssAtomSet::Counter)]
 	pub name: T![Function],
 	pub params: CounterFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct CounterFunctionParams<'a>(T![Ident], Option<T![,]>, Option<CounterStyle<'a>>);
+pub struct CounterFunctionParams<'a>(T![Ident], #[semantic_eq(skip)] Option<T![,]>, Option<CounterStyle<'a>>);
 
 /// <https://drafts.csswg.org/css-lists-3/#counter-functions>
 ///
@@ -34,12 +35,19 @@ pub struct CountersFunction<'a> {
 	#[atom(CssAtomSet::Counters)]
 	pub name: T![Function],
 	pub params: CountersFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct CountersFunctionParams<'a>(T![Ident], Option<T![,]>, T![String], Option<T![,]>, Option<CounterStyle<'a>>);
+pub struct CountersFunctionParams<'a>(
+	T![Ident],
+	#[semantic_eq(skip)] Option<T![,]>,
+	T![String],
+	#[semantic_eq(skip)] Option<T![,]>,
+	Option<CounterStyle<'a>>,
+);
 
 /// <https://drafts.csswg.org/css-lists-3/#counter-functions>
 ///

--- a/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
+++ b/crates/css_ast/src/functions/dynamic_range_limit_mix_function.rs
@@ -13,6 +13,7 @@ pub struct DynamicRangeLimitMixFunction<'a> {
 	#[atom(CssAtomSet::DynamicRangeLimitMix)]
 	pub name: T![Function],
 	pub params: CommaSeparated<'a, DynamicRangeLimitMixFunctionParams<'a>>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/easing_functions.rs
+++ b/crates/css_ast/src/functions/easing_functions.rs
@@ -65,6 +65,7 @@ pub struct LinearFunction<'a> {
 	#[atom(CssAtomSet::Linear)]
 	pub name: T![Function],
 	pub params: CommaSeparated<'a, LinearFunctionParams>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -97,6 +98,7 @@ pub struct CubicBezierFunction {
 	#[atom(CssAtomSet::CubicBezier)]
 	pub name: T![Function],
 	pub params: CubicBezierFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -104,10 +106,13 @@ pub struct CubicBezierFunction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct CubicBezierFunctionParams {
 	x1: T![Number],
+	#[semantic_eq(skip)]
 	c1: Option<T![,]>,
 	x2: T![Number],
+	#[semantic_eq(skip)]
 	c2: Option<T![,]>,
 	y1: T![Number],
+	#[semantic_eq(skip)]
 	c3: Option<T![,]>,
 	y2: T![Number],
 }
@@ -120,12 +125,13 @@ pub struct StepsFunction {
 	#[atom(CssAtomSet::Steps)]
 	pub name: T![Function],
 	pub params: StepsFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct StepsFunctionParams(CSSInt, Option<T![,]>, Option<StepPosition>);
+pub struct StepsFunctionParams(CSSInt, #[semantic_eq(skip)] Option<T![,]>, Option<StepPosition>);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/functions/filter_functions.rs
+++ b/crates/css_ast/src/functions/filter_functions.rs
@@ -65,6 +65,7 @@ pub struct BlurFunction {
 	#[atom(CssAtomSet::Blur)]
 	pub name: T![Function],
 	pub radius: Option<NonNegative<Length>>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -77,6 +78,7 @@ pub struct BrightnessFunction {
 	#[atom(CssAtomSet::Brightness)]
 	pub name: T![Function],
 	pub value: Option<NumberOrPercentage>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -89,6 +91,7 @@ pub struct ContrastFunction {
 	#[atom(CssAtomSet::Contrast)]
 	pub name: T![Function],
 	pub value: Option<NumberOrPercentage>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -106,6 +109,7 @@ pub struct DropShadowFunction<'a> {
 	pub offset_x: Length,
 	pub offset_y: Length,
 	pub blur_radius: Option<NonNegative<Length>>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -118,6 +122,7 @@ pub struct GrayscaleFunction {
 	#[atom(CssAtomSet::Grayscale)]
 	pub name: T![Function],
 	pub value: Option<NumberOrPercentage>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -130,6 +135,7 @@ pub struct HueRotateFunction {
 	#[atom(CssAtomSet::HueRotate)]
 	pub name: T![Function],
 	pub angle: Option<AngleOrZero>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -142,6 +148,7 @@ pub struct InvertFunction {
 	#[atom(CssAtomSet::Invert)]
 	pub name: T![Function],
 	pub value: Option<NumberOrPercentage>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -154,6 +161,7 @@ pub struct OpacityFunction {
 	#[atom(CssAtomSet::Opacity)]
 	pub name: T![Function],
 	pub value: Option<NumberOrPercentage>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -166,6 +174,7 @@ pub struct SaturateFunction {
 	#[atom(CssAtomSet::Saturate)]
 	pub name: T![Function],
 	pub value: Option<NumberOrPercentage>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -178,6 +187,7 @@ pub struct SepiaFunction {
 	#[atom(CssAtomSet::Sepia)]
 	pub name: T![Function],
 	pub value: Option<NumberOrPercentage>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/fit_content_function.rs
+++ b/crates/css_ast/src/functions/fit_content_function.rs
@@ -14,6 +14,7 @@ pub struct FitContentFunction {
 	#[atom(CssAtomSet::FitContent)]
 	pub name: T![Function],
 	pub params: LengthPercentage,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/gradient_functions.rs
+++ b/crates/css_ast/src/functions/gradient_functions.rs
@@ -36,6 +36,7 @@ pub struct LinearGradientFunction<'a> {
 	#[atom(CssAtomSet::LinearGradient)]
 	pub name: T![Function],
 	pub params: LinearGradientFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -43,7 +44,7 @@ pub struct LinearGradientFunction<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct LinearGradientFunctionParams<'a>(
 	Option<LinearDirection>,
-	Option<T![,]>,
+	#[semantic_eq(skip)] Option<T![,]>,
 	CommaSeparated<'a, ColorStopOrHint<'a>>,
 );
 
@@ -61,6 +62,7 @@ pub struct RepeatingLinearGradientFunction<'a> {
 	#[atom(CssAtomSet::RepeatingLinearGradient)]
 	pub name: T![Function],
 	pub params: RepeatingLinearGradientFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -68,7 +70,7 @@ pub struct RepeatingLinearGradientFunction<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct RepeatingLinearGradientFunctionParams<'a>(
 	Option<LinearDirection>,
-	Option<T![,]>,
+	#[semantic_eq(skip)] Option<T![,]>,
 	CommaSeparated<'a, ColorStopOrHint<'a>>,
 );
 
@@ -88,6 +90,7 @@ pub struct RadialGradientFunction<'a> {
 	#[atom(CssAtomSet::RadialGradient)]
 	pub name: T![Function],
 	pub params: RadialGradientFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -98,7 +101,7 @@ pub struct RadialGradientFunctionParams<'a>(
 	Option<RadialShape>,
 	Option<T![Ident]>,
 	Option<Position>,
-	Option<T![,]>,
+	#[semantic_eq(skip)] Option<T![,]>,
 	CommaSeparated<'a, ColorStopOrHint<'a>>,
 );
 
@@ -118,6 +121,7 @@ pub struct RepeatingRadialGradientFunction<'a> {
 	#[atom(CssAtomSet::RepeatingRadialGradient)]
 	pub name: T![Function],
 	pub params: RepeatingRadialGradientFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -128,7 +132,7 @@ pub struct RepeatingRadialGradientFunctionParams<'a>(
 	Option<RadialShape>,
 	Option<T![Ident]>,
 	Option<Position>,
-	Option<T![,]>,
+	#[semantic_eq(skip)] Option<T![,]>,
 	CommaSeparated<'a, ColorStopOrHint<'a>>,
 );
 

--- a/crates/css_ast/src/functions/image_set_function.rs
+++ b/crates/css_ast/src/functions/image_set_function.rs
@@ -15,6 +15,7 @@ pub struct ImageSetFunction<'a> {
 	#[atom(CssAtomSet::ImageSet)]
 	pub name: T![Function],
 	pub params: CommaSeparated<'a, ImageSetParams<'a>>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -29,7 +30,7 @@ pub enum ImageSetParams<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum ResolutionOrType {
 	Resolution(Resolution),
-	Type(#[atom(CssAtomSet::Type)] T![Function], T![String], T![')']),
+	Type(#[atom(CssAtomSet::Type)] T![Function], T![String], #[semantic_eq(skip)] T![')']),
 }
 
 #[cfg(test)]

--- a/crates/css_ast/src/functions/keypress_function.rs
+++ b/crates/css_ast/src/functions/keypress_function.rs
@@ -13,6 +13,7 @@ pub struct KeypressFunction {
 	#[atom(CssAtomSet::Keypress)]
 	pub name: T![Function],
 	pub params: T![String],
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/leader_function.rs
+++ b/crates/css_ast/src/functions/leader_function.rs
@@ -14,6 +14,7 @@ pub struct LeaderFunction {
 	#[atom(CssAtomSet::Leader)]
 	pub name: T![Function],
 	pub params: LeaderType,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/light_dark_function.rs
+++ b/crates/css_ast/src/functions/light_dark_function.rs
@@ -15,8 +15,10 @@ pub struct LightDarkFunction<'a> {
 	pub name: T![Function],
 	pub light: Color<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub comma: T![,],
 	pub dark: Color<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/param_function.rs
+++ b/crates/css_ast/src/functions/param_function.rs
@@ -14,6 +14,7 @@ pub struct ParamFunction<'a> {
 	#[atom(CssAtomSet::Param)]
 	pub name: T![Function],
 	pub params: ParamFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -21,6 +22,7 @@ pub struct ParamFunction<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct ParamFunctionParams<'a> {
 	pub ident: T![DashedIdent],
+	#[semantic_eq(skip)]
 	pub comma: T![,],
 	pub value: Option<ComponentValues<'a>>,
 }

--- a/crates/css_ast/src/functions/rect_function.rs
+++ b/crates/css_ast/src/functions/rect_function.rs
@@ -17,14 +17,18 @@ pub struct RectFunction {
 	pub name: T![Function],
 	pub top: AutoOr<Length>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub comma1: Option<T![,]>,
 	pub right: AutoOr<Length>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub comma2: Option<T![,]>,
 	pub bottom: AutoOr<Length>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub comma3: Option<T![,]>,
 	pub left: AutoOr<Length>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/relative_color.rs
+++ b/crates/css_ast/src/functions/relative_color.rs
@@ -252,6 +252,7 @@ pub struct RgbRelativeParams<'a> {
 	pub red: RelativeChannelValue<RgbChannelKeyword>,
 	pub green: RelativeChannelValue<RgbChannelKeyword>,
 	pub blue: RelativeChannelValue<RgbChannelKeyword>,
+	#[semantic_eq(skip)]
 	pub slash: Option<T![/]>,
 	pub alpha: Option<RelativeChannelValue<RgbChannelKeyword>>,
 }
@@ -270,6 +271,7 @@ pub struct HslRelativeParams<'a> {
 	pub hue: RelativeHueValue<HslChannelKeyword>,
 	pub saturation: RelativeChannelValue<HslChannelKeyword>,
 	pub lightness: RelativeChannelValue<HslChannelKeyword>,
+	#[semantic_eq(skip)]
 	pub slash: Option<T![/]>,
 	pub alpha: Option<RelativeChannelValue<HslChannelKeyword>>,
 }
@@ -288,6 +290,7 @@ pub struct HwbRelativeParams<'a> {
 	pub hue: RelativeHueValue<HwbChannelKeyword>,
 	pub whiteness: RelativeChannelValue<HwbChannelKeyword>,
 	pub blackness: RelativeChannelValue<HwbChannelKeyword>,
+	#[semantic_eq(skip)]
 	pub slash: Option<T![/]>,
 	pub alpha: Option<RelativeChannelValue<HwbChannelKeyword>>,
 }
@@ -306,6 +309,7 @@ pub struct LabRelativeParams<'a> {
 	pub l: RelativeChannelValue<LabChannelKeyword>,
 	pub a: RelativeChannelValue<LabChannelKeyword>,
 	pub b: RelativeChannelValue<LabChannelKeyword>,
+	#[semantic_eq(skip)]
 	pub slash: Option<T![/]>,
 	pub alpha: Option<RelativeChannelValue<LabChannelKeyword>>,
 }
@@ -324,6 +328,7 @@ pub struct LchRelativeParams<'a> {
 	pub lightness: RelativeChannelValue<LchChannelKeyword>,
 	pub chroma: RelativeChannelValue<LchChannelKeyword>,
 	pub hue: RelativeHueValue<LchChannelKeyword>,
+	#[semantic_eq(skip)]
 	pub slash: Option<T![/]>,
 	pub alpha: Option<RelativeChannelValue<LchChannelKeyword>>,
 }
@@ -346,6 +351,7 @@ pub struct ColorRelativeParams<'a> {
 	pub c1: RelativeChannelValue<ColorChannelKeyword>,
 	pub c2: RelativeChannelValue<ColorChannelKeyword>,
 	pub c3: RelativeChannelValue<ColorChannelKeyword>,
+	#[semantic_eq(skip)]
 	pub slash: Option<T![/]>,
 	pub alpha: Option<RelativeChannelValue<ColorChannelKeyword>>,
 }
@@ -363,6 +369,7 @@ pub struct RgbRelativeFunction<'a> {
 	#[atom(CssAtomSet::Rgb)]
 	pub name: T![Function],
 	pub params: RgbRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -390,6 +397,7 @@ pub struct RgbaRelativeFunction<'a> {
 	#[atom(CssAtomSet::Rgba)]
 	pub name: T![Function],
 	pub params: RgbRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -417,6 +425,7 @@ pub struct HslRelativeFunction<'a> {
 	#[atom(CssAtomSet::Hsl)]
 	pub name: T![Function],
 	pub params: HslRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -444,6 +453,7 @@ pub struct HslaRelativeFunction<'a> {
 	#[atom(CssAtomSet::Hsla)]
 	pub name: T![Function],
 	pub params: HslRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -471,6 +481,7 @@ pub struct HwbRelativeFunction<'a> {
 	#[atom(CssAtomSet::Hwb)]
 	pub name: T![Function],
 	pub params: HwbRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -498,6 +509,7 @@ pub struct LabRelativeFunction<'a> {
 	#[atom(CssAtomSet::Lab)]
 	pub name: T![Function],
 	pub params: LabRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -525,6 +537,7 @@ pub struct LchRelativeFunction<'a> {
 	#[atom(CssAtomSet::Lch)]
 	pub name: T![Function],
 	pub params: LchRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -552,6 +565,7 @@ pub struct OklabRelativeFunction<'a> {
 	#[atom(CssAtomSet::Oklab)]
 	pub name: T![Function],
 	pub params: LabRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -579,6 +593,7 @@ pub struct OklchRelativeFunction<'a> {
 	#[atom(CssAtomSet::Oklch)]
 	pub name: T![Function],
 	pub params: LchRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -606,6 +621,7 @@ pub struct ColorRelativeFunction<'a> {
 	#[atom(CssAtomSet::Color)]
 	pub name: T![Function],
 	pub params: ColorRelativeParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/repeat_function.rs
+++ b/crates/css_ast/src/functions/repeat_function.rs
@@ -15,6 +15,7 @@ pub struct RepeatFunction<'a> {
 	#[atom(CssAtomSet::Repeat)]
 	pub name: T![Function],
 	pub params: RepeatFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -25,6 +26,7 @@ pub struct RepeatFunctionParams<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub count: AutoOr<PositiveNonZeroInt>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub comma: Option<T![,]>,
 	pub tracks: Vec<'a, LineWidth>,
 }

--- a/crates/css_ast/src/functions/snap_block_function.rs
+++ b/crates/css_ast/src/functions/snap_block_function.rs
@@ -14,12 +14,18 @@ pub struct SnapBlockFunction {
 	#[atom(CssAtomSet::SnapBlock)]
 	pub name: T![Function],
 	pub params: SnapBlockFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct SnapBlockFunctionParams(LengthPercentage, Option<T![,]>, Option<SnapBlockKeyword>, Option<T![,]>);
+pub struct SnapBlockFunctionParams(
+	LengthPercentage,
+	#[semantic_eq(skip)] Option<T![,]>,
+	Option<SnapBlockKeyword>,
+	#[semantic_eq(skip)] Option<T![,]>,
+);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/functions/snap_inline_function.rs
+++ b/crates/css_ast/src/functions/snap_inline_function.rs
@@ -14,12 +14,18 @@ pub struct SnapInlineFunction {
 	#[atom(CssAtomSet::SnapInline)]
 	pub name: T![Function],
 	pub params: SnapInlineFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct SnapInlineFunctionParams(LengthPercentage, Option<T![,]>, Option<SnapInlineKeyword>, Option<T![,]>);
+pub struct SnapInlineFunctionParams(
+	LengthPercentage,
+	#[semantic_eq(skip)] Option<T![,]>,
+	Option<SnapInlineKeyword>,
+	#[semantic_eq(skip)] Option<T![,]>,
+);
 
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]

--- a/crates/css_ast/src/functions/string_function.rs
+++ b/crates/css_ast/src/functions/string_function.rs
@@ -13,6 +13,7 @@ pub struct StringFunction {
 	#[atom(CssAtomSet::String)]
 	pub name: T![Function],
 	pub params: StringFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -20,6 +21,7 @@ pub struct StringFunction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct StringFunctionParams {
 	pub ident: T![Ident],
+	#[semantic_eq(skip)]
 	pub comma: Option<T![,]>,
 	pub keyword: Option<StringKeyword>,
 }

--- a/crates/css_ast/src/functions/stripes_function.rs
+++ b/crates/css_ast/src/functions/stripes_function.rs
@@ -17,6 +17,7 @@ pub struct StripesFunction<'a> {
 	pub name: T![Function],
 	pub params: CommaSeparated<'a, ColorStripe<'a>>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/superellipse_function.rs
+++ b/crates/css_ast/src/functions/superellipse_function.rs
@@ -14,5 +14,6 @@ pub struct SuperellipseFunction {
 	#[atom(CssAtomSet::Superellipse)]
 	pub name: T![Function],
 	pub params: NumberOrInfinity,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }

--- a/crates/css_ast/src/functions/symbols_function.rs
+++ b/crates/css_ast/src/functions/symbols_function.rs
@@ -14,6 +14,7 @@ pub struct SymbolsFunction<'a> {
 	#[atom(CssAtomSet::Symbols)]
 	pub name: T![Function],
 	pub params: SymbolsFunctionParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/target_functions.rs
+++ b/crates/css_ast/src/functions/target_functions.rs
@@ -63,6 +63,7 @@ pub struct TargetCounterFunction<'a> {
 	#[atom(CssAtomSet::TargetCounter)]
 	pub name: T![Function],
 	pub params: TargetCounterParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -70,9 +71,9 @@ pub struct TargetCounterFunction<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct TargetCounterParams<'a>(
 	TargetCounterKind,
-	Option<T![,]>,
+	#[semantic_eq(skip)] Option<T![,]>,
 	T![Ident],
-	Option<T![,]>,
+	#[semantic_eq(skip)] Option<T![,]>,
 	Option<CounterStyle<'a>>,
 );
 
@@ -84,6 +85,7 @@ pub struct TargetCountersFunction<'a> {
 	#[atom(CssAtomSet::TargetCounters)]
 	pub name: T![Function],
 	pub params: TargetCountersParams<'a>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -91,11 +93,11 @@ pub struct TargetCountersFunction<'a> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct TargetCountersParams<'a>(
 	TargetCounterKind,
-	Option<T![,]>,
+	#[semantic_eq(skip)] Option<T![,]>,
 	T![Ident],
-	Option<T![,]>,
+	#[semantic_eq(skip)] Option<T![,]>,
 	T![String],
-	Option<T![,]>,
+	#[semantic_eq(skip)] Option<T![,]>,
 	Option<CounterStyle<'a>>,
 );
 
@@ -107,12 +109,13 @@ pub struct TargetTextFunction {
 	#[atom(CssAtomSet::TargetText)]
 	pub name: T![Function],
 	pub params: TargetTextParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
-pub struct TargetTextParams(TargetCounterKind, Option<T![,]>, Option<TextFunctionContent>);
+pub struct TargetTextParams(TargetCounterKind, #[semantic_eq(skip)] Option<T![,]>, Option<TextFunctionContent>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/css_ast/src/functions/transform_functions.rs
+++ b/crates/css_ast/src/functions/transform_functions.rs
@@ -44,6 +44,7 @@ pub struct MatrixFunction {
 	#[atom(CssAtomSet::Matrix)]
 	pub name: T![Function],
 	pub params: MatrixFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -51,15 +52,15 @@ pub struct MatrixFunction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct MatrixFunctionParams(
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
 );
 
@@ -76,6 +77,7 @@ pub struct Matrix3dFunction {
 	#[atom(CssAtomSet::Matrix3d)]
 	pub name: T![Function],
 	pub params: Matrix3dFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -84,35 +86,35 @@ pub struct Matrix3dFunction {
 #[allow(clippy::type_complexity)] // TODO: simplify types
 pub struct Matrix3dFunctionParams(
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
 );
 
@@ -129,8 +131,10 @@ pub struct TranslateFunction {
 	#[atom(CssAtomSet::Translate)]
 	pub name: T![Function],
 	pub x: LengthPercentage,
+	#[semantic_eq(skip)]
 	pub comma: Option<T![,]>,
 	pub y: Option<LengthPercentage>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -147,6 +151,7 @@ pub struct Translate3dFunction {
 	#[atom(CssAtomSet::Translate3d)]
 	pub name: T![Function],
 	pub params: Translate3dFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -154,9 +159,9 @@ pub struct Translate3dFunction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Translate3dFunctionParams(
 	pub LengthPercentage,
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub LengthPercentage,
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub Length,
 );
 
@@ -173,6 +178,7 @@ pub struct TranslatexFunction {
 	#[atom(CssAtomSet::Translatex)]
 	pub name: T![Function],
 	pub params: LengthPercentage,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -189,6 +195,7 @@ pub struct TranslateyFunction {
 	#[atom(CssAtomSet::Translatey)]
 	pub name: T![Function],
 	pub params: LengthPercentage,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -205,6 +212,7 @@ pub struct TranslatezFunction {
 	#[atom(CssAtomSet::Translatez)]
 	pub name: T![Function],
 	pub params: Length,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -220,7 +228,9 @@ pub struct TranslatezFunction {
 pub struct ScaleFunction {
 	#[atom(CssAtomSet::Scale)]
 	pub name: T![Function],
+	#[semantic_eq(skip)]
 	pub params: (NumberOrPercentage, Option<T![,]>, Option<NumberOrPercentage>),
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -237,6 +247,7 @@ pub struct Scale3dFunction {
 	#[atom(CssAtomSet::Scale3d)]
 	pub name: T![Function],
 	pub params: Scale3dFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -244,9 +255,9 @@ pub struct Scale3dFunction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Scale3dFunctionParams(
 	pub NumberOrPercentage,
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub NumberOrPercentage,
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub NumberOrPercentage,
 );
 
@@ -263,6 +274,7 @@ pub struct ScalexFunction {
 	#[atom(CssAtomSet::Scalex)]
 	pub name: T![Function],
 	pub params: NumberOrPercentage,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -279,6 +291,7 @@ pub struct ScaleyFunction {
 	#[atom(CssAtomSet::Scaley)]
 	pub name: T![Function],
 	pub params: NumberOrPercentage,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -295,6 +308,7 @@ pub struct ScalezFunction {
 	#[atom(CssAtomSet::Scalez)]
 	pub name: T![Function],
 	pub params: NumberOrPercentage,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -311,6 +325,7 @@ pub struct RotateFunction {
 	#[atom(CssAtomSet::Rotate)]
 	pub name: T![Function],
 	pub params: AngleOrZero,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -327,6 +342,7 @@ pub struct Rotate3dFunction {
 	#[atom(CssAtomSet::Rotate3d)]
 	pub name: T![Function],
 	pub params: Rotate3dFunctionParams,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -334,11 +350,11 @@ pub struct Rotate3dFunction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub struct Rotate3dFunctionParams(
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub T![Number],
-	pub Option<T![,]>,
+	#[semantic_eq(skip)] pub Option<T![,]>,
 	pub AngleOrZero,
 );
 
@@ -355,6 +371,7 @@ pub struct RotatexFunction {
 	#[atom(CssAtomSet::Rotatex)]
 	pub name: T![Function],
 	pub params: AngleOrZero,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -371,6 +388,7 @@ pub struct RotateyFunction {
 	#[atom(CssAtomSet::Rotatey)]
 	pub name: T![Function],
 	pub params: AngleOrZero,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -387,6 +405,7 @@ pub struct RotatezFunction {
 	#[atom(CssAtomSet::Rotatez)]
 	pub name: T![Function],
 	pub params: AngleOrZero,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -402,7 +421,9 @@ pub struct RotatezFunction {
 pub struct SkewFunction {
 	#[atom(CssAtomSet::Skew)]
 	pub name: T![Function],
+	#[semantic_eq(skip)]
 	pub params: (AngleOrZero, Option<T![,]>, Option<AngleOrZero>),
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -419,6 +440,7 @@ pub struct SkewxFunction {
 	#[atom(CssAtomSet::Skewx)]
 	pub name: T![Function],
 	pub params: AngleOrZero,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -435,6 +457,7 @@ pub struct SkewyFunction {
 	#[atom(CssAtomSet::Skewy)]
 	pub name: T![Function],
 	pub params: AngleOrZero,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -451,6 +474,7 @@ pub struct PerspectiveFunction {
 	#[atom(CssAtomSet::Perspective)]
 	pub name: T![Function],
 	pub params: NoneOr<Length>,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/functions/url.rs
+++ b/crates/css_ast/src/functions/url.rs
@@ -14,9 +14,9 @@ use super::prelude::*;
 pub enum Url {
 	Url(T![Url]),
 	#[atom(CssAtomSet::Url)]
-	UrlFunction(T![Function], T![String], T![')']),
+	UrlFunction(T![Function], T![String], #[semantic_eq(skip)] T![')']),
 	#[atom(CssAtomSet::Src)]
-	SrcFunction(T![Function], T![String], T![')']),
+	SrcFunction(T![Function], T![String], #[semantic_eq(skip)] T![')']),
 }
 
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/rules/charset.rs
+++ b/crates/css_ast/src/rules/charset.rs
@@ -12,6 +12,7 @@ pub struct CharsetRule {
 	at_keyword: T![AtKeyword],
 	space: T![' '],
 	string: T![String],
+	#[semantic_eq(skip)]
 	semicolon: Option<T![;]>,
 }
 

--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -224,25 +224,43 @@ impl<'a> Parse<'a> for ScrollStateQuery<'a> {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum ScrollStateFeature {
 	Stuck(
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T!['(']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T!['(']>,
 		#[cfg_attr(feature = "visitable", visit(skip))] T![Ident],
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![:]>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![:]>,
 		Option<StuckScrollStateFeatureKeyword>,
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![')']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![')']>,
 	),
 	Snapped(
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T!['(']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T!['(']>,
 		#[cfg_attr(feature = "visitable", visit(skip))] T![Ident],
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![:]>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![:]>,
 		Option<SnappedScrollStateFeatureKeyword>,
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![')']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![')']>,
 	),
 	Scrollable(
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T!['(']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T!['(']>,
 		#[cfg_attr(feature = "visitable", visit(skip))] T![Ident],
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![:]>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![:]>,
 		Option<ScrollableScrollStateFeatureKeyword>,
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![')']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![')']>,
 	),
 }
 

--- a/crates/css_ast/src/rules/container/mod.rs
+++ b/crates/css_ast/src/rules/container/mod.rs
@@ -149,12 +149,12 @@ macro_rules! container_feature {
 			Style(
 				#[cfg_attr(feature = "visitable", visit(skip))] T![Function],
 				StyleQuery<'a>,
-				#[cfg_attr(feature = "visitable", visit(skip))] T![')'],
+				#[cfg_attr(feature = "visitable", visit(skip))] #[semantic_eq(skip)] T![')'],
 			),
 			ScrollState(
 				#[cfg_attr(feature = "visitable", visit(skip))] T![Function],
 				ScrollStateQuery<'a>,
-				#[cfg_attr(feature = "visitable", visit(skip))] T![')'],
+				#[cfg_attr(feature = "visitable", visit(skip))] #[semantic_eq(skip)] T![')'],
 			),
 		}
 	}

--- a/crates/css_ast/src/rules/document.rs
+++ b/crates/css_ast/src/rules/document.rs
@@ -27,15 +27,15 @@ pub struct DocumentMatcherList<'a>(pub CommaSeparated<'a, DocumentMatcher>);
 pub enum DocumentMatcher {
 	Url(T![Url]),
 	#[atom(CssAtomSet::Url)]
-	UrlFunction(T![Function], T![String], T![')']),
+	UrlFunction(T![Function], T![String], #[semantic_eq(skip)] T![')']),
 	#[atom(CssAtomSet::UrlPrefix)]
-	UrlPrefix(T![Function], T![String], T![')']),
+	UrlPrefix(T![Function], T![String], #[semantic_eq(skip)] T![')']),
 	#[atom(CssAtomSet::Domain)]
-	Domain(T![Function], T![String], T![')']),
+	Domain(T![Function], T![String], #[semantic_eq(skip)] T![')']),
 	#[atom(CssAtomSet::MediaDocument)]
-	MediaDocument(T![Function], T![String], T![')']),
+	MediaDocument(T![Function], T![String], #[semantic_eq(skip)] T![')']),
 	#[atom(CssAtomSet::Regexp)]
-	Regexp(T![Function], T![String], T![')']),
+	Regexp(T![Function], T![String], #[semantic_eq(skip)] T![')']),
 }
 
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/rules/import.rs
+++ b/crates/css_ast/src/rules/import.rs
@@ -24,6 +24,7 @@ pub struct ImportRule<'a> {
 	pub supports_condition: Option<ImportSupportsFunction<'a>>,
 	pub media_condition: Option<MediaQueryList<'a>>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub semicolon: Option<T![;]>,
 }
 
@@ -49,6 +50,7 @@ pub struct ImportLayerFunction<'a> {
 	pub name: T![Function],
 	pub layer: LayerName<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -62,6 +64,7 @@ pub struct ImportSupportsFunction<'a> {
 	pub name: T![Function],
 	pub condition: SupportsCondition<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -15,6 +15,7 @@ pub struct LayerRule<'a> {
 	#[metadata(delegate)]
 	pub block: Option<LayerRuleBlock<'a>>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub semicolon: Option<T![;]>,
 }
 

--- a/crates/css_ast/src/rules/media/features/hack.rs
+++ b/crates/css_ast/src/rules/media/features/hack.rs
@@ -5,7 +5,7 @@ use csskit_derives::*;
 #[derive(Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum HackMediaFeature {
-	IEBackslashZero(T!['('], T![Ident], T![:], T![Dimension], T![')']),
+	IEBackslashZero(T!['('], T![Ident], T![:], T![Dimension], #[semantic_eq(skip)] T![')']),
 }
 
 impl<'a> Parse<'a> for HackMediaFeature {

--- a/crates/css_ast/src/rules/namespace.rs
+++ b/crates/css_ast/src/rules/namespace.rs
@@ -19,6 +19,7 @@ pub struct NamespaceRule {
 	pub prefix: Option<T![Ident]>,
 	pub resource: UrlOrString,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub semicolon: Option<T![;]>,
 }
 

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -65,10 +65,10 @@ impl<'a> ToSpecificity for PageSelector<'a> {
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum PagePseudoClass {
-	Left(T![:], T![Ident]),
-	Right(T![:], T![Ident]),
-	First(T![:], T![Ident]),
-	Blank(T![:], T![Ident]),
+	Left(#[semantic_eq(skip)] T![:], T![Ident]),
+	Right(#[semantic_eq(skip)] T![:], T![Ident]),
+	First(#[semantic_eq(skip)] T![:], T![Ident]),
+	Blank(#[semantic_eq(skip)] T![:], T![Ident]),
 }
 
 impl ToSpecificity for PagePseudoClass {

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -119,30 +119,52 @@ impl<'a> Parse<'a> for SupportsCondition<'a> {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum SupportsFeature<'a> {
 	FontTech(
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T!['(']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T!['(']>,
 		#[cfg_attr(feature = "visitable", visit(skip))] T![Function],
 		ComponentValues<'a>,
-		#[cfg_attr(feature = "visitable", visit(skip))] T![')'],
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![')']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		T![')'],
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![')']>,
 	),
 	FontFormat(
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T!['(']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T!['(']>,
 		#[cfg_attr(feature = "visitable", visit(skip))] T![Function],
 		ComponentValues<'a>,
-		#[cfg_attr(feature = "visitable", visit(skip))] T![')'],
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![')']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		T![')'],
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![')']>,
 	),
 	Selector(
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T!['(']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T!['(']>,
 		#[cfg_attr(feature = "visitable", visit(skip))] T![Function],
 		ComplexSelector<'a>,
-		#[cfg_attr(feature = "visitable", visit(skip))] T![')'],
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![')']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		T![')'],
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![')']>,
 	),
 	Property(
-		#[cfg_attr(feature = "visitable", visit(skip))] T!['('],
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		T!['('],
 		BumpBox<'a, Declaration<'a, StyleValue<'a>, CssMetadata>>,
-		#[cfg_attr(feature = "visitable", visit(skip))] Option<T![')']>,
+		#[cfg_attr(feature = "visitable", visit(skip))]
+		#[semantic_eq(skip)]
+		Option<T![')']>,
 	),
 }
 

--- a/crates/css_ast/src/selector/attribute.rs
+++ b/crates/css_ast/src/selector/attribute.rs
@@ -10,6 +10,7 @@ use super::NamespacePrefix;
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct Attribute {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub open: T!['['],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub namespace_prefix: Option<NamespacePrefix>,
@@ -19,6 +20,7 @@ pub struct Attribute {
 	pub value: Option<AttributeValue>,
 	pub modifier: Option<AttributeModifier>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![']']>,
 }
 
@@ -54,12 +56,12 @@ impl<'a> Parse<'a> for Attribute {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum AttributeOperator {
-	Exact(T![=]),
-	SpaceList(T![~=]),
-	LangPrefix(T![|=]),
-	Prefix(T![^=]),
-	Suffix(T!["$="]),
-	Contains(T![*=]),
+	Exact(#[semantic_eq(skip)] T![=]),
+	SpaceList(#[semantic_eq(skip)] T![~=]),
+	LangPrefix(#[semantic_eq(skip)] T![|=]),
+	Prefix(#[semantic_eq(skip)] T![^=]),
+	Suffix(#[semantic_eq(skip)] T!["$="]),
+	Contains(#[semantic_eq(skip)] T![*=]),
 }
 
 #[derive(

--- a/crates/css_ast/src/selector/class.rs
+++ b/crates/css_ast/src/selector/class.rs
@@ -6,6 +6,7 @@ use csskit_derives::*;
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct Class {
+	#[semantic_eq(skip)]
 	pub dot: T![.],
 	pub name: T![Ident],
 }

--- a/crates/css_ast/src/selector/combinator.rs
+++ b/crates/css_ast/src/selector/combinator.rs
@@ -7,11 +7,11 @@ use csskit_derives::*;
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum Combinator {
-	Child(T![>]),
-	NextSibling(T![+]),
-	SubsequentSibling(T![~]),
-	Column(T![||]),
-	Nesting(T![&]),
+	Child(#[semantic_eq(skip)] T![>]),
+	NextSibling(#[semantic_eq(skip)] T![+]),
+	SubsequentSibling(#[semantic_eq(skip)] T![~]),
+	Column(#[semantic_eq(skip)] T![||]),
+	Nesting(#[semantic_eq(skip)] T![&]),
 	Descendant(T![' ']),
 }
 

--- a/crates/css_ast/src/selector/functional_pseudo_class.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_class.rs
@@ -81,10 +81,12 @@ impl<'a> Parse<'a> for FunctionalPseudoClass<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct DirPseudoFunction {
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[atom(CssAtomSet::Dir)]
 	pub function: T![Function],
 	pub value: DirValue,
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -105,6 +107,7 @@ pub enum DirValue {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct HasPseudoFunction<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Has)]
@@ -112,6 +115,7 @@ pub struct HasPseudoFunction<'a> {
 	#[parse(state = State::DisallowRelativeSelector)]
 	pub value: RelativeSelector<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -121,12 +125,14 @@ pub struct HasPseudoFunction<'a> {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct HostPseudoFunction<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Host)]
 	pub function: T![Function],
 	pub value: SelectorList<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -136,12 +142,14 @@ pub struct HostPseudoFunction<'a> {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct HostContextPseudoFunction<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::HostContext)]
 	pub function: T![Function],
 	pub value: SelectorList<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -151,12 +159,14 @@ pub struct HostContextPseudoFunction<'a> {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct IsPseudoFunction<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Is)]
 	pub function: T![Function],
 	pub value: ForgivingSelector<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -165,10 +175,12 @@ pub struct IsPseudoFunction<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct LangPseudoFunction<'a> {
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[atom(CssAtomSet::Lang)]
 	pub function: T![Function],
 	pub value: LangValues<'a>,
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -189,12 +201,14 @@ pub enum LangValue {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct NotPseudoFunction<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Not)]
 	pub function: T![Function],
 	pub value: SelectorList<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -204,12 +218,14 @@ pub struct NotPseudoFunction<'a> {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct NthChildPseudoFunction {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthChild)]
 	pub function: T![Function],
 	pub value: Nth,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -219,12 +235,14 @@ pub struct NthChildPseudoFunction {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct NthColPseudoFunction {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthCol)]
 	pub function: T![Function],
 	pub value: Nth,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -234,12 +252,14 @@ pub struct NthColPseudoFunction {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct NthLastChildPseudoFunction {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthLastChild)]
 	pub function: T![Function],
 	pub value: Nth,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -249,12 +269,14 @@ pub struct NthLastChildPseudoFunction {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct NthLastColPseudoFunction {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthLastCol)]
 	pub function: T![Function],
 	pub value: Nth,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -264,12 +286,14 @@ pub struct NthLastColPseudoFunction {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct NthLastOfTypePseudoFunction {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthLastOfType)]
 	pub function: T![Function],
 	pub value: Nth,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -279,12 +303,14 @@ pub struct NthLastOfTypePseudoFunction {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct NthOfTypePseudoFunction {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::NthOfType)]
 	pub function: T![Function],
 	pub value: Nth,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -294,12 +320,14 @@ pub struct NthOfTypePseudoFunction {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct WherePseudoFunction<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Where)]
 	pub function: T![Function],
 	pub value: ForgivingSelector<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -308,10 +336,12 @@ pub struct WherePseudoFunction<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct StatePseudoFunction {
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[atom(CssAtomSet::State)]
 	pub function: T![Function],
 	pub value: T![Ident],
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -320,10 +350,12 @@ pub struct StatePseudoFunction {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct HeadingPseudoFunction<'a> {
+	#[semantic_eq(skip)]
 	pub colon: T![:],
 	#[atom(CssAtomSet::Heading)]
 	pub function: T![Function],
 	pub value: CommaSeparated<'a, Nth>,
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 

--- a/crates/css_ast/src/selector/functional_pseudo_element.rs
+++ b/crates/css_ast/src/selector/functional_pseudo_element.rs
@@ -71,10 +71,12 @@ impl<'a> Parse<'a> for FunctionalPseudoElement<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct HighlightPseudoElement {
+	#[semantic_eq(skip)]
 	pub colons: T![::],
 	#[atom(CssAtomSet::Highlight)]
 	pub function: T![Function],
 	pub value: T![Ident],
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -84,12 +86,14 @@ pub struct HighlightPseudoElement {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct SlottedPseudoElement<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colons: T![::],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	#[atom(CssAtomSet::Slotted)]
 	pub function: T![Function],
 	pub value: CompoundSelector<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -98,10 +102,12 @@ pub struct SlottedPseudoElement<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct PartPseudoElement<'a> {
+	#[semantic_eq(skip)]
 	pub colons: T![::],
 	#[atom(CssAtomSet::Part)]
 	pub function: T![Function],
 	pub value: Vec<'a, T![Ident]>,
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -110,10 +116,12 @@ pub struct PartPseudoElement<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct PickerPseudoElement {
+	#[semantic_eq(skip)]
 	pub colons: T![::],
 	#[atom(CssAtomSet::Picker)]
 	pub function: T![Function],
 	pub value: T![Ident],
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -122,10 +130,12 @@ pub struct PickerPseudoElement {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct ViewTransitionGroupPseudoElement<'a> {
+	#[semantic_eq(skip)]
 	pub colons: T![::],
 	#[atom(CssAtomSet::ViewTransitionGroup)]
 	pub function: T![Function],
 	pub value: PtNameAndClassSelector<'a>,
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -134,10 +144,12 @@ pub struct ViewTransitionGroupPseudoElement<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct ViewTransitionImagePairPseudoElement<'a> {
+	#[semantic_eq(skip)]
 	pub colons: T![::],
 	#[atom(CssAtomSet::ViewTransitionImagePair)]
 	pub function: T![Function],
 	pub value: PtNameAndClassSelector<'a>,
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -146,10 +158,12 @@ pub struct ViewTransitionImagePairPseudoElement<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct ViewTransitionNewPseudoElement<'a> {
+	#[semantic_eq(skip)]
 	pub colons: T![::],
 	#[atom(CssAtomSet::ViewTransitionNew)]
 	pub function: T![Function],
 	pub value: PtNameAndClassSelector<'a>,
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -158,10 +172,12 @@ pub struct ViewTransitionNewPseudoElement<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct ViewTransitionOldPseudoElement<'a> {
+	#[semantic_eq(skip)]
 	pub colons: T![::],
 	#[atom(CssAtomSet::ViewTransitionOld)]
 	pub function: T![Function],
 	pub value: PtNameAndClassSelector<'a>,
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -170,7 +186,7 @@ pub struct ViewTransitionOldPseudoElement<'a> {
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum PtNameAndClassSelector<'a> {
-	Wildcard(T![*]),
+	Wildcard(#[semantic_eq(skip)] T![*]),
 	Named(T![Ident], Vec<'a, (T![.], T![Ident])>),
 	Classes(Vec<'a, (T![.], T![Ident])>),
 }

--- a/crates/css_ast/src/selector/moz.rs
+++ b/crates/css_ast/src/selector/moz.rs
@@ -93,15 +93,60 @@ pseudo_element!(
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum MozFunctionalPseudoElement<'a> {
-	TreeCell(T![::], #[atom(CssAtomSet::TreeCell)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeCellText(T![::], #[atom(CssAtomSet::TreeCellText)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeCheckbox(T![::], #[atom(CssAtomSet::TreeCheckbox)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeColumn(T![::], #[atom(CssAtomSet::TreeColumn)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeImage(T![::], #[atom(CssAtomSet::TreeImage)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeLine(T![::], #[atom(CssAtomSet::TreeLine)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeRow(T![::], #[atom(CssAtomSet::TreeRow)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeSeparator(T![::], #[atom(CssAtomSet::TreeSeparator)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
-	TreeTwisty(T![::], #[atom(CssAtomSet::TreeTwisty)] T![Function], CommaSeparated<'a, T![Ident]>, T![')']),
+	TreeCell(
+		T![::],
+		#[atom(CssAtomSet::TreeCell)] T![Function],
+		CommaSeparated<'a, T![Ident]>,
+		#[semantic_eq(skip)] T![')'],
+	),
+	TreeCellText(
+		T![::],
+		#[atom(CssAtomSet::TreeCellText)] T![Function],
+		CommaSeparated<'a, T![Ident]>,
+		#[semantic_eq(skip)] T![')'],
+	),
+	TreeCheckbox(
+		T![::],
+		#[atom(CssAtomSet::TreeCheckbox)] T![Function],
+		CommaSeparated<'a, T![Ident]>,
+		#[semantic_eq(skip)] T![')'],
+	),
+	TreeColumn(
+		T![::],
+		#[atom(CssAtomSet::TreeColumn)] T![Function],
+		CommaSeparated<'a, T![Ident]>,
+		#[semantic_eq(skip)] T![')'],
+	),
+	TreeImage(
+		T![::],
+		#[atom(CssAtomSet::TreeImage)] T![Function],
+		CommaSeparated<'a, T![Ident]>,
+		#[semantic_eq(skip)] T![')'],
+	),
+	TreeLine(
+		T![::],
+		#[atom(CssAtomSet::TreeLine)] T![Function],
+		CommaSeparated<'a, T![Ident]>,
+		#[semantic_eq(skip)] T![')'],
+	),
+	TreeRow(
+		T![::],
+		#[atom(CssAtomSet::TreeRow)] T![Function],
+		CommaSeparated<'a, T![Ident]>,
+		#[semantic_eq(skip)] T![')'],
+	),
+	TreeSeparator(
+		T![::],
+		#[atom(CssAtomSet::TreeSeparator)] T![Function],
+		CommaSeparated<'a, T![Ident]>,
+		#[semantic_eq(skip)] T![')'],
+	),
+	TreeTwisty(
+		T![::],
+		#[atom(CssAtomSet::TreeTwisty)] T![Function],
+		CommaSeparated<'a, T![Ident]>,
+		#[semantic_eq(skip)] T![')'],
+	),
 }
 
 #[derive(Parse, Peek, ToCursors, ToSpan, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/css_ast/src/selector/namespace.rs
+++ b/crates/css_ast/src/selector/namespace.rs
@@ -46,9 +46,9 @@ impl<'a> Parse<'a> for Namespace {
 #[derive(Peek, ToSpan, ToCursors, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NamespacePrefix {
-	None(T![|]),
-	Name(T![Ident], T![|]),
-	Wildcard(T![*], T![|]),
+	None(#[semantic_eq(skip)] T![|]),
+	Name(T![Ident], #[semantic_eq(skip)] T![|]),
+	Wildcard(T![*], #[semantic_eq(skip)] T![|]),
 }
 
 impl<'a> Parse<'a> for NamespacePrefix {
@@ -80,7 +80,7 @@ impl<'a> Parse<'a> for NamespacePrefix {
 #[derive(Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 pub enum NamespaceTag {
-	Wildcard(T![*]),
+	Wildcard(#[semantic_eq(skip)] T![*]),
 	Tag(Tag),
 }
 

--- a/crates/css_ast/src/selector/pseudo_class.rs
+++ b/crates/css_ast/src/selector/pseudo_class.rs
@@ -79,7 +79,7 @@ macro_rules! define_pseudo_class {
 #[derive(csskit_derives::NodeWithMetadata)]
 		#[cfg_attr(feature = "css_feature_data", derive(::csskit_derives::ToCSSFeature), css_feature("css.selectors"))]
 		pub enum PseudoClass {
-			$($(#[$meta])* $ident(T![:], T![Ident]),)+
+			$($(#[$meta])* $ident(#[semantic_eq(skip)] T![:], T![Ident]),)+
 			Webkit(WebkitPseudoClass),
 			Moz(MozPseudoClass),
 			Ms(MsPseudoClass),

--- a/crates/css_ast/src/selector/pseudo_element.rs
+++ b/crates/css_ast/src/selector/pseudo_element.rs
@@ -38,7 +38,7 @@ macro_rules! define_pseudo_element {
 		#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 		pub enum PseudoElement {
-			$($(#[$meta])* $ident(T![::], T![Ident]),)+
+			$($(#[$meta])* $ident(#[semantic_eq(skip)] T![::], T![Ident]),)+
 			Webkit(WebkitPseudoElement),
 			Moz(MozPseudoElement),
 			Ms(MsPseudoElement),

--- a/crates/css_ast/src/selector/webkit.rs
+++ b/crates/css_ast/src/selector/webkit.rs
@@ -107,11 +107,13 @@ impl<'a> Parse<'a> for WebkitFunctionalPseudoElement<'a> {
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct WebkitDistrubutedFunctionalPseudoElement<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub colons: T![::],
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub function: T![Function],
 	pub value: CompoundSelector<'a>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 

--- a/crates/css_ast/src/types/bg_position_and_size.rs
+++ b/crates/css_ast/src/types/bg_position_and_size.rs
@@ -12,6 +12,7 @@ use crate::{BgPosition, BgSize};
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct BgPositionAndSize {
 	pub position: BgPosition,
+	#[semantic_eq(skip)]
 	pub size: Option<(T![/], BgSize)>,
 }
 

--- a/crates/css_ast/src/types/gap_rule_list.rs
+++ b/crates/css_ast/src/types/gap_rule_list.rs
@@ -41,9 +41,11 @@ pub struct GapRepeatRule<'a> {
 	#[cfg_attr(feature = "visitable", visit(skip))]
 	pub count: AutoOr<PositiveNonZeroInt>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub comma: T![,],
 	pub rules: CommaSeparated<'a, GapRule<'a>>,
 	#[cfg_attr(feature = "visitable", visit(skip))]
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/types/generic_font_family.rs
+++ b/crates/css_ast/src/types/generic_font_family.rs
@@ -26,6 +26,7 @@ pub struct GenericScriptSpecific {
 	#[atom(CssAtomSet::Generic)]
 	pub name: T![Function],
 	pub params: GenericScriptSpecificKeyword,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_ast/src/types/ratio.rs
+++ b/crates/css_ast/src/types/ratio.rs
@@ -12,6 +12,7 @@ use crate::units::CSSInt;
 #[derive(csskit_derives::NodeWithMetadata)]
 pub struct Ratio {
 	pub numerator: CSSInt,
+	#[semantic_eq(skip)]
 	pub slash: Option<T![/]>,
 	pub denominator: Option<CSSInt>,
 }

--- a/crates/css_ast/src/types/reversed_counter_name.rs
+++ b/crates/css_ast/src/types/reversed_counter_name.rs
@@ -14,6 +14,7 @@ pub struct ReversedCounterName {
 	#[atom(CssAtomSet::Reversed)]
 	pub function: T![Function],
 	pub name: CounterName,
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -34,9 +34,10 @@ macro_rules! cursor_wrapped {
 	};
 }
 
-macro_rules! define_kinds {
-	($($(#[$meta:meta])* $ident:ident,)*) => {
-		$(
+/// Shared body for [define_kinds!] and [define_fixed_kinds!]; everything except the
+/// `SemanticEq` impl, which differs between the two (see [define_fixed_kinds!]).
+macro_rules! define_kind_common {
+	($(#[$meta:meta])* $ident:ident) => {
 		$(#[$meta])*
 		#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 		#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
@@ -94,10 +95,37 @@ macro_rules! define_kinds {
 				self.0.to_span()
 			}
 		}
+	};
+}
+
+macro_rules! define_kinds {
+	($($(#[$meta:meta])* $ident:ident,)*) => {
+		$(
+		define_kind_common!($(#[$meta])* $ident);
 
 		impl $crate::SemanticEq for $ident {
 			fn semantic_eq(&self, s: &Self) -> bool {
 				self.0.semantic_eq(&s.0)
+			}
+		}
+		)*
+	};
+}
+
+/// Like [define_kinds!], but for kinds whose content is entirely fixed by the Rust type - once
+/// parsing succeeds there is no varying data left to compare (e.g. a [Comma] is always just a
+/// `,`; the only bits that could otherwise differ are non-semantic associated-whitespace
+/// formatting hints). `semantic_eq` for these kinds is therefore always `true`, skipping the
+/// token comparison outright.
+macro_rules! define_fixed_kinds {
+	($($(#[$meta:meta])* $ident:ident,)*) => {
+		$(
+		define_kind_common!($(#[$meta])* $ident);
+
+		impl $crate::SemanticEq for $ident {
+			#[inline(always)]
+			fn semantic_eq(&self, _: &Self) -> bool {
+				true
 			}
 		}
 		)*
@@ -250,8 +278,11 @@ macro_rules! custom_delim {
 		}
 
 		impl $crate::SemanticEq for $ident {
-			fn semantic_eq(&self, other: &Self) -> bool {
-				self.0.semantic_eq(&other.0)
+			#[inline(always)]
+			fn semantic_eq(&self, _: &Self) -> bool {
+				// The character is fixed by the type itself (parsing only succeeds for
+				// `$ch`), so there is nothing left to compare.
+				true
 			}
 		}
 	};
@@ -331,8 +362,11 @@ macro_rules! custom_double_delim {
 		}
 
 		impl $crate::SemanticEq for $ident {
-			fn semantic_eq(&self, other: &Self) -> bool {
-				self.0.semantic_eq(&other.0) && self.1.semantic_eq(&other.1)
+			#[inline(always)]
+			fn semantic_eq(&self, _: &Self) -> bool {
+				// Both characters are fixed by the type itself (`$first` then `$second`), so
+				// there is nothing left to compare.
+				true
 			}
 		}
 	};
@@ -356,7 +390,9 @@ define_kinds! {
 
 	/// Represents a token with [Kind::Delim][Kind::Delim], can be any single character. Use [T![Delim]][crate::T] to refer to this.
 	Delim,
+}
 
+define_fixed_kinds! {
 	/// Represents a token with [Kind::Colon][Kind::Colon] - a `:` character. Use [T![:]][crate::T] to refer to this.
 	Colon,
 
@@ -825,8 +861,11 @@ pub mod double {
 	}
 
 	impl SemanticEq for ColonColon {
-		fn semantic_eq(&self, other: &Self) -> bool {
-			self.0.semantic_eq(&other.0) && self.1.semantic_eq(&other.1)
+		#[inline(always)]
+		fn semantic_eq(&self, _: &Self) -> bool {
+			// Both `:` characters are fixed by the type itself, so there is nothing left to
+			// compare.
+			true
 		}
 	}
 }
@@ -982,4 +1021,49 @@ macro_rules! T {
 	[!important] => { $crate::token_macros::double::BangImportant };
 
 	[$ident:ident] => { $crate::token_macros::$ident }
+}
+
+#[cfg(test)]
+mod fixed_kind_semantic_eq_tests {
+	use super::*;
+	use crate::SemanticEq;
+	use css_lexer::{AssociatedWhitespaceRules, SourceOffset};
+
+	// Colon, Semicolon, Comma, and the paren/curly/square brackets are "delim-like": they
+	// share Delim's bit layout and can carry non-semantic associated-whitespace formatting
+	// hints, which makes two otherwise-identical tokens compare unequal via plain `PartialEq`.
+	// `semantic_eq` must ignore this entirely for these kinds, since there is no other varying
+	// content once the type is known.
+	#[test]
+	fn fixed_punctuation_kinds_are_always_semantic_eq() {
+		macro_rules! check {
+			($ty:ident, $token:expr) => {{
+				let plain = $ty(Cursor::new(SourceOffset(0), $token));
+				let with_rule = $ty(Cursor::new(
+					SourceOffset(0),
+					$token.with_associated_whitespace(AssociatedWhitespaceRules::EnforceBefore),
+				));
+				assert_ne!(
+					plain,
+					with_rule,
+					"associated whitespace should still affect PartialEq for {}",
+					stringify!($ty)
+				);
+				assert!(
+					plain.semantic_eq(&with_rule),
+					"{} should always be semantic_eq regardless of associated whitespace",
+					stringify!($ty)
+				);
+			}};
+		}
+		check!(Colon, Token::COLON);
+		check!(Semicolon, Token::SEMICOLON);
+		check!(Comma, Token::COMMA);
+		check!(LeftCurly, Token::LEFT_CURLY);
+		check!(RightCurly, Token::RIGHT_CURLY);
+		check!(LeftSquare, Token::LEFT_SQUARE);
+		check!(RightSquare, Token::RIGHT_SQUARE);
+		check!(LeftParen, Token::LEFT_PAREN);
+		check!(RightParen, Token::RIGHT_PAREN);
+	}
 }

--- a/crates/css_parse/src/traits/semantic_eq.rs
+++ b/crates/css_parse/src/traits/semantic_eq.rs
@@ -1,4 +1,4 @@
-use css_lexer::{Cursor, Kind};
+use css_lexer::{AssociatedWhitespaceRules, Cursor};
 
 /// Trait for semantic equality comparison that ignores source positions and whitespace.
 ///
@@ -14,15 +14,12 @@ pub trait SemanticEq {
 // Implement for Cursor - compare tokens without considering source offset
 impl SemanticEq for Cursor {
 	fn semantic_eq(&self, other: &Self) -> bool {
-		// For Delims, we ignore associated whitespace rules since
-		// those are formatting hints, not semantic content
-		match self.token().kind() {
-			Kind::Delim => {
-				self.token().with_associated_whitespace(css_lexer::AssociatedWhitespaceRules::none())
-					== other.token().with_associated_whitespace(css_lexer::AssociatedWhitespaceRules::none())
-			}
-			_ => self.token() == other.token(),
-		}
+		// Associated whitespace rules are formatting hints, not semantic content, so ignore
+		// them. `with_associated_whitespace` is a no-op for kinds that don't carry such rules
+		// (only "delim-like" kinds do: Delim, Colon, Semicolon, Comma, and the paren/curly/
+		// square brackets), so this is safe to apply unconditionally.
+		self.token().with_associated_whitespace(AssociatedWhitespaceRules::none())
+			== other.token().with_associated_whitespace(AssociatedWhitespaceRules::none())
 	}
 }
 
@@ -108,6 +105,35 @@ mod tests {
 
 		// Standard PartialEq should distinguish them
 		assert_ne!(cursor1, cursor2);
+	}
+
+	#[test]
+	fn test_cursor_semantic_eq_ignores_associated_whitespace_for_all_delim_like_kinds() {
+		// Colon, Semicolon, Comma, and the paren/curly/square brackets share Delim's bit
+		// layout and can also carry associated-whitespace formatting hints. Those hints are
+		// not semantic content, so two tokens differing only by them must compare equal.
+		for token in [
+			css_lexer::Token::COLON,
+			css_lexer::Token::SEMICOLON,
+			css_lexer::Token::COMMA,
+			css_lexer::Token::LEFT_PAREN,
+			css_lexer::Token::RIGHT_PAREN,
+			css_lexer::Token::LEFT_CURLY,
+			css_lexer::Token::RIGHT_CURLY,
+			css_lexer::Token::LEFT_SQUARE,
+			css_lexer::Token::RIGHT_SQUARE,
+		] {
+			let plain = Cursor::new(css_lexer::SourceOffset(0), token);
+			let with_whitespace_rule = Cursor::new(
+				css_lexer::SourceOffset(0),
+				token.with_associated_whitespace(css_lexer::AssociatedWhitespaceRules::EnforceBefore),
+			);
+			assert!(
+				plain.semantic_eq(&with_whitespace_rule),
+				"{:?} should be semantic_eq regardless of associated whitespace",
+				token.kind()
+			);
+		}
 	}
 
 	#[test]

--- a/crates/csskit_ast/src/rule_block.rs
+++ b/crates/csskit_ast/src/rule_block.rs
@@ -139,6 +139,7 @@ pub struct DiagnosticAttrFunction {
 	#[atom(CsskitAtomSet::Attr)]
 	pub open: T![Function],
 	pub name: T![Ident],
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 
@@ -147,6 +148,7 @@ pub struct DiagnosticAttrFunction {
 pub struct DiagnosticSizeFunction {
 	#[atom(CsskitAtomSet::Size)]
 	pub open: T![Function],
+	#[semantic_eq(skip)]
 	pub close: T![')'],
 }
 

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -828,15 +828,15 @@ pub struct SizeComparison {
 #[derive(Peek, Parse, ToSpan, ToCursors, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SizeOperator {
 	/// `!=` operator (not equal)
-	NotEqual(T![!=]),
+	NotEqual(#[semantic_eq(skip)] T![!=]),
 	/// `>` operator (greater than)
-	GreaterThan(T![>]),
+	GreaterThan(#[semantic_eq(skip)] T![>]),
 	/// `<` operator (less than)
-	LessThan(T![<]),
+	LessThan(#[semantic_eq(skip)] T![<]),
 	/// `>=` operator (greater than or equal)
-	GreaterThanOrEqual(T![>=]),
+	GreaterThanOrEqual(#[semantic_eq(skip)] T![>=]),
 	/// `<=` operator (less than or equal)
-	LessThanOrEqual(T![<=]),
+	LessThanOrEqual(#[semantic_eq(skip)] T![<=]),
 }
 
 impl QuerySizePseudo {

--- a/crates/csskit_ast/src/when_rule.rs
+++ b/crates/csskit_ast/src/when_rule.rs
@@ -114,10 +114,12 @@ impl<'a> Peek<'a> for WhenCondition<'a> {
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[peek(Kind::LeftParen)]
 pub struct WhenFeature {
+	#[semantic_eq(skip)]
 	pub open: T!['('],
 	pub stat: T![DashedIdent],
 	pub operator: ComparisonOperator,
 	pub value: T![Number],
+	#[semantic_eq(skip)]
 	pub close: Option<T![')']>,
 }
 
@@ -134,13 +136,13 @@ impl WhenFeature {
 #[derive(Parse, Peek, ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ComparisonOperator {
 	/// `>`
-	GreaterThan(T![>]),
+	GreaterThan(#[semantic_eq(skip)] T![>]),
 	/// `<`
-	LessThan(T![<]),
+	LessThan(#[semantic_eq(skip)] T![<]),
 	/// `>=`
-	GreaterThanOrEqual(T![>=]),
+	GreaterThanOrEqual(#[semantic_eq(skip)] T![>=]),
 	/// `<=`
-	LessThanOrEqual(T![<=]),
+	LessThanOrEqual(#[semantic_eq(skip)] T![<=]),
 	/// `=`
-	Equal(T![=]),
+	Equal(#[semantic_eq(skip)] T![=]),
 }

--- a/crates/csskit_derives/src/attributes.rs
+++ b/crates/csskit_derives/src/attributes.rs
@@ -70,8 +70,8 @@ impl ToTokens for Atom {
 	}
 }
 
-pub fn extract_peek_skip(attrs: &[Attribute]) -> bool {
-	for attr in attrs.iter().filter(|a| a.path().is_ident("peek")) {
+fn extract_skip(attrs: &[Attribute], attr_name: &str) -> bool {
+	for attr in attrs.iter().filter(|a| a.path().is_ident(attr_name)) {
 		if let Meta::List(meta) = &attr.meta {
 			let mut skip = false;
 			meta.parse_nested_meta(|nested| {
@@ -87,6 +87,17 @@ pub fn extract_peek_skip(attrs: &[Attribute]) -> bool {
 		}
 	}
 	false
+}
+
+pub fn extract_peek_skip(attrs: &[Attribute]) -> bool {
+	extract_skip(attrs, "peek")
+}
+
+/// `#[semantic_eq(skip)]` marks a field as excluded from `derive(SemanticEq)`
+/// comparisons, e.g. closing punctuation (`)` `}` `]`) whose kind is fixed and
+/// therefore never meaningfully differs between two parsed values.
+pub fn extract_semantic_eq_skip(attrs: &[Attribute]) -> bool {
+	extract_skip(attrs, "semantic_eq")
 }
 
 pub fn extract_atom(attrs: &[Attribute]) -> Result<Option<Atom>> {

--- a/crates/csskit_derives/src/semantic_eq.rs
+++ b/crates/csskit_derives/src/semantic_eq.rs
@@ -1,4 +1,4 @@
-use crate::WhereCollector;
+use crate::{WhereCollector, attributes::extract_semantic_eq_skip};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Data, DeriveInput, Error, Fields, Result, parse_quote};
@@ -25,8 +25,10 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 		return Err(Error::new(input.ident.span(), "Cannot derive SemanticEq on a Union"));
 	}
 
-	let s_a = structure_with_prefix(&input, "a")?;
-	let s_b = structure_with_prefix(&input, "b")?;
+	let mut s_a = structure_with_prefix(&input, "a")?;
+	let mut s_b = structure_with_prefix(&input, "b")?;
+	s_a.filter(|bi| !extract_semantic_eq_skip(&bi.ast().attrs));
+	s_b.filter(|bi| !extract_semantic_eq_skip(&bi.ast().attrs));
 
 	let mut wc = WhereCollector::new();
 	for variant in s_a.variants() {
@@ -51,7 +53,7 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 			.collect();
 		let a_pat = s_a.variants()[0].pat();
 		let b_pat = s_b.variants()[0].pat();
-		let body = steps.into_iter().reduce(|acc, item| quote! { #acc && #item }).unwrap_or_default();
+		let body = steps.into_iter().reduce(|acc, item| quote! { #acc && #item }).unwrap_or(quote! { true });
 		quote! {
 			let #a_pat = self;
 			let #b_pat = other;

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_skip_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_enum_skip_field.snap
@@ -1,0 +1,16 @@
+---
+source: crates/csskit_derives/src/test/test_semantic_eq.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::SemanticEq for Foo {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        use ::css_parse::SemanticEq;
+        match (self, other) {
+            (Foo::Bar { name: a_name, .. }, Foo::Bar { name: b_name, .. }) => {
+                a_name.semantic_eq(&b_name)
+            }
+            _ => false,
+        }
+    }
+}

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_struct_skip_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_semantic_eq__semantic_eq_struct_skip_field.snap
@@ -1,0 +1,13 @@
+---
+source: crates/csskit_derives/src/test/test_semantic_eq.rs
+expression: pretty
+---
+#[automatically_derived]
+impl ::css_parse::SemanticEq for StringFunction {
+    fn semantic_eq(&self, other: &Self) -> bool {
+        use ::css_parse::SemanticEq;
+        let StringFunction { name: a_name, .. } = self;
+        let StringFunction { name: b_name, .. } = other;
+        a_name.semantic_eq(&b_name)
+    }
+}

--- a/crates/csskit_derives/src/test/test_semantic_eq.rs
+++ b/crates/csskit_derives/src/test/test_semantic_eq.rs
@@ -50,6 +50,32 @@ fn semantic_eq_enum_with_named_struct_variant_multiple_fields() {
 }
 
 #[test]
+fn semantic_eq_struct_skip_field() {
+	let data = to_deriveinput! {
+		struct StringFunction {
+			name: Ident,
+			#[semantic_eq(skip)]
+			close: T![')'],
+		}
+	};
+	assert_semantic_eq_snapshot!(data, "semantic_eq_struct_skip_field");
+}
+
+#[test]
+fn semantic_eq_enum_skip_field() {
+	let data = to_deriveinput! {
+		enum Foo {
+			Bar {
+				name: Ident,
+				#[semantic_eq(skip)]
+				close: T![')'],
+			},
+		}
+	};
+	assert_semantic_eq_snapshot!(data, "semantic_eq_enum_skip_field");
+}
+
+#[test]
 fn semantic_eq_enum_mixed_variants() {
 	let data = to_deriveinput! {
 		enum FlexWrap {


### PR DESCRIPTION
Some fields carry no semantic content of their own (e.g. a trailing `)` or `;`),
especially as they need to exist to be parsed. Much like
https://github.com/csskit/csskit/pull/1266 we need to introduce a new `skip`
attribute to allow fields to be skipped from codegen.

This change does just that: it adds `#[semantic_eq(skip)]` as a new attribute
that elides the codegen for that field. This change also adds this annotation in
a whole bunch of places. Lastly, in this process, I discovered that semantic_eq
wasn't actually correct for some fields (e.g. delims with specific whitespace
flags) and so that has also been fixed.
