### PR TITLE
css_parse/csskit/csskit_transform: Use css_parse::String where possible

### DIFF
--- a/crates/css_parse/src/arena_string.rs
+++ b/crates/css_parse/src/arena_string.rs
@@ -2,6 +2,7 @@ use crate::{Arena, Vec};
 use allocator_api2::alloc::Allocator;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::io;
 use std::ops::Deref;
 
 /// A growable, arena-allocated UTF-8 string.
@@ -12,7 +13,8 @@ use std::ops::Deref;
 ///
 /// The contents are always valid UTF-8: the only ways to append are [`String::push_str`], [`String::push`] and the
 /// [`fmt::Write`] impl, all of which take a `str` or a `char`, and nothing exposes the bytes mutably or truncates
-/// them. [`String::as_str`] and [`String::into_str`] rely on that invariant to hand out a `str` without revalidating.
+/// them. [`String::from_reader_in`] is the sole byte-wise entry point and validates before handing back a `String`.
+/// [`String::as_str`] and [`String::into_str`] rely on that invariant to hand out a `str` without revalidating.
 #[repr(C)]
 pub struct String<'a, A: Allocator = &'a Arena> {
 	bytes: Vec<'a, u8, A>,
@@ -29,6 +31,33 @@ impl<'a, A: Allocator> String<'a, A> {
 	#[inline]
 	pub fn with_capacity_in(cap: usize, alloc: A) -> Self {
 		Self { bytes: Vec::with_capacity_in(cap, alloc) }
+	}
+
+	/// Read `reader` to end into a new `String`, the arena equivalent of [`std::io::Read::read_to_string`].
+	///
+	/// The bytes are validated as UTF-8 once, on the whole buffer, before the `String` exists; an invalid stream is
+	/// reported as [`std::io::ErrorKind::InvalidData`] and no `String` is returned.
+	pub fn from_reader_in<R: io::Read>(mut reader: R, alloc: A) -> io::Result<Self> {
+		/// Bytes offered to each `read` call; the arena `Vec` doubles its capacity as this is appended.
+		const CHUNK: usize = 8 * 1024;
+		let mut bytes = Vec::new_in(alloc);
+		let mut filled = 0;
+		loop {
+			if filled == bytes.len() {
+				bytes.extend_from_slice(&[0; CHUNK]);
+			}
+			match reader.read(&mut bytes[filled..]) {
+				Ok(0) => break,
+				Ok(read) => filled += read,
+				Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+				Err(err) => return Err(err),
+			}
+		}
+		bytes.truncate(filled);
+		match std::str::from_utf8(&bytes) {
+			Ok(_) => Ok(Self { bytes }),
+			Err(err) => Err(io::Error::new(io::ErrorKind::InvalidData, err)),
+		}
 	}
 
 	/// Length in bytes, not characters.
@@ -80,7 +109,8 @@ impl<'a, A: Allocator> String<'a, A> {
 	fn as_utf8(bytes: &[u8]) -> &str {
 		debug_assert!(std::str::from_utf8(bytes).is_ok(), "arena String must always hold valid UTF-8");
 		// SAFETY: the buffer only ever grows through `push_str`, `push` and the `fmt::Write` impl, each of which appends a
-		// `str` or a UTF-8 encoded `char`. Nothing hands the bytes out mutably or truncates them.
+		// `str` or a UTF-8 encoded `char`, or through `from_reader_in`, which validates the whole buffer before
+		// constructing the `String`. Nothing hands the bytes out mutably or truncates them.
 		unsafe { std::str::from_utf8_unchecked(bytes) }
 	}
 }
@@ -170,6 +200,29 @@ mod test {
 	use super::String;
 	use crate::Arena;
 	use std::fmt::Write;
+	use std::io::{self, Read};
+
+	/// Hands out one byte per `read`, with a single `Interrupted` in the middle, as a real socket may.
+	struct DribbleReader<'r> {
+		bytes: &'r [u8],
+		interrupt_at: usize,
+		reads: usize,
+	}
+
+	impl<'r> Read for DribbleReader<'r> {
+		fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+			self.reads += 1;
+			if self.reads == self.interrupt_at {
+				return Err(io::Error::from(io::ErrorKind::Interrupted));
+			}
+			let Some((first, rest)) = self.bytes.split_first() else {
+				return Ok(0);
+			};
+			buf[0] = *first;
+			self.bytes = rest;
+			Ok(1)
+		}
+	}
 
 	#[test]
 	fn new_is_empty_and_allocates_nothing() {
@@ -270,5 +323,40 @@ mod test {
 		assert_eq!(a, b);
 		assert_eq!(a, "same");
 		assert_eq!(a, *"same");
+	}
+
+	#[test]
+	fn from_reader_in_reads_to_end() {
+		let alloc = Arena::default();
+		let str = String::from_reader_in("body{color:blue}".as_bytes(), &alloc).unwrap();
+		assert_eq!(str.as_str(), "body{color:blue}");
+		assert_eq!(str.len(), 16);
+	}
+
+	#[test]
+	fn from_reader_in_rejects_invalid_utf8() {
+		let alloc = Arena::default();
+		let err = String::from_reader_in(&[b'a', 0xff, b'b'][..], &alloc).unwrap_err();
+		assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+	}
+
+	#[test]
+	fn from_reader_in_grows_past_one_chunk() {
+		let alloc = Arena::default();
+		// A multibyte codepoint straddles the 8KiB read boundary, so a chunk-local decode would split it.
+		let mut expected = std::string::String::from("x".repeat(8 * 1024 - 2));
+		expected.push('😀');
+		expected.push_str(&"y".repeat(4096));
+		let str = String::from_reader_in(expected.as_bytes(), &alloc).unwrap();
+		assert_eq!(str.len(), expected.len());
+		assert_eq!(str.as_str(), expected);
+	}
+
+	#[test]
+	fn from_reader_in_handles_partial_reads_and_interruptions() {
+		let alloc = Arena::default();
+		let reader = DribbleReader { bytes: "a£😀b".as_bytes(), interrupt_at: 3, reads: 0 };
+		let str = String::from_reader_in(reader, &alloc).unwrap();
+		assert_eq!(str.as_str(), "a£😀b");
 	}
 }

--- a/crates/css_parse/src/cursor_to_source_cursor_sink.rs
+++ b/crates/css_parse/src/cursor_to_source_cursor_sink.rs
@@ -1,4 +1,5 @@
 use crate::{Cursor, CursorSink, SourceCursor, SourceCursorSink};
+use allocator_api2::alloc::Allocator;
 use std::fmt::Write;
 
 pub struct CursorToSourceCursorSink<'a, T: SourceCursorSink<'a>> {
@@ -19,6 +20,12 @@ impl<'a, T: SourceCursorSink<'a>> CursorSink for CursorToSourceCursorSink<'a, T>
 }
 
 impl<'a> SourceCursorSink<'a> for String {
+	fn append(&mut self, c: SourceCursor<'a>) {
+		let _ = write!(self, "{c}");
+	}
+}
+
+impl<'a, 'alloc, A: Allocator> SourceCursorSink<'a> for crate::String<'alloc, A> {
 	fn append(&mut self, c: SourceCursor<'a>) {
 		let _ = write!(self, "{c}");
 	}
@@ -46,6 +53,20 @@ mod test {
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
 		let mut parser = Parser::new(&bump, source_text, lexer);
 		parser.parse_entirely::<ComponentValues>().output.unwrap().to_cursors(&mut transform);
+		assert_eq!(str, "black white");
+	}
+
+	#[test]
+	fn test_source_cursor_sink_for_arena_string() {
+		let source_text = "black white";
+		let bump = Bump::default();
+		let mut str = crate::String::new_in(&bump);
+		{
+			let mut transform = CursorToSourceCursorSink::new(source_text, &mut str);
+			let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
+			let mut parser = Parser::new(&bump, source_text, lexer);
+			parser.parse_entirely::<ComponentValues>().output.unwrap().to_cursors(&mut transform);
+		}
 		assert_eq!(str, "black white");
 	}
 }

--- a/crates/csskit/src/commands/build.rs
+++ b/crates/csskit/src/commands/build.rs
@@ -4,7 +4,6 @@ use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
 use css_parse::{CursorCompactWriteSink, Parser, ToCursors};
-use std::io::Read;
 
 /// Convert one or more CSS files into production ready CSS.
 #[derive(Debug, Args)]
@@ -22,12 +21,10 @@ impl Build {
 	pub fn run(&self, _config: GlobalConfig) -> CliResult {
 		let Build { content, output } = self;
 		let bump = Bump::default();
-		let mut str = String::new();
+		let mut str = css_parse::String::new_in(&bump);
 		let start = std::time::Instant::now();
-		for (file_name, mut source) in content.sources()? {
-			let mut source_string = String::new();
-			source.read_to_string(&mut source_string)?;
-			let source_text = source_string.as_str();
+		for (file_name, source) in content.sources()? {
+			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 			let mut parser = Parser::new(&bump, source_text, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
@@ -36,7 +33,7 @@ impl Build {
 				result.with_trivia().to_cursors(&mut stream);
 			} else {
 				for compact_err in result.errors {
-					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
+					let report = crate::commands::format_diagnostic_error(&compact_err, source_text, file_name);
 					println!("{report}");
 				}
 				Err(CliError::ParseFailed)?;

--- a/crates/csskit/src/commands/check.rs
+++ b/crates/csskit/src/commands/check.rs
@@ -103,13 +103,13 @@ impl Check {
 		let bump = Bump::new();
 
 		// Read and parse the csskit sheet
-		let rule_source = fs::read_to_string(sheet)?;
-		let rule_lexer = Lexer::new(CsskitAtomSet::get_dyn_set(), &rule_source);
-		let mut rule_parser = Parser::new(&bump, &rule_source, rule_lexer);
+		let rule_source = css_parse::String::from_reader_in(fs::File::open(sheet)?, &bump)?.into_str();
+		let rule_lexer = Lexer::new(CsskitAtomSet::get_dyn_set(), rule_source);
+		let mut rule_parser = Parser::new(&bump, rule_source, rule_lexer);
 		let rule_result = rule_parser.parse_entirely::<Sheet>();
 		let parsed_rules = rule_result.output.ok_or_else(|| {
 			if let Some(e) = rule_result.errors.first() {
-				eprintln!("{}", format_diagnostic_error(e, &rule_source, sheet));
+				eprintln!("{}", format_diagnostic_error(e, rule_source, sheet));
 			}
 			hint_bad_sheet(sheet, input, &config);
 			CliError::ParseFailed
@@ -120,28 +120,29 @@ impl Check {
 		let mut file_envelopes: Vec<CheckFileEnvelope> = Vec::new();
 
 		for css_file_path in input.iter() {
-			let css_source = match fs::read_to_string(css_file_path) {
-				Ok(s) => s,
-				Err(e) => {
-					match format {
-						OutputFormat::Json => {
-							file_envelopes.push(CheckFileEnvelope {
-								file: css_file_path.clone(),
-								ok: false,
-								error: Some(ErrorRecord { kind: ErrorKind::Io, message: e.to_string() }),
-								diagnostics: Vec::new(),
-								stats: Vec::new(),
-							});
+			let css_source =
+				match fs::File::open(css_file_path).and_then(|file| css_parse::String::from_reader_in(file, &bump)) {
+					Ok(source) => source.into_str(),
+					Err(e) => {
+						match format {
+							OutputFormat::Json => {
+								file_envelopes.push(CheckFileEnvelope {
+									file: css_file_path.clone(),
+									ok: false,
+									error: Some(ErrorRecord { kind: ErrorKind::Io, message: e.to_string() }),
+									diagnostics: Vec::new(),
+									stats: Vec::new(),
+								});
+							}
+							OutputFormat::Text => eprintln!("{css_file_path}: {e}"),
 						}
-						OutputFormat::Text => eprintln!("{css_file_path}: {e}"),
+						error_count += 1;
+						continue;
 					}
-					error_count += 1;
-					continue;
-				}
-			};
+				};
 
-			let css_lexer = Lexer::new(&CssAtomSet::ATOMS, &css_source);
-			let mut css_parser = Parser::new(&bump, &css_source, css_lexer);
+			let css_lexer = Lexer::new(&CssAtomSet::ATOMS, css_source);
+			let mut css_parser = Parser::new(&bump, css_source, css_lexer);
 			let css_result = css_parser.parse_entirely();
 
 			let stylesheet = match css_result.output {
@@ -151,8 +152,8 @@ impl Check {
 						.errors
 						.first()
 						.map(|e| {
-							eprintln!("{}", format_diagnostic_error(e, &css_source, css_file_path));
-							e.message(&css_source).to_string()
+							eprintln!("{}", format_diagnostic_error(e, css_source, css_file_path));
+							e.message(css_source).to_string()
 						})
 						.unwrap_or_else(|| "parse failed".to_string());
 					match format {
@@ -172,14 +173,14 @@ impl Check {
 				}
 			};
 
-			let mut collector = Collector::new(&parsed_rules, &rule_source, &bump);
-			collector.collect(&stylesheet, &css_source);
+			let mut collector = Collector::new(&parsed_rules, rule_source, &bump);
+			collector.collect(&stylesheet, css_source);
 
 			let mut file_failed = false;
 			let mut file_diagnostics: Vec<DiagnosticData> = Vec::new();
-			let line_index = matches!(format, OutputFormat::Json).then(|| LineIndex::new_in(&css_source, &bump));
+			let line_index = matches!(format, OutputFormat::Json).then(|| LineIndex::new_in(css_source, &bump));
 
-			for diagnostic in collector.diagnostics(&css_source) {
+			for diagnostic in collector.diagnostics(css_source) {
 				let is_error = matches!(diagnostic.severity, ResolvedDiagnosticLevel::Error);
 				let is_warning = matches!(diagnostic.severity, ResolvedDiagnosticLevel::Warning);
 				let counts_as_failure = is_error || (*deny_warnings && is_warning);
@@ -203,7 +204,7 @@ impl Check {
 					}
 					OutputFormat::Text => {
 						let handler = if config.colors() {
-							let highlighter = CssHighlighter::new(css_source.clone(), &stylesheet);
+							let highlighter = CssHighlighter::new(css_source.to_string(), &stylesheet);
 							GraphicalReportHandler::new_themed(GraphicalTheme::unicode())
 								.with_syntax_highlighting(highlighter)
 						} else {
@@ -211,7 +212,7 @@ impl Check {
 						};
 
 						let miette_diag = diagnostic.into_miette();
-						let named_source = NamedSource::new(css_file_path, css_source.clone());
+						let named_source = NamedSource::new(css_file_path, css_source.to_string());
 						let report = Report::new(miette_diag).with_source_code(named_source);
 						let mut output = String::new();
 						if handler.render_report(&mut output, &*report).is_ok() {

--- a/crates/csskit/src/commands/dbg_lex.rs
+++ b/crates/csskit/src/commands/dbg_lex.rs
@@ -2,7 +2,6 @@ use crate::{CliResult, GlobalConfig, InputArgs};
 use clap::Args;
 use css_ast::CssAtomSet;
 use css_lexer::{Kind, Lexer};
-use std::io::Read;
 
 /// Show the debug output for lexed tokens from a file
 #[derive(Debug, Args)]
@@ -14,10 +13,9 @@ pub struct DbgLex {
 impl DbgLex {
 	pub fn run(&self, _config: GlobalConfig) -> CliResult {
 		let DbgLex { content } = self;
-		for (_file_name, mut source) in content.sources()? {
-			let mut source_string = String::new();
-			source.read_to_string(&mut source_string)?;
-			let source_text = source_string.as_str();
+		let bump = css_parse::Arena::default();
+		for (_file_name, source) in content.sources()? {
+			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
 			let mut lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 
 			loop {

--- a/crates/csskit/src/commands/dbg_parse.rs
+++ b/crates/csskit/src/commands/dbg_parse.rs
@@ -4,7 +4,6 @@ use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
 use css_parse::Parser;
-use std::io::Read;
 
 /// Show the debug output for a parsed file
 #[derive(Debug, Args)]
@@ -17,10 +16,8 @@ impl DbgParse {
 	pub fn run(&self, _config: GlobalConfig) -> CliResult {
 		let DbgParse { content } = self;
 		let bump = Bump::default();
-		for (file_name, mut source) in content.sources()? {
-			let mut source_string = String::new();
-			source.read_to_string(&mut source_string)?;
-			let source_text = source_string.as_str();
+		for (file_name, source) in content.sources()? {
+			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 			let mut parser = Parser::new(&bump, source_text, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
@@ -28,7 +25,7 @@ impl DbgParse {
 				println!("{stylesheet:#?}");
 			} else {
 				for compact_err in result.errors {
-					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
+					let report = crate::commands::format_diagnostic_error(&compact_err, source_text, file_name);
 					println!("{report}");
 				}
 			}

--- a/crates/csskit/src/commands/expand.rs
+++ b/crates/csskit/src/commands/expand.rs
@@ -4,7 +4,6 @@ use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
 use css_parse::{CursorExpandedWriteSink, Parser, ToCursors};
-use std::io::Read;
 
 /// Expand CSS files to their most verbose form (the opposite of minify).
 #[derive(Debug, Args)]
@@ -40,15 +39,13 @@ impl Expand {
 			eprintln!("Ignoring output option, because check was passed");
 		}
 		let mut checks = 0;
-		for (file_name, mut source) in content.sources()? {
-			let mut source_string = String::new();
-			source.read_to_string(&mut source_string)?;
-			let source_text = source_string.as_str();
+		for (file_name, source) in content.sources()? {
+			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 			let mut parser = Parser::new(&bump, source_text, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
 			if let Some(ref _stylesheet) = result.output {
-				let mut str = String::new();
+				let mut str = css_parse::String::new_in(&bump);
 				let mut stream = CursorExpandedWriteSink::new(source_text, &mut str)
 					.with_extra_semicolons(*semicolons)
 					.with_escape_idents(*escape_idents);
@@ -65,7 +62,7 @@ impl Expand {
 				}
 			} else {
 				for compact_err in result.errors {
-					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
+					let report = crate::commands::format_diagnostic_error(&compact_err, source_text, file_name);
 					println!("{report}");
 				}
 			}

--- a/crates/csskit/src/commands/extract.rs
+++ b/crates/csskit/src/commands/extract.rs
@@ -6,7 +6,6 @@ use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::{Lexer, LineIndex, Span};
 use css_parse::Parser;
 use serde::Serialize;
-use std::io::Read;
 
 /// Position metadata for a single result within a file.
 #[derive(Serialize, Debug, Clone)]
@@ -194,31 +193,33 @@ pub trait Extract: Sized {
 		let mut envelopes: Vec<FileEnvelope<Self::Row>> = Vec::new();
 		let mut first_file = true;
 
-		for (filename, mut source) in self.input().sources()? {
-			let mut src = String::new();
-			if let Err(e) = source.read_to_string(&mut src) {
-				match self.format() {
-					OutputFormat::Json => {
-						envelopes.push(FileEnvelope::err(
-							filename,
-							ErrorRecord { kind: ErrorKind::Io, message: e.to_string() },
-						));
+		for (filename, source) in self.input().sources()? {
+			let src = match css_parse::String::from_reader_in(source, &bump) {
+				Ok(src) => src.into_str(),
+				Err(e) => {
+					match self.format() {
+						OutputFormat::Json => {
+							envelopes.push(FileEnvelope::err(
+								filename,
+								ErrorRecord { kind: ErrorKind::Io, message: e.to_string() },
+							));
+						}
+						OutputFormat::Text => {
+							eprintln!("{filename}: {e}");
+						}
 					}
-					OutputFormat::Text => {
-						eprintln!("{filename}: {e}");
-					}
+					continue;
 				}
-				continue;
-			}
+			};
 
 			let mut ctx = Self::FileContext::default();
 			let mut on_stylesheet = |ss: &StyleSheet| {
 				if matches!(self.format(), OutputFormat::Text) {
-					ctx = self.build_context(ss, &src);
+					ctx = self.build_context(ss, src);
 				}
 			};
 
-			match self.parse_and_extract_file(filename, &src, &bump, &mut on_stylesheet) {
+			match self.parse_and_extract_file(filename, src, &bump, &mut on_stylesheet) {
 				Ok(rows) => match self.format() {
 					OutputFormat::Text => {
 						if rows.is_empty() {
@@ -236,14 +237,14 @@ pub trait Extract: Sized {
 								}
 							}
 							self.render_file_preamble(filename, rows.len(), config.colors());
-							let index = LineIndex::new_in(&src, &bump);
+							let index = LineIndex::new_in(src, &bump);
 							for (span, row) in &rows {
-								self.render_text(&ctx, filename, &src, &index, *span, row, config.colors());
+								self.render_text(&ctx, filename, src, &index, *span, row, config.colors());
 							}
 						}
 					}
 					OutputFormat::Json => {
-						let index = LineIndex::new_in(&src, &bump);
+						let index = LineIndex::new_in(src, &bump);
 						let records = rows
 							.into_iter()
 							.map(|(span, data)| Record { location: Location::from_span(span, &index), data })

--- a/crates/csskit/src/commands/find.rs
+++ b/crates/csskit/src/commands/find.rs
@@ -13,7 +13,6 @@ use csskit_ast::{CsskitAtomSet, QuerySelectorList, SelectorMatcher};
 use csskit_highlight::{AnsiHighlightCursorStream, DefaultAnsiTheme, TokenHighlighter};
 use itertools::Itertools;
 use serde::Serialize;
-use std::io::Read;
 use strsim::levenshtein;
 
 #[derive(Debug, Args)]
@@ -91,14 +90,13 @@ impl Find {
 		let mut total = 0;
 		let mut files = 0;
 
-		for (filename, mut source) in self.input.sources()? {
-			let mut src = String::new();
-			source.read_to_string(&mut src)?;
+		for (filename, source) in self.input.sources()? {
+			let src = css_parse::String::from_reader_in(source, &bump)?.into_str();
 
-			let lexer = Lexer::new(&CssAtomSet::ATOMS, &src);
-			let mut parser = Parser::new(&bump, &src, lexer);
+			let lexer = Lexer::new(&CssAtomSet::ATOMS, src);
+			let mut parser = Parser::new(&bump, src, lexer);
 			let Some(stylesheet) = parser.parse_entirely::<StyleSheet>().output else { continue };
-			let count = SelectorMatcher::new(selectors, &self.selector, &src).run(&stylesheet).count();
+			let count = SelectorMatcher::new(selectors, &self.selector, src).run(&stylesheet).count();
 			if count == 0 {
 				continue;
 			}

--- a/crates/csskit/src/commands/fmt.rs
+++ b/crates/csskit/src/commands/fmt.rs
@@ -5,7 +5,6 @@ use css_ast::{CssAtomSet, StyleSheet, Visitable};
 use css_lexer::{Lexer, QuoteStyle};
 use css_parse::{CursorPrettyWriteSink, Parser, ToCursors};
 use csskit_highlight::{AnsiHighlightCursorStream, DefaultAnsiTheme, TokenHighlighter};
-use std::io::Read;
 
 /// Format CSS files to make them more readable.
 #[derive(Debug, Args)]
@@ -42,15 +41,13 @@ impl Fmt {
 			eprintln!("Ignoring output option, because check was passed");
 		}
 		let mut checks = 0;
-		for (file_name, mut source) in content.sources()? {
-			let mut source_string = String::new();
-			source.read_to_string(&mut source_string)?;
-			let source_text = source_string.as_str();
+		for (file_name, source) in content.sources()? {
+			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 			let mut parser = Parser::new(&bump, source_text, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
 			if let Some(stylesheet) = result.output.as_ref() {
-				let mut str = String::new();
+				let mut str = css_parse::String::new_in(&bump);
 				if color {
 					let mut highlighter = TokenHighlighter::new();
 					let _ = stylesheet.accept(&mut highlighter);
@@ -73,7 +70,7 @@ impl Fmt {
 				}
 			} else {
 				for compact_err in result.errors {
-					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
+					let report = crate::commands::format_diagnostic_error(&compact_err, source_text, file_name);
 					println!("{report}");
 				}
 			}

--- a/crates/csskit/src/commands/min.rs
+++ b/crates/csskit/src/commands/min.rs
@@ -6,7 +6,6 @@ use css_lexer::Lexer;
 use css_parse::{CursorCompactWriteSink, CursorOverlaySink, Parser, ToCursors};
 use csskit_highlight::{AnsiHighlightCursorStream, DefaultAnsiTheme, TokenHighlighter};
 use csskit_transform::{CssMinifierFeature, Transformer};
-use std::io::Read;
 
 /// Minify CSS files to compress them optimized delivery.
 #[derive(Debug, Args)]
@@ -35,10 +34,8 @@ impl Min {
 			eprintln!("Ignoring output option, because check was passed");
 		}
 		let mut checks = 0;
-		for (file_name, mut source) in content.sources()? {
-			let mut source_string = String::new();
-			source.read_to_string(&mut source_string)?;
-			let source_text = source_string.as_str();
+		for (file_name, source) in content.sources()? {
+			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 			let mut parser = Parser::new(&bump, source_text, lexer);
 			let mut result = parser.parse_entirely::<StyleSheet>().with_trivia();
@@ -48,7 +45,7 @@ impl Min {
 				transformer.transform(stylesheet);
 				let overlays = transformer.overlays();
 
-				let mut str = String::new();
+				let mut str = css_parse::String::new_in(&bump);
 				if color {
 					let mut highlighter = TokenHighlighter::new();
 					let _ = stylesheet.accept(&mut highlighter);
@@ -83,7 +80,7 @@ impl Min {
 				}
 			} else {
 				for compact_err in result.errors {
-					let report = crate::commands::format_diagnostic_error(&compact_err, &source_string, file_name);
+					let report = crate::commands::format_diagnostic_error(&compact_err, source_text, file_name);
 					println!("{report}");
 				}
 			}

--- a/crates/csskit/src/commands/tree.rs
+++ b/crates/csskit/src/commands/tree.rs
@@ -1,5 +1,3 @@
-use std::io::Read;
-
 use bumpalo::Bump;
 use clap::Args;
 use css_ast::VisitNode;
@@ -132,23 +130,22 @@ impl Tree {
 	pub fn run(&self, _config: GlobalConfig) -> CliResult {
 		let bump = Bump::default();
 
-		for (filename, mut source) in self.input.sources()? {
-			let mut src = String::new();
-			source.read_to_string(&mut src)?;
+		for (filename, source) in self.input.sources()? {
+			let src = css_parse::String::from_reader_in(source, &bump)?.into_str();
 
-			let lexer = Lexer::new(&CssAtomSet::ATOMS, &src);
-			let mut parser = Parser::new(&bump, &src, lexer);
+			let lexer = Lexer::new(&CssAtomSet::ATOMS, src);
+			let mut parser = Parser::new(&bump, src, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
 
 			let Some(stylesheet) = result.output.as_ref() else {
 				for err in result.errors {
-					eprintln!("{}", crate::commands::format_diagnostic_error(&err, &src, filename));
+					eprintln!("{}", crate::commands::format_diagnostic_error(&err, src, filename));
 				}
 				return Err(CliError::ParseFailed);
 			};
 
 			// Collect all nodes
-			let mut visitor = CollectionVisitor::new(&src);
+			let mut visitor = CollectionVisitor::new(src);
 			let _ = stylesheet.accept(&mut visitor);
 
 			// Print root

--- a/crates/csskit_transform/src/reduce_colors.rs
+++ b/crates/csskit_transform/src/reduce_colors.rs
@@ -4,6 +4,7 @@ use css_ast::{
 	CalcableValue, Color, ColorFunction, ColorMixFunction, HueInterpolationDirection, InterpolationColorSpace,
 	ToChromashift, Visitable,
 };
+use css_parse::{Arena, format_in};
 
 pub struct ReduceColors<'a, 'ctx, N: Visitable + NodeWithMetadata<CssMetadata>> {
 	pub transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>,
@@ -22,16 +23,16 @@ where
 	}
 }
 
-trait Shortest {
-	fn shortest(&self) -> Option<String>;
+trait Shortest<'a> {
+	fn shortest(&self, arena: &'a Arena) -> Option<&'a str>;
 }
 
-impl Shortest for chromashift::Color {
-	fn shortest(&self) -> Option<String> {
+impl<'a> Shortest<'a> for chromashift::Color {
+	fn shortest(&self, arena: &'a Arena) -> Option<&'a str> {
 		[
-			Some(Hex::from(*self).to_string()),
-			Named::try_from(*self).ok().map(|named| named.to_string()),
-			Some(Srgb::from(*self).round().to_string()),
+			Some(format_in!(in arena, "{}", Hex::from(*self)).into_str()),
+			Named::try_from(*self).ok().map(|named| format_in!(in arena, "{named}").into_str()),
+			Some(format_in!(in arena, "{}", Srgb::from(*self).round()).into_str()),
 		]
 		.into_iter()
 		.flatten()
@@ -41,11 +42,11 @@ impl Shortest for chromashift::Color {
 
 /// Formats a CSS alpha value (0–1) from chromashift's internal 0–100 representation.
 /// Returns `None` when the alpha is fully opaque (100.0).
-fn css_alpha(alpha: f32) -> Option<String> {
+fn css_alpha(alpha: f32) -> Option<f64> {
 	if alpha >= 100.0 {
 		return None;
 	}
-	Some(format!("{}", round_dp(alpha as f64 / 100.0, 3)))
+	Some(round_dp(alpha as f64 / 100.0, 3))
 }
 
 /// Serialises a chromashift colour into valid CSS function syntax.
@@ -54,34 +55,48 @@ fn css_alpha(alpha: f32) -> Option<String> {
 /// compact writer will then minify (removing leading zeros, collapsing whitespace around `/`, etc.).
 ///
 /// Returns `None` for colour types that don't have a non-sRGB CSS function syntax (Hex, Named, Srgb, Hsv).
-trait ToCss {
-	fn to_css(&self) -> Option<String>;
+trait ToCss<'a> {
+	fn to_css(&self, arena: &'a Arena) -> Option<&'a str>;
 }
 
 macro_rules! impl_to_css_3ch {
 	($ty:ident, $name:literal, $c1:ident, $c2:ident, $c3:ident) => {
-		impl ToCss for chromashift::$ty {
-			fn to_css(&self) -> Option<String> {
+		impl<'a> ToCss<'a> for chromashift::$ty {
+			fn to_css(&self, arena: &'a Arena) -> Option<&'a str> {
 				let alpha = css_alpha(self.alpha);
 				if let Some(a) = alpha {
-					Some(format!(concat!($name, "({} {} {} / {})"), self.$c1, self.$c2, self.$c3, a))
+					Some(
+						format_in!(in arena, concat!($name, "({} {} {} / {})"), self.$c1, self.$c2, self.$c3, a)
+							.into_str(),
+					)
 				} else {
-					Some(format!(concat!($name, "({} {} {})"), self.$c1, self.$c2, self.$c3))
+					Some(format_in!(in arena, concat!($name, "({} {} {})"), self.$c1, self.$c2, self.$c3).into_str())
 				}
 			}
 		}
 	};
 	($ty:ident, $name:literal, $c1:ident, $c2:ident: $suf2:literal, $c3:ident: $suf3:literal) => {
-		impl ToCss for chromashift::$ty {
-			fn to_css(&self) -> Option<String> {
+		impl<'a> ToCss<'a> for chromashift::$ty {
+			fn to_css(&self, arena: &'a Arena) -> Option<&'a str> {
 				let alpha = css_alpha(self.alpha);
 				if let Some(a) = alpha {
-					Some(format!(
-						concat!($name, "({} {}", $suf2, " {}", $suf3, " / {})"),
-						self.$c1, self.$c2, self.$c3, a
-					))
+					Some(
+						format_in!(
+							in arena,
+							concat!($name, "({} {}", $suf2, " {}", $suf3, " / {})"),
+							self.$c1, self.$c2, self.$c3, a
+						)
+						.into_str(),
+					)
 				} else {
-					Some(format!(concat!($name, "({} {}", $suf2, " {}", $suf3, ")"), self.$c1, self.$c2, self.$c3))
+					Some(
+						format_in!(
+							in arena,
+							concat!($name, "({} {}", $suf2, " {}", $suf3, ")"),
+							self.$c1, self.$c2, self.$c3
+						)
+						.into_str(),
+					)
 				}
 			}
 		}
@@ -90,13 +105,27 @@ macro_rules! impl_to_css_3ch {
 
 macro_rules! impl_to_css_color_fn {
 	($ty:ident, $space:literal) => {
-		impl ToCss for chromashift::$ty {
-			fn to_css(&self) -> Option<String> {
+		impl<'a> ToCss<'a> for chromashift::$ty {
+			fn to_css(&self, arena: &'a Arena) -> Option<&'a str> {
 				let alpha = css_alpha(self.alpha);
 				if let Some(a) = alpha {
-					Some(format!(concat!("color(", $space, " {} {} {} / {})"), self.red, self.green, self.blue, a))
+					Some(
+						format_in!(
+							in arena,
+							concat!("color(", $space, " {} {} {} / {})"),
+							self.red, self.green, self.blue, a
+						)
+						.into_str(),
+					)
 				} else {
-					Some(format!(concat!("color(", $space, " {} {} {})"), self.red, self.green, self.blue))
+					Some(
+						format_in!(
+							in arena,
+							concat!("color(", $space, " {} {} {})"),
+							self.red, self.green, self.blue
+						)
+						.into_str(),
+					)
 				}
 			}
 		}
@@ -105,8 +134,8 @@ macro_rules! impl_to_css_color_fn {
 
 macro_rules! impl_to_css_xyz {
 	($ty:ident, $space:literal) => {
-		impl ToCss for chromashift::$ty {
-			fn to_css(&self) -> Option<String> {
+		impl<'a> ToCss<'a> for chromashift::$ty {
+			fn to_css(&self, arena: &'a Arena) -> Option<&'a str> {
 				let alpha = css_alpha(self.alpha);
 				// CSS color(xyz-*) uses 0–1 scale; chromashift stores 0–100 internally.
 				// After dividing, re-apply round_dp(4) to eliminate float display artifacts
@@ -115,9 +144,9 @@ macro_rules! impl_to_css_xyz {
 				let y = round_dp(self.y / 100.0, 4);
 				let z = round_dp(self.z / 100.0, 4);
 				if let Some(a) = alpha {
-					Some(format!(concat!("color(", $space, " {} {} {} / {})"), x, y, z, a))
+					Some(format_in!(in arena, concat!("color(", $space, " {} {} {} / {})"), x, y, z, a).into_str())
 				} else {
-					Some(format!(concat!("color(", $space, " {} {} {})"), x, y, z))
+					Some(format_in!(in arena, concat!("color(", $space, " {} {} {})"), x, y, z).into_str())
 				}
 			}
 		}
@@ -140,22 +169,22 @@ impl_to_css_color_fn!(Rec2020, "rec2020");
 impl_to_css_xyz!(XyzD50, "xyz-d50");
 impl_to_css_xyz!(XyzD65, "xyz-d65");
 
-impl ToCss for chromashift::Color {
-	fn to_css(&self) -> Option<String> {
+impl<'a> ToCss<'a> for chromashift::Color {
+	fn to_css(&self, arena: &'a Arena) -> Option<&'a str> {
 		match self {
-			chromashift::Color::Lab(c) => c.to_css(),
-			chromashift::Color::Lch(c) => c.to_css(),
-			chromashift::Color::Oklab(c) => c.to_css(),
-			chromashift::Color::Oklch(c) => c.to_css(),
-			chromashift::Color::Hsl(c) => c.to_css(),
-			chromashift::Color::Hwb(c) => c.to_css(),
-			chromashift::Color::DisplayP3(c) => c.to_css(),
-			chromashift::Color::LinearRgb(c) => c.to_css(),
-			chromashift::Color::A98Rgb(c) => c.to_css(),
-			chromashift::Color::ProphotoRgb(c) => c.to_css(),
-			chromashift::Color::Rec2020(c) => c.to_css(),
-			chromashift::Color::XyzD50(c) => c.to_css(),
-			chromashift::Color::XyzD65(c) => c.to_css(),
+			chromashift::Color::Lab(c) => c.to_css(arena),
+			chromashift::Color::Lch(c) => c.to_css(arena),
+			chromashift::Color::Oklab(c) => c.to_css(arena),
+			chromashift::Color::Oklch(c) => c.to_css(arena),
+			chromashift::Color::Hsl(c) => c.to_css(arena),
+			chromashift::Color::Hwb(c) => c.to_css(arena),
+			chromashift::Color::DisplayP3(c) => c.to_css(arena),
+			chromashift::Color::LinearRgb(c) => c.to_css(arena),
+			chromashift::Color::A98Rgb(c) => c.to_css(arena),
+			chromashift::Color::ProphotoRgb(c) => c.to_css(arena),
+			chromashift::Color::Rec2020(c) => c.to_css(arena),
+			chromashift::Color::XyzD50(c) => c.to_css(arena),
+			chromashift::Color::XyzD65(c) => c.to_css(arena),
 			// sRGB types don't need native-space CSS — they use Shortest
 			chromashift::Color::Hex(_)
 			| chromashift::Color::Named(_)
@@ -180,29 +209,31 @@ where
 		let Some(chroma_color) = color.to_chromashift() else {
 			return;
 		};
+		let arena = self.transformer.bump();
 		let len = color.to_span().len() as usize;
 
 		if chroma_color.in_gamut_of(ColorSpace::Srgb)
-			&& let Some(candidate) = chroma_color.shortest()
+			&& let Some(candidate) = chroma_color.shortest(arena)
 			&& candidate.len() < len
 		{
-			self.transformer.replace_parsed::<Color>(color.to_span(), &candidate);
+			self.transformer.replace_parsed::<Color>(color.to_span(), candidate);
 			return;
 		}
 
 		// Try the native-space rounded form. This preserves the original colour space
 		// while reducing precision to perceptually safe levels.
 		let rounded = chroma_color.round();
-		if let Some(css) = rounded.to_css()
+		if let Some(css) = rounded.to_css(arena)
 			&& css.len() < len
 		{
-			self.transformer.replace_parsed::<Color>(color.to_span(), &css);
+			self.transformer.replace_parsed::<Color>(color.to_span(), css);
 		}
 	}
 
 	fn visit_color_mix_function<'b>(&mut self, mix: &ColorMixFunction<'b>) -> VisitFlow {
 		let outer_span = mix.to_span();
 		let outer_len = outer_span.len() as usize;
+		let arena = self.transformer.bump();
 
 		let n = mix.parts.len();
 		let default_pct = 100.0 / n as f32;
@@ -236,12 +267,12 @@ where
 			{
 				let (part, _) = &mix.parts[dominant];
 				let chroma = part.color.to_chromashift();
-				let str = chroma.and_then(|c| c.shortest()).unwrap_or_else(|| {
+				let str = chroma.and_then(|c| c.shortest(arena)).unwrap_or_else(|| {
 					let span = part.color.to_span();
-					self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
+					&self.transformer.source_text[span.start().0 as usize..span.end().0 as usize]
 				});
 				self.transformer.clear_pending_edits(outer_span);
-				self.transformer.replace_parsed::<Color>(outer_span, &str);
+				self.transformer.replace_parsed::<Color>(outer_span, str);
 				return VisitFlow::SKIP_CHILDREN;
 			}
 		}
@@ -253,12 +284,12 @@ where
 				let first = chromata[0].unwrap();
 				if chromata[1..].iter().all(|c| c.unwrap().delta_e(first) < COLOR_EPSILON) {
 					let (part, _) = &mix.parts[0];
-					let str = first.shortest().unwrap_or_else(|| {
+					let str = first.shortest(arena).unwrap_or_else(|| {
 						let span = part.color.to_span();
-						self.transformer.source_text[span.start().0 as usize..span.end().0 as usize].to_string()
+						&self.transformer.source_text[span.start().0 as usize..span.end().0 as usize]
 					});
 					self.transformer.clear_pending_edits(outer_span);
-					self.transformer.replace_parsed::<Color>(outer_span, &str);
+					self.transformer.replace_parsed::<Color>(outer_span, str);
 					return VisitFlow::SKIP_CHILDREN;
 				}
 			}
@@ -271,11 +302,11 @@ where
 			let mixed_alpha = (mixed.to_alpha() as f64 / 100.0 * alpha_mult * 100.0) as f32;
 			let mixed = mixed.with_alpha(mixed_alpha);
 			let rounded = mixed.round();
-			let native_css = rounded.to_css();
-			let srgb_css = if mixed.in_gamut_of(ColorSpace::Srgb) { mixed.shortest() } else { None };
+			let native_css = rounded.to_css(arena);
+			let srgb_css = if mixed.in_gamut_of(ColorSpace::Srgb) { mixed.shortest(arena) } else { None };
 			let candidate =
 				native_css.into_iter().chain(srgb_css).min_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
-			if let Some(ref candidate) = candidate
+			if let Some(candidate) = candidate
 				&& candidate.len() < outer_len
 			{
 				self.transformer.replace_parsed::<Color>(outer_span, candidate);

--- a/crates/csskit_transform/src/reduce_time_units.rs
+++ b/crates/csskit_transform/src/reduce_time_units.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use css_ast::{Time, Visitable};
+use css_parse::format_in;
 
 pub struct ReduceTimeUnits<'a, 'ctx, N: Visitable + NodeWithMetadata<CssMetadata>> {
 	pub transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>,
@@ -25,17 +26,22 @@ where
 {
 	fn visit_time(&mut self, time: &Time) {
 		if let Time::Ms(dim) = time {
+			let arena = self.transformer.bump();
 			let seconds = time.as_seconds();
 			let sc = self.transformer.to_source_cursor((*dim).into());
-			let value = if seconds.fract() == 0.0 { format!("{}", seconds as i64) } else { format!("{seconds}") };
+			let value = if seconds.fract() == 0.0 {
+				format_in!(in arena, "{}", seconds as i64)
+			} else {
+				format_in!(in arena, "{seconds}")
+			};
 			let seconds_len = value.len() - value.starts_with("0.") as usize - value.starts_with("-0.") as usize + 1;
 			let ms_len = if sc.may_compact() {
-				format!("{}", self.transformer.to_source_cursor((*dim).into()).compact()).len()
+				format_in!(in arena, "{}", self.transformer.to_source_cursor((*dim).into()).compact()).len()
 			} else {
 				sc.token().len() as usize
 			};
 			if seconds_len < ms_len {
-				self.transformer.replace_parsed::<Time>(time.to_span(), &format!("{value}s"));
+				self.transformer.replace_parsed::<Time>(time.to_span(), format_in!(in arena, "{value}s").into_str());
 			}
 		}
 	}

--- a/crates/csskit_transform/src/reduce_urls.rs
+++ b/crates/csskit_transform/src/reduce_urls.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use css_ast::{Url, UrlOrString, Visitable};
+use css_parse::format_in;
 
 pub struct ReduceUrls<'a, 'ctx, N: Visitable + NodeWithMetadata<CssMetadata>> {
 	pub transformer: &'ctx Transformer<'a, CssMetadata, N, CssMinifierFeature>,
@@ -27,17 +28,16 @@ where
 		let UrlOrString::Url(url) = url_or_string else {
 			return;
 		};
+		let arena = self.transformer.bump();
 		match url {
 			Url::UrlFunction(_, string, _) | Url::SrcFunction(_, string, _) => {
+				let sc = self.transformer.to_source_cursor((*string).into());
+				let token = sc.token();
+				let start = token.leading_len() as usize;
+				let end = sc.source().len() - token.trailing_len() as usize;
 				self.transformer.replace_parsed::<UrlOrString>(
 					url_or_string.to_span(),
-					&format!("\"{}\"", {
-						let sc = self.transformer.to_source_cursor((*string).into());
-						let token = sc.token();
-						let start = token.leading_len() as usize;
-						let end = sc.source().len() - token.trailing_len() as usize;
-						&sc.source()[start..end]
-					}),
+					format_in!(in arena, "\"{}\"", &sc.source()[start..end]).into_str(),
 				);
 			}
 			Url::Url(url_token) => {
@@ -47,8 +47,10 @@ where
 				let trailing_len = token.trailing_len() as usize;
 				let url_content = &sc.source()[leading_len..(sc.source().len() - trailing_len)];
 				let url_content = url_content.trim();
-				self.transformer
-					.replace_parsed::<UrlOrString>(url_or_string.to_span(), &format!("\"{}\"", url_content));
+				self.transformer.replace_parsed::<UrlOrString>(
+					url_or_string.to_span(),
+					format_in!(in arena, "\"{url_content}\"").into_str(),
+				);
 			}
 		}
 	}

--- a/crates/csskit_transform/src/transformer.rs
+++ b/crates/csskit_transform/src/transformer.rs
@@ -166,12 +166,11 @@ impl<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> 
 		self.edits.borrow_mut().push(TransformEdit::InsertAfter { anchor, cursors });
 	}
 
-	pub fn replace_parsed<T>(&self, span: impl ToSpan, css: &str)
+	pub fn replace_parsed<T>(&self, span: impl ToSpan, css: &'a str)
 	where
 		T: Parse<'a> + ToCursors,
 	{
-		let owned = self.bump.alloc_str(css);
-		self.replace(span, self.parse_value::<T>(owned));
+		self.replace(span, self.parse_value::<T>(css));
 	}
 
 	pub fn commit_overlays(&self) -> Result<(), CommitError> {


### PR DESCRIPTION
https://github.com/csskit/csskit/pull/1324 introduced css_parse::String, which can now be used across many places where we currently just allocate using std::String, including implementing read_to_string.