### PR TITLE
css_ast/css_parse: Implement ToNormalisedValue trait

### DIFF
--- a/crates/css_ast/src/constraints.rs
+++ b/crates/css_ast/src/constraints.rs
@@ -1,5 +1,5 @@
 use crate::CssDiagnostic;
-use css_parse::{Cursor, Diagnostic, KindSet, Parse, Parser, Peek, Result, ToNumberValue};
+use css_parse::{Cursor, Diagnostic, KindSet, Parse, Parser, Peek, Result, ToNormalisedValue, ToNumberValue};
 use csskit_derives::*;
 
 /// A non-negative value wrapper.
@@ -147,7 +147,7 @@ impl<'a, T: Peek<'a>, const MIN: i32, const MAX: i32> Peek<'a> for Ranged<T, MIN
 	}
 }
 
-impl<'a, T: Parse<'a> + ToNumberValue, const MIN: i32, const MAX: i32> Parse<'a> for Ranged<T, MIN, MAX> {
+impl<'a, T: Parse<'a> + ToNormalisedValue, const MIN: i32, const MAX: i32> Parse<'a> for Ranged<T, MIN, MAX> {
 	fn parse<I>(p: &mut Parser<'a, I>) -> Result<Self>
 	where
 		I: Iterator<Item = Cursor> + Clone,
@@ -155,7 +155,7 @@ impl<'a, T: Parse<'a> + ToNumberValue, const MIN: i32, const MAX: i32> Parse<'a>
 		let cursor = p.peek_n(1);
 		let value = p.parse::<T>()?;
 
-		if let Some(num) = value.to_number_value()
+		if let Some(num) = value.to_normalised_value()
 			&& (num < MIN as f32 || num > MAX as f32)
 		{
 			Err(Diagnostic::new(cursor, Diagnostic::number_out_of_bounds))?;

--- a/crates/css_ast/src/units/angles.rs
+++ b/crates/css_ast/src/units/angles.rs
@@ -41,6 +41,12 @@ impl ToNumberValue for Angle {
 	}
 }
 
+impl ToNormalisedValue for Angle {
+	fn to_normalised_value(&self) -> Option<f32> {
+		Some(self.as_degrees())
+	}
+}
+
 impl Angle {
 	const DEG_GRAD: f32 = 0.9;
 	const DEG_RAD: f32 = 57.295_78;

--- a/crates/css_ast/src/units/flex.rs
+++ b/crates/css_ast/src/units/flex.rs
@@ -26,6 +26,12 @@ impl ToNumberValue for Flex {
 	}
 }
 
+impl ToNormalisedValue for Flex {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.to_number_value()
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/css_ast/src/units/int.rs
+++ b/crates/css_ast/src/units/int.rs
@@ -33,6 +33,12 @@ impl ToNumberValue for CSSInt {
 	}
 }
 
+impl ToNormalisedValue for CSSInt {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.to_number_value()
+	}
+}
+
 impl<'a> Peek<'a> for CSSInt {
 	const PEEK_KINDSET: KindSet = KindSet::new(&[Kind::Number]);
 

--- a/crates/css_ast/src/units/length.rs
+++ b/crates/css_ast/src/units/length.rs
@@ -131,6 +131,12 @@ impl ToNumberValue for Length {
 	}
 }
 
+impl ToNormalisedValue for Length {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.to_number_value()
+	}
+}
+
 #[derive(
 	Parse, Peek, IntoCursor, ToSpan, SemanticEq, ToCursors, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
 )]
@@ -158,6 +164,12 @@ impl From<LengthPercentage> for f32 {
 impl ToNumberValue for LengthPercentage {
 	fn to_number_value(&self) -> Option<f32> {
 		Some((*self).into())
+	}
+}
+
+impl ToNormalisedValue for LengthPercentage {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.to_number_value()
 	}
 }
 
@@ -217,6 +229,12 @@ impl ToNumberValue for LengthPercentageOrFlex {
 	}
 }
 
+impl ToNormalisedValue for LengthPercentageOrFlex {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.to_number_value()
+	}
+}
+
 #[derive(
 	Parse, Peek, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
 )]
@@ -241,6 +259,12 @@ impl From<NumberLength> for f32 {
 impl ToNumberValue for NumberLength {
 	fn to_number_value(&self) -> Option<f32> {
 		Some((*self).into())
+	}
+}
+
+impl ToNormalisedValue for NumberLength {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.to_number_value()
 	}
 }
 

