### PR TITLE
css_parse: Drop CursorSource trait

### DIFF
--- a/crates/css_parse/src/traits/cursor_source.rs
+++ b/crates/css_parse/src/traits/cursor_source.rs
@@ -1,8 +1,0 @@
-use crate::Cursor;
-
-/// This trait provides the generic `impl` that [ToCursors][crate::ToCursors] can use. This provides just enough API
-/// surface for nodes to put the cursors they represent into some buffer which can later be read, the details of which
-/// are elided.
-pub trait CursorSource {
-	fn iter_cursors(&self) -> impl Iterator<Item = &Cursor>;
-}

--- a/crates/css_parse/src/traits/mod.rs
+++ b/crates/css_parse/src/traits/mod.rs
@@ -1,6 +1,5 @@
 mod boolean_feature;
 mod cursor_sink;
-mod cursor_source;
 mod declaration_value;
 mod discrete_feature;
 mod lists;
@@ -17,7 +16,6 @@ mod to_number_value;
 
 pub use boolean_feature::*;
 pub use cursor_sink::*;
-pub use cursor_source::*;
 pub use declaration_value::*;
 pub use discrete_feature::*;
 pub use lists::*;


### PR DESCRIPTION
This trait is just dead code. ToCursors doesn't use it.
