### PR TITLE
css_parse: Implement an Arena allocated String

### DIFF
--- a/crates/css_parse/src/arena_string.rs
+++ b/crates/css_parse/src/arena_string.rs
@@ -1,0 +1,274 @@
+use crate::{Arena, Vec};
+use allocator_api2::alloc::Allocator;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+
+/// A growable, arena-allocated UTF-8 string.
+///
+/// Wraps [`Vec<u8>`][crate::Vec] the same way [`std::string::String`] wraps [`std::vec::Vec`], so it inherits the
+/// allocator generic from [Vec] too. Like the other arena collections it never runs destructors: the bytes are
+/// released wholesale when the arena is dropped.
+///
+/// The contents are always valid UTF-8: the only ways to append are [`String::push_str`], [`String::push`] and the
+/// [`fmt::Write`] impl, all of which take a `str` or a `char`, and nothing exposes the bytes mutably or truncates
+/// them. [`String::as_str`] and [`String::into_str`] rely on that invariant to hand out a `str` without revalidating.
+#[repr(C)]
+pub struct String<'a, A: Allocator = &'a Arena> {
+	bytes: Vec<'a, u8, A>,
+}
+
+impl<'a, A: Allocator> String<'a, A> {
+	/// Create a new, empty `String` backed by `alloc`. Allocates nothing until the first push.
+	#[inline]
+	pub fn new_in(alloc: A) -> Self {
+		Self { bytes: Vec::new_in(alloc) }
+	}
+
+	/// Create an empty `String` with room for at least `cap` bytes.
+	#[inline]
+	pub fn with_capacity_in(cap: usize, alloc: A) -> Self {
+		Self { bytes: Vec::with_capacity_in(cap, alloc) }
+	}
+
+	/// Length in bytes, not characters.
+	#[inline]
+	pub fn len(&self) -> usize {
+		self.bytes.len()
+	}
+
+	#[inline]
+	pub fn is_empty(&self) -> bool {
+		self.bytes.is_empty()
+	}
+
+	/// Capacity in bytes.
+	#[inline]
+	pub fn capacity(&self) -> usize {
+		self.bytes.capacity()
+	}
+
+	/// Append a string slice.
+	#[inline]
+	pub fn push_str(&mut self, str: &str) {
+		self.bytes.extend_from_slice(str.as_bytes());
+	}
+
+	/// Append a single character, encoded as UTF-8.
+	#[inline]
+	pub fn push(&mut self, char: char) {
+		let mut buf = [0; 4];
+		self.push_str(char.encode_utf8(&mut buf));
+	}
+
+	/// Borrow the contents as a `str`.
+	#[inline]
+	pub fn as_str(&self) -> &str {
+		Self::as_utf8(&self.bytes)
+	}
+
+	/// Consume the `String`, returning a `str` borrowed from the arena for `'a`.
+	///
+	/// Use this to hand a parsed-in-arena string to an API that wants `&'a str`; the bytes outlive the `String` because
+	/// they belong to the arena, not to this handle.
+	#[inline]
+	pub fn into_str(self) -> &'a str {
+		Self::as_utf8(self.bytes.into_slice())
+	}
+
+	#[inline]
+	fn as_utf8(bytes: &[u8]) -> &str {
+		debug_assert!(std::str::from_utf8(bytes).is_ok(), "arena String must always hold valid UTF-8");
+		// SAFETY: the buffer only ever grows through `push_str`, `push` and the `fmt::Write` impl, each of which appends a
+		// `str` or a UTF-8 encoded `char`. Nothing hands the bytes out mutably or truncates them.
+		unsafe { std::str::from_utf8_unchecked(bytes) }
+	}
+}
+
+impl<'a, A: Allocator> Deref for String<'a, A> {
+	type Target = str;
+
+	#[inline]
+	fn deref(&self) -> &str {
+		self.as_str()
+	}
+}
+
+impl<'a, A: Allocator> AsRef<str> for String<'a, A> {
+	#[inline]
+	fn as_ref(&self) -> &str {
+		self.as_str()
+	}
+}
+
+impl<'a, A: Allocator> fmt::Write for String<'a, A> {
+	#[inline]
+	fn write_str(&mut self, str: &str) -> fmt::Result {
+		self.push_str(str);
+		Ok(())
+	}
+}
+
+impl<'a, A: Allocator> fmt::Display for String<'a, A> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt::Display::fmt(self.as_str(), f)
+	}
+}
+
+impl<'a, A: Allocator> fmt::Debug for String<'a, A> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt::Debug::fmt(self.as_str(), f)
+	}
+}
+
+impl<'a, A: Allocator> PartialEq for String<'a, A> {
+	fn eq(&self, other: &Self) -> bool {
+		**self == **other
+	}
+}
+
+impl<'a, A: Allocator> Eq for String<'a, A> {}
+
+impl<'a, A: Allocator> PartialEq<str> for String<'a, A> {
+	fn eq(&self, other: &str) -> bool {
+		&**self == other
+	}
+}
+
+impl<'a, A: Allocator> PartialEq<&str> for String<'a, A> {
+	fn eq(&self, other: &&str) -> bool {
+		&**self == *other
+	}
+}
+
+impl<'a, A: Allocator> Hash for String<'a, A> {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		(**self).hash(state);
+	}
+}
+
+/// A [`std::format!`]-style constructor for the arena [`String`].
+///
+/// ```
+/// use css_parse::{Arena, format_in};
+/// let alloc = Arena::default();
+/// let str = format_in!(in &alloc, "{}px", 12);
+/// assert_eq!(str.as_str(), "12px");
+/// ```
+#[macro_export]
+macro_rules! format_in {
+	(in $alloc:expr, $($arg:tt)*) => {{
+		let mut str = $crate::String::new_in($alloc);
+		::core::fmt::Write::write_fmt(&mut str, ::core::format_args!($($arg)*))
+			.expect("formatting into an arena String cannot fail");
+		str
+	}};
+}
+
+#[cfg(test)]
+mod test {
+	use super::String;
+	use crate::Arena;
+	use std::fmt::Write;
+
+	#[test]
+	fn new_is_empty_and_allocates_nothing() {
+		let alloc = Arena::default();
+		let str = String::new_in(&alloc);
+		assert!(str.is_empty());
+		assert_eq!(str.len(), 0);
+		assert_eq!(str.as_str(), "");
+	}
+
+	#[test]
+	fn push_str_appends_in_order() {
+		let alloc = Arena::default();
+		let mut str = String::new_in(&alloc);
+		str.push_str("foo");
+		str.push_str("bar");
+		assert_eq!(str.as_str(), "foobar");
+		assert_eq!(str.len(), 6);
+	}
+
+	#[test]
+	fn push_encodes_multibyte_chars() {
+		let alloc = Arena::default();
+		let mut str = String::new_in(&alloc);
+		str.push('a');
+		str.push('£');
+		str.push('😀');
+		assert_eq!(str.as_str(), "a£😀");
+		// 1 + 2 + 4 bytes, so length counts bytes rather than characters.
+		assert_eq!(str.len(), 7);
+	}
+
+	#[test]
+	fn write_macro_formats_through_fmt_write() {
+		let alloc = Arena::default();
+		let mut str = String::new_in(&alloc);
+		write!(&mut str, "{}px", 12).unwrap();
+		assert_eq!(str.as_str(), "12px");
+	}
+
+	#[test]
+	fn format_in_builds_a_string() {
+		let alloc = Arena::default();
+		let str = format_in!(in &alloc, "{}{}", 12, "px");
+		assert_eq!(str, "12px");
+	}
+
+	#[test]
+	fn into_str_outlives_the_string() {
+		let alloc = Arena::default();
+		let borrowed: &str = {
+			let mut str = String::new_in(&alloc);
+			str.push_str("outlives");
+			str.into_str()
+		};
+		assert_eq!(borrowed, "outlives");
+	}
+
+	#[test]
+	fn survives_reallocation() {
+		let alloc = Arena::default();
+		let mut str = String::new_in(&alloc);
+		for i in 0..512 {
+			write!(&mut str, "{}", i % 10).unwrap();
+		}
+		// Every byte must survive the regrowth, so compare against the whole expected sequence.
+		let expected: std::string::String = (0..512).map(|i| char::from(b'0' + (i % 10) as u8)).collect();
+		assert_eq!(str.len(), 512);
+		assert_eq!(str.as_str(), expected);
+	}
+
+	#[test]
+	fn with_capacity_reserves_without_writing() {
+		let alloc = Arena::default();
+		let mut str = String::with_capacity_in(16, &alloc);
+		assert!(str.is_empty());
+		assert!(str.capacity() >= 16);
+		str.push_str("fits");
+		assert_eq!(str.as_str(), "fits");
+	}
+
+	#[test]
+	fn deref_exposes_str_methods() {
+		let alloc = Arena::default();
+		let mut str = String::new_in(&alloc);
+		str.push_str("  padded  ");
+		assert_eq!(str.trim(), "padded");
+		assert!(str.contains("padded"));
+	}
+
+	#[test]
+	fn equality_against_str_and_self() {
+		let alloc = Arena::default();
+		let mut a = String::new_in(&alloc);
+		a.push_str("same");
+		let mut b = String::new_in(&alloc);
+		b.push_str("same");
+		assert_eq!(a, b);
+		assert_eq!(a, "same");
+		assert_eq!(a, *"same");
+	}
+}

