### PR TITLE
css_parse: Reimplement computed value declaration peeking/parsing in DeclarationValue

### DIFF
--- a/coverage/popular/bootstrap.4.6.2.find.1.txt
+++ b/coverage/popular/bootstrap.4.6.2.find.1.txt
@@ -1,8 +1,13 @@
 find :unknown
 ---
 coverage/popular/bootstrap.4.6.2.css
+2260:3:  background-position: right calc(0.375em + 0.1875rem) center;
+2276:3:  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
 2282:3:  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") right 0.75rem center/8px 10px no-repeat, #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem) no-repeat;
+2371:3:  background-position: right calc(0.375em + 0.1875rem) center;
+2387:3:  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
 2393:3:  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") right 0.75rem center/8px 10px no-repeat, #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23dc3545' viewBox='0 0 12 12'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e") center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem) no-repeat;
+4872:3:  border-radius: 0 0 calc(0.25rem - 1px) calc(0.25rem - 1px);
 5530:3:  -webkit-animation: 1s linear infinite progress-bar-stripes;
 5531:3:  animation: 1s linear infinite progress-bar-stripes;
 5536:5:    -webkit-animation: none;

--- a/coverage/popular/bootstrap.5.3.0.find.1.txt
+++ b/coverage/popular/bootstrap.5.3.0.find.1.txt
@@ -2,22 +2,37 @@ find :unknown
 ---
 coverage/popular/bootstrap.5.3.0.css
 348:3:  color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+1879:3:  box-shadow: inset 0 0 0 9999px var(--bs-table-bg-state, var(--bs-table-bg-type, var(--bs-table-accent-bg)));
+1904:3:  border-width: 0 var(--bs-border-width);
+2344:3:  text-shadow: 0 0 0 var(--bs-body-color);
 2652:3:  color: rgba(var(--bs-body-color-rgb), 0.65);
 2659:3:  color: rgba(var(--bs-body-color-rgb), 0.65);
 2684:3:  color: rgba(var(--bs-body-color-rgb), 0.65);
+2822:3:  background-position: right calc(0.375em + 0.1875rem) center;
 2827:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+2832:3:  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
 2841:3:  background-position: right 0.75rem center, center right 2.25rem;
 2842:3:  background-size: 16px 12px, calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 2846:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
 2860:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+2912:3:  background-position: right calc(0.375em + 0.1875rem) center;
 2917:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+2922:3:  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
 2931:3:  background-position: right 0.75rem center, center right 2.25rem;
 2932:3:  background-size: 16px 12px, calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
 2936:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
 2950:3:  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+3641:3:  border-top: 1px solid var(--bs-dropdown-divider-bg);
+4064:3:  box-shadow: 0 0 0 var(--bs-navbar-toggler-focus-width);
+4478:3:  border-radius: 0 0 var(--bs-card-inner-border-radius) var(--bs-card-inner-border-radius);
+4615:3:  box-shadow: inset 0 calc(-1 * var(--bs-accordion-border-width)) 0 var(--bs-accordion-border-color);
 4957:5:    background-position-x: 1rem;
 5009:3:  animation: 1s linear infinite progress-bar-stripes;
 5013:5:    animation: none;
