### PR TITLE
csskit_derives: Allow multiple fields to delegate metadata

### DIFF
--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -570,6 +570,64 @@ mod tests {
 		assert!(metadata.used_at_rules.contains(AtRuleId::Media));
 	}
 
+	// Child leaf types carrying distinct node_kinds bits, used to verify delegation
+	// propagates and merges children's metadata upward.
+	#[derive(csskit_derives::NodeWithMetadata)]
+	#[metadata(node_kinds = StyleRule)]
+	struct ChildA;
+
+	#[derive(csskit_derives::NodeWithMetadata)]
+	#[metadata(node_kinds = AtRule)]
+	struct ChildB;
+
+	// Type-level delegate on a struct merges every field's metadata into self_metadata.
+	#[derive(csskit_derives::NodeWithMetadata)]
+	#[metadata(node_kinds = Function, delegate)]
+	struct StructDelegate {
+		a: ChildA,
+		b: ChildB,
+	}
+
+	// Enum delegate over a named-field variant and a tuple variant.
+	#[derive(csskit_derives::NodeWithMetadata)]
+	#[metadata(delegate)]
+	enum EnumDelegate {
+		Named { a: ChildA, b: ChildB },
+		Tuple(ChildA),
+		Empty,
+	}
+
+	#[test]
+	fn test_struct_type_level_delegate_merges_all_fields() {
+		let node = StructDelegate { a: ChildA, b: ChildB };
+		let meta = node.metadata();
+		// self_metadata bit plus both children.
+		assert!(meta.node_kinds.contains(NodeKinds::Function));
+		assert!(meta.node_kinds.contains(NodeKinds::StyleRule));
+		assert!(meta.node_kinds.contains(NodeKinds::AtRule));
+	}
+
+	#[test]
+	fn test_enum_delegate_named_variant() {
+		let meta = EnumDelegate::Named { a: ChildA, b: ChildB }.metadata();
+		assert!(meta.node_kinds.contains(NodeKinds::StyleRule));
+		assert!(meta.node_kinds.contains(NodeKinds::AtRule));
+		assert!(!meta.node_kinds.contains(NodeKinds::Function));
+	}
+
+	#[test]
+	fn test_enum_delegate_tuple_variant() {
+		let meta = EnumDelegate::Tuple(ChildA).metadata();
+		assert!(meta.node_kinds.contains(NodeKinds::StyleRule));
+		assert!(!meta.node_kinds.contains(NodeKinds::AtRule));
+	}
+
+	#[test]
+	fn test_enum_delegate_empty_variant() {
+		let meta = EnumDelegate::Empty.metadata();
+		assert!(meta.is_empty());
+	}
+
 	#[test]
 	fn test_vendor_prefixes_try_from() {
 		// Vendor-prefixed atoms should convert successfully

--- a/crates/css_ast/src/selector/o.rs
+++ b/crates/css_ast/src/selector/o.rs
@@ -6,7 +6,7 @@ pseudo_element!(
 	#[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
-#[derive(csskit_derives::NodeWithMetadata)]
+	#[derive(csskit_derives::NodeWithMetadata)]
 	pub enum OPseudoElement {
 		InnerSpinButton: CssAtomSet::_OInnerSpinButton,
 		OuterSpinButton: CssAtomSet::_OOuterSpinButton,
@@ -23,7 +23,7 @@ pseudo_class!(
 	#[derive(ToCursors, ToSpan, SemanticEq, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 	#[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 	#[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
-#[derive(csskit_derives::NodeWithMetadata)]
+	#[derive(csskit_derives::NodeWithMetadata)]
 	pub enum OPseudoClass {
 		Prefocus: CssAtomSet::_OPrefocus,
 	}

--- a/crates/css_ast/src/types/display_box.rs
+++ b/crates/css_ast/src/types/display_box.rs
@@ -10,6 +10,7 @@ use super::prelude::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub enum DisplayBox {
 	#[atom(CssAtomSet::Contents)]
 	Contents(T![Ident]),

--- a/crates/css_ast/src/types/display_internal.rs
+++ b/crates/css_ast/src/types/display_internal.rs
@@ -14,6 +14,7 @@ use super::prelude::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub enum DisplayInternal {
 	#[atom(CssAtomSet::TableRowGroup)]
 	TableRowGroup(T![Ident]),

--- a/crates/css_ast/src/types/display_legacy.rs
+++ b/crates/css_ast/src/types/display_legacy.rs
@@ -10,6 +10,7 @@ use super::prelude::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub enum DisplayLegacy {
 	#[atom(CssAtomSet::InlineBlock)]
 	InlineBlock(T![Ident]),

--- a/crates/css_ast/src/types/display_legacy_vendor.rs
+++ b/crates/css_ast/src/types/display_legacy_vendor.rs
@@ -16,6 +16,7 @@ use super::prelude::*;
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub enum DisplayLegacyVendor {
 	#[atom(CssAtomSet::Box)]
 	LegacyBox(T![Ident]),

--- a/crates/css_ast/src/types/display_listitem.rs
+++ b/crates/css_ast/src/types/display_listitem.rs
@@ -10,6 +10,7 @@ use css_parse::parse_optionals;
 #[derive(Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(children))]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub struct DisplayListitem {
 	pub outside: Option<DisplayOutside>,
 	pub inside: Option<DisplayListitemInside>,
@@ -42,6 +43,7 @@ impl<'a> Parse<'a> for DisplayListitem {
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(skip))]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub enum DisplayListitemInside {
 	#[atom(CssAtomSet::Flow)]
 	Flow(T![Ident]),

--- a/crates/css_ast/src/types/generic_font_family.rs
+++ b/crates/css_ast/src/types/generic_font_family.rs
@@ -22,6 +22,7 @@ pub enum GenericFontFamily {}
 /// ```
 #[derive(Peek, Parse, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub struct GenericScriptSpecific {
 	#[atom(CssAtomSet::Generic)]
 	pub name: T![Function],
@@ -37,6 +38,7 @@ pub struct GenericScriptSpecific {
 /// ```
 #[derive(Peek, Parse, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub enum GenericScriptSpecificKeyword {
 	#[atom(CssAtomSet::Fangsong)]
 	Fangsong(T![Ident]),
@@ -55,6 +57,7 @@ pub enum GenericScriptSpecificKeyword {
 /// ```
 #[derive(Peek, Parse, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub enum GenericComplete {
 	#[atom(CssAtomSet::Serif)]
 	Serif(T![Ident]),
@@ -79,6 +82,7 @@ pub enum GenericComplete {
 /// ```
 #[derive(Peek, Parse, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
+#[derive(csskit_derives::NodeWithMetadata)]
 pub enum GenericIncomplete {
 	#[atom(CssAtomSet::UiSerif)]
 	UiSerif(T![Ident]),

--- a/crates/csskit_derives/src/node_with_metadata.rs
+++ b/crates/csskit_derives/src/node_with_metadata.rs
@@ -35,18 +35,17 @@ impl MetadataArgs {
 		}
 	}
 
-	/// Which struct field to delegate `metadata()` to, if any.
-	///
-	/// Generic newtypes (e.g. `NonNegative<T>`) auto-delegate so `T`'s metadata
-	/// propagates without an explicit attribute. Non-generic single-field structs
-	/// don't auto-delegate: their inner type may not implement `NodeWithMetadata`.
-	fn delegate_field(fields: &Fields, generics: &Generics) -> Option<TokenStream> {
+	/// Which struct fields to delegate `metadata()` to. The returned accessors are merged together with
+	/// `self_metadata()`.
+	fn delegate_fields(fields: &Fields, generics: &Generics) -> Vec<TokenStream> {
+		let mut explicit = Vec::new();
 		match fields {
 			Fields::Named(named) => {
 				for field in &named.named {
-					if MetadataArgs::from_attributes(&field.attrs).map(|a| a.delegate).unwrap_or(false) {
-						let ident = field.ident.as_ref()?;
-						return Some(quote! { #ident });
+					if MetadataArgs::from_attributes(&field.attrs).map(|a| a.delegate).unwrap_or(false)
+						&& let Some(ident) = field.ident.as_ref()
+					{
+						explicit.push(quote! { #ident });
 					}
 				}
 			}
@@ -54,17 +53,20 @@ impl MetadataArgs {
 				for (i, field) in unnamed.unnamed.iter().enumerate() {
 					if MetadataArgs::from_attributes(&field.attrs).map(|a| a.delegate).unwrap_or(false) {
 						let idx = Index::from(i);
-						return Some(quote! { #idx });
+						explicit.push(quote! { #idx });
 					}
 				}
 			}
-			Fields::Unit => return None,
+			Fields::Unit => return explicit,
+		}
+		if !explicit.is_empty() {
+			return explicit;
 		}
 
 		// Auto-delegate for generic single-field structs (newtypes).
 		let has_type_params = generics.type_params().next().is_some();
 		if !has_type_params {
-			return None;
+			return explicit;
 		}
 
 		let total_fields = match fields {
@@ -75,18 +77,18 @@ impl MetadataArgs {
 		if total_fields == 1 {
 			match fields {
 				Fields::Named(named) => {
-					let ident = named.named.first()?.ident.as_ref()?;
-					Some(quote! { #ident })
+					if let Some(ident) = named.named.first().and_then(|f| f.ident.as_ref()) {
+						explicit.push(quote! { #ident });
+					}
 				}
 				Fields::Unnamed(_) => {
 					let idx = Index::from(0);
-					Some(quote! { #idx })
+					explicit.push(quote! { #idx });
 				}
-				Fields::Unit => None,
+				Fields::Unit => {}
 			}
-		} else {
-			None
 		}
+		explicit
 	}
 
 	fn needs_delegation_bounds(&self, data: &Data, generics: &Generics) -> bool {
@@ -94,7 +96,7 @@ impl MetadataArgs {
 			return true;
 		}
 		if let Data::Struct(DataStruct { fields, .. }) = data {
-			return MetadataArgs::delegate_field(fields, generics).is_some();
+			return !MetadataArgs::delegate_fields(fields, generics).is_empty();
 		}
 		false
 	}
@@ -134,9 +136,9 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 	let declaration_kinds = MetadataArgs::pipe_tokens(&args.declaration_kinds, parse_quote! { crate::DeclarationKind });
 	let property_kinds = MetadataArgs::pipe_tokens(&args.property_kinds, parse_quote! { crate::PropertyKind });
 
-	let field_delegate = match &input.data {
-		Data::Struct(DataStruct { fields, .. }) => MetadataArgs::delegate_field(fields, &input.generics),
-		_ => None,
+	let field_delegates = match &input.data {
+		Data::Struct(DataStruct { fields, .. }) => MetadataArgs::delegate_fields(fields, &input.generics),
+		_ => Vec::new(),
 	};
 
 	let self_metadata = quote! {
@@ -188,8 +190,25 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 							expr
 						};
 
+						// Generate pattern based on whether variant has named or unnamed fields.
+						let pattern = match &variant.fields {
+							Fields::Named(named) => {
+								let field_bindings: Vec<_> = named
+									.named
+									.iter()
+									.zip(bindings.iter())
+									.map(|(field, binding)| {
+										let fname = field.ident.as_ref().unwrap();
+										quote! { #fname: #binding }
+									})
+									.collect();
+								quote! { Self::#variant_ident { #(#field_bindings),*, .. } }
+							}
+							_ => quote! { Self::#variant_ident(#(#bindings),*) },
+						};
+
 						quote! {
-							Self::#variant_ident(#(#bindings),*) => #metadata_expr,
+							#pattern => #metadata_expr,
 						}
 					}
 				})
@@ -202,20 +221,47 @@ pub fn derive(input: DeriveInput) -> Result<TokenStream> {
 					}
 				}
 			}
+		} else if let Data::Struct(DataStruct { fields, .. }) = &input.data {
+			let field_accessors: Vec<TokenStream> = match fields {
+				Fields::Named(named) => {
+					named.named.iter().filter_map(|f| f.ident.as_ref().map(|i| quote! { #i })).collect()
+				}
+				Fields::Unnamed(unnamed) => (0..unnamed.unnamed.len())
+					.map(|i| {
+						let idx = Index::from(i);
+						quote! { #idx }
+					})
+					.collect(),
+				Fields::Unit => Vec::new(),
+			};
+			let child_meta = field_accessors.iter().fold(quote! { self.self_metadata() }, |acc, field_path| {
+				quote! {
+					css_parse::NodeMetadata::merge(
+						#acc,
+						<_ as css_parse::NodeWithMetadata<crate::CssMetadata>>::metadata(&self.#field_path),
+					)
+				}
+			});
+			quote! {
+				fn metadata(&self) -> crate::CssMetadata {
+					#child_meta
+				}
+			}
 		} else {
-			return Err(Error::new_spanned(
-				ident,
-				"#[metadata(delegate)] on a type-level attribute can only be used on enums. Use field-level #[metadata(delegate)] for structs.",
-			));
+			return Err(Error::new_spanned(ident, "#[metadata(delegate)] can only be used on enums or structs."));
 		}
-	} else if let Some(field_path) = field_delegate {
-		let field_access = quote! { self.#field_path };
-		let child_meta_access =
-			quote! { <_ as css_parse::NodeWithMetadata<crate::CssMetadata>>::metadata(&#field_access) };
+	} else if !field_delegates.is_empty() {
+		let child_meta = field_delegates.iter().fold(quote! { self.self_metadata() }, |acc, field_path| {
+			quote! {
+				css_parse::NodeMetadata::merge(
+					#acc,
+					<_ as css_parse::NodeWithMetadata<crate::CssMetadata>>::metadata(&self.#field_path),
+				)
+			}
+		});
 		quote! {
 			fn metadata(&self) -> crate::CssMetadata {
-				let child_meta = #child_meta_access;
-				css_parse::NodeMetadata::merge(child_meta, self.self_metadata())
+				#child_meta
 			}
 		}
 	} else {


### PR DESCRIPTION
Currently the NodeWithMetadata derive allows a `delegate` attribute to pull
metadata from a specific field or variant, and it will just use that field's
metadata. This is useful, but it would be more useful to delegate to multiple
fields and merge all of them.

This change does just that - it extends the delegate attribute to be allowed on
multiple fields, and the derive macro will merge all delegate fields' metadata.

This also adds derive(NodeWithMetadata) to a bunch of types that missed it.
