### PR TITLE
Don't build release-debug on collect-benchmarks scripts

### DIFF
--- a/.mise-tasks/collect-benchmarks
+++ b/.mise-tasks/collect-benchmarks
@@ -1,5 +1,5 @@
 #!/bin/bash
-#MISE depends=["build-release", "build-release-debug"]
+#MISE depends=["build-release"]
 #MISE description="Collect benchmark results for historical tracking"
 
 CSSKIT_BIN="./target/release/csskit"

--- a/.mise.toml
+++ b/.mise.toml
@@ -33,7 +33,7 @@ run = "cargo build --all-features --release"
 [tasks.build-release-debug]
 description = "Build release-debug"
 sources = ["Cargo.toml", "crates/**/*.toml", "crates/**/*.rs"]
-outputs = ["target/release/csskit"]
+outputs = ["target/release-debug/csskit"]
 run = "cargo build --all-features --profile release-debug"
 
 [tasks.test]


### PR DESCRIPTION
For some reason we added `build-release-debug` as a dependency of the
`collect-benchmarks` task, meaning it was taking twice as long to compile as it
needed to. This fixes that.