+5250:3:  border-width: 0 0 var(--bs-list-group-border-width);
+5374:3:  background: transparent var(--bs-btn-close-bg) center/1em auto no-repeat;
+5842:3:  border-width: 0 calc(var(--bs-tooltip-arrow-width) * 0.5) var(--bs-tooltip-arrow-height);
+5965:3:  border-width: 0 calc(var(--bs-popover-arrow-width) * 0.5) var(--bs-popover-arrow-height);
 6830:3:  animation: placeholder-glow 2s ease-in-out infinite;
 6839:3:  -webkit-mask-image: linear-gradient(130deg, #000 55%, rgba(0, 0, 0, 0.8) 75%, #000 95%);
 6843:3:  animation: placeholder-wave 2s linear infinite;

--- a/coverage/popular/mini.css.3.0.1.find.1.txt
+++ b/coverage/popular/mini.css.3.0.1.find.1.txt
@@ -1,4 +1,48 @@
 find :unknown
 ---
 coverage/popular/mini.css.3.0.1.css
+130:3:  background: linear-gradient(to right, transparent, var(--border-color) 20%, var(--border-color) 80%, transparent);
+140:3:  border: 0.0625rem solid var(--secondary-border-color);
+141:3:  border-left: 0.375rem solid var(--blockquote-color);
+142:3:  border-radius: 0 var(--universal-border-radius) var(--universal-border-radius) 0;
+187:3:  border: 0.0625rem solid var(--secondary-border-color);
+188:3:  border-left: 0.25rem solid var(--pre-color);
+189:3:  border-radius: 0 var(--universal-border-radius) var(--universal-border-radius) 0;
+239:3:  padding: 0 calc(1.5 * var(--universal-padding));
+255:3:  padding: 0 calc(var(--universal-padding) / 2);
+404:5:    padding: 0 calc(var(--universal-padding) / 2);
+526:5:    padding: 0 calc(var(--universal-padding) / 2);
+657:3:  border: 0.0625rem solid var(--card-border-color);
+676:3:  border-bottom: 0.0625rem solid var(--card-border-color);
+755:3:  border: 0.0625rem solid var(--form-border-color);
+762:3:  border: 0.0625rem solid var(--form-border-color);
+835:3:  border: 0.0625rem solid var(--input-border-color);
+932:3:  border: 0.0625rem solid var(--button-border-color);
+957:3:  border: 0.0625rem solid var(--button-group-border-color);
+974:3:  border-left: 0.0625rem solid var(--button-group-border-color);
+983:5:    border-top: 0.0625rem solid var(--button-group-border-color);
+1064:3:  border-bottom: 0.0625rem solid var(--header-border-color);
+1104:3:  border: 0.0625rem solid var(--nav-border-color);
+1136:3:  border: 0.0625rem solid var(--nav-border-color);
+1151:3:  border: 0.0625rem solid var(--nav-border-color);
+1158:3:  border-top: 0.0625rem solid var(--footer-border-color);
+1216:3:  border: 0.0625rem solid var(--drawer-border-color);
+1309:3:  border: 0.0625rem solid var(--table-border-color);
+1315:3:  border-bottom: 0.0625rem solid var(--table-border-separator-color);
+1321:3:  border-radius: 0 0 var(--universal-border-radius) var(--universal-border-radius);
+1342:3:  border-top: 0.0625rem solid var(--table-border-color);
+1401:3:  border-bottom: 0.0625rem solid var(--table-border-color);
+1410:3:  border-left: 0.0625rem solid var(--table-border-color);
+1411:3:  border-right: 0.0625rem solid var(--table-border-separator-color);
+1419:3:  border-top: 0.0625rem solid var(--table-border-color);
+1423:3:  border-right: 0.0625rem solid var(--table-border-color);
+1467:5:    border: 0.0625rem solid var(--table-border-color);
+1743:3:  border: 0.0625rem solid var(--collapse-border-color);
+1778:3:  border: 0.0625rem solid var(--collapse-border-color);
+1796:3:  border-radius: 0 0 var(--universal-border-radius) var(--universal-border-radius);
+1808:3:  border-radius: 0 0 var(--universal-border-radius) var(--universal-border-radius);
+1898:3:  border: 0.25rem solid var(--spinner-back-color);
+1899:3:  border-left: 0.25rem solid var(--spinner-fore-color);
 1903:3:  animation: spinner-donut-anim 1.2s linear infinite;
+1942:3:  margin: 0 calc(var(--universal-margin) / 4);
+2062:3:  border: 0.0625rem solid var(--generic-border-color) !important;

--- a/coverage/popular/missing.1.2.0.find.1.txt
+++ b/coverage/popular/missing.1.2.0.find.1.txt
@@ -1,8 +1,21 @@
 find :unknown
 ---
 coverage/popular/missing.1.2.0.css
+92:3:  outline: .2em solid var(--accent);
+101:3:  outline: .2em solid var(--fg);
+548:3:  margin-inline: 0 var(--gap);
+659:5:    transform: translateX(calc(0px - var(--sidenote-width) + min(var(--gutter-width), var(--sidenote-width))));
+699:3:  border: 1px outset var(--graphical-fg);
+777:3:  padding: 0 calc(var(--rhythm, 1rlh) / 4);
+868:3:  padding: 0 calc(var(--rhythm, 1rlh) / 4);
 1188:3:  animation: bg 2s;
 1195:1:dialog:not([popover], [open]),
+1228:3:  text-shadow: 0 .1em .2em var(--fg);
 1294:5:    display: inline list-item;
 1307:1:chip {
+1449:3:  padding: 0 calc(var(--rhythm, 1rlh) / 4);
+1489:3:  padding: 0 calc(var(--gap) / 2);
+1568:7:      transform: translateX(calc(100% + 2 * var(--toggle-nub-margin)));
+1577:7:      transform: translateX(calc(50% + var(--toggle-nub-margin)));
+1820:3:  transform: translateX(calc(-.5 * var(--full-width)));
 2091:3:  role[menuitem] {

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -302,8 +302,6 @@ impl<'a> StyleValue<'a> {
 }
 
 impl<'a> DeclarationValue<'a, CssMetadata> for StyleValue<'a> {
-	type ComputedValue = Computed<'a>;
-
 	fn declaration_metadata(decl: &Declaration<'a, Self, CssMetadata>) -> CssMetadata {
 		let mut meta = decl.value.metadata();
 		// Mark this node as a declaration
@@ -374,6 +372,13 @@ impl<'a> DeclarationValue<'a, CssMetadata> for StyleValue<'a> {
 		I: Iterator<Item = Cursor> + Clone,
 	{
 		p.parse::<Custom>().map(Self::Custom)
+	}
+
+	fn is_computed_declaration_value<I>(p: &Parser<'a, I>, c: Cursor) -> bool
+	where
+		I: Iterator<Item = Cursor> + Clone,
+	{
+		<Computed>::peek(p, c)
 	}
 
 	fn parse_computed_declaration_value<I>(p: &mut Parser<'a, I>, _name: Cursor) -> ParserResult<Self>

--- a/crates/css_ast/src/rules/counter_style.rs
+++ b/crates/css_ast/src/rules/counter_style.rs
@@ -1,7 +1,7 @@
 use super::prelude::*;
 #[cfg(feature = "visitable")]
 use crate::visit::{NodeId, QueryableNode};
-use crate::{Computed, Inherits, PropertyGroup, Todo};
+use crate::{Inherits, PropertyGroup, Todo};
 use csskit_derives::*;
 use csskit_proc_macro::syntax;
 
@@ -67,8 +67,6 @@ pub enum CounterStyleRuleStyleValue<'a> {
 }
 
 impl<'a> DeclarationValue<'a, CssMetadata> for CounterStyleRuleStyleValue<'a> {
-	type ComputedValue = Computed<'a>;
-
 	fn valid_declaration_name<I>(p: &Parser<'a, I>, c: Cursor) -> bool
 	where
 		I: Iterator<Item = Cursor> + Clone,

--- a/crates/css_ast/src/rules/font_face.rs
+++ b/crates/css_ast/src/rules/font_face.rs
@@ -1,7 +1,7 @@
 use css_parse::DeclarationValue;
 
 use super::prelude::*;
-use crate::{Computed, CssMetadata};
+use crate::CssMetadata;
 
 /// <https://drafts.csswg.org/css-fonts/#font-face-rule>
 #[derive(Parse, Peek, ToSpan, ToCursors, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -31,8 +31,6 @@ pub struct FontFaceRuleBlock<'a>(#[metadata(delegate)] DeclarationList<'a, FontF
 pub struct FontFaceRuleStyleValue<'a>(#[metadata(delegate)] pub StyleValue<'a>);
 
 impl<'a> DeclarationValue<'a, CssMetadata> for FontFaceRuleStyleValue<'a> {
-	type ComputedValue = Computed<'a>;
-
 	fn valid_declaration_name<I>(p: &Parser<'a, I>, c: Cursor) -> bool
 	where
 		I: Iterator<Item = Cursor> + Clone,

--- a/crates/css_ast/src/rules/property.rs
+++ b/crates/css_ast/src/rules/property.rs
@@ -1,5 +1,4 @@
 use super::prelude::*;
-use crate::Computed;
 #[cfg(feature = "visitable")]
 use crate::visit::{NodeId, QueryableNode};
 
@@ -82,8 +81,6 @@ pub enum InheritsValue {
 pub struct SyntaxValue(T![String]);
 
 impl<'a, M: NodeMetadata> DeclarationValue<'a, M> for PropertyRuleStyleValue<'a> {
-	type ComputedValue = Computed<'a>;
-
 	fn valid_declaration_name<I>(p: &Parser<'a, I>, c: Cursor) -> bool
 	where
 		I: Iterator<Item = Cursor> + Clone,

--- a/crates/css_ast/tests/snapshots/basic_snapshots__basic_vars.snap
+++ b/crates/css_ast/tests/snapshots/basic_snapshots__basic_vars.snap
@@ -33,7 +33,7 @@ StyleSheet(
                 offset: SourceOffset(17),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.4.6.2.snap
@@ -50391,7 +50391,7 @@ StyleSheet(
                 offset: SourceOffset(37005),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -51145,7 +51145,7 @@ StyleSheet(
                 offset: SourceOffset(37563),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -54966,7 +54966,7 @@ StyleSheet(
                 offset: SourceOffset(41372),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -55720,7 +55720,7 @@ StyleSheet(
                 offset: SourceOffset(41942),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -128783,7 +128783,7 @@ StyleSheet(
                 offset: SourceOffset(101172),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__bootstrap.5.3.0.snap
@@ -44806,7 +44806,7 @@ StyleSheet(
                 offset: SourceOffset(31301),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -45636,7 +45636,7 @@ StyleSheet(
                 offset: SourceOffset(31831),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -59666,7 +59666,7 @@ StyleSheet(
                 offset: SourceOffset(43752),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -75239,7 +75239,7 @@ StyleSheet(
                 offset: SourceOffset(58005),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -75886,7 +75886,7 @@ StyleSheet(
                 offset: SourceOffset(58445),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -79725,7 +79725,7 @@ StyleSheet(
                 offset: SourceOffset(61741),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -80372,7 +80372,7 @@ StyleSheet(
                 offset: SourceOffset(62190),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -105780,7 +105780,7 @@ StyleSheet(
                 offset: SourceOffset(83152),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -120109,7 +120109,7 @@ StyleSheet(
                 offset: SourceOffset(95490),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -132584,7 +132584,7 @@ StyleSheet(
                 offset: SourceOffset(106490),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -137574,7 +137574,7 @@ StyleSheet(
                 offset: SourceOffset(111209),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -158891,7 +158891,7 @@ StyleSheet(
                 offset: SourceOffset(132184),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -163783,7 +163783,7 @@ StyleSheet(
                 offset: SourceOffset(138371),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -178839,7 +178839,7 @@ StyleSheet(
                 offset: SourceOffset(150769),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -185056,7 +185056,7 @@ StyleSheet(
                 offset: SourceOffset(156113),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__mini.css.3.0.1.snap
@@ -3219,7 +3219,7 @@ StyleSheet(
                 offset: SourceOffset(2329),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -3666,7 +3666,7 @@ StyleSheet(
                 offset: SourceOffset(2640),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -3734,7 +3734,7 @@ StyleSheet(
                 offset: SourceOffset(2702),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -3802,7 +3802,7 @@ StyleSheet(
                 offset: SourceOffset(2759),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -5353,7 +5353,7 @@ StyleSheet(
                 offset: SourceOffset(3831),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -5421,7 +5421,7 @@ StyleSheet(
                 offset: SourceOffset(3893),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -5489,7 +5489,7 @@ StyleSheet(
                 offset: SourceOffset(3942),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -6433,7 +6433,7 @@ StyleSheet(
                 offset: SourceOffset(4591),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -6906,7 +6906,7 @@ StyleSheet(
                 offset: SourceOffset(4869),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -9747,7 +9747,7 @@ StyleSheet(
                       offset: SourceOffset(6808),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -12596,7 +12596,7 @@ StyleSheet(
                       offset: SourceOffset(8946),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -15561,7 +15561,7 @@ StyleSheet(
                 offset: SourceOffset(11257),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -16108,7 +16108,7 @@ StyleSheet(
                 offset: SourceOffset(11663),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -18009,7 +18009,7 @@ StyleSheet(
                 offset: SourceOffset(13195),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -18311,7 +18311,7 @@ StyleSheet(
                 offset: SourceOffset(13417),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -20513,7 +20513,7 @@ StyleSheet(
                 offset: SourceOffset(14970),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -25032,7 +25032,7 @@ StyleSheet(
                 offset: SourceOffset(17739),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -26770,7 +26770,7 @@ StyleSheet(
                 offset: SourceOffset(18854),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -27476,7 +27476,7 @@ StyleSheet(
                 offset: SourceOffset(19350),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -27749,7 +27749,7 @@ StyleSheet(
                       offset: SourceOffset(19562),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -33296,7 +33296,7 @@ StyleSheet(
                 offset: SourceOffset(23284),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -35116,7 +35116,7 @@ StyleSheet(
                 offset: SourceOffset(24477),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -36301,7 +36301,7 @@ StyleSheet(
                 offset: SourceOffset(25256),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -36816,7 +36816,7 @@ StyleSheet(
                 offset: SourceOffset(25588),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -37035,7 +37035,7 @@ StyleSheet(
                 offset: SourceOffset(25748),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -38542,7 +38542,7 @@ StyleSheet(
                 offset: SourceOffset(26833),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -41222,7 +41222,7 @@ StyleSheet(
                 offset: SourceOffset(28830),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -41445,7 +41445,7 @@ StyleSheet(
                 offset: SourceOffset(29007),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -41662,7 +41662,7 @@ StyleSheet(
                 offset: SourceOffset(29160),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -42274,7 +42274,7 @@ StyleSheet(
                 offset: SourceOffset(29571),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -43936,7 +43936,7 @@ StyleSheet(
                 offset: SourceOffset(30577),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -44247,7 +44247,7 @@ StyleSheet(
                 offset: SourceOffset(30780),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -44315,7 +44315,7 @@ StyleSheet(
                 offset: SourceOffset(30839),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -44576,7 +44576,7 @@ StyleSheet(
                 offset: SourceOffset(31038),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -44723,7 +44723,7 @@ StyleSheet(
                 offset: SourceOffset(31142),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -46060,7 +46060,7 @@ StyleSheet(
                       offset: SourceOffset(32165),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -55027,7 +55027,7 @@ StyleSheet(
                 offset: SourceOffset(38508),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -56102,7 +56102,7 @@ StyleSheet(
                 offset: SourceOffset(39349),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -56695,7 +56695,7 @@ StyleSheet(
                 offset: SourceOffset(39794),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -57099,7 +57099,7 @@ StyleSheet(
                 offset: SourceOffset(40117),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -59499,7 +59499,7 @@ StyleSheet(
                 offset: SourceOffset(42122),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -59567,7 +59567,7 @@ StyleSheet(
                 offset: SourceOffset(42178),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -60401,7 +60401,7 @@ StyleSheet(
                 offset: SourceOffset(42953),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -63160,7 +63160,7 @@ StyleSheet(
                 offset: SourceOffset(52854),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__missing.1.2.0.snap
@@ -1842,7 +1842,7 @@ StyleSheet(
                 offset: SourceOffset(1366),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -2069,7 +2069,7 @@ StyleSheet(
                 offset: SourceOffset(1511),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -16099,7 +16099,7 @@ StyleSheet(
                 offset: SourceOffset(10910),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -19609,7 +19609,7 @@ StyleSheet(
                         offset: SourceOffset(13449),
                         len: 1,
                       )),
-                      value: Computed(ComponentValues(
+                      value: Unknown(ComponentValues(
                         values: [
                           Whitespace(Cursor(
                             kind: "Whitespace",
@@ -20689,7 +20689,7 @@ StyleSheet(
                 offset: SourceOffset(14082),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -22899,7 +22899,7 @@ StyleSheet(
                 offset: SourceOffset(15500),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -26769,7 +26769,7 @@ StyleSheet(
                 offset: SourceOffset(18016),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -39918,7 +39918,7 @@ StyleSheet(
                 offset: SourceOffset(27650),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -46855,7 +46855,7 @@ StyleSheet(
                 offset: SourceOffset(32072),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -48400,7 +48400,7 @@ StyleSheet(
                 offset: SourceOffset(33146),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -51087,7 +51087,7 @@ StyleSheet(
                                 offset: SourceOffset(35056),
                                 len: 1,
                               )),
-                              value: Computed(ComponentValues(
+                              value: Unknown(ComponentValues(
                                 values: [
                                   Whitespace(Cursor(
                                     kind: "Whitespace",
@@ -51474,7 +51474,7 @@ StyleSheet(
                                 offset: SourceOffset(35325),
                                 len: 1,
                               )),
-                              value: Computed(ComponentValues(
+                              value: Unknown(ComponentValues(
                                 values: [
                                   Whitespace(Cursor(
                                     kind: "Whitespace",
@@ -61661,7 +61661,7 @@ StyleSheet(
                 offset: SourceOffset(42639),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",

--- a/crates/css_ast/tests/snapshots/popular_snapshots__water.2.1.1.snap
+++ b/crates/css_ast/tests/snapshots/popular_snapshots__water.2.1.1.snap
@@ -3825,7 +3825,7 @@ StyleSheet(
                 offset: SourceOffset(4221),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -4298,7 +4298,7 @@ StyleSheet(
                       offset: SourceOffset(4687),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -4737,7 +4737,7 @@ StyleSheet(
                 offset: SourceOffset(5115),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -5210,7 +5210,7 @@ StyleSheet(
                       offset: SourceOffset(5580),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -5649,7 +5649,7 @@ StyleSheet(
                 offset: SourceOffset(6011),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -6122,7 +6122,7 @@ StyleSheet(
                       offset: SourceOffset(6479),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -8671,7 +8671,7 @@ StyleSheet(
                 offset: SourceOffset(8088),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -8921,7 +8921,7 @@ StyleSheet(
                       offset: SourceOffset(8283),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -9060,7 +9060,7 @@ StyleSheet(
                 offset: SourceOffset(8369),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -9310,7 +9310,7 @@ StyleSheet(
                       offset: SourceOffset(8555),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -17162,7 +17162,7 @@ StyleSheet(
                 offset: SourceOffset(14124),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -17559,7 +17559,7 @@ StyleSheet(
                       offset: SourceOffset(14827),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -17941,7 +17941,7 @@ StyleSheet(
                       offset: SourceOffset(15511),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -18323,7 +18323,7 @@ StyleSheet(
                       offset: SourceOffset(16195),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -18705,7 +18705,7 @@ StyleSheet(
                       offset: SourceOffset(16879),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -19285,7 +19285,7 @@ StyleSheet(
                 offset: SourceOffset(17694),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -19499,7 +19499,7 @@ StyleSheet(
                       offset: SourceOffset(17825),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -19679,7 +19679,7 @@ StyleSheet(
                 offset: SourceOffset(17920),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -19893,7 +19893,7 @@ StyleSheet(
                       offset: SourceOffset(18052),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -20073,7 +20073,7 @@ StyleSheet(
                 offset: SourceOffset(18147),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -20287,7 +20287,7 @@ StyleSheet(
                       offset: SourceOffset(18279),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -20467,7 +20467,7 @@ StyleSheet(
                 offset: SourceOffset(18376),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -20681,7 +20681,7 @@ StyleSheet(
                       offset: SourceOffset(18510),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -22249,7 +22249,7 @@ StyleSheet(
                 offset: SourceOffset(19600),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -22514,7 +22514,7 @@ StyleSheet(
                       offset: SourceOffset(19795),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -30291,7 +30291,7 @@ StyleSheet(
                 offset: SourceOffset(25133),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -30742,7 +30742,7 @@ StyleSheet(
                       offset: SourceOffset(25441),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -31152,7 +31152,7 @@ StyleSheet(
                 offset: SourceOffset(25702),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -31325,7 +31325,7 @@ StyleSheet(
                       offset: SourceOffset(25823),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -31780,7 +31780,7 @@ StyleSheet(
                 offset: SourceOffset(26152),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -31953,7 +31953,7 @@ StyleSheet(
                       offset: SourceOffset(26282),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -32092,7 +32092,7 @@ StyleSheet(
                 offset: SourceOffset(26369),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -32265,7 +32265,7 @@ StyleSheet(
                       offset: SourceOffset(26493),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",
@@ -38653,7 +38653,7 @@ StyleSheet(
                 offset: SourceOffset(31440),
                 len: 1,
               )),
-              value: Computed(ComponentValues(
+              value: Unknown(ComponentValues(
                 values: [
                   Whitespace(Cursor(
                     kind: "Whitespace",
@@ -39069,7 +39069,7 @@ StyleSheet(
                       offset: SourceOffset(31735),
                       len: 1,
                     )),
-                    value: Computed(ComponentValues(
+                    value: Unknown(ComponentValues(
                       values: [
                         Whitespace(Cursor(
                           kind: "Whitespace",

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -251,8 +251,6 @@ mod tests {
 	}
 
 	impl<'a, M: NodeMetadata> DeclarationValue<'a, M> for Decl {
-		type ComputedValue = T![Eof];
-
 		fn is_initial(&self) -> bool {
 			false
 		}

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -58,8 +58,6 @@ impl<'a, M: NodeMetadata> NodeWithMetadata<M> for ComponentValues<'a> {
 }
 
 impl<'a> DeclarationValue<'a, ()> for ComponentValues<'a> {
-	type ComputedValue = ComponentValues<'a>;
-
 	fn is_initial(&self) -> bool {
 		false
 	}
@@ -89,6 +87,13 @@ impl<'a> DeclarationValue<'a, ()> for ComponentValues<'a> {
 		Iter: Iterator<Item = crate::Cursor> + Clone,
 	{
 		Self::parse(p)
+	}
+
+	fn is_computed_declaration_value<Iter>(p: &Parser<'a, Iter>, c: Cursor) -> bool
+	where
+		Iter: Iterator<Item = crate::Cursor> + Clone,
+	{
+		<Self as Peek>::peek(p, c)
 	}
 
 	fn parse_computed_declaration_value<Iter>(p: &mut Parser<'a, Iter>, _name: Cursor) -> Result<Self>

--- a/crates/css_parse/src/syntax/declaration.rs
+++ b/crates/css_parse/src/syntax/declaration.rs
@@ -192,8 +192,6 @@ mod tests {
 	}
 
 	impl<'a, M: NodeMetadata> DeclarationValue<'a, M> for Decl {
-		type ComputedValue = T![Eof];
-
 		fn is_initial(&self) -> bool {
 			false
 		}

--- a/crates/css_parse/src/syntax/qualified_rule.rs
+++ b/crates/css_parse/src/syntax/qualified_rule.rs
@@ -170,8 +170,6 @@ mod tests {
 	}
 
 	impl<'a> DeclarationValue<'a, ()> for Decl {
-		type ComputedValue = T![Eof];
-
 		fn is_initial(&self) -> bool {
 			false
 		}

--- a/crates/css_parse/src/traits/declaration_value.rs
+++ b/crates/css_parse/src/traits/declaration_value.rs
@@ -7,8 +7,6 @@ use css_lexer::ToSpan;
 /// A trait that can be used for AST nodes representing a Declaration's Value. It offers some
 /// convenience functions for handling such values.
 pub trait DeclarationValue<'a, M: NodeMetadata>: Sized + NodeWithMetadata<M> + ToSpan + ToCursors + SemanticEq {
-	type ComputedValue: Peek<'a>;
-
 	/// Returns metadata for this value when used in a declaration context.
 	/// This allows the value to inspect the declaration (e.g., checking for !important)
 	/// and include that information in the metadata.
@@ -102,6 +100,21 @@ pub trait DeclarationValue<'a, M: NodeMetadata>: Sized + NodeWithMetadata<M> + T
 		Err(Diagnostic::new(c, Diagnostic::unexpected))?
 	}
 
+	/// Determines if the given [Cursor] begins a computed value (an arbitrary substitution function such as
+	/// `var()`/`env()`, or a typed math function such as `calc()`/`min()`).
+	///
+	/// This is used by [`parse_declaration_value`][DeclarationValue::parse_declaration_value] as the fallback check after
+	/// property-specific parsing fails or stops early: if this returns `true` the whole declaration is re-parsed via
+	/// [`parse_computed_declaration_value`][DeclarationValue::parse_computed_declaration_value].
+	///
+	/// The default implementation returns `false`, i.e. this DeclarationValue has no computed fallback.
+	fn is_computed_declaration_value<Iter>(_p: &Parser<'a, Iter>, _c: Cursor) -> bool
+	where
+		Iter: Iterator<Item = crate::Cursor> + Clone,
+	{
+		false
+	}
+
 	/// Like `parse()` but with the additional context of the `name` [Cursor]. This is only called before verifying that
 	/// the next token was peeked to be a ComputedValue, therefore this should return a `Self` reflecting a Computed
 	/// property. Alternatively, if this DeclarationValue disallows computed declarations then this is the right place to
@@ -147,6 +160,13 @@ pub trait DeclarationValue<'a, M: NodeMetadata>: Sized + NodeWithMetadata<M> + T
 
 	// Like `parse()` but with the additional context of the `name` [Cursor] - the same [Cursor]
 	// passed to [DeclarationValue::valid_declaration_name()].
+	//
+	// Parsing order:
+	// 1. Custom properties (--dashed-ident)
+	// 2. Unknown property names
+	// 3. Property-specific parsing (via parse_specified_declaration_value)
+	// 4. Fallback to Computed for var/calc if property parsing failed/stopped early
+	// 5. Unknown as final fallback
 	fn parse_declaration_value<Iter>(p: &mut Parser<'a, Iter>, name: Cursor) -> Result<Self>
 	where
 		Iter: Iterator<Item = crate::Cursor> + Clone,
@@ -157,9 +177,6 @@ pub trait DeclarationValue<'a, M: NodeMetadata>: Sized + NodeWithMetadata<M> + T
 		if !Self::valid_declaration_name(p, name) {
 			return Self::parse_unknown_declaration_value(p, name);
 		}
-		if <Self::ComputedValue>::peek(p, p.peek_n(1)) {
-			return Self::parse_computed_declaration_value(p, name);
-		}
 		let checkpoint = p.checkpoint();
 		if let Ok(val) = Self::parse_specified_declaration_value(p, name) {
 			let c = p.peek_n(1);
@@ -167,11 +184,11 @@ pub trait DeclarationValue<'a, M: NodeMetadata>: Sized + NodeWithMetadata<M> + T
 				return Ok(val);
 			}
 		}
-		if <Self::ComputedValue>::peek(p, p.peek_n(1)) {
-			p.rewind(checkpoint.clone());
-			if let Ok(val) = Self::parse_computed_declaration_value(p, name) {
-				return Ok(val);
-			}
+		p.rewind(checkpoint.clone());
+		if Self::is_computed_declaration_value(p, p.peek_n(1))
+			&& let Ok(val) = Self::parse_computed_declaration_value(p, name)
+		{
+			return Ok(val);
 		}
 		p.rewind(checkpoint);
 		Self::parse_unknown_declaration_value(p, name)

--- a/crates/csskit_ast/src/rule_block.rs
+++ b/crates/csskit_ast/src/rule_block.rs
@@ -184,8 +184,6 @@ impl<'a> NodeWithMetadata<()> for RuleDeclarationValue<'a> {
 }
 
 impl<'a> DeclarationValue<'a, ()> for RuleDeclarationValue<'a> {
-	type ComputedValue = T![Eof];
-
 	fn is_initial(&self) -> bool {
 		false
 	}

--- a/crates/csskit_ast/src/stat_rule.rs
+++ b/crates/csskit_ast/src/stat_rule.rs
@@ -47,8 +47,6 @@ impl NodeWithMetadata<()> for StatDeclarationValue {
 }
 
 impl<'a> DeclarationValue<'a, ()> for StatDeclarationValue {
-	type ComputedValue = T![Eof];
-
 	fn is_initial(&self) -> bool {
 		false
 	}


### PR DESCRIPTION
Many `DeclarationValue` types handle computed values in subtly different ways,
and consequently we've got hacks for this such as setting the `ComputedValue`
type to `T![Eof]`.

This change drops the ComputedValue type, in favour of an
`is_computed_declaration_value` trait method to make it easier and more flexible
to handle computed values in ASTs.
