### PR TITLE
css_parse: Re-export `Arena` as Bumpalo, rename `bump` to `alloc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,7 +648,6 @@ name = "css_ast"
 version = "0.0.28"
 dependencies = [
  "bitmask-enum",
- "bumpalo",
  "chromashift",
  "console",
  "criterion",
@@ -751,7 +750,6 @@ version = "0.0.28"
 dependencies = [
  "allocator-api2",
  "anstyle",
- "bumpalo",
  "chromashift",
  "clap",
  "css_ast",
@@ -777,7 +775,6 @@ name = "csskit_ast"
 version = "0.0.28"
 dependencies = [
  "bitmask-enum",
- "bumpalo",
  "criterion",
  "css_ast",
  "css_lexer",
@@ -813,7 +810,6 @@ version = "0.0.28"
 dependencies = [
  "anstyle",
  "bitmask-enum",
- "bumpalo",
  "chromashift",
  "console",
  "css_ast",
@@ -832,7 +828,6 @@ name = "csskit_lsp"
 version = "0.0.28"
 dependencies = [
  "bitmask-enum",
- "bumpalo",
  "console",
  "criterion",
  "crossbeam-channel",
@@ -913,7 +908,6 @@ name = "csskit_transform"
 version = "0.0.28"
 dependencies = [
  "bitmask-enum",
- "bumpalo",
  "chromashift",
  "criterion",
  "css_ast",
@@ -932,7 +926,6 @@ dependencies = [
 name = "csskit_wasm"
 version = "0.0.28"
 dependencies = [
- "bumpalo",
  "console_error_panic_hook",
  "css_ast",
  "css_lexer",

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -22,7 +22,6 @@ derive_atom_set = { workspace = true }                   # @release
 css_feature_data = { workspace = true, optional = true } # @release
 chromashift = { workspace = true, optional = true }      # @release
 
-bumpalo = { workspace = true, features = ["collections", "boxed"] }
 miette = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 smallvec = { workspace = true }

--- a/crates/css_ast/benches/parse_popular.rs
+++ b/crates/css_ast/benches/parse_popular.rs
@@ -1,8 +1,7 @@
-use bumpalo::Bump;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::Parser;
+use css_parse::{Arena, Parser};
 use glob::glob;
 #[cfg(target_family = "unix")]
 use pprof::criterion::{Output, PProfProfiler};
@@ -32,7 +31,7 @@ fn popular(c: &mut Criterion) {
 		group.throughput(Throughput::Bytes(file.source_text.len() as u64));
 		group.bench_with_input(BenchmarkId::from_parameter(&file.name), &file.source_text, |b, source_text| {
 			b.iter_with_large_drop(|| {
-				let allocator = Bump::default();
+				let allocator = Arena::default();
 				let lexer = Lexer::new(&CssAtomSet::ATOMS, &source_text);
 				let _ = Parser::new(&allocator, source_text, lexer).parse_entirely::<StyleSheet>();
 

--- a/crates/css_ast/src/constraints.rs
+++ b/crates/css_ast/src/constraints.rs
@@ -258,7 +258,7 @@ impl<T, const VALUE: i32> Exact<T, VALUE> {
 /// Wraps any collection type that derefs to a slice (`Deref<Target = [_]>`)
 /// and validates at parse time that the collection contains at least one item.
 ///
-/// Works with [`bumpalo::collections::Vec`] and any other slice-backed type.
+/// Works with [`css_parse::Vec`] and any other slice-backed type.
 #[node]
 #[derive(Peek, ToCursors, ToSpan, SemanticEq, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde(transparent))]

--- a/crates/css_ast/src/functions/if_function.rs
+++ b/crates/css_ast/src/functions/if_function.rs
@@ -90,7 +90,7 @@ impl<'a> Parse<'a> for IfTest<'a> {
 			let open = p.parse::<LeftParen>()?;
 			let expr = p.parse::<IfConditionExpr>()?;
 			let close = p.parse::<RightParen>()?;
-			return Ok(Self::Group(open, Box::new_in(p.bump(), expr), close));
+			return Ok(Self::Group(open, Box::new_in(p.alloc(), expr), close));
 		}
 		let function = p.parse::<Function>()?;
 		match p.to_atom::<CssAtomSet>(function.into()) {
@@ -102,7 +102,7 @@ impl<'a> Parse<'a> for IfTest<'a> {
 				if c == Kind::Ident && p.peek_n(2) == Kind::Colon {
 					let decl = p.parse::<Declaration<'a, StyleValue<'a>, CssMetadata>>()?;
 					let close = p.parse::<RightParen>()?;
-					Ok(Self::SupportsDeclaration(function, Box::new_in(p.bump(), decl), close))
+					Ok(Self::SupportsDeclaration(function, Box::new_in(p.alloc(), decl), close))
 				} else {
 					let condition = p.parse::<SupportsCondition>()?;
 					let close = p.parse::<RightParen>()?;
@@ -263,7 +263,7 @@ impl<'a, V: Parse<'a> + Peek<'a>> Parse<'a> for IfFunction<'a, V> {
 		I: Iterator<Item = Cursor> + Clone,
 	{
 		let name = p.parse::<Function>()?;
-		let mut branches = Vec::new_in(p.bump());
+		let mut branches = Vec::new_in(p.alloc());
 		loop {
 			let branch = p.parse::<IfBranch<'a, V>>()?;
 			let semicolon = p.parse_if_peek::<Semicolon>()?;

--- a/crates/css_ast/src/metadata.rs
+++ b/crates/css_ast/src/metadata.rs
@@ -615,7 +615,7 @@ mod tests {
 	use super::*;
 	use crate::{CssAtomSet, StyleSheet};
 	use css_lexer::Lexer;
-	use css_parse::{NodeMetadata, NodeWithMetadata, Parser};
+	use css_parse::{Arena, NodeMetadata, NodeWithMetadata, Parser};
 
 	#[test]
 	fn test_block_metadata_merge() {
@@ -642,9 +642,9 @@ mod tests {
 	#[test]
 	fn test_stylesheet_metadata_simple() {
 		let css = "body { color: red; width: 100px; }";
-		let bump = bumpalo::Bump::new();
+		let alloc = Arena::new();
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, css);
-		let mut parser = Parser::new(&bump, css, lexer);
+		let mut parser = Parser::new(&alloc, css, lexer);
 		let stylesheet = parser.parse::<StyleSheet>().unwrap();
 
 		let metadata = stylesheet.metadata();
@@ -658,9 +658,9 @@ mod tests {
 	#[test]
 	fn test_stylesheet_metadata_with_important() {
 		let css = "body { color: red !important; }";
-		let bump = bumpalo::Bump::new();
+		let alloc = Arena::new();
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, css);
-		let mut parser = Parser::new(&bump, css, lexer);
+		let mut parser = Parser::new(&alloc, css, lexer);
 		let stylesheet = parser.parse::<StyleSheet>().unwrap();
 
 		let metadata = stylesheet.metadata();
@@ -672,9 +672,9 @@ mod tests {
 	#[test]
 	fn test_stylesheet_metadata_custom_properties() {
 		let css = "body { --custom: value; }";
-		let bump = bumpalo::Bump::new();
+		let alloc = Arena::new();
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, css);
-		let mut parser = Parser::new(&bump, css, lexer);
+		let mut parser = Parser::new(&alloc, css, lexer);
 		let stylesheet = parser.parse::<StyleSheet>().unwrap();
 
 		let metadata = stylesheet.metadata();
@@ -685,9 +685,9 @@ mod tests {
 	#[test]
 	fn test_stylesheet_metadata_nested_media() {
 		let css = "@media screen { body { color: red; } }";
-		let bump = bumpalo::Bump::new();
+		let alloc = Arena::new();
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, css);
-		let mut parser = Parser::new(&bump, css, lexer);
+		let mut parser = Parser::new(&alloc, css, lexer);
 		let stylesheet = parser.parse::<StyleSheet>().unwrap();
 
 		let metadata = stylesheet.metadata();

--- a/crates/css_ast/src/properties/mod.rs
+++ b/crates/css_ast/src/properties/mod.rs
@@ -420,9 +420,8 @@ impl<'a> SemanticEqTrait for crate::StyleValue<'a> {
 mod tests {
 	use super::*;
 	use crate::{CssAtomSet, CssMetadata};
-	use bumpalo::Bump;
 	use css_lexer::Lexer;
-	use css_parse::{Declaration, Parser, assert_parse};
+	use css_parse::{Arena, Declaration, Parser, assert_parse};
 
 	type Property<'a> = Declaration<'a, StyleValue<'a>, CssMetadata>;
 
@@ -469,29 +468,29 @@ mod tests {
 
 	#[test]
 	fn test_property_validation() {
-		let bump = Bump::new();
+		let alloc = Arena::new();
 
 		let input = "width:1px";
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, input);
-		let mut p = Parser::new(&bump, input, lexer);
+		let mut p = Parser::new(&alloc, input, lexer);
 		let decl = p.parse::<Property>().unwrap();
 		assert!(!decl.value.is_unknown(), "width should be recognized as a known property");
 
 		let input = "notarealproperty:value";
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, input);
-		let mut p = Parser::new(&bump, input, lexer);
+		let mut p = Parser::new(&alloc, input, lexer);
 		let decl = p.parse::<Property>().unwrap();
 		assert!(decl.value.is_unknown(), "notarealproperty should be parsed as unknown");
 
 		let input = "-webkit-filter:blur(4px)";
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, input);
-		let mut p = Parser::new(&bump, input, lexer);
+		let mut p = Parser::new(&alloc, input, lexer);
 		let decl = p.parse::<Property>().unwrap();
 		assert!(!decl.value.is_unknown(), "-webkit-filter should be recognized as a known property");
 
 		let input = "--custom:value";
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, input);
-		let mut p = Parser::new(&bump, input, lexer);
+		let mut p = Parser::new(&alloc, input, lexer);
 		let decl = p.parse::<Property>().unwrap();
 		assert!(decl.value.is_custom(), "--custom should be parsed as custom property");
 	}

--- a/crates/css_ast/src/rules/container/features.rs
+++ b/crates/css_ast/src/rules/container/features.rs
@@ -116,7 +116,7 @@ impl<'a> Parse<'a> for StyleFeature<'a> {
 			return Ok(Self::CustomProperty(p.parse::<T![Ident]>()?));
 		}
 		let decl = p.parse::<Declaration<'a, StyleValue<'a>, CssMetadata>>()?;
-		Ok(Self::Declaration(Box::new_in(p.bump(), decl)))
+		Ok(Self::Declaration(Box::new_in(p.alloc(), decl)))
 	}
 }
 

--- a/crates/css_ast/src/rules/layer.rs
+++ b/crates/css_ast/src/rules/layer.rs
@@ -38,7 +38,7 @@ impl<'a> Parse<'a> for LayerName<'a> {
 	where
 		I: Iterator<Item = Cursor> + Clone,
 	{
-		let mut parts = Vec::new_in(p.bump());
+		let mut parts = Vec::new_in(p.alloc());
 		let first = p.parse::<T![Ident]>()?;
 		loop {
 			if p.peek::<T![.]>() {

--- a/crates/css_ast/src/rules/page.rs
+++ b/crates/css_ast/src/rules/page.rs
@@ -46,7 +46,7 @@ impl<'a> Parse<'a> for PageSelector<'a> {
 	where
 		I: Iterator<Item = Cursor> + Clone,
 	{
-		let mut pseudos = Vec::new_in(p.bump());
+		let mut pseudos = Vec::new_in(p.alloc());
 		let page_type = p.parse_if_peek::<T![Ident]>()?;
 		loop {
 			if p.peek::<T![:]>() {

--- a/crates/css_ast/src/rules/supports.rs
+++ b/crates/css_ast/src/rules/supports.rs
@@ -188,11 +188,11 @@ impl<'a> Parse<'a> for SupportsFeature<'a> {
 			if is_declaration {
 				let property = p.parse::<Declaration<'a, StyleValue<'a>, CssMetadata>>()?;
 				let close = p.parse_if_peek::<T![')']>()?;
-				return Ok(Self::Property(open, Box::new_in(p.bump(), property), close));
+				return Ok(Self::Property(open, Box::new_in(p.alloc(), property), close));
 			}
 			let condition = p.parse::<SupportsCondition>()?;
 			let close = p.parse::<T![')']>()?;
-			return Ok(Self::Condition(open, Box::new_in(p.bump(), condition), close));
+			return Ok(Self::Condition(open, Box::new_in(p.alloc(), condition), close));
 		}
 		if p.peek::<T![Function]>() {
 			let function = p.parse::<T![Function]>()?;

--- a/crates/css_ast/src/selector/nth.rs
+++ b/crates/css_ast/src/selector/nth.rs
@@ -66,7 +66,7 @@ impl<'a> Parse<'a> for Nth {
 			a = if c.token().is_int() { c.token().value() as i32 } else { 1 };
 		} else {
 			let source_cursor = p.to_source_cursor(c);
-			let anb = source_cursor.parse(p.bump());
+			let anb = source_cursor.parse(p.alloc());
 			let mut chars = anb.chars();
 			let mut char = chars.next();
 			a = if c.token().is_int() {

--- a/crates/css_ast/src/selector/tag.rs
+++ b/crates/css_ast/src/selector/tag.rs
@@ -81,7 +81,7 @@ impl<'a> Peek<'a> for CustomElementTag {
 	where
 		I: Iterator<Item = Cursor> + Clone,
 	{
-		let str = p.to_source_cursor(c).parse(p.bump());
+		let str = p.to_source_cursor(c).parse(p.alloc());
 		if Self::is_invalid(p.to_atom(c)) {
 			return false;
 		}

--- a/crates/css_ast/src/stylerule.rs
+++ b/crates/css_ast/src/stylerule.rs
@@ -90,7 +90,7 @@ impl<'a> RuleVariants<'a> for NestedGroupRule<'a> {
 			)+ ) => {
 				match p.to_atom::<CssAtomSet>(name) {
 					$(CssAtomSet::$name => p.parse::<rules::$ty>().map(Self::$name),)+
-					CssAtomSet::Supports => p.parse::<rules::SupportsRule>().map(|r| Self::Supports(Box::new_in(p.bump(), r))),
+					CssAtomSet::Supports => p.parse::<rules::SupportsRule>().map(|r| Self::Supports(Box::new_in(p.alloc(), r))),
 					_ => Err(Diagnostic::new(name.into(), Diagnostic::unexpected_at_rule))?,
 				}
 			}

--- a/crates/css_ast/src/stylesheet.rs
+++ b/crates/css_ast/src/stylesheet.rs
@@ -151,8 +151,8 @@ impl<'a> RuleVariants<'a> for Rule<'a> {
 			)+ ) => {
 				match p.to_atom::<CssAtomSet>(c) {
 					$($atoms => p.parse::<rules::$ty>().map(Self::$name),)+
-					CssAtomSet::Import => p.parse::<rules::ImportRule>().map(|r| Self::Import(Box::new_in(p.bump(), r))),
-					CssAtomSet::Supports => p.parse::<rules::SupportsRule>().map(|r| Self::Supports(Box::new_in(p.bump(), r))),
+					CssAtomSet::Import => p.parse::<rules::ImportRule>().map(|r| Self::Import(Box::new_in(p.alloc(), r))),
+					CssAtomSet::Supports => p.parse::<rules::SupportsRule>().map(|r| Self::Supports(Box::new_in(p.alloc(), r))),
 					_ => Err(Diagnostic::new(p.next(), Diagnostic::unexpected))?,
 				}
 			}

--- a/crates/css_ast/src/test_helpers.rs
+++ b/crates/css_ast/src/test_helpers.rs
@@ -72,15 +72,14 @@ apply_visit_methods!(visit_mut_trait);
 #[cfg(feature = "visitable")]
 macro_rules! assert_visits {
 	($source: expr, $parse_type: ty $(, $visit_type: ty)* $(,)?) => {{
-		use bumpalo::Bump;
+		use css_parse::{Arena, Parser};
 		use css_lexer::Lexer;
-		use css_parse::Parser;
 		use $crate::VisitableMut;
 
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let source_text = $source;
 		let lexer = Lexer::new(&$crate::CssAtomSet::ATOMS, source_text);
-		let mut parser = Parser::new(&bump, source_text, lexer);
+		let mut parser = Parser::new(&alloc, source_text, lexer);
 		let result = parser.parse_entirely::<$parse_type>();
 		if !result.errors.is_empty() {
 			panic!("\n\nParse {:?} failed. Saw error {:?}", source_text, result.errors[0]);
@@ -122,9 +121,9 @@ macro_rules! assert_visit_flow {
 	) => {{
 		use $crate::Visitable;
 		use $crate::NodeId;
-		let bump = bumpalo::Bump::new();
+		let alloc = ::css_parse::Arena::new();
 		let lexer = css_lexer::Lexer::new(&$crate::CssAtomSet::ATOMS, $source);
-		let mut parser = css_parse::Parser::new(&bump, $source, lexer);
+		let mut parser = css_parse::Parser::new(&alloc, $source, lexer);
 		let parsed = parser.parse_entirely::<$ty>().output.expect("parse failed");
 		let mut v = $visitor;
 		let _result = parsed.accept(&mut v);
@@ -140,13 +139,12 @@ pub(crate) use assert_visit_flow;
 #[macro_export]
 macro_rules! assert_feature_id {
 	($source: expr, $ty: ty, $id: literal) => {{
-		use bumpalo::Bump;
 		use css_lexer::Lexer;
-		use css_parse::Parser;
-		let bump = Bump::default();
+		use css_parse::{Arena, Parser};
+		let alloc = Arena::default();
 		let source_text = $source;
 		let lexer = Lexer::new(&$crate::CssAtomSet::ATOMS, source_text);
-		let mut parser = Parser::new(&bump, source_text, lexer);
+		let mut parser = Parser::new(&alloc, source_text, lexer);
 		let result = parser.parse_entirely::<$ty>();
 		if !result.errors.is_empty() {
 			panic!("\n\nParse {:?} failed. Saw error {:?}", source_text, result.errors[0]);
@@ -224,8 +222,7 @@ impl crate::Visit for ControlFlowTestVisitor {
 mod tests {
 	use super::*;
 	use crate::{Color, VisitMut, VisitableMut};
-	use bumpalo::Bump;
-	use css_parse::{Parse, Parser};
+	use css_parse::{Arena, Parse, Parser};
 
 	// Test visitor that intentionally skips exit calls
 	struct UnbalancedVisitor {
@@ -251,10 +248,10 @@ mod tests {
 	fn test_unbalanced_visitor_panics() {
 		use css_lexer::Lexer;
 
-		let arena = Bump::new();
+		let alloc = Arena::new();
 		let input = "red";
 		let lexer = Lexer::new(&crate::CssAtomSet::ATOMS, input);
-		let mut parser = Parser::new(&arena, input, lexer);
+		let mut parser = Parser::new(&alloc, input, lexer);
 
 		let mut color = Color::parse(&mut parser).unwrap();
 		let mut visitor = UnbalancedVisitor::new();
@@ -268,10 +265,10 @@ mod tests {
 	fn test_balanced_visitor_succeeds() {
 		use css_lexer::Lexer;
 
-		let arena = Bump::new();
+		let alloc = Arena::new();
 		let input = "red";
 		let lexer = Lexer::new(&crate::CssAtomSet::ATOMS, input);
-		let mut parser = Parser::new(&arena, input, lexer);
+		let mut parser = Parser::new(&alloc, input, lexer);
 
 		let mut color = Color::parse(&mut parser).unwrap();
 		let mut visitor = TestVisitor::new();

--- a/crates/css_ast/src/values/value.rs
+++ b/crates/css_ast/src/values/value.rs
@@ -27,11 +27,11 @@ macro_rules! impl_value_slot_parse {
 			{
 				if p.peek::<$sub<T>>() {
 					if !p.enter_substitution() {
-						return Ok(Self::Unresolved(::css_parse::Box::new_in(p.bump(), p.parse::<Unresolved>()?)));
+						return Ok(Self::Unresolved(::css_parse::Box::new_in(p.alloc(), p.parse::<Unresolved>()?)));
 					}
 					let sub = p.parse::<$sub<T>>();
 					p.exit_substitution();
-					return Ok(Self::Substituted(::css_parse::Box::new_in(p.bump(), sub?)));
+					return Ok(Self::Substituted(::css_parse::Box::new_in(p.alloc(), sub?)));
 				}
 				Ok(Self::Literal(p.parse::<$lit>()?))
 			}
@@ -270,9 +270,8 @@ mod tests {
 	#[test]
 	fn depth_limit_rejects_to_unresolved() {
 		// Build var(--a, var(--a, ... )) nested past MAX_SUBSTITUTION_DEPTH.
-		use bumpalo::Bump;
 		use css_lexer::Lexer;
-		use css_parse::Parser;
+		use css_parse::{Arena, Parser};
 
 		let depth = (Parser::<std::vec::IntoIter<css_parse::Cursor>>::MAX_SUBSTITUTION_DEPTH as usize) + 5;
 		let mut input = String::new();
@@ -284,9 +283,9 @@ mod tests {
 			input.push(')');
 		}
 
-		let bump = Bump::new();
+		let alloc = Arena::new();
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, &input);
-		let mut p = Parser::new(&bump, &input, lexer);
+		let mut p = Parser::new(&alloc, &input, lexer);
 		// Must not stack-overflow; deepest level degrades to Unresolved rather than recursing.
 		let result = p.parse_entirely::<ValueColor>();
 		assert!(result.output.is_some(), "expected parse to succeed via Unresolved degradation");

--- a/crates/css_ast/tests/allocations.rs
+++ b/crates/css_ast/tests/allocations.rs
@@ -1,7 +1,6 @@
-use bumpalo::Bump;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::Parser;
+use css_parse::{Arena, Parser};
 #[cfg(feature = "_dhat-heap-testing")]
 use dhat::{Alloc, HeapStats, Profiler, assert_eq};
 use std::fs::read_to_string;
@@ -12,23 +11,23 @@ static ALLOC: Alloc = Alloc;
 
 #[test]
 fn allocation_test() {
-	let simple_bump_size = 1984;
-	let simple_bump = Bump::with_capacity(simple_bump_size);
+	let simple_alloc_size = 1984;
+	let simple_alloc = Arena::with_capacity(simple_alloc_size);
 	let simple_str = "body{color:blue}";
 	let simple_lexer = Lexer::new(&CssAtomSet::ATOMS, simple_str);
-	let mut simple_parser = Parser::new(&simple_bump, simple_str, simple_lexer);
+	let mut simple_parser = Parser::new(&simple_alloc, simple_str, simple_lexer);
 
-	let escaped_bump_size = 16320;
-	let escaped_bump = Bump::with_capacity(escaped_bump_size);
+	let escaped_alloc_size = 16320;
+	let escaped_alloc = Arena::with_capacity(escaped_alloc_size);
 	let escaped_str = "bo\\d y{background-image:\\75\\52\\6c(a);width:1\\70\\78}";
 	let escaped_lexer = Lexer::new(&CssAtomSet::ATOMS, escaped_str);
-	let mut escape_parser = Parser::new(&escaped_bump, escaped_str, escaped_lexer);
+	let mut escape_parser = Parser::new(&escaped_alloc, escaped_str, escaped_lexer);
 
-	let big_bump_size = 331_222_976;
-	let big_bump = Bump::with_capacity(big_bump_size);
+	let big_alloc_size = 331_222_976;
+	let big_alloc = Arena::with_capacity(big_alloc_size);
 	let big_str = read_to_string("../../coverage/popular/tailwind.2.2.19.min.css").unwrap();
 	let big_lexer = Lexer::new(&CssAtomSet::ATOMS, &big_str);
-	let mut big_parser = Parser::new(&big_bump, &big_str, big_lexer);
+	let mut big_parser = Parser::new(&big_alloc, &big_str, big_lexer);
 
 	#[cfg(feature = "_dhat-heap-testing")]
 	let _profiler = Profiler::builder()
@@ -61,7 +60,7 @@ fn allocation_test() {
 	}
 
 	// XXX: If these fail because the numbers go down, great! If they go up, investigate why.
-	assert_eq!(simple_bump.allocated_bytes(), simple_bump_size);
-	assert_eq!(escaped_bump.allocated_bytes(), escaped_bump_size);
-	assert_eq!(big_bump.allocated_bytes(), big_bump_size);
+	assert_eq!(simple_alloc.allocated_bytes(), simple_alloc_size);
+	assert_eq!(escaped_alloc.allocated_bytes(), escaped_alloc_size);
+	assert_eq!(big_alloc.allocated_bytes(), big_alloc_size);
 }

--- a/crates/css_ast/tests/helpers.rs
+++ b/crates/css_ast/tests/helpers.rs
@@ -1,13 +1,12 @@
 #[macro_export]
 macro_rules! assert_snap_ast {
 	($source_path: literal) => {{
-		use bumpalo::Bump;
 		use css_ast::{CssAtomSet, StyleSheet};
 		use css_lexer::Lexer;
-		use css_parse::Parser;
+		use css_parse::{Arena, Parser};
 		use std::fs::read_to_string;
 
-		let allocator = Bump::default();
+		let allocator = Arena::default();
 		let source_text = read_to_string($source_path).unwrap();
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, &source_text);
 		let mut parser = Parser::new(&allocator, &source_text, lexer);

--- a/crates/css_ast/tests/popular_snapshots.rs
+++ b/crates/css_ast/tests/popular_snapshots.rs
@@ -1,9 +1,8 @@
 mod helpers;
 
-use bumpalo::Bump;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::Parser;
+use css_parse::{Arena, Parser};
 use glob::glob;
 use std::fs::read_to_string;
 
@@ -22,7 +21,7 @@ fn popular_snapshots() {
 		}
 
 		let result = std::panic::catch_unwind(|| {
-			let allocator = Bump::default();
+			let allocator = Arena::default();
 			let source_text = read_to_string(&source_path).unwrap();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, &source_text);
 			let mut parser = Parser::new(&allocator, &source_text, lexer);

--- a/crates/css_lexer/README.md
+++ b/crates/css_lexer/README.md
@@ -14,7 +14,7 @@ A spec-compliant CSS tokenizer with zero-copy cursors and optional feature gates
 ## Optional Features
 
 - `miette` - Enables `From<>` implementations for miette span types
-- `bump` - Enables `From<>` implementations for bump Vec
+- `bumpalo` - Enables `From<>` implementations for bumpalo Vec
 - `serde` - Enables serialization/deserialization support
 
 ## Part of csskit

--- a/crates/css_parse/src/arena_box.rs
+++ b/crates/css_parse/src/arena_box.rs
@@ -148,7 +148,7 @@ impl<'a, T: Parse<'a>> Parse<'a> for Box<'a, T> {
 		I: Iterator<Item = Cursor> + Clone,
 	{
 		let value = T::parse(p)?;
-		Ok(Box::new_in(p.bump(), value))
+		Ok(Box::new_in(p.alloc(), value))
 	}
 }
 

--- a/crates/css_parse/src/arena_vec.rs
+++ b/crates/css_parse/src/arena_vec.rs
@@ -7,6 +7,29 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
+/// A `bumpalo::vec!`-style constructor for the arena [`Vec`], generic over the allocator backend.
+///
+/// - `vec_in![in alloc]` -> empty
+/// - `vec_in![in alloc; elem; n]` -> `n` clones of `elem`
+/// - `vec_in![in alloc; a, b, c]` -> the listed elements, in order
+#[macro_export]
+macro_rules! vec_in {
+	(in $alloc:expr $(,)?) => { $crate::Vec::new_in($alloc) };
+	(in $alloc:expr; $elem:expr; $n:expr) => {{
+		let n = $n;
+		let mut v = $crate::Vec::with_capacity_in(n, $alloc);
+		for _ in 0..n {
+			v.push(::core::clone::Clone::clone(&$elem));
+		}
+		v
+	}};
+	(in $alloc:expr; $($x:expr),+ $(,)?) => {{
+		let mut v = $crate::Vec::new_in($alloc);
+		$( v.push($x); )+
+		v
+	}};
+}
+
 /// A growable, arena-allocated contiguous array, generic over any [`Allocator`].
 ///
 /// Unlike `std`'s `Vec`, this never runs element destructors: values live in the arena and are released wholesale when
@@ -511,8 +534,8 @@ mod test {
 
 	#[test]
 	fn new_is_empty_and_allocates_nothing() {
-		let arena = Arena::new();
-		let v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let v: Vec<i32> = Vec::new_in(&alloc);
 		assert!(v.is_empty());
 		assert_eq!(v.len(), 0);
 		assert_eq!(v.capacity(), 0);
@@ -521,8 +544,8 @@ mod test {
 
 	#[test]
 	fn with_capacity_reserves_but_stays_empty() {
-		let arena = Arena::new();
-		let v: Vec<i32> = Vec::with_capacity_in(16, &arena);
+		let alloc = Arena::new();
+		let v: Vec<i32> = Vec::with_capacity_in(16, &alloc);
 		assert!(v.is_empty());
 		assert_eq!(v.len(), 0);
 		assert!(v.capacity() >= 16);
@@ -530,15 +553,15 @@ mod test {
 
 	#[test]
 	fn with_capacity_zero_allocates_nothing() {
-		let arena = Arena::new();
-		let v: Vec<i32> = Vec::with_capacity_in(0, &arena);
+		let alloc = Arena::new();
+		let v: Vec<i32> = Vec::with_capacity_in(0, &alloc);
 		assert_eq!(v.capacity(), 0);
 	}
 
 	#[test]
 	fn push_grows_and_preserves_order() {
-		let arena = Arena::new();
-		let mut v: Vec<u32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<u32> = Vec::new_in(&alloc);
 		for i in 0..1000u32 {
 			v.push(i);
 		}
@@ -551,8 +574,8 @@ mod test {
 
 	#[test]
 	fn pop_returns_last_then_none() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([10, 20, 30]);
 		assert_eq!(v.pop(), Some(30));
 		assert_eq!(v.pop(), Some(20));
@@ -563,8 +586,8 @@ mod test {
 
 	#[test]
 	fn insert_at_boundaries_and_middle() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2, 3]);
 		v.insert(0, 0); // front
 		assert_eq!(&*v, &[0, 1, 2, 3]);
@@ -576,16 +599,16 @@ mod test {
 
 	#[test]
 	fn insert_into_empty() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.insert(0, 42);
 		assert_eq!(&*v, &[42]);
 	}
 
 	#[test]
 	fn insert_out_of_bounds_panics() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2]);
 		let result = catch_unwind(AssertUnwindSafe(|| v.insert(3, 0)));
 		assert!(result.is_err());
@@ -593,8 +616,8 @@ mod test {
 
 	#[test]
 	fn remove_at_boundaries_and_middle() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([0, 1, 2, 3, 4]);
 		assert_eq!(v.remove(0), 0); // front
 		assert_eq!(&*v, &[1, 2, 3, 4]);
@@ -606,8 +629,8 @@ mod test {
 
 	#[test]
 	fn remove_out_of_bounds_panics() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2]);
 		let result = catch_unwind(AssertUnwindSafe(|| v.remove(2)));
 		assert!(result.is_err());
@@ -615,9 +638,9 @@ mod test {
 
 	#[test]
 	fn truncate_shortens_without_dropping() {
-		let arena = Arena::new();
+		let alloc = Arena::new();
 		let drops = Rc::new(Cell::new(0));
-		let mut v: Vec<DropCounter> = Vec::new_in(&arena);
+		let mut v: Vec<DropCounter> = Vec::new_in(&alloc);
 		for i in 0..5 {
 			v.push(DropCounter::new(i, &drops));
 		}
@@ -628,8 +651,8 @@ mod test {
 
 	#[test]
 	fn truncate_longer_than_len_is_noop() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2, 3]);
 		v.truncate(10);
 		assert_eq!(&*v, &[1, 2, 3]);
@@ -637,9 +660,9 @@ mod test {
 
 	#[test]
 	fn clear_empties_without_dropping() {
-		let arena = Arena::new();
+		let alloc = Arena::new();
 		let drops = Rc::new(Cell::new(0));
-		let mut v: Vec<DropCounter> = Vec::new_in(&arena);
+		let mut v: Vec<DropCounter> = Vec::new_in(&alloc);
 		for i in 0..3 {
 			v.push(DropCounter::new(i, &drops));
 		}
@@ -650,8 +673,8 @@ mod test {
 
 	#[test]
 	fn extend_from_slice_clones_elements() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.push(1);
 		v.extend_from_slice(&[2, 3, 4]);
 		assert_eq!(&*v, &[1, 2, 3, 4]);
@@ -659,8 +682,8 @@ mod test {
 
 	#[test]
 	fn extend_with_accurate_size_hint_reserves_once() {
-		let arena = Arena::new();
-		let mut v: Vec<u32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<u32> = Vec::new_in(&alloc);
 		v.extend(0..64u32);
 		assert_eq!(v.len(), 64);
 		for i in 0..64u32 {
@@ -670,8 +693,8 @@ mod test {
 
 	#[test]
 	fn extend_empty_iterator_is_noop() {
-		let arena = Arena::new();
-		let mut v: Vec<u32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<u32> = Vec::new_in(&alloc);
 		v.extend(std::iter::empty::<u32>());
 		assert!(v.is_empty());
 		assert_eq!(v.capacity(), 0);
@@ -679,8 +702,8 @@ mod test {
 
 	#[test]
 	fn retain_keeps_matching_and_shifts() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([0, 1, 2, 3, 4, 5, 6, 7]);
 		v.retain(|&x| x % 2 == 0);
 		assert_eq!(&*v, &[0, 2, 4, 6]);
@@ -688,8 +711,8 @@ mod test {
 
 	#[test]
 	fn retain_all_and_none() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2, 3]);
 		v.retain(|_| true);
 		assert_eq!(&*v, &[1, 2, 3]);
@@ -699,9 +722,9 @@ mod test {
 
 	#[test]
 	fn retain_drops_removed_exactly_once() {
-		let arena = Arena::new();
+		let alloc = Arena::new();
 		let drops = Rc::new(Cell::new(0));
-		let mut v: Vec<DropCounter> = Vec::new_in(&arena);
+		let mut v: Vec<DropCounter> = Vec::new_in(&alloc);
 		for i in 0..6 {
 			v.push(DropCounter::new(i, &drops));
 		}
@@ -714,9 +737,9 @@ mod test {
 
 	#[test]
 	fn retain_panic_drops_no_element_twice() {
-		let arena = Arena::new();
+		let alloc = Arena::new();
 		let drops = Rc::new(Cell::new(0));
-		let mut v: Vec<DropCounter> = Vec::new_in(&arena);
+		let mut v: Vec<DropCounter> = Vec::new_in(&alloc);
 		for i in 0..5 {
 			v.push(DropCounter::new(i, &drops));
 		}
@@ -738,8 +761,8 @@ mod test {
 
 	#[test]
 	fn drain_empty_range() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2, 3]);
 		let drained: std::vec::Vec<i32> = v.drain(1..1).collect();
 		assert!(drained.is_empty());
@@ -748,8 +771,8 @@ mod test {
 
 	#[test]
 	fn drain_suffix() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([0, 1, 2, 3, 4]);
 		let drained: std::vec::Vec<i32> = v.drain(3..).collect();
 		assert_eq!(drained, vec![3, 4]);
@@ -758,8 +781,8 @@ mod test {
 
 	#[test]
 	fn drain_inclusive_bound() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([0, 1, 2, 3, 4]);
 		let drained: std::vec::Vec<i32> = v.drain(1..=3).collect();
 		assert_eq!(drained, vec![1, 2, 3]);
@@ -768,8 +791,8 @@ mod test {
 
 	#[test]
 	fn drain_start_after_end_panics() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([0, 1, 2]);
 		use std::ops::Bound;
 		let bad_range = (Bound::Included(2u32), Bound::Excluded(1u32));
@@ -781,8 +804,8 @@ mod test {
 
 	#[test]
 	fn drain_out_of_bounds_panics() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([0, 1, 2]);
 		let result = catch_unwind(AssertUnwindSafe(|| {
 			let _ = v.drain(1..99);
@@ -792,9 +815,9 @@ mod test {
 
 	#[test]
 	fn drain_yielded_and_remaining_drop_exactly_once() {
-		let arena = Arena::new();
+		let alloc = Arena::new();
 		let drops = Rc::new(Cell::new(0));
-		let mut v: Vec<DropCounter> = Vec::new_in(&arena);
+		let mut v: Vec<DropCounter> = Vec::new_in(&alloc);
 		for i in 0..6 {
 			v.push(DropCounter::new(i, &drops));
 		}
@@ -812,9 +835,9 @@ mod test {
 
 	#[test]
 	fn drain_fully_consumed_then_no_extra_drops() {
-		let arena = Arena::new();
+		let alloc = Arena::new();
 		let drops = Rc::new(Cell::new(0));
-		let mut v: Vec<DropCounter> = Vec::new_in(&arena);
+		let mut v: Vec<DropCounter> = Vec::new_in(&alloc);
 		for i in 0..4 {
 			v.push(DropCounter::new(i, &drops));
 		}
@@ -830,8 +853,8 @@ mod test {
 
 	#[test]
 	fn drain_size_hint_not_relied_on_but_iteration_correct() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([5, 6, 7, 8]);
 		let mut iter = v.drain(0..4);
 		assert_eq!(iter.next(), Some(5));
@@ -843,8 +866,8 @@ mod test {
 
 	#[test]
 	fn drain_prefix_shifts_tail() {
-		let arena = Arena::default();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::default();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([0, 1, 2, 3, 4, 5]);
 		let drained: std::vec::Vec<i32> = v.drain(0..2).collect();
 		assert_eq!(drained, vec![0, 1]);
@@ -853,8 +876,8 @@ mod test {
 
 	#[test]
 	fn drain_middle_shifts_tail() {
-		let arena = Arena::default();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::default();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([0, 1, 2, 3, 4, 5]);
 		let drained: std::vec::Vec<i32> = v.drain(2..4).collect();
 		assert_eq!(drained, vec![2, 3]);
@@ -863,8 +886,8 @@ mod test {
 
 	#[test]
 	fn drain_full_range() {
-		let arena = Arena::default();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::default();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2, 3]);
 		let drained: std::vec::Vec<i32> = v.drain(..).collect();
 		assert_eq!(drained, vec![1, 2, 3]);
@@ -873,8 +896,8 @@ mod test {
 
 	#[test]
 	fn drain_dropped_without_iterating_still_shifts() {
-		let arena = Arena::default();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::default();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([0, 1, 2, 3, 4]);
 		drop(v.drain(1..3));
 		assert_eq!(&*v, &[0, 3, 4]);
@@ -882,8 +905,8 @@ mod test {
 
 	#[test]
 	fn retain_preserves_length_when_predicate_panics() {
-		let arena = Arena::new();
-		let mut values = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut values = Vec::new_in(&alloc);
 		values.extend([0, 1, 2]);
 		let calls = Cell::new(0);
 
@@ -905,8 +928,8 @@ mod test {
 
 	#[test]
 	fn into_iter_yields_all_in_order() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2, 3, 4]);
 		let collected: std::vec::Vec<i32> = v.into_iter().collect();
 		assert_eq!(collected, vec![1, 2, 3, 4]);
@@ -914,8 +937,8 @@ mod test {
 
 	#[test]
 	fn into_iter_size_hint_is_exact() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2, 3]);
 		let mut iter = v.into_iter();
 		assert_eq!(iter.size_hint(), (3, Some(3)));
@@ -925,9 +948,9 @@ mod test {
 
 	#[test]
 	fn into_iter_partial_consume_drops_remainder_once() {
-		let arena = Arena::new();
+		let alloc = Arena::new();
 		let drops = Rc::new(Cell::new(0));
-		let mut v: Vec<DropCounter> = Vec::new_in(&arena);
+		let mut v: Vec<DropCounter> = Vec::new_in(&alloc);
 		for i in 0..5 {
 			v.push(DropCounter::new(i, &drops));
 		}
@@ -945,9 +968,9 @@ mod test {
 
 	#[test]
 	fn into_iter_fully_consumed_no_leak() {
-		let arena = Arena::new();
+		let alloc = Arena::new();
 		let drops = Rc::new(Cell::new(0));
-		let mut v: Vec<DropCounter> = Vec::new_in(&arena);
+		let mut v: Vec<DropCounter> = Vec::new_in(&alloc);
 		for i in 0..4 {
 			v.push(DropCounter::new(i, &drops));
 		}
@@ -959,8 +982,8 @@ mod test {
 
 	#[test]
 	fn clone_is_independent_copy() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([1, 2, 3]);
 		let mut c = v.clone();
 		c.push(4);
@@ -970,13 +993,13 @@ mod test {
 
 	#[test]
 	fn eq_and_ord_delegate_to_slice() {
-		let arena = Arena::new();
-		let mut a: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut a: Vec<i32> = Vec::new_in(&alloc);
 		a.extend([1, 2, 3]);
-		let mut b: Vec<i32> = Vec::new_in(&arena);
+		let mut b: Vec<i32> = Vec::new_in(&alloc);
 		b.extend([1, 2, 3]);
 		assert_eq!(a, b);
-		let mut c: Vec<i32> = Vec::new_in(&arena);
+		let mut c: Vec<i32> = Vec::new_in(&alloc);
 		c.extend([1, 2, 4]);
 		assert!(a < c);
 		assert_ne!(a, c);
@@ -984,8 +1007,8 @@ mod test {
 
 	#[test]
 	fn index_and_index_mut() {
-		let arena = Arena::new();
-		let mut v: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<i32> = Vec::new_in(&alloc);
 		v.extend([10, 20, 30]);
 		assert_eq!(v[1], 20);
 		v[1] = 99;
@@ -997,10 +1020,10 @@ mod test {
 	fn hash_matches_equal_vecs() {
 		use std::collections::hash_map::DefaultHasher;
 		use std::hash::{Hash, Hasher};
-		let arena = Arena::new();
-		let mut a: Vec<i32> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut a: Vec<i32> = Vec::new_in(&alloc);
 		a.extend([1, 2, 3]);
-		let mut b: Vec<i32> = Vec::new_in(&arena);
+		let mut b: Vec<i32> = Vec::new_in(&alloc);
 		b.extend([1, 2, 3]);
 		let mut ha = DefaultHasher::new();
 		let mut hb = DefaultHasher::new();
@@ -1011,8 +1034,8 @@ mod test {
 
 	#[test]
 	fn realloc_preserves_boxed_contents() {
-		let arena = Arena::new();
-		let mut v: Vec<std::boxed::Box<u32>> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<std::boxed::Box<u32>> = Vec::new_in(&alloc);
 		for i in 0..512u32 {
 			v.push(std::boxed::Box::new(i));
 		}
@@ -1025,8 +1048,8 @@ mod test {
 
 	#[test]
 	fn zero_sized_type_push_pop_len() {
-		let arena = Arena::new();
-		let mut v: Vec<()> = Vec::new_in(&arena);
+		let alloc = Arena::new();
+		let mut v: Vec<()> = Vec::new_in(&alloc);
 		for _ in 0..100 {
 			v.push(());
 		}

--- a/crates/css_parse/src/cursor_compact_write_sink.rs
+++ b/crates/css_parse/src/cursor_compact_write_sink.rs
@@ -128,8 +128,8 @@ impl<'a, T: SourceCursorSink<'a>> SourceCursorSink<'a> for CursorCompactWriteSin
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::Arena;
 	use crate::{ComponentValues, EmptyAtomSet, Parser, ToCursors};
-	use bumpalo::Bump;
 	use css_lexer::Lexer;
 
 	macro_rules! assert_format {
@@ -138,12 +138,12 @@ mod test {
 		};
 		($struct: ident, $before: literal, $after: literal) => {
 			let source_text = $before;
-			let bump = Bump::default();
+			let alloc = Arena::default();
 			let mut sink = String::new();
 			{
 				let mut stream = CursorCompactWriteSink::new(source_text, &mut sink);
 				let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-				let mut parser = Parser::new(&bump, source_text, lexer);
+				let mut parser = Parser::new(&alloc, source_text, lexer);
 				parser.parse_entirely::<$struct>().with_trivia().to_cursors(&mut stream);
 			}
 			assert_eq!(sink, $after.trim());

--- a/crates/css_parse/src/cursor_expanded_write_sink.rs
+++ b/crates/css_parse/src/cursor_expanded_write_sink.rs
@@ -68,8 +68,8 @@ impl<'a, T: SourceCursorSink<'a>> SourceCursorSink<'a> for CursorExpandedWriteSi
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::Arena;
 	use crate::{ComponentValues, EmptyAtomSet, Parser, ToCursors};
-	use bumpalo::Bump;
 	use css_lexer::Lexer;
 
 	macro_rules! assert_expand {
@@ -78,11 +78,11 @@ mod test {
 		};
 		($struct: ident, $before: literal, $after: literal) => {
 			let source_text = $before;
-			let bump = Bump::default();
+			let alloc = Arena::default();
 			let mut sink = String::new();
 			let mut stream = CursorExpandedWriteSink::new(source_text, &mut sink).with_escape_idents(true);
 			let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			parser.parse_entirely::<$struct>().output.unwrap().to_cursors(&mut stream);
 			assert_eq!(sink, $after);
 		};

--- a/crates/css_parse/src/cursor_ordered_sink.rs
+++ b/crates/css_parse/src/cursor_ordered_sink.rs
@@ -17,10 +17,10 @@ pub struct CursorOrderedSink<'a, S> {
 }
 
 impl<'a, S: CursorSink> CursorOrderedSink<'a, S> {
-	pub fn new(bump: &'a Arena, sink: &'a mut S) -> Self {
+	pub fn new(alloc: &'a Arena, sink: &'a mut S) -> Self {
 		Self {
 			sink,
-			buffer: Vec::new_in(bump),
+			buffer: Vec::new_in(alloc),
 			committed_position: SourceOffset(0),
 			#[cfg(debug_assertions)]
 			seen_eof: false,
@@ -139,21 +139,21 @@ impl<'a, S: CursorSink> CursorSink for CursorOrderedSink<'a, S> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::Vec as BumpVec;
+	use crate::Arena;
+	use crate::Vec as ArenaVec;
 	use crate::{ComponentValues, EmptyAtomSet, Parser, SourceCursor, ToCursors};
-	use bumpalo::Bump;
 	use css_lexer::Lexer;
 	use std::fmt::Write;
 
 	#[test]
 	fn test_basic() {
 		let source_text = "foo bar";
-		let bump = Bump::default();
-		let mut output = BumpVec::new_in(&bump);
+		let alloc = Arena::default();
+		let mut output = ArenaVec::new_in(&alloc);
 		{
-			let mut ordered_sink = CursorOrderedSink::new(&bump, &mut output);
+			let mut ordered_sink = CursorOrderedSink::new(&alloc, &mut output);
 			let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			parser.parse_entirely::<ComponentValues>().output.unwrap().to_cursors(&mut ordered_sink);
 			ordered_sink.flush();
 		}
@@ -168,10 +168,10 @@ mod tests {
 	fn test_manual_flush() {
 		use crate::{SourceOffset, Token};
 
-		let bump = Bump::default();
-		let mut output = BumpVec::new_in(&bump);
+		let alloc = Arena::default();
+		let mut output = ArenaVec::new_in(&alloc);
 		{
-			let mut ordered_sink = CursorOrderedSink::new(&bump, &mut output);
+			let mut ordered_sink = CursorOrderedSink::new(&alloc, &mut output);
 			let cursor1 = Cursor::new(SourceOffset(0), Token::SPACE); // position 0, length 1
 			let cursor2 = Cursor::new(SourceOffset(10), Token::SPACE); // position 10, length 1
 			let cursor3 = Cursor::new(SourceOffset(4), Token::SPACE); // position 4, length 1
@@ -191,10 +191,10 @@ mod tests {
 	#[test]
 	fn test_contiguous_eager_emission() {
 		use crate::{SourceOffset, Token};
-		let bump = Bump::default();
-		let mut output = BumpVec::new_in(&bump);
+		let alloc = Arena::default();
+		let mut output = ArenaVec::new_in(&alloc);
 		{
-			let mut ordered_sink = CursorOrderedSink::new(&bump, &mut output);
+			let mut ordered_sink = CursorOrderedSink::new(&alloc, &mut output);
 			// Create cursors that form a contiguous sequence
 			let cursor_at_0 = Cursor::new(SourceOffset(0), Token::SPACE);
 			let cursor_at_1 = Cursor::new(SourceOffset(1), Token::SPACE);
@@ -210,11 +210,11 @@ mod tests {
 	#[test]
 	fn test_gap_filling() {
 		use crate::{SourceOffset, Token};
-		let bump = Bump::default();
-		let mut output = BumpVec::new_in(&bump);
+		let alloc = Arena::default();
+		let mut output = ArenaVec::new_in(&alloc);
 
 		{
-			let mut ordered_sink = CursorOrderedSink::new(&bump, &mut output);
+			let mut ordered_sink = CursorOrderedSink::new(&alloc, &mut output);
 			// Create cursors with a gap, then fill the gap
 			let cursor_at_0 = Cursor::new(SourceOffset(0), Token::SPACE); // ends at 1
 			let cursor_at_2 = Cursor::new(SourceOffset(2), Token::SPACE); // ends at 3
@@ -233,10 +233,10 @@ mod tests {
 	#[test]
 	fn test_sequential() {
 		use crate::{SourceOffset, Token};
-		let bump = Bump::default();
-		let mut output = BumpVec::new_in(&bump);
+		let alloc = Arena::default();
+		let mut output = ArenaVec::new_in(&alloc);
 		{
-			let mut ordered_sink = CursorOrderedSink::new(&bump, &mut output);
+			let mut ordered_sink = CursorOrderedSink::new(&alloc, &mut output);
 			let cursor1 = Cursor::new(SourceOffset(0), Token::SPACE);
 			let cursor2 = Cursor::new(SourceOffset(1), Token::SPACE);
 			let cursor3 = Cursor::new(SourceOffset(2), Token::SPACE);
@@ -254,10 +254,10 @@ mod tests {
 	#[test]
 	fn test_varied_order() {
 		use crate::{SourceOffset, Token};
-		let bump = Bump::default();
-		let mut output = BumpVec::new_in(&bump);
+		let alloc = Arena::default();
+		let mut output = ArenaVec::new_in(&alloc);
 		{
-			let mut ordered_sink = CursorOrderedSink::new(&bump, &mut output);
+			let mut ordered_sink = CursorOrderedSink::new(&alloc, &mut output);
 			let cursor_at_4 = Cursor::new(SourceOffset(4), Token::SPACE); // ends at 5
 			let cursor_at_0 = Cursor::new(SourceOffset(0), Token::SPACE); // ends at 1
 			let cursor_at_6 = Cursor::new(SourceOffset(6), Token::SPACE); // ends at 7

--- a/crates/css_parse/src/cursor_overlay_sink.rs
+++ b/crates/css_parse/src/cursor_overlay_sink.rs
@@ -47,8 +47,8 @@ pub struct CursorOverlaySet<'a> {
 }
 
 impl<'a> CursorOverlaySet<'a> {
-	pub fn new(bump: &'a Arena) -> Self {
-		Self { segments: Vec::new_in(bump) }
+	pub fn new(alloc: &'a Arena) -> Self {
+		Self { segments: Vec::new_in(alloc) }
 	}
 
 	pub fn insert(&mut self, span: Span, cursors: Vec<'a, SourceCursor<'a>>) {
@@ -181,19 +181,19 @@ impl<'a, 'o, T: SourceCursorSink<'a>> CursorSink for CursorOverlaySink<'a, 'o, T
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::Arena;
 	use crate::Vec;
 	use crate::{
 		ComponentValue, ComponentValues, CursorPrettyWriteSink, CursorToSourceCursorSink, CursorWriteSink,
 		EmptyAtomSet, Parser, QuoteStyle, T, ToCursors, ToSpan,
 	};
-	use bumpalo::Bump;
 	use css_lexer::Lexer;
 
-	fn snippet_cursors<'a>(bump: &'a Bump, snippet: &'a str) -> Vec<'a, SourceCursor<'a>> {
+	fn snippet_cursors<'a>(alloc: &'a Arena, snippet: &'a str) -> Vec<'a, SourceCursor<'a>> {
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, snippet);
-		let mut parser = Parser::new(bump, snippet, lexer);
+		let mut parser = Parser::new(alloc, snippet, lexer);
 		let parsed = parser.parse_entirely::<ComponentValues<'a>>();
-		let mut cursors = Vec::new_in(bump);
+		let mut cursors = Vec::new_in(alloc);
 		let mut sink = CursorToSourceCursorSink::new(snippet, &mut cursors);
 		parsed.to_cursors(&mut sink);
 		cursors
@@ -202,19 +202,19 @@ mod test {
 	#[test]
 	fn test_basic() {
 		let source_text = "black white";
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-		let mut p = Parser::new(&bump, source_text, lexer);
+		let mut p = Parser::new(&alloc, source_text, lexer);
 		let output = p.parse_entirely::<(T![Ident], T![Ident])>().output.unwrap();
 
 		let overlay_text = "green";
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, overlay_text);
-		let mut p = Parser::new(&bump, overlay_text, lexer);
+		let mut p = Parser::new(&alloc, overlay_text, lexer);
 		let overlay = p.parse_entirely::<T![Ident]>();
-		let mut source_cursors = Vec::new_in(&bump);
+		let mut source_cursors = Vec::new_in(&alloc);
 		let mut sink = CursorToSourceCursorSink::new(overlay_text, &mut source_cursors);
 		overlay.to_cursors(&mut sink);
-		let mut overlays = CursorOverlaySet::new(&bump);
+		let mut overlays = CursorOverlaySet::new(&alloc);
 		overlays.insert(output.1.to_span(), source_cursors);
 
 		let mut str = String::new();
@@ -227,20 +227,20 @@ mod test {
 	#[test]
 	fn test_with_pretty_writer() {
 		let source_text = "foo{use:other;}";
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-		let mut p = Parser::new(&bump, source_text, lexer);
+		let mut p = Parser::new(&alloc, source_text, lexer);
 		let output = p.parse_entirely::<Vec<'_, ComponentValue>>().output.unwrap();
 		let ComponentValue::SimpleBlock(ref block) = output[1] else { panic!("output[1] was not a block") };
 
 		let overlay_text = "inner{foo: bar;}";
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, overlay_text);
-		let mut p = Parser::new(&bump, overlay_text, lexer);
+		let mut p = Parser::new(&alloc, overlay_text, lexer);
 		let overlay = p.parse_entirely::<Vec<'_, ComponentValue>>();
-		let mut source_cursors = Vec::new_in(&bump);
+		let mut source_cursors = Vec::new_in(&alloc);
 		let mut sink = CursorToSourceCursorSink::new(overlay_text, &mut source_cursors);
 		overlay.to_cursors(&mut sink);
-		let mut overlays = CursorOverlaySet::new(&bump);
+		let mut overlays = CursorOverlaySet::new(&alloc);
 		overlays.insert(block.values.to_span(), source_cursors);
 
 		let mut str = String::new();
@@ -267,20 +267,20 @@ foo {
 	#[test]
 	fn test_insert_before_and_after() {
 		let source_text = "ab";
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-		let mut parser = Parser::new(&bump, source_text, lexer);
+		let mut parser = Parser::new(&alloc, source_text, lexer);
 		let output = parser.parse_entirely::<Vec<'_, ComponentValue>>().output.unwrap();
 
-		let mut overlays = CursorOverlaySet::new(&bump);
+		let mut overlays = CursorOverlaySet::new(&alloc);
 		overlays.push_segment(OverlaySegment::new(
 			Span::new(SourceOffset(0), SourceOffset(0)),
-			snippet_cursors(&bump, "pre"),
+			snippet_cursors(&alloc, "pre"),
 			OverlayKind::InsertBefore,
 		));
 		overlays.push_segment(OverlaySegment::new(
 			Span::new(SourceOffset(2), SourceOffset(2)),
-			snippet_cursors(&bump, "post"),
+			snippet_cursors(&alloc, "post"),
 			OverlayKind::InsertAfter,
 		));
 
@@ -293,30 +293,30 @@ foo {
 	#[test]
 	fn test_multiple_inserts_preserve_order() {
 		let source_text = "x";
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-		let mut parser = Parser::new(&bump, source_text, lexer);
+		let mut parser = Parser::new(&alloc, source_text, lexer);
 		let output = parser.parse_entirely::<Vec<'_, ComponentValue>>().output.unwrap();
 
-		let mut overlays = CursorOverlaySet::new(&bump);
+		let mut overlays = CursorOverlaySet::new(&alloc);
 		overlays.push_segment(OverlaySegment::new(
 			Span::new(SourceOffset(0), SourceOffset(0)),
-			snippet_cursors(&bump, "A"),
+			snippet_cursors(&alloc, "A"),
 			OverlayKind::InsertBefore,
 		));
 		overlays.push_segment(OverlaySegment::new(
 			Span::new(SourceOffset(0), SourceOffset(0)),
-			snippet_cursors(&bump, "B"),
+			snippet_cursors(&alloc, "B"),
 			OverlayKind::InsertBefore,
 		));
 		overlays.push_segment(OverlaySegment::new(
 			Span::new(SourceOffset(1), SourceOffset(1)),
-			snippet_cursors(&bump, "C"),
+			snippet_cursors(&alloc, "C"),
 			OverlayKind::InsertAfter,
 		));
 		overlays.push_segment(OverlaySegment::new(
 			Span::new(SourceOffset(1), SourceOffset(1)),
-			snippet_cursors(&bump, "D"),
+			snippet_cursors(&alloc, "D"),
 			OverlayKind::InsertAfter,
 		));
 

--- a/crates/css_parse/src/cursor_pretty_write_sink.rs
+++ b/crates/css_parse/src/cursor_pretty_write_sink.rs
@@ -101,29 +101,29 @@ impl<'a, T: SourceCursorSink<'a>> SourceCursorSink<'a> for CursorPrettyWriteSink
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::Arena;
 	use crate::ToCursors;
 	use crate::{ComponentValues, EmptyAtomSet, Parser};
-	use bumpalo::Bump;
 	use css_lexer::Lexer;
 
 	macro_rules! assert_format {
 		($struct: ident, $before: literal, $after: literal) => {
 			let source_text = $before;
-			let bump = Bump::default();
+			let alloc = Arena::default();
 			let mut sink = String::new();
 			let mut stream = CursorPrettyWriteSink::new(source_text, &mut sink, None, QuoteStyle::Double);
 			let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			parser.parse_entirely::<$struct>().output.unwrap().to_cursors(&mut stream);
 			assert_eq!(sink, $after.trim());
 		};
 		($before: literal, $after: literal) => {
 			let source_text = $before;
-			let bump = Bump::default();
+			let alloc = Arena::default();
 			let mut sink = String::new();
 			let mut stream = CursorPrettyWriteSink::new(source_text, &mut sink, None, QuoteStyle::Double);
 			let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			parser.parse_entirely::<ComponentValues>().output.unwrap().to_cursors(&mut stream);
 			assert_eq!(sink, $after.trim());
 		};

--- a/crates/css_parse/src/cursor_to_source_cursor_sink.rs
+++ b/crates/css_parse/src/cursor_to_source_cursor_sink.rs
@@ -40,18 +40,18 @@ impl<'a, T: SourceCursorSink<'a>> SourceCursorSink<'a> for &mut T {
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::Arena;
 	use crate::{ComponentValues, EmptyAtomSet, Parser, ToCursors};
-	use bumpalo::Bump;
 	use css_lexer::Lexer;
 
 	#[test]
 	fn test_source_cursor_sink_for_string() {
 		let source_text = "black white";
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let mut str = String::new();
 		let mut transform = CursorToSourceCursorSink::new(source_text, &mut str);
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-		let mut parser = Parser::new(&bump, source_text, lexer);
+		let mut parser = Parser::new(&alloc, source_text, lexer);
 		parser.parse_entirely::<ComponentValues>().output.unwrap().to_cursors(&mut transform);
 		assert_eq!(str, "black white");
 	}
@@ -59,12 +59,12 @@ mod test {
 	#[test]
 	fn test_source_cursor_sink_for_arena_string() {
 		let source_text = "black white";
-		let bump = Bump::default();
-		let mut str = crate::String::new_in(&bump);
+		let alloc = crate::Arena::default();
+		let mut str = crate::String::new_in(&alloc);
 		{
 			let mut transform = CursorToSourceCursorSink::new(source_text, &mut str);
 			let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			parser.parse_entirely::<ComponentValues>().output.unwrap().to_cursors(&mut transform);
 		}
 		assert_eq!(str, "black white");

--- a/crates/css_parse/src/cursor_write_sink.rs
+++ b/crates/css_parse/src/cursor_write_sink.rs
@@ -44,18 +44,18 @@ impl<'a, T: Write> SourceCursorSink<'a> for CursorWriteSink<'a, T> {
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::Arena;
 	use crate::{ComponentValues, EmptyAtomSet, Parser, ToCursors};
-	use bumpalo::Bump;
 	use css_lexer::Lexer;
 
 	#[test]
 	fn test() {
 		let source_text = "foo{bar:baz();}";
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let mut str = String::new();
 		let mut stream = CursorWriteSink::new(source_text, &mut str);
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-		let mut parser = Parser::new(&bump, source_text, lexer);
+		let mut parser = Parser::new(&alloc, source_text, lexer);
 		parser.parse_entirely::<ComponentValues>().output.unwrap().to_cursors(&mut stream);
 		assert_eq!(str, "foo{bar:baz();}");
 	}

--- a/crates/css_parse/src/feature.rs
+++ b/crates/css_parse/src/feature.rs
@@ -10,12 +10,11 @@ use bitmask_enum::bitmask;
 /// ```
 /// use css_lexer::Lexer;
 /// use css_parse::*;