--- a/crates/css_ast/src/units/mod.rs
+++ b/crates/css_ast/src/units/mod.rs
@@ -29,7 +29,8 @@ pub use time::*;
 mod prelude {
 	pub(crate) use crate::{CssAtomSet, Exact};
 	pub(crate) use css_parse::{
-		Cursor, Diagnostic, Kind, KindSet, Parse, Parser, Peek, Result as ParserResult, T, ToNumberValue,
+		Cursor, Diagnostic, Kind, KindSet, Parse, Parser, Peek, Result as ParserResult, T, ToNormalisedValue,
+		ToNumberValue,
 	};
 	pub(crate) use csskit_derives::*;
 }

--- a/crates/css_ast/src/units/percentage.rs
+++ b/crates/css_ast/src/units/percentage.rs
@@ -33,6 +33,12 @@ impl ToNumberValue for Percentage {
 	}
 }
 
+impl ToNormalisedValue for Percentage {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.to_number_value()
+	}
+}
+
 #[derive(
 	Peek, Parse, ToCursors, IntoCursor, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
 )]
@@ -57,6 +63,12 @@ impl From<NumberPercentage> for f32 {
 impl ToNumberValue for NumberPercentage {
 	fn to_number_value(&self) -> Option<f32> {
 		Some((*self).into())
+	}
+}
+
+impl ToNormalisedValue for NumberPercentage {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.to_number_value()
 	}
 }
 

--- a/crates/css_ast/src/units/time.rs
+++ b/crates/css_ast/src/units/time.rs
@@ -43,6 +43,12 @@ impl ToNumberValue for Time {
 	}
 }
 
+impl ToNormalisedValue for Time {
+	fn to_normalised_value(&self) -> Option<f32> {
+		Some(self.as_seconds())
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/crates/css_ast/src/values/fonts/impls.rs
+++ b/crates/css_ast/src/values/fonts/impls.rs
@@ -112,6 +112,7 @@ mod tests {
 		assert_parse_error!(CssAtomSet::ATOMS, FontStyleStyleValue, "oblique 45px");
 		assert_parse_error!(CssAtomSet::ATOMS, FontStyleStyleValue, "oblique 91deg");
 		assert_parse_error!(CssAtomSet::ATOMS, FontStyleStyleValue, "oblique -91deg");
+		assert_parse_error!(CssAtomSet::ATOMS, FontStyleStyleValue, "oblique 1turn");
 	}
 
 	#[test]

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -1,4 +1,6 @@
-use crate::{Cursor, CursorSink, Kind, KindSet, Parse, Parser, Peek, Result, Span, ToNumberValue, Token};
+use crate::{
+	Cursor, CursorSink, Kind, KindSet, Parse, Parser, Peek, Result, Span, ToNormalisedValue, ToNumberValue, Token,
+};
 
 macro_rules! cursor_wrapped {
 	($ident:ident) => {
@@ -629,6 +631,12 @@ impl PartialEq<f32> for Number {
 impl ToNumberValue for Number {
 	fn to_number_value(&self) -> Option<f32> {
 		Some(self.value())
+	}
+}
+
+impl ToNormalisedValue for Number {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.to_number_value()
 	}
 }
 

--- a/crates/css_parse/src/traits/to_number_value.rs
+++ b/crates/css_parse/src/traits/to_number_value.rs
@@ -11,3 +11,20 @@ impl<T: ToNumberValue> ToNumberValue for Option<T> {
 		self.as_ref().and_then(|t| t.to_number_value())
 	}
 }
+
+/// Returns the canonical (unit-normalised) numeric value for range validation.
+///
+/// Unlike `ToNumberValue` which returns the raw token value, this returns the value in a unit suitable for range
+/// comparison. For example, `Angle` returns degrees regardless of whether the token was `deg`, `rad`, `grad`, or
+/// `turn`.
+///
+/// For plain numeric types (integers, numbers, lengths, percentages) the value is identical to the raw token value.
+pub trait ToNormalisedValue {
+	fn to_normalised_value(&self) -> Option<f32>;
+}
+
+impl<T: ToNormalisedValue> ToNormalisedValue for Option<T> {
+	fn to_normalised_value(&self) -> Option<f32> {
+		self.as_ref().and_then(|t| t.to_normalised_value())
+	}
+}


### PR DESCRIPTION
ToNumberValue is helpful for post-parse AST work, such as minification, as it
returns the literal number value of a token, without having to type match it.
However this limits the ability to do range checking on canonical units for
range checks; for example FontStyleStyleValue limits to -90..90deg, and
ToNumberValue will return the non-canonical version, so e.g. `1turn` returns
`1`, leading to erroneous parse errors.

This change introduces a different trait - `ToNormalisedValue`. This trait is
subtly different in that it will normalise down to a canonical unit (dependant
on type), for e.g. `Angle`'s `ToNormalisedValue` always returns degrees,
therefore `1turn` returns `360`.
