### PR TITLE
csskit_derives: Ensure atom checks properly peek

### DIFF
--- a/crates/csskit_derives/src/peek.rs
+++ b/crates/csskit_derives/src/peek.rs
@@ -66,7 +66,9 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 				let atom = extract_atom(&syn_field.attrs)?;
 				let atoms = atom.map(|a| vec![a]).unwrap_or_default();
 				let peek_ty = option_inner(view.ty).unwrap_or(view.ty);
-				if let Some(kind) = map_type_to_kind(peek_ty) {
+				if atoms.is_empty()
+					&& let Some(kind) = map_type_to_kind(peek_ty)
+				{
 					let ident = Ident::new(kind, Span::call_site());
 					kinds.push(quote! { ::css_lexer::Kind::#ident });
 				} else {

--- a/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_atom_on_kind_mapped_field.snap
+++ b/crates/csskit_derives/src/test/snapshots/csskit_derives__test__test_peek__peek_struct_with_atom_on_kind_mapped_field.snap
@@ -1,0 +1,15 @@
+---
+source: crates/csskit_derives/src/test/test_peek.rs
+expression: pretty
+---
+#[automatically_derived]
+impl<'a> ::css_parse::Peek<'a> for CalcFunction {
+    #[inline(always)]
+    fn peek<I>(p: &::css_parse::Parser<'a, I>, c: ::css_parse::Cursor) -> bool
+    where
+        I: ::std::iter::Iterator<Item = ::css_parse::Cursor> + ::std::clone::Clone,
+    {
+        use ::css_parse::Peek;
+        (<Function>::peek(p, c) && (p.equals_atom(c.into(), &CssAtomSet::Calc)))
+    }
+}

--- a/crates/csskit_derives/src/test/test_peek.rs
+++ b/crates/csskit_derives/src/test/test_peek.rs
@@ -110,6 +110,18 @@ fn peek_struct_all_must_occur() {
 }
 
 #[test]
+fn peek_struct_with_atom_on_kind_mapped_field() {
+	let data = to_deriveinput! {
+		struct CalcFunction {
+			#[atom(CssAtomSet::Calc)]
+			name: Function,
+			close: RightParen,
+		}
+	};
+	assert_peek_snapshot!(data, "peek_struct_with_atom_on_kind_mapped_field");
+}
+
+#[test]
 fn peek_enum_struct_variant_one_must_occur() {
 	let data = to_deriveinput! {
 		enum FlexWrap {


### PR DESCRIPTION
We try to simplify derive(Peek) by using PEEK_KINDSET where possible, but the
check was too eager, resulting in some cases where e.g. atom checks were
dropped.

This change checks to ensure atoms is also empty before generating the
PEEK_KINDSET branch, ensuring that if the peeked field requires an atom check,
it gets it.