-/// use bumpalo::Bump;
-/// let bump = Bump::default();
+/// let alloc = Arena::default();
 /// let features = Feature::SingleLineComments | Feature::SeparateWhitespace;
 /// let source_text = "// foo";
 /// let lexer = Lexer::new_with_features(&EmptyAtomSet::ATOMS, &source_text, features.into());
-/// let mut parser = Parser::new(&bump, &source_text, lexer).with_features(features);
+/// let mut parser = Parser::new(&alloc, &source_text, lexer).with_features(features);
 /// ```
 #[bitmask(u8)]
 pub enum Feature {

--- a/crates/css_parse/src/lib.rs
+++ b/crates/css_parse/src/lib.rs
@@ -10,7 +10,7 @@
 //! [1]: https://drafts.csswg.org/css-syntax-3/
 //! [2]: https://en.wikipedia.org/wiki/Recursive_descent_parser
 //!
-//! Parsing requires a heap allocator to allocate into, [bumpalo::Bump] being the allocator of choice. This needs to be
+//! Parsing requires a heap allocator to allocate into, [Arena] being the allocator of choice. This needs to be
 //! created before parsing, the parser result will have a lifetime bound to the allocator.
 //!
 //! The [Parser] _may_ be configured with additional [Features][Feature] to allow for different parsing or lexing

--- a/crates/css_parse/src/macros/pseudo_class.rs
+++ b/crates/css_parse/src/macros/pseudo_class.rs
@@ -10,7 +10,6 @@
 /// use css_parse::*;
 /// use csskit_derives::*;
 /// use derive_atom_set::*;
-/// use bumpalo::Bump;
 ///
 /// #[derive(Debug, Default, AtomSet, Copy, Clone, PartialEq)]
 /// pub enum MyAtomSet {

--- a/crates/css_parse/src/macros/pseudo_element.rs
+++ b/crates/css_parse/src/macros/pseudo_element.rs
@@ -10,7 +10,6 @@
 /// use css_parse::*;
 /// use csskit_derives::*;
 /// use derive_atom_set::*;
-/// use bumpalo::Bump;
 ///
 /// #[derive(Debug, Default, AtomSet, Copy, Clone, PartialEq)]
 /// pub enum MyAtomSet {

--- a/crates/css_parse/src/parser.rs
+++ b/crates/css_parse/src/parser.rs
@@ -32,7 +32,7 @@ pub struct Parser<'a, I: Iterator<Item = Cursor> + Clone> {
 
 	pub(crate) state: State,
 
-	pub(crate) bump: &'a Arena,
+	pub(crate) alloc: &'a Arena,
 
 	skip: KindSet,
 
@@ -69,7 +69,7 @@ where
 	I: Iterator<Item = Cursor> + Clone,
 {
 	/// Create a new parser with an iterator over cursors
-	pub fn new(bump: &'a Arena, source_text: &'a str, mut cursor_iter: I) -> Self {
+	pub fn new(alloc: &'a Arena, source_text: &'a str, mut cursor_iter: I) -> Self {
 		let eof_cursor = eof_cursor(source_text.len());
 		let mut buffer = [eof_cursor; BUFFER_LEN];
 		buffer.fill_with(|| cursor_iter.next().unwrap_or(eof_cursor));
@@ -78,15 +78,15 @@ where
 			source_text,
 			cursor_iter,
 			features: Feature::none(),
-			errors: Vec::new_in(bump),
-			trivia: Vec::new_in(bump),
+			errors: Vec::new_in(alloc),
+			trivia: Vec::new_in(alloc),
 			state: State::none(),
 			skip: KindSet::TRIVIA,
 			stop: KindSet::NONE,
 			buffer,
 			buffer_index: 0,
 			substitution_depth: 0,
-			bump,
+			alloc,
 			#[cfg(debug_assertions)]
 			last_cursor: None,
 		}
@@ -109,8 +109,8 @@ where
 	}
 
 	#[inline]
-	pub fn bump(&self) -> &'a Arena {
-		self.bump
+	pub fn alloc(&self) -> &'a Arena {
+		self.alloc
 	}
 
 	/// Maximum nesting depth of substitution functions before parsing bails to `Unresolved`.
@@ -193,8 +193,8 @@ where
 				self.errors.push(Diagnostic::new(start, Diagnostic::expected_end).with_end_cursor(end));
 			}
 		}
