### PR TITLE
css_lexer: Implement fearless_simd paths for scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,10 +698,10 @@ dependencies = [
  "criterion",
  "derive_atom_set",
  "dhat",
+ "fearless_simd",
  "fnv",
  "glob",
  "insta",
- "memchr",
  "miette",
  "pprof",
  "serde",
@@ -1175,7 +1175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1183,6 +1183,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fearless_simd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f5f895dac0865bc235f1364793899569a7db538137f1024dccea56bf41c78d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1785,7 +1791,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2462,7 +2468,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2694,7 +2700,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2751,7 +2757,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3028,7 +3034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3232,7 +3238,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3852,7 +3858,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ bumpalo = { version = "3.20.3" }
 # Data structure libraries/helpers
 bitmask-enum = { version = "2.2.5" }
 fnv = { version = "1.0.7" }
+fearless_simd = { version = "0.6.0" }
 indexmap = { version = "2.14.0" }
 itertools = { version = "0.15.0" }
-memchr = { version = "2.8.2" }
 phf = { version = "0.14.0" }
 ropey = { version = "1.6.1" }
 smallvec = { version = "1.15.2" }

--- a/crates/css_lexer/Cargo.toml
+++ b/crates/css_lexer/Cargo.toml
@@ -22,8 +22,8 @@ bumpalo = { workspace = true, features = [
 ], optional = true }
 bitmask-enum = { workspace = true }
 derive_atom_set = { workspace = true } # @release
+fearless_simd = { workspace = true }
 fnv = { workspace = true, optional = true }
-memchr = { workspace = true }
 
 miette = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }

--- a/crates/css_lexer/src/lib.rs
+++ b/crates/css_lexer/src/lib.rs
@@ -88,6 +88,7 @@ mod kindset;
 mod pairwise;
 mod private;
 mod quote_style;
+mod simd;
 mod small_str_buf;
 mod source_cursor;
 mod source_offset;

--- a/crates/css_lexer/src/private.rs
+++ b/crates/css_lexer/src/private.rs
@@ -9,6 +9,7 @@ use crate::{
 			is_ident_start_sequence,
 		},
 		is_escape_sequence, is_non_printable, is_quote, is_url_ident, is_whitespace,
+		simd_scan::{scan_bad_url, scan_byte, scan_ident, scan_line_comment, scan_string, scan_url},
 		tables::{ASCII_NEWLINE, ASCII_WHITESPACE},
 	},
 };
@@ -214,14 +215,9 @@ impl<'a> ByteCursor<'a> {
 				dashed_ident = true;
 			}
 			let scan_start = i;
-			while i < end {
-				let byte = bytes[i];
-				if !is_ident_byte(byte) {
-					break;
-				}
-				contains_non_lower_ascii |= byte.wrapping_sub(b'A') < 26;
-				i += 1;
-			}
+			let (off, upper) = scan_ident(&bytes[i..]);
+			i += off;
+			contains_non_lower_ascii |= upper;
 
 			let ascii_len = (i - scan_start) as u32;
 			let len = i as u32;