--- a/crates/css_parse/src/arena_vec.rs
+++ b/crates/css_parse/src/arena_vec.rs
@@ -218,6 +218,18 @@ impl<'a, T, A: Allocator> Vec<'a, T, A> {
 			marker: std::marker::PhantomData,
 		}
 	}
+
+	/// Consume the `Vec`, returning its contents as a slice borrowed from the arena for `'a`.
+	///
+	/// Use this to hand arena-allocated data to an API wanting `&'a [T]`: the elements outlive this handle because they
+	/// belong to the arena, not to the `Vec`.
+	#[inline]
+	pub fn into_slice(self) -> &'a [T] {
+		// SAFETY: `ptr` is aligned and points at `len` initialised `T`s living in the arena for `'a` (or is dangling when
+		// `len` is 0, which `from_raw_parts` permits). `Vec` has no `Drop`, so nothing destroys the elements behind the
+		// returned reference.
+		unsafe { std::slice::from_raw_parts(self.raw.ptr.as_ptr(), self.raw.len as usize) }
+	}
 }
 
 impl<'a, T: Clone, A: Allocator> Vec<'a, T, A> {

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -284,6 +284,7 @@ pub use css_lexer::{
 };
 
 mod arena_box;
+mod arena_string;
 mod arena_vec;
 mod comparison;
 mod cursor_compact_write_sink;
@@ -319,6 +320,7 @@ pub type Result<T> = std::result::Result<T, diagnostics::Diagnostic>;
 pub type Arena = bumpalo::Bump;
 
 pub use arena_box::*;
+pub use arena_string::String;
 pub use arena_vec::{Drain, IntoIter, Vec};
 pub use comparison::*;
 pub use cursor_compact_write_sink::*;

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -36,7 +36,7 @@ macro_rules! assert_parse {
 			if !result.errors.is_empty() {
 				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
 			}
-			let mut actual = ::bumpalo::collections::String::new_in(&bump);
+			let mut actual = $crate::String::new_in(&bump);
 			{
 				let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
 				let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
@@ -61,7 +61,7 @@ macro_rules! assert_parse {
 			if !result.errors.is_empty() {
 				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
 			}
-			let mut actual = ::bumpalo::collections::String::new_in(&bump);
+			let mut actual = $crate::String::new_in(&bump);
 			{
 				let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
 				let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
@@ -88,7 +88,7 @@ macro_rules! assert_parse {
 			if !result.errors.is_empty() {
 				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
 			}
-			let mut actual = ::bumpalo::collections::String::new_in(&bump);
+			let mut actual = $crate::String::new_in(&bump);
 			{
 				let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
 				let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
@@ -137,7 +137,7 @@ macro_rules! assert_parse_error {
 		let result = parser.parse::<$ty>();
 		if parser.at_end() {
 			if let Ok(result) = result {
-				let mut actual = ::bumpalo::collections::String::new_in(&bump);
+				let mut actual = $crate::String::new_in(&bump);
 				{
 					let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
 					let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
@@ -174,7 +174,7 @@ macro_rules! assert_peek_false {
 		let result = parser.parse::<$ty>();
 		if parser.at_end() {
 			if let Ok(result) = result {
-				let mut actual = ::bumpalo::collections::String::new_in(&bump);
+				let mut actual = $crate::String::new_in(&bump);
 				{
 					let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
 					let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);

--- a/crates/csskit_highlight/src/test_helpers.rs
+++ b/crates/csskit_highlight/src/test_helpers.rs
@@ -93,7 +93,7 @@ impl<'a, T: fmt::Write> CursorSink for HTMLHighlightCursorStream<'a, T> {
 
 macro_rules! assert_highlight {
 	($name: literal, $str: literal $(,)*) => {
-		use bumpalo::{Bump, collections::String};
+		use bumpalo::Bump;
 		use css_ast::{CssAtomSet, StyleSheet, Visitable};
 		use css_lexer::Lexer;
 		use css_parse::{Parser, ToCursors};
@@ -105,7 +105,7 @@ macro_rules! assert_highlight {
 		if !result.errors.is_empty() {
 			panic!("\n\nParse on {}:{} failed. ({:?}) saw error {:?}", file!(), line!(), $str, result.errors[0]);
 		}
-		let mut actual = String::new_in(&bump);
+		let mut actual = css_parse::String::new_in(&bump);
 		let mut cursors = HTMLHighlightCursorStream::new($str, &mut actual);
 		let node = result.output.clone().unwrap();
 		let _ = node.accept(&mut cursors.highlighter);

--- a/crates/csskit_transform/benches/minify_popular.rs
+++ b/crates/csskit_transform/benches/minify_popular.rs
@@ -36,7 +36,7 @@ fn popular(c: &mut Criterion) {
 				{
 					let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 					let mut result = Parser::new(&bump, source_text.as_str(), lexer).parse_entirely::<StyleSheet>();
-					let mut string = bumpalo::collections::String::new_in(&bump);
+					let mut string = css_parse::String::new_in(&bump);
 					if let Some(stylesheet) = result.output.as_mut() {
 						// let mut transformer = ReduceInitial::default();
 						// TODO! Re-introduce minifyer

--- a/crates/csskit_transform/src/reduce_lengths.rs
+++ b/crates/csskit_transform/src/reduce_lengths.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use css_ast::{DeclarationValue, Length, MathFunction, UnitlessZeroResolves, VisitNode, Visitable};
-use css_parse::Declaration;
+use css_parse::{Declaration, format_in};
 use std::cell::Cell;
 
 pub struct ReduceLengths<'a, 'ctx, N: Visitable + NodeWithMetadata<CssMetadata>> {
@@ -86,11 +86,11 @@ where
 		if can_reduce_to_unitless && matches!(resolved, ResolvedType::UnitedZero | ResolvedType::Resolved(0.0)) {
 			self.transformer.replace(length, self.transformer.parse_value::<Length>("0"));
 		} else if let ResolvedType::Resolved(px) = resolved {
-			let replacement = bumpalo::format!(in self.transformer.bump(), "{}px", px);
+			let replacement = format_in!(in self.transformer.bump(), "{}px", px);
 			let original_span = length.to_span();
 			let original_len = (original_span.end().0 - original_span.start().0) as usize;
 			if replacement.len() <= original_len {
-				self.transformer.replace(length, self.transformer.parse_value::<Length>(replacement.into_bump_str()));
+				self.transformer.replace(length, self.transformer.parse_value::<Length>(replacement.into_str()));
 			}
 		}
 	}


### PR DESCRIPTION
In https://github.com/csskit/csskit/pull/1306 we implemented a generic Vec which allocates to an allocator_api2 allocator; this Vec also used u32s as we know we don't need larger storage than this. This also helps us migrate away from Bumpalo, as we are no longer coupled to bumpalo's Vec. We still use Bumplalo's String, however.

This change adds css_parse::String, an arena allocated UTF-8 string, backed by our Vec implementation. It wraps Vec<u8> the same way std::String wraps std::Vec, so it inherits the allocator capabilities of the Vec. A format_in! macro also allows us to do format!-style construction.