### PR TITLE
csskit-wasm: Fix wasm-opt errors

### DIFF
--- a/.mise-tasks/build-csskit-wasm
+++ b/.mise-tasks/build-csskit-wasm
@@ -25,14 +25,14 @@ wasm-bindgen \
   --target bundler \
   "$REPO_ROOT/target/wasm32-unknown-unknown/release/csskit_wasm.wasm"
 
-npx --yes wasm-opt@1.4.0 \
+wasm-opt \
   --enable-bulk-memory \
   --enable-nontrapping-float-to-int \
   -Oz \
   -o "$PKG/csskit_wasm_bg.wasm" \
   "$PKG/csskit_wasm_bg.wasm"
 
-npx --yes wasm-opt@1.4.0 \
+wasm-opt \
   --enable-bulk-memory \
   --enable-nontrapping-float-to-int \
   -Oz \

--- a/.mise.toml
+++ b/.mise.toml
@@ -9,6 +9,7 @@ hyperfine = "latest"
 "cargo:git-cliff" = "2.10.1"
 "cargo:samply" = "0.13.1"
 "cargo:wasm-bindgen-cli" = "0.2.122"
+"aqua:WebAssembly/binaryen" = "131"
 "cargo:cargo-fuzz" = "0.13.1"
 
 [tasks.clean]

--- a/packages/csskit/package.json
+++ b/packages/csskit/package.json
@@ -32,8 +32,5 @@
         "csskit-linux-x64": "0.0.28",
         "csskit-win32-arm64": "0.0.28",
         "csskit-win32-x64": "0.0.28"
-    },
-    "allowScripts": {
-        "wasm-opt@1.4.0": true
     }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -42,7 +42,7 @@
 			}
 		},
 		"../packages/csskit": {
-			"version": "0.0.27",
+			"version": "0.0.28",
 			"license": "MIT",
 			"bin": {
 				"csskit": "bin/csskit"
@@ -51,12 +51,12 @@
 				"url": "https://github.com/sponsors/keithamus"
 			},
 			"optionalDependencies": {
-				"csskit-darwin-arm64": "0.0.27",
-				"csskit-darwin-x64": "0.0.27",
-				"csskit-linux-arm64": "0.0.27",
-				"csskit-linux-x64": "0.0.27",
-				"csskit-win32-arm64": "0.0.27",
-				"csskit-win32-x64": "0.0.27"
+				"csskit-darwin-arm64": "0.0.28",
+				"csskit-darwin-x64": "0.0.28",
+				"csskit-linux-arm64": "0.0.28",
+				"csskit-linux-x64": "0.0.28",
+				"csskit-win32-arm64": "0.0.28",
+				"csskit-win32-x64": "0.0.28"
 			}
 		},
 		"node_modules/@11ty/dependency-tree": {


### PR DESCRIPTION
Currently we use the npm package `wasm-opt` to optimise binaries, but this stopped working recently. It's just a wrapper around binaryen so we can simply install & use binaryen instead.