@@ -438,18 +434,9 @@ impl<'a> ByteCursor<'a> {
 					}
 				}
 				_ => {
-					// Bulk scan: find next ), \, or space (most common terminators)
+					// Bulk scan: find the next byte that needs per-byte handling.
 					let remaining = self.remaining_bytes();
-					let scan_end = match memchr::memchr3(b')', b'\\', b' ', remaining) {
-						Some(offset) => offset,
-						None => remaining.len(),
-					};
-					// Within scanned range, check for rare sentinels:
-					// whitespace/control (<=0x20), quotes, (, DEL, non-ASCII
-					let safe_end = remaining[..scan_end]
-						.iter()
-						.position(|&b| b <= 0x20 || b == b'\'' || b == b'"' || b == b'(' || b == 0x7F || b >= 0x80)
-						.unwrap_or(scan_end);
+					let safe_end = scan_url(remaining);
 					if safe_end > 0 {
 						self.advance_n(safe_end);
 						len += safe_end as u32;
@@ -484,34 +471,31 @@ impl<'a> ByteCursor<'a> {
 				break;
 			}
 			// Bulk-skip to the next ')' or '\\' — the only bytes that need special handling.
-			match memchr::memchr2(b')', b'\\', remaining) {
-				Some(offset) => {
-					// Skip everything before the sentinel.
-					if offset > 0 {
-						self.advance_n(offset);
-						len += offset as u32;
-					}
-					let b = self.peek_byte(0);
-					if b == b')' {
-						self.pos += 1;
-						len += 1;
-						break;
-					}
-					// b == b'\\'
-					self.pos += 1;
-					let next = self.peek_char();
-					if is_escape_sequence('\\', next) {
-						len += self.consume_escape_sequence();
-					} else if let Some(ch2) = self.next_char() {
-						len += ch2.len_utf8() as u32 + 1;
-					}
-				}
-				None => {
-					// No ')' or '\\' in remaining input — consume it all.
-					len += remaining.len() as u32;
-					self.advance_n(remaining.len());
-					break;
-				}
+			let offset = scan_bad_url(remaining);
+			if offset == remaining.len() {
+				// No ')' or '\\' in remaining input — consume it all.
+				len += remaining.len() as u32;
+				self.advance_n(remaining.len());
+				break;
+			}
+			// Skip everything before the sentinel.
+			if offset > 0 {
+				self.advance_n(offset);
+				len += offset as u32;
+			}
+			let b = self.peek_byte(0);
+			if b == b')' {
+				self.pos += 1;
+				len += 1;
+				break;
+			}
+			// b == b'\\'
+			self.pos += 1;
+			let next = self.peek_char();
+			if is_escape_sequence('\\', next) {
+				len += self.consume_escape_sequence();
+			} else if let Some(ch2) = self.next_char() {
+				len += ch2.len_utf8() as u32 + 1;
 			}
 		}
 		Token::new_bad_url(len)
@@ -731,18 +715,9 @@ impl<'a> ByteCursor<'a> {
 					}
 				}
 				_ => {
-					// Bulk scan: find next delimiter, backslash, or newline
+					// Bulk scan: find the next byte that needs per-byte handling.
 					let remaining = self.remaining_bytes();
-					let scan_end = match memchr::memchr3(delimiter, b'\\', b'\n', remaining) {
-						Some(offset) => offset,
-						None => remaining.len(),
-					};
-					// Within the scanned range, check for rare sentinels:
-					// \r (0x0D), \x0C (FF), \0 (NUL), or non-ASCII (>= 0x80)
-					let safe_end = remaining[..scan_end]
-						.iter()
-						.position(|&b| (b < 0x0E && (b == 0 || b == 0x0D || b == 0x0C)) || b >= 0x80)
-						.unwrap_or(scan_end);
+					let safe_end = scan_string(remaining, delimiter);
 					if safe_end > 0 {
 						self.advance_n(safe_end);
 						len += safe_end as u32;
@@ -1033,22 +1008,19 @@ impl<'a> Lexer<'a> {
 						};
 						loop {
 							let remaining = cursor.remaining_bytes();
-							match memchr::memchr(b'*', remaining) {
-								Some(offset) => {
-									let advance = offset + 1;
-									cursor.advance_n(advance);
-									len += advance as u32;
-									if cursor.peek_byte(0) == b'/' {
-										cursor.advance_n(1);
-										len += 1;
-										break;
-									}
-								}
-								None => {
-									len += remaining.len() as u32;
-									cursor.advance_n(remaining.len());
-									break;
-								}
+							let offset = scan_byte(remaining, b'*');
+							if offset == remaining.len() {
+								len += remaining.len() as u32;
+								cursor.advance_n(remaining.len());
+								break;
+							}
+							let advance = offset + 1;
+							cursor.advance_n(advance);
+							len += advance as u32;
+							if cursor.peek_byte(0) == b'/' {
+								cursor.advance_n(1);
+								len += 1;
+								break;
 							}
 						}
 						Token::new_comment(comment_style, len)
@@ -1062,14 +1034,7 @@ impl<'a> Lexer<'a> {
 							_ => CommentStyle::Single,
 						};
 						let remaining = cursor.remaining_bytes();
-						let line_end = match memchr::memchr3(b'\n', b'\r', 0x0C, remaining) {
-							Some(offset) => offset,
-							None => remaining.len(),
-						};
-						let safe_end = match memchr::memchr(0, &remaining[..line_end]) {
-							Some(nul_pos) => nul_pos,
-							None => line_end,
-						};
+						let safe_end = scan_line_comment(remaining);
 						len += safe_end as u32;
 						cursor.advance_n(safe_end);
 						Token::new_comment(comment_style, len)

--- a/crates/css_lexer/src/simd.rs
+++ b/crates/css_lexer/src/simd.rs
@@ -1,0 +1,3 @@
+pub(crate) use fearless_simd::{Level, Simd, dispatch, prelude::*, u8x16};
+use std::sync::LazyLock;
+pub(crate) static LEVEL: LazyLock<Level> = LazyLock::new(Level::new);

--- a/crates/css_lexer/src/syntax/mod.rs
+++ b/crates/css_lexer/src/syntax/mod.rs
@@ -1,5 +1,6 @@
 pub mod identifier;
 pub mod parse_escape;
+pub mod simd_scan;
 pub mod tables;
 
 pub use parse_escape::*;

--- a/crates/css_lexer/src/syntax/simd_scan.rs
+++ b/crates/css_lexer/src/syntax/simd_scan.rs
@@ -1,0 +1,316 @@
+use super::identifier::is_ident_byte;
+use crate::simd::*;
+
+#[inline(always)]
+fn scan_lanes<S: Simd>(
+	simd: S,
+	bytes: &[u8],
+	stop_bits: impl Fn(u8x16<S>) -> u64,
+	stop_byte: impl Fn(u8) -> bool,
+	side_bits: impl Fn(u8x16<S>) -> u64,
+	side_byte: impl Fn(u8) -> bool,
+) -> (usize, bool) {
+	const LANES: usize = 16;
+	const FULL: u64 = (1 << LANES) - 1;
+	let mut side = false;
+	let mut i = 0;
+	while i + LANES <= bytes.len() {
+		let v = u8x16::from_slice(simd, &bytes[i..i + LANES]);
+		let stop = stop_bits(v) & FULL;
+		let sides = side_bits(v);
+		if stop != 0 {
+			let at = stop.trailing_zeros();
+			side |= (sides & ((1u64 << at) - 1)) != 0;
+			return (i + at as usize, side);
+		}
+		side |= (sides & FULL) != 0;
+		i += LANES;
+	}
+	while i < bytes.len() {
+		let b = bytes[i];
+		if stop_byte(b) {
+			return (i, side);
+		}
+		side |= side_byte(b);
+		i += 1;
+	}
+	(bytes.len(), side)
+}
+
+/// Scan `bytes` from the start for the first byte that is not an ASCII CSS ident byte (`a-z A-Z 0-9 - _`).
+///
+/// Returns `(offset, contains_upper)` where `offset` is the index of the first non-ident byte (or `bytes.len()`) and
+/// `contains_upper` is true if any `A-Z` byte occurred strictly before `offset`.
+#[inline]
+pub(crate) fn scan_ident(bytes: &[u8]) -> (usize, bool) {
+	dispatch!(*LEVEL, simd => scan_ident_impl(simd, bytes))
+}
+
+#[inline(always)]
+fn scan_ident_impl<S: Simd>(simd: S, bytes: &[u8]) -> (usize, bool) {
+	let lc = u8x16::splat(simd, 0x20);
+	let a = u8x16::splat(simd, b'a');
+	let z = u8x16::splat(simd, b'z');
+	let d0 = u8x16::splat(simd, b'0');
+	let d9 = u8x16::splat(simd, b'9');
+	let ca = u8x16::splat(simd, b'A');
+	let cz = u8x16::splat(simd, b'Z');
+	let dash = u8x16::splat(simd, b'-');
+	let underscore = u8x16::splat(simd, b'_');
+	scan_lanes(
+		simd,
+		bytes,
+		|v| {
+			let lower = v | lc;
+			let is_alpha = lower.simd_ge(a) & lower.simd_le(z);
+			let is_digit = v.simd_ge(d0) & v.simd_le(d9);
+			let is_ident = is_alpha | is_digit | v.simd_eq(dash) | v.simd_eq(underscore);
+			!is_ident.to_bitmask()
+		},
+		|b| !is_ident_byte(b),
+		|v| (v.simd_ge(ca) & v.simd_le(cz)).to_bitmask(),
+		|b| b.wrapping_sub(b'A') < 26,
+	)
+}
+
+/// Scan a string-token body for the first byte needing per-byte handlingw the closing delimiter, `\`, a newline (`\n`
+/// `\r` `\x0C`), NUL, or any non-ASCII byte (`>= 0x80`).
+#[inline]
+pub(crate) fn scan_string(bytes: &[u8], delimiter: u8) -> usize {
+	dispatch!(*LEVEL, simd => scan_string_impl(simd, bytes, delimiter))
+}
+
+#[inline(always)]
+fn scan_string_impl<S: Simd>(simd: S, bytes: &[u8], delimiter: u8) -> usize {
+	let delim = u8x16::splat(simd, delimiter);
+	let bs = u8x16::splat(simd, b'\\');
+	let lf = u8x16::splat(simd, b'\n');
+	let cr = u8x16::splat(simd, b'\r');
+	let ff = u8x16::splat(simd, 0x0C);
+	let nul = u8x16::splat(simd, 0);
+	let hi = u8x16::splat(simd, 0x80);
+	scan_lanes(
+		simd,
+		bytes,
+		|v| {
+			(v.simd_eq(delim)
+				| v.simd_eq(bs)
+				| v.simd_eq(lf)
+				| v.simd_eq(cr)
+				| v.simd_eq(ff)
+				| v.simd_eq(nul)
+				| v.simd_ge(hi))
+			.to_bitmask()
+		},
+		|b| b == delimiter || b == b'\\' || b == b'\n' || b == b'\r' || b == 0x0C || b == 0 || b >= 0x80,
+		|_| 0,
+		|_| false,
+	)
+	.0
+}
+
+/// Scan a url-token body for the first byte needing per-byte handling: whitespace/control (`<= 0x20`), a quote, `(`,
+/// `)`, `\`, DEL (`0x7F`), or any non-ASCII byte (`>= 0x80`).
+#[inline]
+pub(crate) fn scan_url(bytes: &[u8]) -> usize {
+	dispatch!(*LEVEL, simd => scan_url_impl(simd, bytes))
+}
+
+#[inline(always)]
+fn scan_url_impl<S: Simd>(simd: S, bytes: &[u8]) -> usize {
+	let ctrl = u8x16::splat(simd, 0x20);
+	let hi = u8x16::splat(simd, 0x80);
+	let squote = u8x16::splat(simd, b'\'');
+	let dquote = u8x16::splat(simd, b'"');
+	let open = u8x16::splat(simd, b'(');
+	let close = u8x16::splat(simd, b')');
+	let bs = u8x16::splat(simd, b'\\');
+	let del = u8x16::splat(simd, 0x7F);
+	scan_lanes(
+		simd,
+		bytes,
+		|v| {
+			(v.simd_le(ctrl)
+				| v.simd_ge(hi)
+				| v.simd_eq(squote)
+				| v.simd_eq(dquote)
+				| v.simd_eq(open)
+				| v.simd_eq(close)
+				| v.simd_eq(bs)
+				| v.simd_eq(del))
+			.to_bitmask()
+		},
+		|b| b <= 0x20 || b >= 0x80 || b == b'\'' || b == b'"' || b == b'(' || b == b')' || b == b'\\' || b == 0x7F,
+		|_| 0,
+		|_| false,
+	)
+	.0
+}
+
+/// Scan for the first occurrence of `needle`, or `bytes.len()` if absent.
+#[inline]
+pub(crate) fn scan_byte(bytes: &[u8], needle: u8) -> usize {
+	dispatch!(*LEVEL, simd => scan_byte_impl(simd, bytes, needle))
+}
+
+#[inline(always)]
+fn scan_byte_impl<S: Simd>(simd: S, bytes: &[u8], needle: u8) -> usize {
+	let n = u8x16::splat(simd, needle);
+	scan_lanes(simd, bytes, |v| v.simd_eq(n).to_bitmask(), |b| b == needle, |_| 0, |_| false).0
+}
+
+/// Scan a bad-url remnant for the first byte needing handling: `)` or `\`.
+#[inline]
+pub(crate) fn scan_bad_url(bytes: &[u8]) -> usize {
+	dispatch!(*LEVEL, simd => scan_bad_url_impl(simd, bytes))
+}
+
+#[inline(always)]
+fn scan_bad_url_impl<S: Simd>(simd: S, bytes: &[u8]) -> usize {
+	let close = u8x16::splat(simd, b')');
+	let bs = u8x16::splat(simd, b'\\');
+	scan_lanes(
+		simd,
+		bytes,
+		|v| (v.simd_eq(close) | v.simd_eq(bs)).to_bitmask(),
+		|b| b == b')' || b == b'\\',
+		|_| 0,
+		|_| false,
+	)
+	.0
+}
+
+/// Scan a single-line-comment body for its terminator: a newline (`\n` `\r` `\x0C`) or NUL.
+#[inline]
+pub(crate) fn scan_line_comment(bytes: &[u8]) -> usize {
+	dispatch!(*LEVEL, simd => scan_line_comment_impl(simd, bytes))
+}
+
+#[inline(always)]
+fn scan_line_comment_impl<S: Simd>(simd: S, bytes: &[u8]) -> usize {
+	let lf = u8x16::splat(simd, b'\n');
+	let cr = u8x16::splat(simd, b'\r');
+	let ff = u8x16::splat(simd, 0x0C);
+	let nul = u8x16::splat(simd, 0);
+	scan_lanes(
+		simd,
+		bytes,
+		|v| (v.simd_eq(lf) | v.simd_eq(cr) | v.simd_eq(ff) | v.simd_eq(nul)).to_bitmask(),
+		|b| b == b'\n' || b == b'\r' || b == 0x0C || b == 0,
+		|_| 0,
+		|_| false,
+	)
+	.0
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn ident() {
+		for (s, want) in [
+			(&b""[..], (0usize, false)),
+			(b"width", (5, false)),
+			(b"width:1px", (5, false)),
+			(b"color) ", (5, false)),
+			(b"has space", (3, false)),
+			(b"Background-Color", (16, true)),
+			(b"ALLCAPS", (7, true)),
+			(b"CAFE\xc3\xa9", (4, true)),
+			(b"emoji\xf0\x9f\x98\x80tail", (5, false)),
+			(b"abcdefghijklmnoP", (16, true)),
+			(b"abcdefghijklmno P", (15, false)),
+			(b"abcdefghijklmnop;Q", (16, false)),
+			(b"abcdefghijklmnopQRSTUVWXYZ0123456789", (36, true)),
+			(b"abcdefghijklmnopqrstuvwxyz0123456;", (33, false)),
+		] {
+			assert_eq!(scan_ident(s), want, "ident {s:?}");
+		}
+	}
+
+	#[test]
+	fn string() {
+		for (s, delim, want) in [
+			(&b""[..], b'"', 0usize),
+			(b"hello world", b'"', 11),
+			(b"quote\"tail", b'"', 5),
+			(b"back\\slash", b'"', 4),
+			(b"line\nbreak", b'"', 4),
+			(b"carriage\rreturn", b'"', 8),
+			(b"formfeed\x0cbyte", b'"', 8),
+			(b"nul\0byte", b'"', 3),
+			(b"unicode\xc3\xa9tail", b'"', 7),
+			(b"it's", b'\'', 2),
+			(b"it's", b'"', 4),
+			(b"0123456789abcde\"", b'"', 15),
+			(b"0123456789abcdef\"g", b'"', 16),
+			(b"0123456789abcdefghijk", b'"', 21),
+		] {
+			assert_eq!(scan_string(s, delim), want, "string {s:?} delim {delim:#x}");
+		}
+	}
+
+	#[test]
+	fn url() {
+		for (s, want) in [
+			(&b""[..], 0usize),
+			(b"path/to/image.png", 17),
+			(b"has space", 3),
+			(b"paren)here", 5),
+			(b"back\\slash", 4),
+			(b"quote'x", 5),
+			(b"open(x", 4),
+			(b"del\x7fx", 3),
+			(b"tab\tbyte", 3),
+			(b"unicode\xe2\x82\xactail", 7),
+			(b"0123456789abcde)", 15),
+			(b"0123456789abcdef)", 16),
+		] {
+			assert_eq!(scan_url(s), want, "url {s:?}");
+		}
+	}
+
+	#[test]
+	fn byte() {
+		for (s, want) in [
+			(&b""[..], 0usize),
+			(b"has*star", 3),
+			(b"no star here", 12),
+			(b"0123456789abcde*", 15),
+			(b"0123456789abcdef*", 16),
+		] {
+			assert_eq!(scan_byte(s, b'*'), want, "byte {s:?}");
+		}
+	}
+
+	#[test]
+	fn bad_url() {
+		for (s, want) in [
+			(&b""[..], 0usize),
+			(b"cleantail", 9),
+			(b"close)here", 5),
+			(b"back\\slash", 4),
+			(b"0123456789abcde)", 15),
+			(b"0123456789abcdef)", 16),
+		] {
+			assert_eq!(scan_bad_url(s), want, "bad_url {s:?}");
+		}
+	}
+
+	#[test]
+	fn line_comment() {
+		for (s, want) in [
+			(&b""[..], 0usize),
+			(b"comment body", 12),
+			(b"line\nfeed", 4),
+			(b"carriage\rreturn", 8),
+			(b"formfeed\x0cbyte", 8),
+			(b"nul\0byte", 3),
+			(b"0123456789abcde\n", 15),
+			(b"0123456789abcdef\n", 16),
+		] {
+			assert_eq!(scan_line_comment(s), want, "line_comment {s:?}");
+		}
+	}
+}


### PR DESCRIPTION
Right now we use memchr in a few places for SIMD accelerated scanning, but we
can do better.

This switches out memchr paths, instead using fearless_simd for SIMD
accelerated scanning in more places, including idents.