-		let errors = mem::replace(&mut self.errors, Vec::new_in(self.bump));
-		let trivia = mem::replace(&mut self.trivia, Vec::new_in(self.bump));
+		let errors = mem::replace(&mut self.errors, Vec::new_in(self.alloc));
+		let trivia = mem::replace(&mut self.trivia, Vec::new_in(self.alloc));
 		ParserReturn::new(output, self.source_text, errors, trivia)
 	}
 
@@ -225,7 +225,7 @@ where
 				return false;
 			}
 			let source_cursor = self.to_source_cursor(c);
-			cursor_bits = atom.str_to_bits(&source_cursor.parse(self.bump));
+			cursor_bits = atom.str_to_bits(&source_cursor.parse(self.alloc));
 		}
 		cursor_bits == atom.bits()
 	}
@@ -237,13 +237,13 @@ where
 				return A::from_bits(0);
 			}
 			let source_cursor = self.to_source_cursor(c);
-			return A::from_str(&source_cursor.parse(self.bump));
+			return A::from_str(&source_cursor.parse(self.alloc));
 		}
 		#[cfg(debug_assertions)]
 		if c == KindSet::ATOM_LIKE && c != Kind::Dimension {
 			let is_dashed = c.token().is_dashed_ident();
 			let source_cursor = self.to_source_cursor(c);
-			let text = source_cursor.parse(self.bump);
+			let text = source_cursor.parse(self.alloc);
 			let comparable = if is_dashed { &text[2..] } else { &text[..] };
 			debug_assert!(
 				A::from_bits(bits) == A::from_str(comparable),
@@ -370,7 +370,7 @@ where
 	}
 
 	pub fn consume_trivia(&mut self) -> Vec<'a, Cursor> {
-		let mut trivia = Vec::new_in(self.bump);
+		let mut trivia = Vec::new_in(self.alloc);
 		for i in self.buffer_index..BUFFER_LEN {
 			let c = self.buffer[i];
 			if c == Kind::Eof {
@@ -424,7 +424,7 @@ where
 	#[allow(clippy::should_implement_trait)]
 	pub fn next(&mut self) -> Cursor {
 		// Collect trivia that should be associated with the next content token
-		let mut pending_trivia = Vec::new_in(self.bump);
+		let mut pending_trivia = Vec::new_in(self.alloc);
 
 		loop {
 			if self.buffer_index >= BUFFER_REFILL_INDEX {
@@ -475,9 +475,9 @@ where
 #[test]
 fn test_filling_buffer_with_skip_tokens() {
 	let str = "/*x*//*x*//*x*//*x*//*x*//*x*//*x*//*x*//*x*//*x*//*x*/a";
-	let bump = bumpalo::Bump::default();
+	let alloc = crate::Arena::default();
 	let lexer = css_lexer::Lexer::new(&css_lexer::EmptyAtomSet::ATOMS, str);
-	let mut p = Parser::new(&bump, str, lexer);
+	let mut p = Parser::new(&alloc, str, lexer);
 	let c = p.next();
 	assert_eq!(c.token(), Kind::Ident);
 	// Must not panic:
@@ -488,9 +488,9 @@ fn test_filling_buffer_with_skip_tokens() {
 #[test]
 fn peek_and_next() {
 	let str = "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21";
-	let bump = bumpalo::Bump::default();
+	let alloc = crate::Arena::default();
 	let lexer = css_lexer::Lexer::new(&css_lexer::EmptyAtomSet::ATOMS, &str);
-	let mut p = Parser::new(&bump, &str, lexer);
+	let mut p = Parser::new(&alloc, &str, lexer);
 	assert_eq!(p.at_end(), false);
 	assert_eq!(p.offset(), 0);
 	for n in 0..=1 {
@@ -528,9 +528,9 @@ fn peek_and_next() {
 #[test]
 fn peek_and_next_with_whitsespace() {
 	let str = "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21";
-	let bump = bumpalo::Bump::default();
+	let alloc = crate::Arena::default();
 	let lexer = css_lexer::Lexer::new(&css_lexer::EmptyAtomSet::ATOMS, &str);
-	let mut p = Parser::new(&bump, &str, lexer);
+	let mut p = Parser::new(&alloc, &str, lexer);
 	p.set_skip(KindSet::COMMENTS);
 	assert_eq!(p.at_end(), false);
 	assert_eq!(p.offset(), 0);

--- a/crates/css_parse/src/syntax/bad_declaration.rs
+++ b/crates/css_parse/src/syntax/bad_declaration.rs
@@ -15,7 +15,7 @@ impl<'a> Parse<'a> for BadDeclaration<'a> {
 	where
 		Iter: Iterator<Item = crate::Cursor> + Clone,
 	{
-		let mut values = Vec::new_in(p.bump());
+		let mut values = Vec::new_in(p.alloc());
 		// To consume the remnants of a bad declaration from a token stream input, given a bool nested:
 		//
 		// Process input:

--- a/crates/css_parse/src/syntax/block.rs
+++ b/crates/css_parse/src/syntax/block.rs
@@ -63,20 +63,21 @@ where
 		Iter: Iterator<Item = crate::Cursor> + Clone,
 	{
 		let open_curly = p.parse::<T!['{']>()?;
-		let mut declarations = Vec::new_in(p.bump());
-		let mut rules = Vec::new_in(p.bump());
+		let mut declarations = Vec::new_in(p.alloc());
+		let mut rules = Vec::new_in(p.alloc());
 		let mut meta = M::default();
 
 		// Per CSS Syntax spec: maintain a buffer of declarations to flush when we encounter rules.
 		// This enables proper interleaving of declarations and rules.
-		let mut decls: Vec<'a, DeclarationOrBad<'a, D, M>> = Vec::new_in(p.bump());
+		let mut decls: Vec<'a, DeclarationOrBad<'a, D, M>> = Vec::new_in(p.alloc());
 
 		// Flush the decls buffer into the rules list as a DeclarationGroup.
 		// Per spec: "If decls is not empty, append it to rules, and set decls to a fresh empty list"
 		macro_rules! flush_decls {
 			() => {
 				if !decls.is_empty() {
-					let group = DeclarationGroup { declarations: std::mem::replace(&mut decls, Vec::new_in(p.bump())) };
+					let group =
+						DeclarationGroup { declarations: std::mem::replace(&mut decls, Vec::new_in(p.alloc())) };
 					if let Some(rule) = R::from_declaration_group(group) {
 						meta = meta.merge(rule.metadata());
 						rules.push(rule);
@@ -346,22 +347,22 @@ mod tests {
 
 	#[test]
 	fn test_bad_string_in_block_does_not_hang() {
-		let bump = bumpalo::Bump::new();
+		let alloc = crate::Arena::new();
 		for src in
 			[":{\".\n", "am:{\"\n", "alm:{\"\n", "alm:{\";.\n", "alm:{\"; }.\n", "alm:s {\n \x16\x00\x00:\";\n }\n"]
 		{
 			let lexer = css_lexer::Lexer::new(&EmptyAtomSet::ATOMS, src);
-			let mut parser = crate::Parser::new(&bump, src, lexer);
+			let mut parser = crate::Parser::new(&alloc, src, lexer);
 			let _ = parser.parse::<Block<Decl, Rule, ()>>();
 		}
 	}
 
 	#[test]
 	fn test_trailing_error_kinds_do_not_oom() {
-		let bump = bumpalo::Bump::new();
+		let alloc = crate::Arena::new();
 		for src in ["{)))))))))))))", "{))))))))))))))", "{\r)))))))))))))"] {
 			let lexer = css_lexer::Lexer::new(&EmptyAtomSet::ATOMS, src);
-			let mut parser = crate::Parser::new(&bump, src, lexer);
+			let mut parser = crate::Parser::new(&alloc, src, lexer);
 			let _ = parser.parse::<Block<Decl, Rule, ()>>();
 		}
 	}

--- a/crates/css_parse/src/syntax/comma_separated.rs
+++ b/crates/css_parse/src/syntax/comma_separated.rs
@@ -35,8 +35,8 @@ pub struct CommaSeparated<'a, T, const MIN: usize = 1> {
 }
 
 impl<'a, T, const MIN: usize> CommaSeparated<'a, T, MIN> {
-	pub fn new_in(bump: &'a Arena) -> Self {
-		Self { items: Vec::new_in(bump) }
+	pub fn new_in(alloc: &'a Arena) -> Self {
+		Self { items: Vec::new_in(alloc) }
 	}
 
 	pub fn is_empty(&self) -> bool {
@@ -65,7 +65,7 @@ impl<'a, T: Parse<'a> + Peek<'a>, const MIN: usize> Parse<'a> for CommaSeparated
 	where
 		Iter: Iterator<Item = crate::Cursor> + Clone,
 	{
-		let mut items = Self::new_in(p.bump());
+		let mut items = Self::new_in(p.alloc());
 		if MIN == 0 && !<T>::peek(p, p.peek_n(1)) {
 			return Ok(items);
 		}

--- a/crates/css_parse/src/syntax/component_values.rs
+++ b/crates/css_parse/src/syntax/component_values.rs
@@ -24,7 +24,7 @@ impl<'a> Parse<'a> for ComponentValues<'a> {
 	where
 		Iter: Iterator<Item = Cursor> + Clone,
 	{
-		let mut values = Vec::new_in(p.bump());
+		let mut values = Vec::new_in(p.alloc());
 		let mut last_was_whitespace = false;
 
 		loop {

--- a/crates/css_parse/src/syntax/declaration_list.rs
+++ b/crates/css_parse/src/syntax/declaration_list.rs
@@ -65,7 +65,7 @@ where
 		Iter: Iterator<Item = crate::Cursor> + Clone,
 	{
 		let open_curly = p.parse::<T!['{']>()?;
-		let mut declarations = Vec::new_in(p.bump());
+		let mut declarations = Vec::new_in(p.alloc());
 		let mut meta: M = Default::default();
 		loop {
 			if p.at_end() {

--- a/crates/css_parse/src/syntax/rule_list.rs
+++ b/crates/css_parse/src/syntax/rule_list.rs
@@ -57,7 +57,7 @@ where
 		Iter: Iterator<Item = crate::Cursor> + Clone,
 	{
 		let open_curly = p.parse::<T!['{']>()?;
-		let mut rules = Vec::new_in(p.bump());
+		let mut rules = Vec::new_in(p.alloc());
 		let mut meta = M::default();
 		loop {
 			p.parse_if_peek::<T![;]>().ok();

--- a/crates/css_parse/src/test_helpers.rs
+++ b/crates/css_parse/src/test_helpers.rs
@@ -29,17 +29,17 @@ macro_rules! assert_parse {
 	($atomset: path, $ty: ty, $str: literal, $expected: literal) => {
 		{
 			let source_text = $str;
-			let bump = ::bumpalo::Bump::default();
+			let alloc = $crate::Arena::default();
 			let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
-			let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
+			let mut parser = $crate::Parser::new(&alloc, &source_text, lexer);
 			let result = parser.parse_entirely::<$ty>().with_trivia();
 			if !result.errors.is_empty() {
 				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
 			}
-			let mut actual = $crate::String::new_in(&bump);
+			let mut actual = $crate::String::new_in(&alloc);
 			{
 				let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
-				let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+				let mut ordered_sink = $crate::CursorOrderedSink::new(&alloc, &mut write_sink);
 				use $crate::ToCursors;
 				result.to_cursors(&mut ordered_sink);
 			}
@@ -54,17 +54,17 @@ macro_rules! assert_parse {
 	($atomset: path, $ty: ty, $str: literal, |$node: ident| $body: expr) => {
 		{
 			let source_text = $str;
-			let bump = ::bumpalo::Bump::default();
+			let alloc = $crate::Arena::default();
 			let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
-			let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
+			let mut parser = $crate::Parser::new(&alloc, &source_text, lexer);
 			let result = parser.parse_entirely::<$ty>().with_trivia();
 			if !result.errors.is_empty() {
 				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
 			}
-			let mut actual = $crate::String::new_in(&bump);
+			let mut actual = $crate::String::new_in(&alloc);
 			{
 				let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
-				let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+				let mut ordered_sink = $crate::CursorOrderedSink::new(&alloc, &mut write_sink);
 				use $crate::ToCursors;
 				result.to_cursors(&mut ordered_sink);
 			}
@@ -78,9 +78,9 @@ macro_rules! assert_parse {
 	($atomset: path, $ty: ty, $str: literal, $($ast: pat)+) => {
 		{
 			let source_text = $str;
-			let bump = ::bumpalo::Bump::default();
+			let alloc = $crate::Arena::default();
 			let lexer = css_lexer::Lexer::new(&$atomset, &source_text);
-			let mut parser = $crate::Parser::new(&bump, &source_text, lexer);
+			let mut parser = $crate::Parser::new(&alloc, &source_text, lexer);
 			if !parser.peek::<$ty>() {
 				panic!("\n\nParse failed because Type didn't peek!\n\n   parser input: {:?}\n", source_text);
 			}
@@ -88,10 +88,10 @@ macro_rules! assert_parse {
 			if !result.errors.is_empty() {
 				panic!("\n\nParse failed. ({:?}) saw error {:?}", source_text, result.errors[0]);
 			}
-			let mut actual = $crate::String::new_in(&bump);
+			let mut actual = $crate::String::new_in(&alloc);
 			{
 				let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
-				let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+				let mut ordered_sink = $crate::CursorOrderedSink::new(&alloc, &mut write_sink);
 				use $crate::ToCursors;
 				result.to_cursors(&mut ordered_sink);
 			}
@@ -128,19 +128,19 @@ pub(crate) use assert_parse;
 macro_rules! assert_parse_error {
 	($atomset: path, $ty: ty, $str: literal) => {
 		let source_text = $str;
-		let bump = ::bumpalo::Bump::default();
+		let alloc = $crate::Arena::default();
 		let lexer = css_lexer::Lexer::new(&$atomset, source_text);
-		let mut parser = $crate::Parser::new(&bump, source_text, lexer);
+		let mut parser = $crate::Parser::new(&alloc, source_text, lexer);
 		if !parser.peek::<$ty>() {
 			panic!("\n\n.\n\nPeek returned false, please don't use `assert_parse_error` - use `assert_peek_false` instead: {:?}", source_text);
 		}
 		let result = parser.parse::<$ty>();
 		if parser.at_end() {
 			if let Ok(result) = result {
-				let mut actual = $crate::String::new_in(&bump);
+				let mut actual = $crate::String::new_in(&alloc);
 				{
 					let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
-					let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+					let mut ordered_sink = $crate::CursorOrderedSink::new(&alloc, &mut write_sink);
 					use $crate::ToCursors;
 					result.to_cursors(&mut ordered_sink);
 				}
@@ -165,19 +165,19 @@ pub(crate) use assert_parse_error;
 macro_rules! assert_peek_false {
 	($atomset: path, $ty: ty, $str: literal) => {
 		let source_text = $str;
-		let bump = ::bumpalo::Bump::default();
+		let alloc = $crate::Arena::default();
 		let lexer = css_lexer::Lexer::new(&$atomset, source_text);
-		let mut parser = $crate::Parser::new(&bump, source_text, lexer);
+		let mut parser = $crate::Parser::new(&alloc, source_text, lexer);
 		if parser.peek::<$ty>() {
 			panic!("\n\n.\n\nPeek returned true! You might want `assert_parse_error` instead: {:?}", source_text);
 		}
 		let result = parser.parse::<$ty>();
 		if parser.at_end() {
 			if let Ok(result) = result {
-				let mut actual = $crate::String::new_in(&bump);
+				let mut actual = $crate::String::new_in(&alloc);
 				{
 					let mut write_sink = $crate::CursorWriteSink::new(&source_text, &mut actual);
-					let mut ordered_sink = $crate::CursorOrderedSink::new(&bump, &mut write_sink);
+					let mut ordered_sink = $crate::CursorOrderedSink::new(&alloc, &mut write_sink);
 					use $crate::ToCursors;
 					result.to_cursors(&mut ordered_sink);
 				}
@@ -207,9 +207,9 @@ macro_rules! assert_parse_span {
 	($atomset: path, $ty: ty, $str: literal) => {
 		let expected = $str;
 		let source_text = expected.lines().find(|line| !line.trim().is_empty()).unwrap_or("");
-		let bump = ::bumpalo::Bump::default();
+		let alloc = $crate::Arena::default();
 		let lexer = css_lexer::Lexer::new(&$atomset, source_text);
-		let mut parser = $crate::Parser::new(&bump, source_text, lexer);
+		let mut parser = $crate::Parser::new(&alloc, source_text, lexer);
 		let result = parser.parse::<$ty>();
 		match result {
 			Ok(result) => {

--- a/crates/css_parse/src/token_macros.rs
+++ b/crates/css_parse/src/token_macros.rs
@@ -213,7 +213,6 @@ macro_rules! define_kind_idents {
 ///
 /// ```
 /// use css_parse::*;
-/// use bumpalo::Bump;
 /// custom_delim!{
 ///   /// A £ character.
 ///   PoundSterling, '£'
@@ -307,7 +306,6 @@ macro_rules! custom_delim {
 ///
 /// ```
 /// use css_parse::*;
-/// use bumpalo::Bump;
 /// custom_double_delim!{
 ///   /// Two % adjacent symbols
 ///   DoublePercent, '%', '%'

--- a/crates/css_parse/src/traits/boolean_feature.rs
+++ b/crates/css_parse/src/traits/boolean_feature.rs
@@ -81,7 +81,6 @@ pub trait BooleanFeature<'a>: Sized {
 /// use css_parse::*;
 /// use csskit_derives::*;
 /// use derive_atom_set::*;
-/// use bumpalo::Bump;
 ///
 /// #[derive(Debug, Default, AtomSet, Copy, Clone, PartialEq)]
 /// pub enum MyAtomSet {
@@ -101,7 +100,7 @@ pub trait BooleanFeature<'a>: Sized {
 /// }
 ///
 /// // Test!
-/// let allocator = Bump::new();
+/// let allocator = Arena::new();
 /// let source_text = "(test-feature)";
 /// let lexer = Lexer::new( &MyAtomSet::ATOMS, &source_text);
 /// let mut p = Parser::new(&allocator, &source_text, lexer);

--- a/crates/css_parse/src/traits/cursor_sink.rs
+++ b/crates/css_parse/src/traits/cursor_sink.rs
@@ -43,18 +43,18 @@ impl<'a, A: Allocator> SourceCursorSink<'a> for Vec<'a, SourceCursor<'a>, A> {
 #[cfg(test)]
 mod test {
 	use super::*;
+	use crate::Arena;
 	use crate::{ComponentValues, EmptyAtomSet, Parser, ToCursors};
-	use bumpalo::Bump;
 	use css_lexer::Lexer;
 
 	#[test]
 	fn test_cursor_sink_for_vec() {
 		use std::fmt::Write;
 		let source_text = "black white";
-		let bump = Bump::default();
-		let mut stream = Vec::new_in(&bump);
+		let alloc = Arena::default();
+		let mut stream = Vec::new_in(&alloc);
 		let lexer = Lexer::new(&EmptyAtomSet::ATOMS, source_text);
-		let mut parser = Parser::new(&bump, source_text, lexer);
+		let mut parser = Parser::new(&alloc, source_text, lexer);
 		parser.parse_entirely::<ComponentValues>().output.unwrap().to_cursors(&mut stream);
 		let mut str = String::new();
 		for c in stream {

--- a/crates/css_parse/src/traits/discrete_feature.rs
+++ b/crates/css_parse/src/traits/discrete_feature.rs
@@ -77,7 +77,6 @@ pub trait DiscreteFeature<'a>: Sized {
 ///
 /// ```
 /// use css_parse::*;
-/// use bumpalo::Bump;
 /// use csskit_derives::{ToCursors, ToSpan};
 /// use derive_atom_set::AtomSet;
 ///

--- a/crates/css_parse/src/traits/lists/feature_condition_list.rs
+++ b/crates/css_parse/src/traits/lists/feature_condition_list.rs
@@ -81,7 +81,7 @@ where
 		let c = p.peek_n(1);
 		if Ident::peek(p, c) {
 			if Self::keyword_is_and(p, c) {
-				let mut features = Vec::new_in(p.bump());
+				let mut features = Vec::new_in(p.alloc());
 				let mut keyword = p.parse::<Ident>()?;
 				loop {
 					features.push((feature, Some(keyword)));
@@ -94,7 +94,7 @@ where
 					keyword = p.parse::<Ident>()?
 				}
 			} else if Self::keyword_is_or(p, c) {
-				let mut features = Vec::new_in(p.bump());
+				let mut features = Vec::new_in(p.alloc());
 				let mut keyword = p.parse::<Ident>()?;
 				loop {
 					features.push((feature, Some(keyword)));

--- a/crates/css_parse/src/traits/parse.rs
+++ b/crates/css_parse/src/traits/parse.rs
@@ -49,7 +49,7 @@ where
 	where
 		Iter: Iterator<Item = Cursor> + Clone,
 	{
-		let mut vec = Vec::new_in(p.bump());
+		let mut vec = Vec::new_in(p.alloc());
 		while let Some(item) = p.parse_if_peek::<T>()? {
 			vec.push(item);
 		}

--- a/crates/css_parse/src/traits/ranged_feature.rs
+++ b/crates/css_parse/src/traits/ranged_feature.rs
@@ -197,7 +197,6 @@ pub trait RangedFeature<'a>: Sized {
 ///
 /// ```
 /// use css_parse::*;
-/// use bumpalo::Bump;
 /// use csskit_derives::{ToCursors, ToSpan};
 /// use derive_atom_set::AtomSet;
 ///
@@ -237,7 +236,6 @@ pub trait RangedFeature<'a>: Sized {
 /// use css_parse::*;
 /// use csskit_derives::*;
 /// use derive_atom_set::*;
-/// use bumpalo::Bump;
 ///
 /// #[derive(Debug, Default, AtomSet, Copy, Clone, PartialEq)]
 /// pub enum MyAtomSet {

--- a/crates/css_parse/src/traits/selectors.rs
+++ b/crates/css_parse/src/traits/selectors.rs
@@ -28,7 +28,7 @@ pub trait CompoundSelector<'a>: Sized + Parse<'a> {
 	where
 		I: Iterator<Item = Cursor> + Clone,
 	{
-		let mut components = Vec::new_in(p.bump());
+		let mut components = Vec::new_in(p.alloc());
 		// Trim leading whitespace
 		p.consume_trivia();
 		while let Some(component) = Self::parse_compound_selector_part(p)? {

--- a/crates/css_parse/src/traits/semantic_eq.rs
+++ b/crates/css_parse/src/traits/semantic_eq.rs
@@ -85,13 +85,13 @@ impl_tuple!(A[sa,oa], B[sb,ob], C[sc,oc], D[sd,od], E[se,oe], F[sf,of], G[sg,og]
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::Arena;
 	use crate::{ComponentValues, Parse, Parser, ToCursors};
-	use bumpalo::Bump;
 	use css_lexer::EmptyAtomSet;
 
-	fn parse<'a, T: Parse<'a> + ToCursors>(bump: &'a Bump, source: &'a str) -> T {
+	fn parse<'a, T: Parse<'a> + ToCursors>(alloc: &'a Arena, source: &'a str) -> T {
 		let lexer = css_lexer::Lexer::new(&EmptyAtomSet::ATOMS, source);
-		let mut parser = Parser::new(bump, source, lexer);
+		let mut parser = Parser::new(alloc, source, lexer);
 		let result = parser.parse_entirely::<T>();
 		result.output.unwrap()
 	}
@@ -143,9 +143,9 @@ mod tests {
 		let source1 = "1px solid red";
 		let source2 = "1px  solid  red"; // Extra whitespace
 
-		let bump = Bump::new();
-		let values1 = parse::<ComponentValues>(&bump, source1);
-		let values2 = parse::<ComponentValues>(&bump, source2);
+		let alloc = Arena::new();
+		let values1 = parse::<ComponentValues>(&alloc, source1);
+		let values2 = parse::<ComponentValues>(&alloc, source2);
 
 		// Semantically equal despite whitespace
 		assert!(values1.semantic_eq(&values2));
@@ -156,9 +156,9 @@ mod tests {
 		let source1 = "1px solid red";
 		let source2 = "2px solid red";
 
-		let bump = Bump::new();
-		let values1 = parse::<ComponentValues>(&bump, source1);
-		let values2 = parse::<ComponentValues>(&bump, source2);
+		let alloc = Arena::new();
+		let values1 = parse::<ComponentValues>(&alloc, source1);
+		let values2 = parse::<ComponentValues>(&alloc, source2);
 
 		// Should NOT be equal due to different values
 		assert!(!values1.semantic_eq(&values2));

--- a/crates/css_parse/src/traits/style_sheet.rs
+++ b/crates/css_parse/src/traits/style_sheet.rs
@@ -26,7 +26,7 @@ pub trait StyleSheet<'a, M: NodeMetadata>: Sized + Parse<'a> {
 	where
 		I: Iterator<Item = Cursor> + Clone,
 	{
-		let mut rules: Vec<'a, Self::Rule> = Vec::new_in(p.bump());
+		let mut rules: Vec<'a, Self::Rule> = Vec::new_in(p.alloc());
 		let mut meta: M = Default::default();
 		loop {
 			// While by default the parser will skip whitespace, the Rule type may be a whitespace sensitive

--- a/crates/css_parse/tests/allocations.rs
+++ b/crates/css_parse/tests/allocations.rs
@@ -1,6 +1,5 @@
-use bumpalo::Bump;
 use css_lexer::Lexer;
-use css_parse::{ComponentValues, EmptyAtomSet, Parser};
+use css_parse::{Arena, ComponentValues, EmptyAtomSet, Parser};
 #[cfg(feature = "_dhat-heap-testing")]
 use dhat::{Alloc, HeapStats, Profiler, assert_eq};
 use std::fs::read_to_string;
@@ -11,23 +10,23 @@ static ALLOC: Alloc = Alloc;
 
 #[test]
 fn allocation_test() {
-	let simple_bump_size = 960;
-	let simple_bump = Bump::with_capacity(simple_bump_size);
+	let simple_alloc_size = 960;
+	let simple_alloc = Arena::with_capacity(simple_alloc_size);
 	let simple_str = "body{color:blue}";
 	let simple_lexer = Lexer::new(&EmptyAtomSet::ATOMS, simple_str);
-	let mut simple_parser = Parser::new(&simple_bump, simple_str, simple_lexer);
+	let mut simple_parser = Parser::new(&simple_alloc, simple_str, simple_lexer);
 
-	let escaped_bump_size = 960;
-	let escaped_bump = Bump::with_capacity(escaped_bump_size);
+	let escaped_alloc_size = 960;
+	let escaped_alloc = Arena::with_capacity(escaped_alloc_size);
 	let escaped_str = "bo\\d y{background-image:\\75\\52\\6c(a);width:1\\70\\78}";
 	let escaped_lexer = Lexer::new(&EmptyAtomSet::ATOMS, escaped_str);
-	let mut escape_parser = Parser::new(&escaped_bump, escaped_str, escaped_lexer);
+	let mut escape_parser = Parser::new(&escaped_alloc, escaped_str, escaped_lexer);
 
-	let big_bump_size = 100_003_776;
-	let big_bump = Bump::with_capacity(big_bump_size);
+	let big_alloc_size = 100_003_776;
+	let big_alloc = Arena::with_capacity(big_alloc_size);
 	let big_str = read_to_string("../../coverage/popular/tailwind.2.2.19.min.css").unwrap();
 	let big_lexer = Lexer::new(&EmptyAtomSet::ATOMS, &big_str);
-	let mut big_parser = Parser::new(&big_bump, &big_str, big_lexer);
+	let mut big_parser = Parser::new(&big_alloc, &big_str, big_lexer);
 
 	#[cfg(feature = "_dhat-heap-testing")]
 	let _profiler = Profiler::builder()
@@ -60,7 +59,7 @@ fn allocation_test() {
 	}
 
 	// XXX: If these fail because the numbers go down, great! If they go up, investigate why.
-	assert_eq!(simple_bump.allocated_bytes(), simple_bump_size);
-	assert_eq!(escaped_bump.allocated_bytes(), escaped_bump_size);
-	assert_eq!(big_bump.allocated_bytes(), big_bump_size);
+	assert_eq!(simple_alloc.allocated_bytes(), simple_alloc_size);
+	assert_eq!(escaped_alloc.allocated_bytes(), escaped_alloc_size);
+	assert_eq!(big_alloc.allocated_bytes(), big_alloc_size);
 }

--- a/crates/csskit/Cargo.toml
+++ b/crates/csskit/Cargo.toml
@@ -29,8 +29,6 @@ anstyle = { workspace = true, optional = true }
 owo-colors = { workspace = true, optional = true }
 strsim = { workspace = true }
 
-bumpalo = { workspace = true, features = ["collections", "boxed"] }
-
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/csskit/src/commands/build.rs
+++ b/crates/csskit/src/commands/build.rs
@@ -1,9 +1,8 @@
 use crate::{CliError, CliResult, GlobalConfig, InputArgs};
-use bumpalo::Bump;
 use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::{CursorCompactWriteSink, Parser, ToCursors};
+use css_parse::{Arena, CursorCompactWriteSink, Parser, ToCursors};
 
 /// Convert one or more CSS files into production ready CSS.
 #[derive(Debug, Args)]
@@ -20,13 +19,13 @@ pub struct Build {
 impl Build {
 	pub fn run(&self, _config: GlobalConfig) -> CliResult {
 		let Build { content, output } = self;
-		let bump = Bump::default();
-		let mut str = css_parse::String::new_in(&bump);
+		let alloc = Arena::default();
+		let mut str = css_parse::String::new_in(&alloc);
 		let start = std::time::Instant::now();
 		for (file_name, source) in content.sources()? {
-			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
+			let source_text = css_parse::String::from_reader_in(source, &alloc)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
 			if result.output.is_some() {
 				let mut stream = CursorCompactWriteSink::new(source_text, &mut str);

--- a/crates/csskit/src/commands/check.rs
+++ b/crates/csskit/src/commands/check.rs
@@ -6,11 +6,10 @@ use crate::{
 		format_diagnostic_error,
 	},
 };
-use bumpalo::Bump;
 use clap::Args;
 use css_ast::CssAtomSet;
 use css_lexer::{DynAtomSet, Lexer, LineIndex, RegisteredAtomSet};
-use css_parse::Parser;
+use css_parse::{Arena, Parser};
 use csskit_ast::{Collector, CsskitAtomSet, ResolvedDiagnosticLevel, StatType, sheet::Sheet};
 use csskit_highlight::CssHighlighter;
 use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource, Report};
@@ -100,12 +99,12 @@ impl Check {
 			return Err(CliError::ParseFailed);
 		}
 
-		let bump = Bump::new();
+		let alloc = Arena::new();
 
 		// Read and parse the csskit sheet
-		let rule_source = css_parse::String::from_reader_in(fs::File::open(sheet)?, &bump)?.into_str();
+		let rule_source = css_parse::String::from_reader_in(fs::File::open(sheet)?, &alloc)?.into_str();
 		let rule_lexer = Lexer::new(CsskitAtomSet::get_dyn_set(), rule_source);
-		let mut rule_parser = Parser::new(&bump, rule_source, rule_lexer);
+		let mut rule_parser = Parser::new(&alloc, rule_source, rule_lexer);
 		let rule_result = rule_parser.parse_entirely::<Sheet>();
 		let parsed_rules = rule_result.output.ok_or_else(|| {
 			if let Some(e) = rule_result.errors.first() {
@@ -121,7 +120,7 @@ impl Check {
 
 		for css_file_path in input.iter() {
 			let css_source =
-				match fs::File::open(css_file_path).and_then(|file| css_parse::String::from_reader_in(file, &bump)) {
+				match fs::File::open(css_file_path).and_then(|file| css_parse::String::from_reader_in(file, &alloc)) {
 					Ok(source) => source.into_str(),
 					Err(e) => {
 						match format {
@@ -142,7 +141,7 @@ impl Check {
 				};
 
 			let css_lexer = Lexer::new(&CssAtomSet::ATOMS, css_source);
-			let mut css_parser = Parser::new(&bump, css_source, css_lexer);
+			let mut css_parser = Parser::new(&alloc, css_source, css_lexer);
 			let css_result = css_parser.parse_entirely();
 
 			let stylesheet = match css_result.output {
@@ -173,12 +172,12 @@ impl Check {
 				}
 			};
 
-			let mut collector = Collector::new(&parsed_rules, rule_source, &bump);
+			let mut collector = Collector::new(&parsed_rules, rule_source, &alloc);
 			collector.collect(&stylesheet, css_source);
 
 			let mut file_failed = false;
 			let mut file_diagnostics: Vec<DiagnosticData> = Vec::new();
-			let line_index = matches!(format, OutputFormat::Json).then(|| LineIndex::new_in(css_source, &bump));
+			let line_index = matches!(format, OutputFormat::Json).then(|| LineIndex::new_in(css_source, &alloc));
 
 			for diagnostic in collector.diagnostics(css_source) {
 				let is_error = matches!(diagnostic.severity, ResolvedDiagnosticLevel::Error);

--- a/crates/csskit/src/commands/colors.rs
+++ b/crates/csskit/src/commands/colors.rs
@@ -5,22 +5,21 @@ use crate::{
 	dimmed, fg,
 };
 use allocator_api2::alloc::Allocator;
-use bumpalo::Bump;
 use chromashift::*;
 use clap::Args;
 use css_ast::{Color as ASTColor, CssAtomSet, StyleSheet, ToChromashift, Visitable};
 use css_lexer::{Lexer, LineIndex};
-use css_parse::{Diagnostic, Parser, Span, ToSpan};
+use css_parse::{Arena, Diagnostic, Parser, Span, ToSpan};
 use itertools::Itertools;
 use serde::Serialize;
 use std::collections::HashSet;
 
-fn extract_colors(src: &str, bump: &Bump) -> Result<Vec<(Color, Span)>, Vec<Diagnostic>> {
+fn extract_colors(src: &str, alloc: &Arena) -> Result<Vec<(Color, Span)>, Vec<Diagnostic>> {
 	let mut visitor = ColorExtractor::new();
 
 	// Try parsing as a bare list of colors first.
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, src);
-	let mut parser = Parser::new(bump, src, lexer);
+	let mut parser = Parser::new(alloc, src, lexer);
 	let result = parser.parse_entirely::<css_parse::Vec<ASTColor>>();
 	if let Some(output) = result.output.filter(|_| result.errors.is_empty()) {
 		let _ = output.accept(&mut visitor);
@@ -29,7 +28,7 @@ fn extract_colors(src: &str, bump: &Bump) -> Result<Vec<(Color, Span)>, Vec<Diag
 
 	// Fall back to full stylesheet parse.
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, src);
-	let mut parser = Parser::new(bump, src, lexer);
+	let mut parser = Parser::new(alloc, src, lexer);
 	let result = parser.parse_entirely::<StyleSheet>();
 	if let Some(stylesheet) = result.output {
 		let _ = stylesheet.accept(&mut visitor);
@@ -360,11 +359,11 @@ impl Extract for ColorCommand {
 		&self,
 		file: &str,
 		src: &str,
-		bump: &Bump,
+		alloc: &Arena,
 		_on_stylesheet: &mut dyn for<'a> FnMut(&StyleSheet<'a>),
 	) -> Result<Vec<(Span, ColorData)>, ErrorRecord> {
 		use crate::commands::extract::ErrorKind;
-		match extract_colors(src, bump) {
+		match extract_colors(src, alloc) {
 			Ok(colors) => {
 				let mut seen: HashSet<Hex> = HashSet::new();
 				Ok(colors

--- a/crates/csskit/src/commands/dbg_lex.rs
+++ b/crates/csskit/src/commands/dbg_lex.rs
@@ -13,9 +13,9 @@ pub struct DbgLex {
 impl DbgLex {
 	pub fn run(&self, _config: GlobalConfig) -> CliResult {
 		let DbgLex { content } = self;
-		let bump = css_parse::Arena::default();
+		let alloc = css_parse::Arena::default();
 		for (_file_name, source) in content.sources()? {
-			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
+			let source_text = css_parse::String::from_reader_in(source, &alloc)?.into_str();
 			let mut lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 
 			loop {

--- a/crates/csskit/src/commands/dbg_parse.rs
+++ b/crates/csskit/src/commands/dbg_parse.rs
@@ -1,9 +1,8 @@
 use crate::{CliResult, GlobalConfig, InputArgs};
-use bumpalo::Bump;
 use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::Parser;
+use css_parse::{Arena, Parser};
 
 /// Show the debug output for a parsed file
 #[derive(Debug, Args)]
@@ -15,11 +14,11 @@ pub struct DbgParse {
 impl DbgParse {
 	pub fn run(&self, _config: GlobalConfig) -> CliResult {
 		let DbgParse { content } = self;
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		for (file_name, source) in content.sources()? {
-			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
+			let source_text = css_parse::String::from_reader_in(source, &alloc)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
 			if let Some(stylesheet) = &result.output {
 				println!("{stylesheet:#?}");

--- a/crates/csskit/src/commands/expand.rs
+++ b/crates/csskit/src/commands/expand.rs
@@ -1,9 +1,8 @@
 use crate::{CliError, CliResult, GlobalConfig, InputArgs};
-use bumpalo::Bump;
 use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::{CursorExpandedWriteSink, Parser, ToCursors};
+use css_parse::{Arena, CursorExpandedWriteSink, Parser, ToCursors};
 
 /// Expand CSS files to their most verbose form (the opposite of minify).
 #[derive(Debug, Args)]
@@ -33,19 +32,19 @@ pub struct Expand {
 impl Expand {
 	pub fn run(&self, _config: GlobalConfig) -> CliResult {
 		let Expand { content, output, check, semicolons, escape_idents } = self;
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let start = std::time::Instant::now();
 		if *check && output.is_some() {
 			eprintln!("Ignoring output option, because check was passed");
 		}
 		let mut checks = 0;
 		for (file_name, source) in content.sources()? {
-			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
+			let source_text = css_parse::String::from_reader_in(source, &alloc)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
 			if let Some(ref _stylesheet) = result.output {
-				let mut str = css_parse::String::new_in(&bump);
+				let mut str = css_parse::String::new_in(&alloc);
 				let mut stream = CursorExpandedWriteSink::new(source_text, &mut str)
 					.with_extra_semicolons(*semicolons)
 					.with_escape_idents(*escape_idents);

--- a/crates/csskit/src/commands/extract.rs
+++ b/crates/csskit/src/commands/extract.rs
@@ -1,10 +1,9 @@
 use crate::{CliResult, GlobalConfig, InputArgs};
 use allocator_api2::alloc::Allocator;
-use bumpalo::Bump;
 use clap::ValueEnum;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::{Lexer, LineIndex, Span};
-use css_parse::Parser;
+use css_parse::{Arena, Parser};
 use serde::Serialize;
 
 /// Position metadata for a single result within a file.
@@ -146,7 +145,7 @@ pub trait Extract: Sized {
 
 	/// Try parsing source as raw content before falling back to StyleSheet.
 	/// Return true if handled.
-	fn try_content(&self, _src: &str, _bump: &Bump, _out: &mut Vec<(Span, Self::Row)>) -> bool {
+	fn try_content(&self, _src: &str, _alloc: &Arena, _out: &mut Vec<(Span, Self::Row)>) -> bool {
 		false
 	}
 
@@ -156,16 +155,16 @@ pub trait Extract: Sized {
 		&self,
 		file: &str,
 		src: &str,
-		bump: &Bump,
+		alloc: &Arena,
 		on_stylesheet: &mut dyn for<'a> FnMut(&StyleSheet<'a>),
 	) -> Result<Vec<(Span, Self::Row)>, ErrorRecord> {
 		let mut rows = Vec::new();
-		if self.try_content(src, bump, &mut rows) {
+		if self.try_content(src, alloc, &mut rows) {
 			return Ok(rows);
 		}
 
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, src);
-		let mut parser = Parser::new(bump, src, lexer);
+		let mut parser = Parser::new(alloc, src, lexer);
 		let result = parser.parse_entirely::<StyleSheet>();
 
 		if let Some(stylesheet) = result.output {
@@ -189,12 +188,12 @@ pub trait Extract: Sized {
 
 	/// Run the command: loop files, parse, extract, render.
 	fn run(&self, config: GlobalConfig) -> CliResult {
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let mut envelopes: Vec<FileEnvelope<Self::Row>> = Vec::new();
 		let mut first_file = true;
 
 		for (filename, source) in self.input().sources()? {
-			let src = match css_parse::String::from_reader_in(source, &bump) {
+			let src = match css_parse::String::from_reader_in(source, &alloc) {
 				Ok(src) => src.into_str(),
 				Err(e) => {
 					match self.format() {
@@ -219,7 +218,7 @@ pub trait Extract: Sized {
 				}
 			};
 
-			match self.parse_and_extract_file(filename, src, &bump, &mut on_stylesheet) {
+			match self.parse_and_extract_file(filename, src, &alloc, &mut on_stylesheet) {
 				Ok(rows) => match self.format() {
 					OutputFormat::Text => {
 						if rows.is_empty() {
@@ -237,14 +236,14 @@ pub trait Extract: Sized {
 								}
 							}
 							self.render_file_preamble(filename, rows.len(), config.colors());
-							let index = LineIndex::new_in(src, &bump);
+							let index = LineIndex::new_in(src, &alloc);
 							for (span, row) in &rows {
 								self.render_text(&ctx, filename, src, &index, *span, row, config.colors());
 							}
 						}
 					}
 					OutputFormat::Json => {
-						let index = LineIndex::new_in(src, &bump);
+						let index = LineIndex::new_in(src, &alloc);
 						let records = rows
 							.into_iter()
 							.map(|(span, data)| Record { location: Location::from_span(span, &index), data })

--- a/crates/csskit/src/commands/find.rs
+++ b/crates/csskit/src/commands/find.rs
@@ -4,11 +4,10 @@ use crate::{
 	green,
 };
 use allocator_api2::alloc::Allocator;
-use bumpalo::Bump;
 use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet, Visitable, visit::NodeId};
 use css_lexer::{Cursor, Lexer, LineIndex, SourceOffset, Span};
-use css_parse::{NodeWithMetadata, Parser, SourceCursor, SourceCursorSink};
+use css_parse::{Arena, NodeWithMetadata, Parser, SourceCursor, SourceCursorSink};
 use csskit_ast::{CsskitAtomSet, QuerySelectorList, SelectorMatcher};
 use csskit_highlight::{AnsiHighlightCursorStream, DefaultAnsiTheme, TokenHighlighter};
 use itertools::Itertools;
@@ -56,9 +55,9 @@ fn line_bounds(source: &str, offset: usize) -> (usize, usize) {
 
 impl Find {
 	pub fn run(&self, config: GlobalConfig) -> CliResult {
-		let selector_bump = Bump::default();
+		let selector_alloc = Arena::default();
 		let lexer = Lexer::new(&CsskitAtomSet::ATOMS, &self.selector);
-		let mut parser = Parser::new(&selector_bump, &self.selector, lexer);
+		let mut parser = Parser::new(&selector_alloc, &self.selector, lexer);
 		let result = parser.parse_entirely::<QuerySelectorList>();
 
 		if !result.errors.is_empty() || result.output.as_ref().is_some_and(|n| n.metadata().is_invalid) {
@@ -86,15 +85,15 @@ impl Find {
 	}
 
 	fn output_count(&self, selectors: &QuerySelectorList) -> CliResult {
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let mut total = 0;
 		let mut files = 0;
 
 		for (filename, source) in self.input.sources()? {
-			let src = css_parse::String::from_reader_in(source, &bump)?.into_str();
+			let src = css_parse::String::from_reader_in(source, &alloc)?.into_str();
 
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, src);
-			let mut parser = Parser::new(&bump, src, lexer);
+			let mut parser = Parser::new(&alloc, src, lexer);
 			let Some(stylesheet) = parser.parse_entirely::<StyleSheet>().output else { continue };
 			let count = SelectorMatcher::new(selectors, &self.selector, src).run(&stylesheet).count();
 			if count == 0 {
@@ -136,9 +135,9 @@ impl Find {
 		eprintln!("\nRun 'csskit tree' to see all node types.");
 	}
 
-	fn parsed_selectors<'b>(&'b self, bump: &'b Bump) -> Option<QuerySelectorList<'b>> {
+	fn parsed_selectors<'b>(&'b self, alloc: &'b Arena) -> Option<QuerySelectorList<'b>> {
 		let lexer = Lexer::new(&CsskitAtomSet::ATOMS, &self.selector);
-		let mut parser = Parser::new(bump, &self.selector, lexer);
+		let mut parser = Parser::new(alloc, &self.selector, lexer);
 		parser.parse_entirely::<QuerySelectorList>().output
 	}
 }
@@ -162,8 +161,8 @@ impl Extract for Find {
 	}
 
 	fn extract<'a>(&self, stylesheet: &StyleSheet<'a>, src: &str, out: &mut Vec<(Span, FindData)>) {
-		let bump = Bump::default();
-		let Some(selectors) = self.parsed_selectors(&bump) else { return };
+		let alloc = Arena::default();
+		let Some(selectors) = self.parsed_selectors(&alloc) else { return };
 		for m in SelectorMatcher::new(&selectors, &self.selector, src).run(stylesheet) {
 			let start = usize::from(m.span.start());
 			let end = usize::from(m.span.end());

--- a/crates/csskit/src/commands/fmt.rs
+++ b/crates/csskit/src/commands/fmt.rs
@@ -1,9 +1,8 @@
 use crate::{CliError, CliResult, GlobalConfig, InputArgs};
-use bumpalo::Bump;
 use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet, Visitable};
 use css_lexer::{Lexer, QuoteStyle};
-use css_parse::{CursorPrettyWriteSink, Parser, ToCursors};
+use css_parse::{Arena, CursorPrettyWriteSink, Parser, ToCursors};
 use csskit_highlight::{AnsiHighlightCursorStream, DefaultAnsiTheme, TokenHighlighter};
 
 /// Format CSS files to make them more readable.
@@ -34,7 +33,7 @@ impl Fmt {
 	pub fn run(&self, config: GlobalConfig) -> CliResult {
 		let Fmt { content, output, check, expand_tab, single_quotes } = self;
 		let color = config.colors() && output.is_none() && !*check;
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let start = std::time::Instant::now();
 		let quotes = if *single_quotes { QuoteStyle::Single } else { QuoteStyle::Double };
 		if *check && output.is_some() {
@@ -42,12 +41,12 @@ impl Fmt {
 		}
 		let mut checks = 0;
 		for (file_name, source) in content.sources()? {
-			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
+			let source_text = css_parse::String::from_reader_in(source, &alloc)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
 			if let Some(stylesheet) = result.output.as_ref() {
-				let mut str = css_parse::String::new_in(&bump);
+				let mut str = css_parse::String::new_in(&alloc);
 				if color {
 					let mut highlighter = TokenHighlighter::new();
 					let _ = stylesheet.accept(&mut highlighter);

--- a/crates/csskit/src/commands/min.rs
+++ b/crates/csskit/src/commands/min.rs
@@ -1,9 +1,8 @@
 use crate::{CliError, CliResult, GlobalConfig, InputArgs};
-use bumpalo::Bump;
 use clap::Args;
 use css_ast::{CssAtomSet, StyleSheet, Visitable};
 use css_lexer::Lexer;
-use css_parse::{CursorCompactWriteSink, CursorOverlaySink, Parser, ToCursors};
+use css_parse::{Arena, CursorCompactWriteSink, CursorOverlaySink, Parser, ToCursors};
 use csskit_highlight::{AnsiHighlightCursorStream, DefaultAnsiTheme, TokenHighlighter};
 use csskit_transform::{CssMinifierFeature, Transformer};
 
@@ -28,24 +27,24 @@ impl Min {
 	pub fn run(&self, config: GlobalConfig) -> CliResult {
 		let Min { content, output, check } = self;
 		let color = config.colors() && output.is_none() && !*check;
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let start = std::time::Instant::now();
 		if *check && output.is_some() {
 			eprintln!("Ignoring output option, because check was passed");
 		}
 		let mut checks = 0;
 		for (file_name, source) in content.sources()? {
-			let source_text = css_parse::String::from_reader_in(source, &bump)?.into_str();
+			let source_text = css_parse::String::from_reader_in(source, &alloc)?.into_str();
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
-			let mut parser = Parser::new(&bump, source_text, lexer);
+			let mut parser = Parser::new(&alloc, source_text, lexer);
 			let mut result = parser.parse_entirely::<StyleSheet>().with_trivia();
 			if let Some(ref mut stylesheet) = result.output {
 				let mut transformer =
-					Transformer::new_in(&bump, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, source_text);
+					Transformer::new_in(&alloc, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, source_text);
 				transformer.transform(stylesheet);
 				let overlays = transformer.overlays();
 
-				let mut str = css_parse::String::new_in(&bump);
+				let mut str = css_parse::String::new_in(&alloc);
 				if color {
 					let mut highlighter = TokenHighlighter::new();
 					let _ = stylesheet.accept(&mut highlighter);

--- a/crates/csskit/src/commands/specificity.rs
+++ b/crates/csskit/src/commands/specificity.rs
@@ -1,12 +1,11 @@
 use crate::InputArgs;
 use crate::commands::{Extract, OutputFormat};
 use allocator_api2::alloc::Allocator;
-use bumpalo::Bump;
 use clap::Args;
 use css_ast::specificity::ToSpecificity;
 use css_ast::{CssAtomSet, SelectorList, StyleRule, StyleSheet, Visit, Visitable, visitor};
 use css_lexer::{Lexer, LineIndex, Span};
-use css_parse::{Parser, ToSpan};
+use css_parse::{Arena, Parser, ToSpan};
 use serde::Serialize;
 
 #[derive(Serialize, Debug)]
@@ -66,9 +65,9 @@ impl Extract for Specificity {
 		self.format
 	}
 
-	fn try_content(&self, src: &str, bump: &Bump, out: &mut Vec<(Span, Self::Row)>) -> bool {
+	fn try_content(&self, src: &str, alloc: &Arena, out: &mut Vec<(Span, Self::Row)>) -> bool {
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, src);
-		let mut parser = Parser::new(bump, src, lexer);
+		let mut parser = Parser::new(alloc, src, lexer);
 		let result = parser.parse_entirely::<SelectorList>();
 		if let Some(selector_list) = result.output.filter(|_| result.errors.is_empty()) {
 			extract_selector_list(&selector_list, src, out);

--- a/crates/csskit/src/commands/tree.rs
+++ b/crates/csskit/src/commands/tree.rs
@@ -1,10 +1,9 @@
-use bumpalo::Bump;
 use clap::Args;
 use css_ast::VisitNode;
 use css_ast::visit::{Visit, Visitable, visitor};
 use css_ast::{CssAtomSet, PROPERTY_KIND_VARIANTS, PropertyKind, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::{Cursor, Parser, ToSpan};
+use css_parse::{Arena, Cursor, Parser, ToSpan};
 use csskit_ast::{QueryFunctionalPseudoClass, QueryPseudoClass};
 
 use crate::{CliError, CliResult, GlobalConfig, InputArgs};
@@ -128,13 +127,13 @@ impl<'a> Visit for CollectionVisitor<'a> {
 
 impl Tree {
 	pub fn run(&self, _config: GlobalConfig) -> CliResult {
-		let bump = Bump::default();
+		let alloc = Arena::default();
 
 		for (filename, source) in self.input.sources()? {
-			let src = css_parse::String::from_reader_in(source, &bump)?.into_str();
+			let src = css_parse::String::from_reader_in(source, &alloc)?.into_str();
 
 			let lexer = Lexer::new(&CssAtomSet::ATOMS, src);
-			let mut parser = Parser::new(&bump, src, lexer);
+			let mut parser = Parser::new(&alloc, src, lexer);
 			let result = parser.parse_entirely::<StyleSheet>();
 
 			let Some(stylesheet) = result.output.as_ref() else {

--- a/crates/csskit_ast/Cargo.toml
+++ b/crates/csskit_ast/Cargo.toml
@@ -20,7 +20,6 @@ visit_flow = { workspace = true } # @release
 css_ast = { workspace = true, features = ["visitable"] } # @release
 csskit_derives = { workspace = true } # @release
 derive_atom_set = { workspace = true } # @release
-bumpalo = { workspace = true, features = ["collections", "boxed"] }
 indexmap = { workspace = true }
 smallvec = { workspace = true }
 miette = { workspace = true, optional = true }

--- a/crates/csskit_ast/benches/collector.rs
+++ b/crates/csskit_ast/benches/collector.rs
@@ -1,8 +1,7 @@
-use bumpalo::Bump;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::Parser;
+use css_parse::{Arena, Parser};
 use csskit_ast::sheet::Sheet;
 use csskit_ast::{Collector, CsskitAtomSet};
 use glob::glob;
@@ -60,7 +59,7 @@ fn collector(c: &mut Criterion) {
 
 			group.bench_function(BenchmarkId::from_parameter(&combined_name), |b| {
 				b.iter_with_large_drop(|| {
-					let allocator = Bump::default();
+					let allocator = Arena::default();
 					{
 						// Parse the CSS stylesheet
 						let css_lexer = Lexer::new(&CssAtomSet::ATOMS, &css_file.source_text);

--- a/crates/csskit_ast/benches/parse_sheet.rs
+++ b/crates/csskit_ast/benches/parse_sheet.rs
@@ -1,7 +1,6 @@
-use bumpalo::Bump;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use css_lexer::Lexer;
-use css_parse::Parser;
+use css_parse::{Arena, Parser};
 use csskit_ast::CsskitAtomSet;
 use csskit_ast::sheet::Sheet;
 use glob::glob;
@@ -33,7 +32,7 @@ fn parse_sheet(c: &mut Criterion) {
 		group.throughput(Throughput::Bytes(file.source_text.len() as u64));
 		group.bench_with_input(BenchmarkId::from_parameter(&file.name), &file.source_text, |b, source_text| {
 			b.iter_with_large_drop(|| {
-				let allocator = Bump::default();
+				let allocator = Arena::default();
 				let lexer = Lexer::new(&CsskitAtomSet::ATOMS, &source_text);
 				let _ = Parser::new(&allocator, source_text, lexer).parse_entirely::<Sheet>();
 

--- a/crates/csskit_ast/benches/selector_matcher.rs
+++ b/crates/csskit_ast/benches/selector_matcher.rs
@@ -1,8 +1,7 @@
-use bumpalo::Bump;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::Parser;
+use css_parse::{Arena, Parser};
 use csskit_ast::sheet::{Rule, Sheet};
 use csskit_ast::{CsskitAtomSet, SelectorMatcher};
 use glob::glob;
@@ -60,7 +59,7 @@ fn selector_matching(c: &mut Criterion) {
 
 			group.bench_function(BenchmarkId::from_parameter(&combined_name), |b| {
 				b.iter_with_large_drop(|| {
-					let allocator = Bump::default();
+					let allocator = Arena::default();
 					{
 						// Parse the CSS stylesheet
 						let css_lexer = Lexer::new(&CssAtomSet::ATOMS, &css_file.source_text);

--- a/crates/csskit_ast/src/collector/mod.rs
+++ b/crates/csskit_ast/src/collector/mod.rs
@@ -8,9 +8,9 @@ use crate::{
 	sheet::{Rule, Sheet},
 	when_rule::{ComparisonOperator, WhenCondition, WhenFeature},
 };
-use bumpalo::{Bump, collections::Vec, vec};
 use css_ast::{AtomSet, PropertyKind, StyleSheet};
 use css_lexer::{Atom, Cursor, RegisteredAtomSet, SourceCursor, SourceOffset, Span, ToSpan};
+use css_parse::{Arena, Vec, vec_in};
 #[cfg(feature = "miette")]
 use miette::{LabeledSpan, MietteDiagnostic, Severity as MietteSeverity};
 use smallvec::SmallVec;
@@ -139,7 +139,7 @@ pub struct Collector<'a> {
 	/// All collection rules (both with and without selectors)
 	collection_rules: Vec<'a, CollectionRule<'a>>,
 	/// Allocator for string parsing
-	allocator: &'a Bump,
+	allocator: &'a Arena,
 }
 
 impl<'a> Collector<'a> {
@@ -205,7 +205,7 @@ impl<'a> Collector<'a> {
 						diagnostic_stats: rule_data.diagnostic_stats,
 						conditions: conditions.clone(),
 						parent_span: node_span,
-						matches: vec![in self.allocator],
+						matches: vec_in![in self.allocator],
 					});
 
 					self.process_nested_rules(&node_rule.block.rules, conditions, node_span);
@@ -227,7 +227,7 @@ impl<'a> Collector<'a> {
 							diagnostic_stats: rule_data.diagnostic_stats,
 							conditions: combined_conditions.clone(),
 							parent_span,
-							matches: vec![in self.allocator],
+							matches: vec_in![in self.allocator],
 						});
 					}
 
@@ -239,9 +239,9 @@ impl<'a> Collector<'a> {
 	}
 
 	/// Create a new Collector from a parsed Sheet.
-	pub fn new(sheet: &'a Sheet<'a>, source: &'a str, allocator: &'a Bump) -> Self {
+	pub fn new(sheet: &'a Sheet<'a>, source: &'a str, allocator: &'a Arena) -> Self {
 		let stats = HashMap::new();
-		let collection_rules = vec![in allocator];
+		let collection_rules = vec_in![in allocator];
 		let mut collector = Self { source, stats, collection_rules, allocator };
 
 		for rule in sheet.rules.iter() {
@@ -272,19 +272,19 @@ impl<'a> Collector<'a> {
 						collectors: rule_data.collectors,
 						diagnostic: rule_data.diagnostic,
 						diagnostic_stats: rule_data.diagnostic_stats,
-						conditions: vec![in allocator],
+						conditions: vec_in![in allocator],
 						parent_span: node_span,
-						matches: vec![in allocator],
+						matches: vec_in![in allocator],
 					});
 
-					collector.process_nested_rules(&node_rule.block.rules, &vec![in allocator], node_span);
+					collector.process_nested_rules(&node_rule.block.rules, &vec_in![in allocator], node_span);
 				}
 				Rule::WhenRule(when_rule) => {
 					if !when_rule.condition.is_valid(source) {
 						continue;
 					}
 
-					let conditions = vec![in allocator; &when_rule.condition];
+					let conditions = vec_in![in allocator; &when_rule.condition];
 
 					let rule_data = collector.extract_rule_data(&when_rule.block.declarations);
 					if !rule_data.collectors.is_empty() || rule_data.diagnostic.is_some() {
@@ -296,7 +296,7 @@ impl<'a> Collector<'a> {
 							conditions: conditions.clone(),
 							// Use a placeholder span - will be updated with stylesheet span in collect()
 							parent_span: Span::new(SourceOffset(0), SourceOffset(0)),
-							matches: vec![in allocator],
+							matches: vec_in![in allocator],
 						});
 					}
 
@@ -485,7 +485,7 @@ impl<'a> Collector<'a> {
 			}
 		}
 
-		let mut processed = vec![in self.allocator; false; self.collection_rules.len()];
+		let mut processed = vec_in![in self.allocator; false; self.collection_rules.len()];
 
 		// First, execute all unconditional rules (conditions is empty)
 		for idx in 0..self.collection_rules.len() {
@@ -524,10 +524,10 @@ impl<'a> Collector<'a> {
 	pub fn diagnostics<'b>(&'b self, css_source: &'b str) -> impl Iterator<Item = CollectorDiagnostic> + 'b {
 		self.collection_rules.iter().flat_map(move |rule| {
 			let Some((severity, components)) = &rule.diagnostic else {
-				return vec![in self.allocator].into_iter();
+				return vec_in![in self.allocator].into_iter();
 			};
 
-			let mut diagnostics = vec![in self.allocator];
+			let mut diagnostics = vec_in![in self.allocator];
 			for match_output in rule.matches.iter() {
 				let message = self.resolve_diagnostic_message(components, match_output, css_source);
 				diagnostics.push(CollectorDiagnostic::new(*severity, match_output.span, message));

--- a/crates/csskit_ast/src/collector/tests.rs
+++ b/crates/csskit_ast/src/collector/tests.rs
@@ -1,23 +1,22 @@
 use super::*;
-use bumpalo::Bump;
 use css_ast::CssAtomSet;
 use css_lexer::Lexer;
-use css_parse::Parser;
+use css_parse::{Arena, Parser, vec_in};
 
-fn run<'a>(bump: &'a Bump, source: &'a str, css_source: &'a str) -> (Stats, Vec<'a, CollectorDiagnostic>) {
+fn run<'a>(alloc: &'a Arena, source: &'a str, css_source: &'a str) -> (Stats, Vec<'a, CollectorDiagnostic>) {
 	let sheet = {
 		let lexer = Lexer::new(CsskitAtomSet::get_dyn_set(), source);
-		let mut parser = Parser::new(bump, source, lexer);
+		let mut parser = Parser::new(alloc, source, lexer);
 		parser.parse_entirely::<crate::sheet::Sheet>().with_trivia().output.unwrap()
 	};
 	let stylesheet = {
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, css_source);
-		let mut parser = Parser::new(bump, css_source, lexer);
+		let mut parser = Parser::new(alloc, css_source, lexer);
 		parser.parse_entirely::<StyleSheet>().with_trivia().output.unwrap()
 	};
-	let mut collector = Collector::new(&sheet, source, bump);
+	let mut collector = Collector::new(&sheet, source, alloc);
 	collector.collect(&stylesheet, css_source);
-	let mut diagnostics = bumpalo::vec![in bump];
+	let mut diagnostics = vec_in![in alloc];
 	for diagnostic in collector.diagnostics(css_source) {
 		diagnostics.push(diagnostic);
 	}
@@ -26,7 +25,7 @@ fn run<'a>(bump: &'a Bump, source: &'a str, css_source: &'a str) -> (Stats, Vec<
 
 #[test]
 fn test_basic() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --total-rules { type: counter; }
 		style-rule { collect: --total-rules; }
@@ -36,7 +35,7 @@ fn test_basic() {
 		#bar {}
 		.baz {}
 	"#;
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let a = CsskitAtomSet::get_dyn_set().atom_from_str("total-rules");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
@@ -44,7 +43,7 @@ fn test_basic() {
 
 #[test]
 fn test_implicit_counter() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --total-rules; }
 	"#;
@@ -53,7 +52,7 @@ fn test_implicit_counter() {
 		#bar {}
 		.baz {}
 	"#;
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let a = CsskitAtomSet::get_dyn_set().atom_from_str("total-rules");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
@@ -61,13 +60,13 @@ fn test_implicit_counter() {
 
 #[test]
 fn test_bytes() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --rule-bytes { type: bytes; }
 		style-rule { collect: --rule-bytes; }
 	"#;
 	let css_source = ".a{}.bb{}";
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	// .a{} = 4 bytes, .bb{} = 5 bytes, total = 9 bytes
 	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rule-bytes");
 	assert_eq!(counters.get(&a), Some(&(StatType::Bytes, 9)));
@@ -76,7 +75,7 @@ fn test_bytes() {
 
 #[test]
 fn test_lines() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --rule-lines { type: lines; }
 		style-rule { collect: --rule-lines; }
@@ -86,7 +85,7 @@ fn test_lines() {
 
 }
 .bb{}";
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rule-lines");
 	assert_eq!(counters.get(&a), Some(&(StatType::Lines, 4)));
 	assert_eq!(diagnostics.len(), 0, "No diagnostics should be generated");
@@ -94,7 +93,7 @@ fn test_lines() {
 
 #[test]
 fn test_diagnostics_with_string() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule {
 			level: warning;
@@ -103,7 +102,7 @@ fn test_diagnostics_with_string() {
 	"#;
 	let css_source = ".foo {} .bar {}";
 
-	let (_, diagnostics) = run(&bump, source, css_source);
+	let (_, diagnostics) = run(&alloc, source, css_source);
 	assert_eq!(diagnostics.len(), 2);
 	assert_eq!(diagnostics[0].message, "Found a style rule");
 	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Warning);
@@ -113,7 +112,7 @@ fn test_diagnostics_with_string() {
 
 #[test]
 fn test_diagnostics_with_attr() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		[name] {
 			level: error;
@@ -122,7 +121,7 @@ fn test_diagnostics_with_attr() {
 	"#;
 	let css_source = ".foo { color: red; margin: 0; }";
 
-	let (_, diagnostics) = run(&bump, source, css_source);
+	let (_, diagnostics) = run(&alloc, source, css_source);
 	assert_eq!(diagnostics.len(), 2);
 	assert_eq!(diagnostics[0].message, "Property color found");
 	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Error);
@@ -132,7 +131,7 @@ fn test_diagnostics_with_attr() {
 
 #[test]
 fn test_diagnostics_with_size() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		selector-list {
 			level: advice;
@@ -141,7 +140,7 @@ fn test_diagnostics_with_size() {
 	"#;
 	let css_source = ".foo {}";
 
-	let (_, diagnostics) = run(&bump, source, css_source);
+	let (_, diagnostics) = run(&alloc, source, css_source);
 	assert_eq!(diagnostics.len(), 1);
 	assert_eq!(diagnostics[0].message, "Selector list has 1 selectors");
 	assert_eq!(diagnostics[0].severity, ResolvedDiagnosticLevel::Advice);
@@ -149,7 +148,7 @@ fn test_diagnostics_with_size() {
 
 #[test]
 fn test_diagnostics_with_size_various() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		selector-list {
 			level: error;
@@ -162,7 +161,7 @@ fn test_diagnostics_with_size_various() {
 		.d, .e, .f {}
 	"#;
 
-	let (_, diagnostics) = run(&bump, source, css_source);
+	let (_, diagnostics) = run(&alloc, source, css_source);
 	assert_eq!(diagnostics.len(), 3);
 	assert_eq!(diagnostics[0].message, "1 selectors");
 	assert_eq!(diagnostics[1].message, "2 selectors");
@@ -171,7 +170,7 @@ fn test_diagnostics_with_size_various() {
 
 #[test]
 fn test_diagnostics_with_stat_reference() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --total { type: counter; }
 		style-rule {
@@ -182,7 +181,7 @@ fn test_diagnostics_with_stat_reference() {
 	"#;
 	let css_source = ".a {} .b {} .c {}";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let a = CsskitAtomSet::get_dyn_set().atom_from_str("total");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
 
@@ -194,7 +193,7 @@ fn test_diagnostics_with_stat_reference() {
 
 #[test]
 fn test_when_rule_true_condition() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --rules; }
 		@when (--rules > 1) {
@@ -204,7 +203,7 @@ fn test_when_rule_true_condition() {
 	"#;
 	let css_source = ".a {} .b {} .c {}";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 1);
@@ -214,7 +213,7 @@ fn test_when_rule_true_condition() {
 
 #[test]
 fn test_when_rule_false_condition() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --rules; }
 		@when (--rules > 10) {
@@ -224,7 +223,7 @@ fn test_when_rule_false_condition() {
 	"#;
 	let css_source = ".a {} .b {}";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let a = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 2)));
 	assert_eq!(diagnostics.len(), 0);
@@ -232,7 +231,7 @@ fn test_when_rule_false_condition() {
 
 #[test]
 fn test_when_rule_with_nested_selector() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --rules; }
 		@when (--rules > 1) {
@@ -245,7 +244,7 @@ fn test_when_rule_with_nested_selector() {
 	"#;
 	let css_source = ".a {} #foo {} .b {}";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
 	let ids = CsskitAtomSet::get_dyn_set().atom_from_str("id-selectors");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
@@ -257,7 +256,7 @@ fn test_when_rule_with_nested_selector() {
 
 #[test]
 fn test_when_rule_equal_comparison() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --rules; }
 		@when (--rules = 2) {
@@ -267,14 +266,14 @@ fn test_when_rule_equal_comparison() {
 	"#;
 	let css_source = ".a {} .b {}";
 
-	let (_, diagnostics) = run(&bump, source, css_source);
+	let (_, diagnostics) = run(&alloc, source, css_source);
 	assert_eq!(diagnostics.len(), 1);
 	assert_eq!(diagnostics[0].message, "Exactly 2 rules");
 }
 
 #[test]
 fn test_nested_if_in_style_rule() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule {
 			collect: --foo;
@@ -286,7 +285,7 @@ fn test_nested_if_in_style_rule() {
 	"#;
 	let css_source = ".a {} .b {} .c {}";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let foo = CsskitAtomSet::get_dyn_set().atom_from_str("foo");
 	assert_eq!(counters.get(&foo), Some(&(StatType::Counter, 3)));
 	assert_eq!(diagnostics.len(), 1);
@@ -296,7 +295,7 @@ fn test_nested_if_in_style_rule() {
 
 #[test]
 fn test_nested_selector_in_style_rule() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --color-decls { type: counter; }
 		style-rule {
@@ -309,7 +308,7 @@ fn test_nested_selector_in_style_rule() {
 	"#;
 	let css_source = ".a { color: red; } .b { background: blue; } .c { color: green; }";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 
 	// Verify stats - only color declarations should be counted
 	let color_decls = CsskitAtomSet::get_dyn_set().atom_from_str("color-decls");
@@ -323,7 +322,7 @@ fn test_nested_selector_in_style_rule() {
 
 #[test]
 fn test_nested_if_with_combined_conditions() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --rules { type: counter; }
 		@stat --decls { type: counter; }
@@ -338,7 +337,7 @@ fn test_nested_if_with_combined_conditions() {
 	"#;
 	let css_source = ".a { color: red; } .b { background: blue; font-size: 12px; }";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
 	let decls = CsskitAtomSet::get_dyn_set().atom_from_str("decls");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 2)));
@@ -349,7 +348,7 @@ fn test_nested_if_with_combined_conditions() {
 
 #[test]
 fn test_conditional_nested_selector() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --rules { type: counter; }
 		@stat --color-decls { type: counter; }
@@ -366,7 +365,7 @@ fn test_conditional_nested_selector() {
 	"#;
 	let css_source = ".a { color: red; } .b { background: blue; } .c { color: green; }";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
 	let color_decls = CsskitAtomSet::get_dyn_set().atom_from_str("color-decls");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
@@ -378,7 +377,7 @@ fn test_conditional_nested_selector() {
 
 #[test]
 fn test_reactive_conditional_chain() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --rules { type: counter; }
 		@stat --warnings { type: counter; }
@@ -404,7 +403,7 @@ fn test_reactive_conditional_chain() {
 	"#;
 	let css_source = ".a {} .b {} .c {}";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
 	let warnings = CsskitAtomSet::get_dyn_set().atom_from_str("warnings");
 	let critical = CsskitAtomSet::get_dyn_set().atom_from_str("critical");
@@ -420,7 +419,7 @@ fn test_reactive_conditional_chain() {
 
 #[test]
 fn test_nested_not_condition_preserved() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --rules { type: counter; }
 		@stat --nested-matches { type: counter; }
@@ -439,7 +438,7 @@ fn test_nested_not_condition_preserved() {
 	"#;
 	let css_source = ".a {} .b {} .c {}";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 
 	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
 	let nested = CsskitAtomSet::get_dyn_set().atom_from_str("nested-matches");
@@ -450,7 +449,7 @@ fn test_nested_not_condition_preserved() {
 
 #[test]
 fn test_nested_not_condition_unmatched() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --rules { type: counter; }
 		@stat --nested-matches { type: counter; }
@@ -467,7 +466,7 @@ fn test_nested_not_condition_unmatched() {
 	"#;
 	let css_source = ".a {} .b {} .c {}";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
 	let nested = CsskitAtomSet::get_dyn_set().atom_from_str("nested-matches");
 	assert_eq!(counters.get(&rules), Some(&(StatType::Counter, 3)));
@@ -477,7 +476,7 @@ fn test_nested_not_condition_unmatched() {
 
 #[test]
 fn test_cycles_direct() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --a; }
 		@when (--a > 0) {
@@ -489,7 +488,7 @@ fn test_cycles_direct() {
 	"#;
 	let css_source = ".x {} .y {} .z {}";
 
-	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let (counters, _diagnostics) = run(&alloc, source, css_source);
 	let a = CsskitAtomSet::get_dyn_set().atom_from_str("a");
 	let b = CsskitAtomSet::get_dyn_set().atom_from_str("b");
 	assert_eq!(counters.get(&a), Some(&(StatType::Counter, 6))); // 3 unconditional + 3 from second @when
@@ -498,7 +497,7 @@ fn test_cycles_direct() {
 
 #[test]
 fn test_cycle_prevention_indirect() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --a; }
 		@when (--a > 0) {
@@ -513,7 +512,7 @@ fn test_cycle_prevention_indirect() {
 	"#;
 	let css_source = ".x {} .y {}";
 
-	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let (counters, _diagnostics) = run(&alloc, source, css_source);
 	let a = CsskitAtomSet::get_dyn_set().atom_from_str("a");
 	let b = CsskitAtomSet::get_dyn_set().atom_from_str("b");
 	let c = CsskitAtomSet::get_dyn_set().atom_from_str("c");
@@ -524,7 +523,7 @@ fn test_cycle_prevention_indirect() {
 
 #[test]
 fn test_cycle_prevention_self_referential() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --count; }
 		@when (--count > 1) {
@@ -533,14 +532,14 @@ fn test_cycle_prevention_self_referential() {
 	"#;
 	let css_source = ".a {} .b {} .c {}";
 
-	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let (counters, _diagnostics) = run(&alloc, source, css_source);
 	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
 	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 6)));
 }
 
 #[test]
 fn test_equality_vs_range_semantics() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --rules; }
 		@when (--rules = 1) {
@@ -552,7 +551,7 @@ fn test_equality_vs_range_semantics() {
 	"#;
 	let css_source = ".a {} .b {}";
 
-	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let (counters, _diagnostics) = run(&alloc, source, css_source);
 	let rules = CsskitAtomSet::get_dyn_set().atom_from_str("rules");
 	let equal = CsskitAtomSet::get_dyn_set().atom_from_str("equal-triggered");
 	let greater = CsskitAtomSet::get_dyn_set().atom_from_str("greater-triggered");
@@ -563,7 +562,7 @@ fn test_equality_vs_range_semantics() {
 
 #[test]
 fn test_equality_intermediate_value_does_not_trigger() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --count; }
 		@when (--count = 2) {
@@ -572,7 +571,7 @@ fn test_equality_intermediate_value_does_not_trigger() {
 	"#;
 	let css_source = ".a {} .b {} .c {}";
 
-	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let (counters, _diagnostics) = run(&alloc, source, css_source);
 	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
 	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("triggered");
 	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 3)));
@@ -581,7 +580,7 @@ fn test_equality_intermediate_value_does_not_trigger() {
 
 #[test]
 fn test_equality_does_trigger_on_exact_match() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		style-rule { collect: --count; }
 		@when (--count = 2) {
@@ -590,7 +589,7 @@ fn test_equality_does_trigger_on_exact_match() {
 	"#;
 	let css_source = ".a {} .b {}"; // Exactly 2 rules
 
-	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let (counters, _diagnostics) = run(&alloc, source, css_source);
 	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
 	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("triggered");
 	assert_eq!(counters.get(&count), Some(&(StatType::Counter, 2)));
@@ -599,7 +598,7 @@ fn test_equality_does_trigger_on_exact_match() {
 
 #[test]
 fn test_equality_triggers_once_then_becomes_false() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --count { type: counter; }
 		@stat --trigger { type: counter; }
@@ -621,7 +620,7 @@ fn test_equality_triggers_once_then_becomes_false() {
 	"#;
 	let css_source = ".a {} .b {}";
 
-	let (counters, diagnostics) = run(&bump, source, css_source);
+	let (counters, diagnostics) = run(&alloc, source, css_source);
 	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
 	let hit = CsskitAtomSet::get_dyn_set().atom_from_str("hit");
 	assert_eq!(counters.get(&hit), Some(&(StatType::Counter, 0)));
@@ -631,7 +630,7 @@ fn test_equality_triggers_once_then_becomes_false() {
 
 #[test]
 fn test_when_only_rules_with_bytes_and_lines() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --trigger { type: counter; }
 		@stat --byte-count { type: bytes; }
@@ -648,7 +647,7 @@ fn test_when_only_rules_with_bytes_and_lines() {
 	"#;
 	let css_source = ".a {} .b {}";
 
-	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let (counters, _diagnostics) = run(&alloc, source, css_source);
 	let trigger = CsskitAtomSet::get_dyn_set().atom_from_str("trigger");
 	let bytes = CsskitAtomSet::get_dyn_set().atom_from_str("byte-count");
 	let lines = CsskitAtomSet::get_dyn_set().atom_from_str("line-count");
@@ -666,7 +665,7 @@ fn test_when_only_rules_with_bytes_and_lines() {
 
 #[test]
 fn test_invalid_when_threshold_skipped() {
-	let bump = Bump::new();
+	let alloc = Arena::new();
 	let source = r#"
 		@stat --count { type: counter; }
 		@stat --triggered { type: counter; }
@@ -679,7 +678,7 @@ fn test_invalid_when_threshold_skipped() {
 	"#;
 	let css_source = ".a {} .b {}";
 
-	let (counters, _diagnostics) = run(&bump, source, css_source);
+	let (counters, _diagnostics) = run(&alloc, source, css_source);
 	let count = CsskitAtomSet::get_dyn_set().atom_from_str("count");
 	let triggered = CsskitAtomSet::get_dyn_set().atom_from_str("triggered");
 

--- a/crates/csskit_ast/src/selector/query.rs
+++ b/crates/csskit_ast/src/selector/query.rs
@@ -140,7 +140,7 @@ impl<'a> Parse<'a> for QueryCompoundSelector<'a> {
 	where
 		I: Iterator<Item = Cursor> + Clone,
 	{
-		let mut parts = Vec::new_in(p.bump());
+		let mut parts = Vec::new_in(p.alloc());
 		let mut metadata = QuerySelectorMetadata::default();
 
 		// Build segments in forward order. Each segment stores the combinator that follows it.

--- a/crates/csskit_ast/src/test_helpers.rs
+++ b/crates/csskit_ast/src/test_helpers.rs
@@ -19,21 +19,20 @@ macro_rules! assert_query {
 	};
 
 	($source:expr, $selector:expr => $parse_type:ty, $expected:expr, [$($node_id:expr),* $(,)?]) => {{
-		use bumpalo::Bump;
+		use css_parse::{Arena, Parser};
 		use css_ast::CssAtomSet;
 		use css_lexer::Lexer;
-		use css_parse::Parser;
 
-		let bump = Bump::new();
-		let selector_bump = Bump::new();
+		let alloc = Arena::new();
+		let selector_alloc = Arena::new();
 		let source = $source;
 		let selector_str: &str = $selector;
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, source);
-		let mut parser = Parser::new(&bump, source, lexer);
+		let mut parser = Parser::new(&alloc, source, lexer);
 		let parsed = parser.parse::<$parse_type>().expect("failed to parse CSS");
 
 		let selector_lexer = Lexer::new(&$crate::CsskitAtomSet::ATOMS, selector_str);
-		let mut selector_parser = Parser::new(&selector_bump, selector_str, selector_lexer);
+		let mut selector_parser = Parser::new(&selector_alloc, selector_str, selector_lexer);
 		let selector_result = selector_parser.parse_entirely::<$crate::selector::QuerySelectorList>();
 		let selectors = selector_result.output.expect("failed to parse selector");
 

--- a/crates/csskit_highlight/Cargo.toml
+++ b/crates/csskit_highlight/Cargo.toml
@@ -31,7 +31,6 @@ miette = { workspace = true, optional = true }
 
 [dev-dependencies]
 css_parse = { workspace = true }
-bumpalo = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 similar = { workspace = true }
 console = { workspace = true }

--- a/crates/csskit_highlight/src/test_helpers.rs
+++ b/crates/csskit_highlight/src/test_helpers.rs
@@ -93,19 +93,18 @@ impl<'a, T: fmt::Write> CursorSink for HTMLHighlightCursorStream<'a, T> {
 
 macro_rules! assert_highlight {
 	($name: literal, $str: literal $(,)*) => {
-		use bumpalo::Bump;
 		use css_ast::{CssAtomSet, StyleSheet, Visitable};
 		use css_lexer::Lexer;
-		use css_parse::{Parser, ToCursors};
+		use css_parse::{Arena, Parser, ToCursors};
 
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, $str);
-		let mut parser = Parser::new(&bump, $str, lexer);
+		let mut parser = Parser::new(&alloc, $str, lexer);
 		let result = parser.parse_entirely::<StyleSheet>();
 		if !result.errors.is_empty() {
 			panic!("\n\nParse on {}:{} failed. ({:?}) saw error {:?}", file!(), line!(), $str, result.errors[0]);
 		}
-		let mut actual = css_parse::String::new_in(&bump);
+		let mut actual = css_parse::String::new_in(&alloc);
 		let mut cursors = HTMLHighlightCursorStream::new($str, &mut actual);
 		let node = result.output.clone().unwrap();
 		let _ = node.accept(&mut cursors.highlighter);

--- a/crates/csskit_lsp/Cargo.toml
+++ b/crates/csskit_lsp/Cargo.toml
@@ -18,7 +18,6 @@ css_ast = { workspace = true, features = ["visitable"] } # @release
 css_lexer = { workspace = true }                         # @release
 csskit_highlight = { workspace = true }                  # @release
 
-bumpalo = { workspace = true, features = ["collections", "boxed"] }
 miette = { workspace = true, features = ["derive"] }
 
 bitmask-enum = { workspace = true }

--- a/crates/csskit_lsp/src/service.rs
+++ b/crates/csskit_lsp/src/service.rs
@@ -1,7 +1,7 @@
-use bumpalo::Bump;
 use crossbeam_channel::{Receiver, Sender, bounded};
 use css_ast::{CssAtomSet, StyleSheet, Visitable};
 use css_lexer::{Lexer, LineIndex};
+use css_parse::Arena;
 use css_parse::{Parser, ParserReturn};
 use csskit_highlight::{Highlight, SemanticKind, SemanticModifier, TokenHighlighter};
 use dashmap::DashMap;
@@ -56,11 +56,11 @@ impl File {
 			thread: Builder::new()
 				.name("LspDocumentHandler".into())
 				.spawn(move || {
-					let mut bump = Bump::default();
+					let mut alloc = Arena::default();
 					let mut string: String = "".into();
 					let lexer = Lexer::new(&CssAtomSet::ATOMS, "");
 					let mut result: ParserReturn<'_, StyleSheet<'_>> =
-						Parser::new(&bump, "", lexer).parse_entirely::<StyleSheet>();
+						Parser::new(&alloc, "", lexer).parse_entirely::<StyleSheet>();
 					while let Ok(call) = read_receiver.recv() {
 						match call {
 							FileCall::RopeChange(rope) => {
@@ -68,10 +68,10 @@ impl File {
 								let _ = span.enter();
 								// TODO! we should be able to optimize this by parsing a subset of the tree and mutating in
 								// place. For now though a partial parse request re-parses it all.
-								bump.reset();
+								alloc.reset();
 								string = rope.clone().into();
 								let lexer = Lexer::new(&CssAtomSet::ATOMS, &string);
-								result = Parser::new(&bump, &string, lexer).parse_entirely::<StyleSheet>();
+								result = Parser::new(&alloc, &string, lexer).parse_entirely::<StyleSheet>();
 								// if let Some(stylesheet) = &result.output {
 								// 	trace!("Sucessfully parsed stylesheet: {:#?}", &stylesheet);
 								// }
@@ -84,8 +84,8 @@ impl File {
 									let _ = stylesheet.accept(&mut highlighter);
 									let mut current_line = 0;
 									let mut current_start = 0;
-									let index_bump = Bump::new();
-									let line_index = LineIndex::new_in(&string, &index_bump);
+									let index_alloc = Arena::new();
+									let line_index = LineIndex::new_in(&string, &index_alloc);
 									let data = highlighter
 										.highlights()
 										.sorted_by(|a, b| Ord::cmp(&a.span(), &b.span()))

--- a/crates/csskit_transform/Cargo.toml
+++ b/crates/csskit_transform/Cargo.toml
@@ -17,7 +17,6 @@ css_ast = { workspace = true, features = ["visitable", "chromashift"] }
 css_parse = { workspace = true }
 visit_flow = { workspace = true }
 css_lexer = { workspace = true }
-bumpalo = { workspace = true }
 bitmask-enum = { workspace = true }
 chromashift = { workspace = true }
 

--- a/crates/csskit_transform/benches/minify_popular.rs
+++ b/crates/csskit_transform/benches/minify_popular.rs
@@ -1,8 +1,7 @@
-use bumpalo::Bump;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::{CursorWriteSink, Parser, ToCursors};
+use css_parse::{Arena, CursorWriteSink, Parser, ToCursors};
 use glob::glob;
 #[cfg(target_family = "unix")]
 use pprof::criterion::{Output, PProfProfiler};
@@ -32,11 +31,11 @@ fn popular(c: &mut Criterion) {
 		group.throughput(Throughput::Bytes(file.source_text.len() as u64));
 		group.bench_with_input(BenchmarkId::from_parameter(&file.name), &file.source_text, |b, source_text| {
 			b.iter_with_large_drop(|| {
-				let bump = Bump::default();
+				let alloc = Arena::default();
 				{
 					let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
-					let mut result = Parser::new(&bump, source_text.as_str(), lexer).parse_entirely::<StyleSheet>();
-					let mut string = css_parse::String::new_in(&bump);
+					let mut result = Parser::new(&alloc, source_text.as_str(), lexer).parse_entirely::<StyleSheet>();
+					let mut string = css_parse::String::new_in(&alloc);
 					if let Some(stylesheet) = result.output.as_mut() {
 						// let mut transformer = ReduceInitial::default();
 						// TODO! Re-introduce minifyer
@@ -45,7 +44,7 @@ fn popular(c: &mut Criterion) {
 						stylesheet.to_cursors(&mut sink);
 					}
 				}
-				bump
+				alloc
 			});
 		});
 	}

--- a/crates/csskit_transform/src/css_minifier.rs
+++ b/crates/csskit_transform/src/css_minifier.rs
@@ -26,16 +26,15 @@ impl Default for CssMinifierFeature {
 mod tests {
 	use super::*;
 	use crate::Transformer;
-	use bumpalo::Bump;
 	use css_ast::{CssAtomSet, StyleSheet};
 	use css_lexer::Lexer;
-	use css_parse::{CursorCompactWriteSink, CursorOverlaySink, Parser, ToCursors};
+	use css_parse::{Arena, CursorCompactWriteSink, CursorOverlaySink, Parser, ToCursors};
 
 	fn minify(source_text: &str, features: CssMinifierFeature) -> (String, bool) {
-		let bump = Bump::default();
-		let mut transformer = Transformer::new_in(&bump, features, &CssAtomSet::ATOMS, source_text);
+		let alloc = Arena::default();
+		let mut transformer = Transformer::new_in(&alloc, features, &CssAtomSet::ATOMS, source_text);
 		let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
-		let mut parser = Parser::new(&bump, source_text, lexer);
+		let mut parser = Parser::new(&alloc, source_text, lexer);
 		let mut result = parser.parse_entirely::<StyleSheet>().with_trivia();
 		let mut output = String::new();
 		if let Some(ref mut node) = result.output {

--- a/crates/csskit_transform/src/reduce_colors.rs
+++ b/crates/csskit_transform/src/reduce_colors.rs
@@ -209,7 +209,7 @@ where
 		let Some(chroma_color) = color.to_chromashift() else {
 			return;
 		};
-		let arena = self.transformer.bump();
+		let arena = self.transformer.alloc();
 		let len = color.to_span().len() as usize;
 
 		if chroma_color.in_gamut_of(ColorSpace::Srgb)
@@ -233,7 +233,7 @@ where
 	fn visit_color_mix_function<'b>(&mut self, mix: &ColorMixFunction<'b>) -> VisitFlow {
 		let outer_span = mix.to_span();
 		let outer_len = outer_span.len() as usize;
-		let arena = self.transformer.bump();
+		let arena = self.transformer.alloc();
 
 		let n = mix.parts.len();
 		let default_pct = 100.0 / n as f32;

--- a/crates/csskit_transform/src/reduce_lengths.rs
+++ b/crates/csskit_transform/src/reduce_lengths.rs
@@ -86,7 +86,7 @@ where
 		if can_reduce_to_unitless && matches!(resolved, ResolvedType::UnitedZero | ResolvedType::Resolved(0.0)) {
 			self.transformer.replace(length, self.transformer.parse_value::<Length>("0"));
 		} else if let ResolvedType::Resolved(px) = resolved {
-			let replacement = format_in!(in self.transformer.bump(), "{}px", px);
+			let replacement = format_in!(in self.transformer.alloc(), "{}px", px);
 			let original_span = length.to_span();
 			let original_len = (original_span.end().0 - original_span.start().0) as usize;
 			if replacement.len() <= original_len {

--- a/crates/csskit_transform/src/reduce_time_units.rs
+++ b/crates/csskit_transform/src/reduce_time_units.rs
@@ -26,7 +26,7 @@ where
 {
 	fn visit_time(&mut self, time: &Time) {
 		if let Time::Ms(dim) = time {
-			let arena = self.transformer.bump();
+			let arena = self.transformer.alloc();
 			let seconds = time.as_seconds();
 			let sc = self.transformer.to_source_cursor((*dim).into());
 			let value = if seconds.fract() == 0.0 {

--- a/crates/csskit_transform/src/reduce_urls.rs
+++ b/crates/csskit_transform/src/reduce_urls.rs
@@ -28,7 +28,7 @@ where
 		let UrlOrString::Url(url) = url_or_string else {
 			return;
 		};
-		let arena = self.transformer.bump();
+		let arena = self.transformer.alloc();
 		match url {
 			Url::UrlFunction(_, string, _) | Url::SrcFunction(_, string, _) => {
 				let sc = self.transformer.to_source_cursor((*string).into());

--- a/crates/csskit_transform/src/test_helpers.rs
+++ b/crates/csskit_transform/src/test_helpers.rs
@@ -1,13 +1,12 @@
 #[cfg(test)]
 macro_rules! assert_transform {
 	($features: ident :: $transform: ident, $atoms: ident, $node: ident, $str: literal, $expected: literal) => {{
-		use bumpalo::Bump;
 		use css_lexer::{Lexer, QuoteStyle};
-		use css_parse::{CursorOverlaySink, CursorPrettyWriteSink, Parser, ToCursors};
+		use css_parse::{Arena, CursorOverlaySink, CursorPrettyWriteSink, Parser, ToCursors};
 
 		let source_text = $str;
 
-		let allocator = Bump::default();
+		let allocator = Arena::default();
 		let lexer = Lexer::new(&$atoms::ATOMS, source_text);
 		let mut parser = Parser::new(&allocator, source_text, lexer);
 		let mut result = parser.parse_entirely::<$node>();
@@ -62,13 +61,12 @@ pub(crate) use assert_transform;
 #[cfg(test)]
 macro_rules! assert_no_transform {
 	($features: ident :: $transform: ident, $atoms: ident, $node: ident, $str: literal) => {{
-		use bumpalo::Bump;
 		use css_lexer::{Lexer, QuoteStyle};
-		use css_parse::{CursorOverlaySink, CursorPrettyWriteSink, Parser, ToCursors};
+		use css_parse::{Arena, CursorOverlaySink, CursorPrettyWriteSink, Parser, ToCursors};
 
 		let source_text = $str;
 
-		let allocator = Bump::default();
+		let allocator = Arena::default();
 		let lexer = Lexer::new(&$atoms::ATOMS, source_text);
 		let mut parser = Parser::new(&allocator, source_text, lexer);
 		let mut result = parser.parse_entirely::<$node>();

--- a/crates/csskit_transform/src/transformer.rs
+++ b/crates/csskit_transform/src/transformer.rs
@@ -1,9 +1,8 @@
-use bumpalo::Bump;
 use css_lexer::{AtomSet, Cursor, DynAtomSet, KindSet, Lexer, ToSpan};
 use css_parse::Vec;
 use css_parse::{
-	CursorOverlaySet, CursorToSourceCursorSink, NodeMetadata, NodeWithMetadata, OverlayKind, OverlaySegment, Parse,
-	Parser, SourceCursor, SourceOffset, Span, ToCursors,
+	Arena, CursorOverlaySet, CursorToSourceCursorSink, NodeMetadata, NodeWithMetadata, OverlayKind, OverlaySegment,
+	Parse, Parser, SourceCursor, SourceOffset, Span, ToCursors,
 };
 use std::{cell::RefCell, marker::PhantomData};
 
@@ -36,7 +35,7 @@ pub trait TransformerFeatures<M, N>: Sized + Default + Copy {
 }
 
 pub struct Transformer<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> {
-	bump: &'a Bump,
+	alloc: &'a Arena,
 	atoms: &'static dyn DynAtomSet,
 	pub(crate) features: F,
 	changed: RefCell<bool>,
@@ -47,14 +46,14 @@ pub struct Transformer<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: Transform
 }
 
 impl<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> Transformer<'a, M, N, F> {
-	pub fn new_in(bump: &'a Bump, features: F, atoms: &'static dyn DynAtomSet, source_text: &'a str) -> Self {
+	pub fn new_in(alloc: &'a Arena, features: F, atoms: &'static dyn DynAtomSet, source_text: &'a str) -> Self {
 		Self {
-			bump,
+			alloc,
 			features,
 			atoms,
 			changed: RefCell::new(false),
-			overlays: RefCell::new(CursorOverlaySet::new(bump)),
-			edits: RefCell::new(Vec::new_in(bump)),
+			overlays: RefCell::new(CursorOverlaySet::new(alloc)),
+			edits: RefCell::new(Vec::new_in(alloc)),
 			source_text,
 			_phantom: PhantomData,
 		}
@@ -72,8 +71,8 @@ impl<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> 
 		*self.changed.borrow()
 	}
 
-	pub fn bump(&self) -> &'a Bump {
-		self.bump
+	pub fn alloc(&self) -> &'a Arena {
+		self.alloc
 	}
 
 	pub fn to_source_cursor(&self, cursor: Cursor) -> SourceCursor<'a> {
@@ -81,7 +80,7 @@ impl<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> 
 	}
 
 	pub fn to_source_cursors(&self, parsed: &impl ToCursors) -> Vec<'a, SourceCursor<'a>> {
-		let mut cursors = Vec::new_in(self.bump());
+		let mut cursors = Vec::new_in(self.alloc());
 		let mut sink = CursorToSourceCursorSink::new(self.source_text, &mut cursors);
 		parsed.to_cursors(&mut sink);
 		cursors
@@ -94,7 +93,7 @@ impl<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> 
 				return A::from_bits(0);
 			}
 			let source_cursor = self.to_source_cursor(c);
-			return A::from_str(&source_cursor.parse(self.bump));
+			return A::from_str(&source_cursor.parse(self.alloc));
 		}
 		A::from_bits(bits)
 	}
@@ -108,7 +107,7 @@ impl<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> 
 		T: Parse<'a> + ToCursors,
 	{
 		let lexer = Lexer::new(self.atoms, source);
-		let mut parser = Parser::new(self.bump, source, lexer);
+		let mut parser = Parser::new(self.alloc, source, lexer);
 		let parsed = parser.parse_entirely::<T>();
 		debug_assert!(
 			parsed.output.is_some(),
@@ -116,7 +115,7 @@ impl<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> 
 			source,
 			parsed.errors
 		);
-		let mut cursors = Vec::new_in(self.bump());
+		let mut cursors = Vec::new_in(self.alloc());
 		let mut sink = CursorToSourceCursorSink::new(source, &mut cursors);
 		parsed.to_cursors(&mut sink);
 		cursors
@@ -179,7 +178,7 @@ impl<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> 
 			return Ok(());
 		}
 
-		let mut pending_segments: Vec<'a, PendingSegment<'a>> = Vec::with_capacity_in(edits.len(), self.bump);
+		let mut pending_segments: Vec<'a, PendingSegment<'a>> = Vec::with_capacity_in(edits.len(), self.alloc);
 
 		for (order, edit) in edits.drain(..).enumerate() {
 			match edit {
@@ -207,7 +206,7 @@ impl<'a, M: NodeMetadata, N: NodeWithMetadata<M>, F: TransformerFeatures<M, N>> 
 						span: target,
 						intent: OverlayKind::Replace,
 						order,
-						cursors: Vec::with_capacity_in(0, self.bump()),
+						cursors: Vec::with_capacity_in(0, self.alloc()),
 					});
 				}
 			}
@@ -284,15 +283,14 @@ mod tests {
 	use crate::CssMinifierFeature;
 
 	use super::*;
-	use bumpalo::Bump;
 	use css_ast::{CssAtomSet, CssMetadata};
-	use css_parse::{ComponentValues, SourceOffset, Span};
+	use css_parse::{Arena, ComponentValues, SourceOffset, Span};
 
 	#[test]
 	fn commit_overlays_rejects_overlapping_edits() {
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let context: Transformer<CssMetadata, ComponentValues, CssMinifierFeature> =
-			Transformer::new_in(&bump, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, "");
+			Transformer::new_in(&alloc, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, "");
 		let first = context.parse_value::<ComponentValues>("a");
 		let second = context.parse_value::<ComponentValues>("b");
 
@@ -311,9 +309,9 @@ mod tests {
 
 	#[test]
 	fn commit_overlays_preserves_insert_order() {
-		let bump = Bump::default();
+		let alloc = Arena::default();
 		let context: Transformer<CssMetadata, ComponentValues, CssMinifierFeature> =
-			Transformer::new_in(&bump, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, "");
+			Transformer::new_in(&alloc, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, "");
 		let anchor = SourceOffset(5);
 
 		context.insert_before(anchor, context.parse_value::<ComponentValues>("A"));

--- a/crates/csskit_transform/tests/css-minify-tests.rs
+++ b/crates/csskit_transform/tests/css-minify-tests.rs
@@ -1,7 +1,6 @@
-use bumpalo::Bump;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::Lexer;
-use css_parse::{CursorCompactWriteSink, CursorOverlaySink, Parser, ToCursors};
+use css_parse::{Arena, CursorCompactWriteSink, CursorOverlaySink, Parser, ToCursors};
 use csskit_transform::{CssMinifierFeature, Transformer};
 use glob::glob;
 use similar::{ChangeTag, TextDiff};
@@ -40,10 +39,10 @@ fn get_tests() -> Vec<CssMinifyTestCase> {
 }
 
 fn minify(source_text: &str) -> String {
-	let bump = Bump::default();
-	let mut transformer = Transformer::new_in(&bump, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, source_text);
+	let alloc = Arena::default();
+	let mut transformer = Transformer::new_in(&alloc, CssMinifierFeature::all_bits(), &CssAtomSet::ATOMS, source_text);
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
-	let mut parser = Parser::new(&bump, source_text, lexer);
+	let mut parser = Parser::new(&alloc, source_text, lexer);
 	let mut result = parser.parse_entirely::<StyleSheet>().with_trivia();
 	let mut output = String::new();
 	if let Some(ref mut node) = result.output {

--- a/crates/csskit_wasm/Cargo.toml
+++ b/crates/csskit_wasm/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["console_error_panic_hook", "serde", "fancy"]
 console_error_panic_hook = ["dep:console_error_panic_hook", "dep:web-sys"]
-serde = ["css_lexer/serde", "css_ast/serde", "css_parse/serde", "bumpalo/serde"]
+serde = ["css_lexer/serde", "css_ast/serde", "css_parse/serde"]
 miette = ["css_parse/miette", "css_ast/miette"]
 fancy = ["miette", "miette/fancy-no-syscall"]
 
@@ -24,7 +24,6 @@ css_ast = { workspace = true, features = ["visitable"] } # @release
 css_parse = { workspace = true } # @release
 csskit_transform = { workspace = true } # @release
 
-bumpalo = { workspace = true }
 miette = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 

--- a/crates/csskit_wasm/src/lib.rs
+++ b/crates/csskit_wasm/src/lib.rs
@@ -1,10 +1,10 @@
 #![deny(warnings)]
-use bumpalo::Bump;
 use core::fmt::Write;
 use css_ast::{CssAtomSet, StyleSheet};
 use css_lexer::{Kind, Lexer, QuoteStyle};
 use css_parse::{
-	CursorCompactWriteSink, CursorOverlaySink, CursorPrettyWriteSink, Diagnostic, DiagnosticMeta, Parser, ToCursors,
+	Arena, CursorCompactWriteSink, CursorOverlaySink, CursorPrettyWriteSink, Diagnostic, DiagnosticMeta, Parser,
+	ToCursors,
 };
 use csskit_transform::{CssMinifierFeature, Transformer};
 #[cfg(all(feature = "miette", not(feature = "fancy")))]
@@ -37,7 +37,7 @@ pub fn lex(source_text: String) -> Result<JsValue, serde_wasm_bindgen::Error> {
 
 #[wasm_bindgen]
 pub fn parse(source_text: String) -> Result<SerializableParserResult, serde_wasm_bindgen::Error> {
-	let allocator = Bump::default();
+	let allocator = Arena::default();
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text.as_str());
 	let result = Parser::new(&allocator, source_text.as_str(), lexer).parse_entirely::<StyleSheet>();
 	let serializer = serde_wasm_bindgen::Serializer::json_compatible();
@@ -66,7 +66,7 @@ pub fn parse(source_text: String) -> Result<SerializableParserResult, serde_wasm
 
 #[wasm_bindgen]
 pub fn minify(source_text: String) -> Result<String, serde_wasm_bindgen::Error> {
-	let allocator = Bump::default();
+	let allocator = Arena::default();
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text.as_str());
 	let mut result = Parser::new(&allocator, source_text.as_str(), lexer).parse_entirely::<StyleSheet>();
 	if !result.errors.is_empty() {
@@ -104,7 +104,7 @@ pub fn format(source_text: String, options: JsValue) -> Result<String, serde_was
 }
 
 fn format_with_options(source_text: &str, options: FormatOptions) -> Result<String, String> {
-	let allocator = Bump::default();
+	let allocator = Arena::default();
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text);
 	let result = Parser::new(&allocator, source_text, lexer).parse_entirely::<StyleSheet>();
 	if !result.errors.is_empty() {
@@ -131,7 +131,7 @@ fn format_with_options(source_text: &str, options: FormatOptions) -> Result<Stri
 
 #[wasm_bindgen]
 pub fn parse_error_report(source_text: String) -> String {
-	let allocator = Bump::default();
+	let allocator = Arena::default();
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, source_text.as_str());
 	let result = Parser::new(&allocator, source_text.as_str(), lexer).parse_entirely::<StyleSheet>();
 	let mut report = String::new();

--- a/fuzz/fuzz_targets/parse_stylesheet.rs
+++ b/fuzz/fuzz_targets/parse_stylesheet.rs
@@ -11,14 +11,14 @@ fuzz_target!(|data: &[u8]| {
 	}
 	let Ok(source) = std::str::from_utf8(data) else { return };
 
-	let bump = Bump::new();
+	let alloc = Bump::new();
 	let lexer = Lexer::new(&CssAtomSet::ATOMS, source);
-	let mut parser = Parser::new(&bump, source, lexer);
+	let mut parser = Parser::new(&alloc, source, lexer);
 	let result = parser.parse_entirely::<StyleSheet>().with_trivia();
 	if let Some(node) = result.output {
-		let mut out = bumpalo::collections::String::new_in(&bump);
+		let mut out = bumpalo::collections::String::new_in(&alloc);
 		let mut write_sink = CursorWriteSink::new(source, &mut out);
-		let mut ordered_sink = CursorOrderedSink::new(&bump, &mut write_sink);
+		let mut ordered_sink = CursorOrderedSink::new(&alloc, &mut write_sink);
 		node.to_cursors(&mut ordered_sink);
 	}
 });


### PR DESCRIPTION
As part of a migration process away from Bumpalo, this change exports `Arena` in
css_parse, and renames `bump` to `alloc`. It also tidies up a few smaller bits,
like adding a `vec_in!` macro.
