### PR TITLE
css_lexer: Use a boxed slice in LineIndex, dropping Bumpalo's Vec.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,7 @@ dependencies = [
 name = "csskit"
 version = "0.0.27"
 dependencies = [
+ "allocator-api2",
  "anstyle",
  "bumpalo",
  "chromashift",

--- a/crates/css_lexer/src/span.rs
+++ b/crates/css_lexer/src/span.rs
@@ -1,4 +1,6 @@
 use crate::SourceOffset;
+use allocator_api2::alloc::{Allocator, Global};
+use allocator_api2::boxed::Box;
 use std::{fmt::Display, hash::Hash, marker::PhantomData, ops::Add};
 
 /// Represents a range of text within a document, as a Start and End offset.
@@ -94,40 +96,30 @@ impl Span {
 /// binary search plus a per-line character count. Prefer this over [`Span::line_and_column`] whenever
 /// resolving more than a couple of spans against one source.
 #[derive(Debug, Clone)]
-pub struct LineIndex<'a> {
+pub struct LineIndex<'a, A: Allocator = Global> {
 	source: &'a str,
 	/// Byte offset of the start of each line. Always begins with 0.
-	#[cfg(feature = "bumpalo")]
-	line_starts: bumpalo::collections::Vec<'a, u32>,
-	#[cfg(not(feature = "bumpalo"))]
-	line_starts: Vec<u32>,
+	line_starts: Box<[u32], A>,
 }
 
-impl<'a> LineIndex<'a> {
+impl<'a> LineIndex<'a, Global> {
 	/// Build a line index for `source` in a single pass.
-	#[cfg(not(feature = "bumpalo"))]
 	pub fn new(source: &'a str) -> Self {
-		let mut line_starts = Vec::with_capacity(source.len() / 32 + 1);
-		line_starts.push(0);
-		for (i, b) in source.bytes().enumerate() {
-			if b == b'\n' {
-				line_starts.push(i as u32 + 1);
-			}
-		}
-		Self { source, line_starts }
+		Self::new_in(source, Global)
 	}
+}
 
-	/// Build a line index for `source` in a single pass, allocating the backing table in `bump`.
-	#[cfg(feature = "bumpalo")]
-	pub fn new_in(source: &'a str, bump: &'a bumpalo::Bump) -> Self {
-		let mut line_starts = bumpalo::collections::Vec::with_capacity_in(source.len() / 32 + 1, bump);
+impl<'a, A: Allocator> LineIndex<'a, A> {
+	/// Build a line index for `source` in a single pass, allocating the backing table in `alloc`.
+	pub fn new_in(source: &'a str, alloc: A) -> Self {
+		let mut line_starts = allocator_api2::vec::Vec::with_capacity_in(source.len() / 32 + 1, alloc);
 		line_starts.push(0);
 		for (i, b) in source.bytes().enumerate() {
 			if b == b'\n' {
 				line_starts.push(i as u32 + 1);
 			}
 		}
-		Self { source, line_starts }
+		Self { source, line_starts: line_starts.into_boxed_slice() }
 	}
 
 	/// Returns the zero-based `(line, column)` of the span's start, where column counts Unicode
@@ -287,24 +279,11 @@ mod test {
 		assert_eq!(vec.to_span(), Span::new(SourceOffset(3), SourceOffset(15)));
 	}
 
-	#[cfg(feature = "bumpalo")]
-	fn line_index<'a>(bump: &'a bumpalo::Bump, source: &'a str) -> LineIndex<'a> {
-		LineIndex::new_in(source, bump)
-	}
-	#[cfg(not(feature = "bumpalo"))]
-	fn line_index<'a>(_bump: &'a (), source: &'a str) -> LineIndex<'a> {
-		LineIndex::new(source)
-	}
-
 	#[test]
 	fn line_index_matches_scan() {
-		#[cfg(feature = "bumpalo")]
-		let bump = bumpalo::Bump::new();
-		#[cfg(not(feature = "bumpalo"))]
-		let bump = ();
 		// Includes a multibyte char (é = 2 bytes) so column-by-char and byte offsets diverge.
 		let source = "a\nbc\n\ndéf\nghi";
-		let index = line_index(&bump, source);
+		let index = LineIndex::new(source);
 		for offset in 0..=source.len() as u32 {
 			// Only test offsets on char boundaries, as spans always land on them.
 			if !source.is_char_boundary(offset as usize) {
@@ -317,12 +296,21 @@ mod test {
 
 	#[test]
 	fn line_index_empty_source() {
-		#[cfg(feature = "bumpalo")]
-		let bump = bumpalo::Bump::new();
-		#[cfg(not(feature = "bumpalo"))]
-		let bump = ();
-		let index = line_index(&bump, "");
+		let index = LineIndex::new("");
 		let span = Span::new(SourceOffset(0), SourceOffset(0));
 		assert_eq!(index.line_and_column(span), (0, 0));
+	}
+
+	#[test]
+	fn line_index_new_in_matches_new() {
+		let source = "a\nbc\n\ndéf\nghi";
+		let index = LineIndex::new_in(source, Global);
+		for offset in 0..=source.len() as u32 {
+			if !source.is_char_boundary(offset as usize) {
+				continue;
+			}
+			let span = Span::new(SourceOffset(offset), SourceOffset(offset));
+			assert_eq!(index.line_and_column(span), span.line_and_column(source), "offset {offset}");
+		}
 	}
 }

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+allocator-api2 = { workspace = true }
 css_lexer = { workspace = true } # @release
 css_ast = { workspace = true, features = ["chromashift", "visitable", "miette"] } # @release
 css_parse = { workspace = true, features = ["miette", "egg"] } # @release

--- a/crates/csskit/src/commands/colors.rs
+++ b/crates/csskit/src/commands/colors.rs
@@ -4,6 +4,7 @@ use crate::{
 	commands::{Extract, OutputFormat, extract::ErrorRecord},
 	dimmed, fg,
 };
+use allocator_api2::alloc::Allocator;
 use bumpalo::Bump;
 use chromashift::*;
 use clap::Args;
@@ -408,12 +409,12 @@ impl Extract for ColorCommand {
 		// Unreachable: parse_and_extract_file is fully overridden.
 	}
 
-	fn render_text(
+	fn render_text<A: Allocator>(
 		&self,
 		_ctx: &ColorContext,
 		file: &str,
 		_src: &str,
-		index: &LineIndex,
+		index: &LineIndex<'_, A>,
 		span: Span,
 		row: &ColorData,
 		color: bool,

--- a/crates/csskit/src/commands/extract.rs
+++ b/crates/csskit/src/commands/extract.rs
@@ -1,4 +1,5 @@
 use crate::{CliResult, GlobalConfig, InputArgs};
+use allocator_api2::alloc::Allocator;
 use bumpalo::Bump;
 use clap::ValueEnum;
 use css_ast::{CssAtomSet, StyleSheet};
@@ -17,7 +18,7 @@ pub struct Location {
 }
 
 impl Location {
-	pub fn from_span(span: Span, index: &LineIndex) -> Self {
+	pub fn from_span<A: Allocator>(span: Span, index: &LineIndex<'_, A>) -> Self {
 		let (line, col) = index.line_and_column(span);
 		Self { line: line + 1, column: col + 1, start: usize::from(span.start()), end: usize::from(span.end()) }
 	}
@@ -117,12 +118,12 @@ pub trait Extract: Sized {
 
 	/// Format one row for text output.
 	#[allow(clippy::too_many_arguments)]
-	fn render_text(
+	fn render_text<A: Allocator>(
 		&self,
 		ctx: &Self::FileContext,
 		file: &str,
 		src: &str,
-		index: &LineIndex,
+		index: &LineIndex<'_, A>,
 		span: Span,
 		row: &Self::Row,
 		color: bool,

--- a/crates/csskit/src/commands/find.rs
+++ b/crates/csskit/src/commands/find.rs
@@ -3,6 +3,7 @@ use crate::{
 	commands::{Extract, OutputFormat},
 	green,
 };
+use allocator_api2::alloc::Allocator;
 use bumpalo::Bump;
 use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet, Visitable, visit::NodeId};
@@ -173,12 +174,12 @@ impl Extract for Find {
 		}
 	}
 
-	fn render_text(
+	fn render_text<A: Allocator>(
 		&self,
 		ctx: &TokenHighlighter,
 		_file: &str,
 		src: &str,
-		index: &LineIndex,
+		index: &LineIndex<'_, A>,
 		span: Span,
 		_row: &FindData,
 		color: bool,

--- a/crates/csskit/src/commands/specificity.rs
+++ b/crates/csskit/src/commands/specificity.rs
@@ -1,5 +1,6 @@
 use crate::InputArgs;
 use crate::commands::{Extract, OutputFormat};
+use allocator_api2::alloc::Allocator;
 use bumpalo::Bump;
 use clap::Args;
 use css_ast::specificity::ToSpecificity;
@@ -81,12 +82,12 @@ impl Extract for Specificity {
 		let _ = stylesheet.accept(&mut visitor);
 	}
 
-	fn render_text(
+	fn render_text<A: Allocator>(
 		&self,
 		_ctx: &(),
 		_file: &str,
 		_src: &str,
-		_index: &LineIndex,
+		_index: &LineIndex<'_, A>,
 		_span: Span,
 		row: &Self::Row,
 		_color: bool,


### PR DESCRIPTION
LineIndex uses a Vec to store all line starts, but the Vec is never extended or otherwise altered, so a slice could be used in place. It cannot be a fixed slice, but we can Box a slice.

This change replaces the bumpalo Vec with a Boxed slice, initially allocated using allocator-api2's Vec, then turned into a Boxed slice (using Box from allocator-api2 also). This allows LineIndex to be used with other custom allocators, not just Bumpalo, and retains a contractual "read only" behaviour.