### PR TITLE
css_ast: repr(C) all nodes, introduce stable-type-layout.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,6 @@ dependencies = [
  "glob",
  "heck",
  "insta",
- "inventory",
  "miette",
  "pprof",
  "prettyplease",
@@ -672,6 +671,7 @@ dependencies = [
  "serde_json",
  "similar 3.1.1",
  "smallvec",
+ "stable-type-layout",
  "syn 2.0.119",
  "thiserror 2.0.19",
  "visit-flow",
@@ -723,11 +723,11 @@ dependencies = [
  "dhat",
  "glob",
  "insta",
- "inventory",
  "miette",
  "serde",
  "serde_json",
  "smallvec",
+ "stable-type-layout",
  "thiserror 2.0.19",
 ]
 
@@ -3009,6 +3009,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "stable-type-layout"
+version = "0.0.28"
+dependencies = [
+ "inventory",
+ "stable-type-layout-derive",
+]
+
+[[package]]
+name = "stable-type-layout-derive"
+version = "0.0.28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ csskit_source_finder = { path = "crates/csskit_source_finder", version = "0.0.28
 csskit_spec_generator = { path = "tools/csskit_spec_generator", version = "0.0.0" }
 csskit_transform = { path = "crates/csskit_transform", version = "0.0.28" }  # @release
 derive_atom_set = { path = "crates/derive_atom_set", version = "0.0.28" }  # @release
+stable_type_layout = { package = "stable-type-layout", path = "crates/stable_type_layout", version = "0.0.28" }  # @release
+stable_type_layout_derive = { package = "stable-type-layout-derive", path = "crates/stable_type_layout_derive", version = "0.0.28" }  # @release
 visit_flow = { package = "visit-flow", path = "crates/visit_flow", version = "0.0.28" }  # @release
 
 # Memory

--- a/crates/css_ast/Cargo.toml
+++ b/crates/css_ast/Cargo.toml
@@ -49,7 +49,7 @@ insta = { workspace = true, features = ["ron"] }
 similar = { workspace = true }
 console = { workspace = true }
 dhat = { workspace = true }
-inventory = { workspace = true }
+stable_type_layout = { workspace = true }  # @release
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 pprof = { workspace = true, features = ["flamegraph", "criterion"] }

--- a/crates/css_ast/build.rs
+++ b/crates/css_ast/build.rs
@@ -25,10 +25,14 @@ fn main() {
 	find_visitable_nodes("src/**/*.rs", &mut all_visitable, |path: &PathBuf| {
 		println!("cargo::rerun-if-changed={}", path.display());
 	});
+	let mut all_visitable = all_visitable.into_iter().collect::<Vec<_>>();
+	all_visitable.sort_unstable_by_key(|node| node.ident().to_string());
 
 	// Find only queryable nodes (for NodeId enum and QueryableNode trait)
 	let mut queryable = HashSet::<_>::new();
 	find_queryable_nodes("src/**/*.rs", &mut queryable, |_| {});
+	let mut queryable = queryable.into_iter().collect::<Vec<_>>();
+	queryable.sort_unstable_by_key(|node| node.ident().to_string());
 
 	// NodeId enum - only queryable types
 	{

--- a/crates/css_ast/src/layout_test.rs
+++ b/crates/css_ast/src/layout_test.rs
@@ -1,24 +1,5 @@
-//! Size tripwire: snapshots `size_of` for every `#[node]` AST type, collected
-//! via `inventory`. An accidental size change fails the snapshot loudly. Kept
-//! `#[cfg(test)]` so it adds no runtime cost or dependency to shipped builds.
-
-pub(crate) struct LayoutInfo {
-	pub name: &'static str,
-	pub size: usize,
-}
-inventory::collect!(LayoutInfo);
-
-fn render() -> String {
-	let mut infos: Vec<&LayoutInfo> = inventory::iter::<LayoutInfo>.into_iter().collect();
-	infos.sort_by_key(|info| info.name);
-	let mut out = String::new();
-	for info in infos {
-		out.push_str(&format!("{}: {}\n", info.name, info.size));
-	}
-	out
-}
-
 #[test]
 fn assert_layouts() {
+	use stable_type_layout::render;
 	insta::assert_snapshot!("assert_layouts", render());
 }

--- a/crates/css_ast/src/snapshots/css_ast__layout_test__assert_layouts.snap
+++ b/crates/css_ast/src/snapshots/css_ast__layout_test__assert_layouts.snap
@@ -2,609 +2,11148 @@
 source: crates/css_ast/src/layout_test.rs
 expression: render()
 ---
-AbsoluteSize: 16
-AcosFunction: 120
-Angle: 16
-AngleOrNumber: 16
-AngleOrZero: 16
-AnimateableFeature: 16
-AnimationAction: 16
-AnyHoverMediaFeature: 64
-AnyHoverMediaFeatureKeyword: 16
-AnyPointerMediaFeature: 64
-AnyPointerMediaFeatureKeyword: 16
-ArcCommand: 256
-ArcCommandParams: 136
-ArcRadii: 64
-ArcRotate: 40
-AsinFunction: 120
-AspectRatioContainerFeature: 224
-AtPosition: 104
-AtanFunction: 120
-Attachment: 16
-AttrFunction: 144
-AttrFunctionParams: 120
-AttrName: 48
-AttrType: 28
-Attribute: 128
-AttributeModifier: 16
-AttributeOperator: 28
-AttributeValue: 16
-Auto: 12
-AutoFillOrFit: 16
-AutoLineWidthList: 128
-AutoTrackList: 272
-BaselineMetric: 16
-BaselinePosition: 16
-BasicShape: 352
-BasicShapeRect: 352
-BgClip: 16
-BgLayer: 296
-BgPosition: 88
-BgPositionAndSize: 152
-BlendMode: 16
-BlockSizeContainerFeature: 124
-BlurFunction: 48
-BooleanKeyword: 16
-BorderRadius: 64
-BrightnessFunction: 48
-CSSFloat: 12
-CSSInt: 12
-CalcKeyword: 16
-CalcProductOperator: 16
-CalcSizeFunction: 24
-CalcSumOperator: 16
-CharsetRule: 52
-CircleFunction: 152
-CircleRadius: 24
-Class: 24
-Color: 24
-ColorChannelKeyword: 16
-ColorFunction: 176
-ColorFunctionColor: 152
-ColorFunctionColorParams: 128
-ColorGamutMediaFeature: 64
-ColorGamutMediaFeatureKeyword: 16
-ColorIndexMediaFeature: 116
-ColorInterpolationMethod: 56
-ColorMediaFeature: 116
-ColorMixFunction: 120
-ColorMixPart: 48
-ColorRelativeFunction: 192
-ColorRelativeParams: 168
-ColorSchemeName: 24
-ColorSpace: 16
-ColorStopOrHint: 48
-ColorStripe: 48
-Combinator: 28
-CommaOrSlash: 12
-CommonLigValues: 16
-CompatAuto: 16
-CompatSpecial: 16
-CompositingOperator: 16
-CompoundSelector: 24
-ContainerCondition: 256
-ContainerConditionList: 24
-ContainerFeature: 224
-ContainerQuery: 240
-ContainerRule: 176
-ContainerRulesBlock: 128
-ContentAltItem: 152
-ContentDistribution: 16
-ContentFunction: 40
-ContentKeyword: 16
-ContentList: 24
-ContentListItem: 176
-ContentPosition: 16
-ContextualAltValues: 16
-ContrastFunction: 48
-CoordBox: 16
-CosFunction: 120
-Counter: 144
-CounterFunction: 120
-CounterFunctionParams: 96
-CounterName: 12
-CounterStyle: 64
-CounterStyleName: 12
-CounterStyleRule: 144
-CounterStyleRuleBlock: 112
-CounterStyleRuleStyleValue: 80
-CountersFunction: 144
-CountersFunctionParams: 120
-CssAtomSet: 4
-CubicBezierFunction: 168
-CubicBezierFunctionParams: 144
-CursorImage: 96
-CursorPredefined: 16
-CurveCommand: 328
-Custom: 24
-CustomDimension: 12
-CustomElementTag: 12
-CustomIdent: 12
-DashedIdent: 12
-Decibel: 12
-DeviceHeightMediaFeature: 124
-DeviceWidthMediaFeature: 124
-DirPseudoFunction: 56
-DirValue: 16
-DiscretionaryLigValues: 16
-DisplayBox: 16
-DisplayInside: 16
-DisplayInternal: 16
-DisplayLegacy: 16
-DisplayLegacyVendor: 16
-DisplayListitem: 44
-DisplayListitemInside: 16
-DisplayModeMediaFeature: 64
-DisplayModeMediaFeatureKeyword: 16
-DisplayOutside: 16
-DocumentMatcher: 40
-DocumentMatcherList: 24
-DocumentRule: 160
-DocumentRuleBlock: 112
-DropShadowFunction: 120
-DynamicRangeLimitMixFunction: 48
-DynamicRangeMediaFeature: 64
-DynamicRangeMediaFeatureKeyword: 16
-EasingFunction: 168
-EastAsianVariantValues: 16
-EastAsianWidthValues: 16
-EllipseFunction: 176
-EnvironmentBlendingMediaFeature: 64
-EnvironmentBlendingMediaFeatureKeyword: 16
-EventTriggerEvent: 40
-ExpFunction: 120
-ExplicitTrackList: 72
-FallbackStyleValue: 12
-FeatureTagToggle: 24
-FeatureTagValue: 40
-FillLayer: 272
-FillOrigin: 16
-FilterFunction: 120
-FilterValue: 120
-FilterValueList: 24
-FitContentFunction: 48
-FixedSize: 96
-Flex: 12
-FontFaceRule: 128
-FontFaceRuleBlock: 112
-FontFaceRuleStyleValue: 752
-ForcedColorsMediaFeature: 64
-ForcedColorsMediaFeatureKeyword: 16
-Frequency: 16
-FunctionalPseudoClass: 104
-FunctionalPseudoElement: 104
-GapRepeatRule: 80
-GapRuleList: 24
-GapRuleOrRepeat: 80
-GenericVoice: 56
-GeometryBox: 16
-Gradient: 24
-GrayscaleFunction: 48
-GridLine: 56
-GridMediaFeature: 64
-HasPseudoFunction: 64
-HeadingPseudoFunction: 64
-HeightContainerFeature: 124
-HeightMediaFeature: 124
-HighlightPseudoElement: 60
-HistoricalLigValues: 16
-HorizontalLineCommand: 56
-HorizontalViewportSegmentsMediaFeature: 116
-HostContextPseudoFunction: 64
-HostPseudoFunction: 64
-HoverMediaFeature: 64
-HoverMediaFeatureKeyword: 16
-HslChannelKeyword: 16
-HslFunction: 168
-HslFunctionParams: 144
-HslRelativeFunction: 176
-HslRelativeParams: 152
-HslaFunction: 168
-HslaRelativeFunction: 176
-HtmlNonConformingTag: 16
-HtmlNonStandardTag: 16
-HtmlTag: 16
-HueInterpolationDirection: 16
-HueInterpolationMethod: 28
-HueRotateFunction: 48
-HwbChannelKeyword: 16
-HwbFunction: 136
-HwbFunctionParams: 112
-HwbRelativeFunction: 176
-HwbRelativeParams: 152
-Id: 12
-IfCondition: 184
-IfConditionExpr: 184
-IfTest: 168
-Image: 40
-Image1d: 48
-ImageSetFunction: 48
-ImageSetParams: 80
-ImportLayer: 64
-ImportLayerFunction: 64
-ImportRule: 264
-ImportSupportsFunction: 96
-InheritsValue: 16
-InlineSizeContainerFeature: 124
-InsetFunction: 344
-InsetValue: 24
-InterpolationColorSpace: 44
-InvertFunction: 48
-InvertedColorsMediaFeature: 64
-InvertedColorsMediaFeatureKeyword: 16
-IsPseudoFunction: 64
-IsolationMode: 16
-Keyframe: 208
-KeyframeSelector: 16
-KeyframeSelectors: 24
-KeyframesName: 16
-KeyframesRule: 144
-KeyframesRuleBlock: 112
-KeypressFunction: 36
-LabChannelKeyword: 16
-LabFunction: 136
-LabFunctionParams: 112
-LabRelativeFunction: 176
-LabRelativeParams: 152
-LangPseudoFunction: 64
-LangValue: 16
-LangValues: 24
-LayerName: 40
-LayerNameList: 24
-LayerRule: 192
-LayerRuleBlock: 128
-LayoutBox: 16
-LchChannelKeyword: 16
-LchFunction: 136
-LchFunctionParams: 112
-LchRelativeFunction: 176
-LchRelativeParams: 152
-LeaderFunction: 40
-LeaderType: 16
-LegacyPseudoElement: 28
-Length: 16
-LengthPercentage: 16
-LengthPercentageNumber: 16
-LengthPercentageOrFlex: 16
-LightDarkFunction: 88
-LineCommand: 120
-LineNameList: 24
-LineNames: 48
-LineStyle: 16
-LineWidth: 24
-LineWidthOrRepeat: 80
-LinearDirection: 48
-LinearFunction: 48
-LinearFunctionParams: 72
-LinearGradientFunction: 112
-LinearGradientFunctionParams: 88
-LogFunction: 152
-MarginRule: 128
-MarginRuleBlock: 112
-MaskingMode: 16
-MathmlTag: 16
-Matrix3dFunction: 648
-Matrix3dFunctionParams: 624
-MatrixFunction: 248
-MatrixFunctionParams: 224
-MediaCondition: 144
-MediaFeature: 128
-MediaPreCondition: 16
-MediaQuery: 192
-MediaQueryList: 24
-MediaRule: 176
-MediaRuleBlock: 128
-MediaType: 16
-MinmaxFunction: 96
-MonochromeMediaFeature: 116
-MoveCommand: 120
-MozDeviceOrientationMediaFeature: 64
-MozDeviceOrientationMediaFeatureKeyword: 16
-MozDevicePixelRatioMediaFeature: 116
-MozDocumentRule: 160
-MozFunctionalPseudoClass: 56
-MozFunctionalPseudoElement: 80
-MozFunctionalPseudoElementKeyword: 16
-MozImagesInMenusMediaFeature: 64
-MozLocaleDirFunctionalPseudoClass: 56
-MozMacGraphiteThemeMediaFeature: 64
-MozMaemoClassicMediaFeature: 64
-MozOsVersionMediaFeature: 64
-MozOsVersionMediaFeatureKeyword: 16
-MozPseudoClass: 28
-MozPseudoElement: 40
-MozTouchEnabledMediaFeature: 64
-MsColumnCountMediaFeature: 116
-MsDevicePixelRatioMediaFeature: 116
-MsFilterStyleValue: 32
-MsHighContrastMediaFeature: 64
-MsHighContrastMediaFeatureKeyword: 16
-MsImeAlignMediaFeature: 64
-MsImeAlignMediaFeatureKeyword: 12
-MsPseudoClass: 28
-MsPseudoElement: 40
-MsViewStateMediaFeature: 64
-MsViewStateMediaFeatureKeyword: 16
-NameRepeat: 88
-NameRepeatParams: 64
-NamedColor: 16
-NamedDirection: 16
-Namespace: 48
-NamespacePrefix: 28
-NamespaceRule: 84
-NamespaceTag: 20
-NavControlsMediaFeature: 64
-NavControlsMediaFeatureKeyword: 16
-NestedGroupRule: 224
-NotPseudoFunction: 64
-Nth: 60
-NthChildPseudoFunction: 100
-NthColPseudoFunction: 100
-NthLastChildPseudoFunction: 100
-NthLastColPseudoFunction: 100
-NthLastOfTypePseudoFunction: 100
-NthOfTypePseudoFunction: 100
-NumberLength: 16
-NumberOrInfinity: 16
-NumberOrPercentage: 16
-NumberPercentage: 16
-NumericFigureValues: 16
-NumericFractionValues: 16
-NumericSpacingValues: 16
-ODevicePixelRatioMediaFeature: 116
-OPseudoClass: 24
-OPseudoElement: 40
-OffsetPath: 40
-OklabFunction: 136
-OklabRelativeFunction: 176
-OklchFunction: 136
-OklchRelativeFunction: 176
-OpacityFunction: 48
-OpacityValue: 16
-OpentypeTag: 12
-OrientationContainerFeature: 64
-OrientationContainerFeatureKeyword: 16
-OrientationMediaFeature: 64
-OrientationMediaFeatureKeyword: 16
-OutlineLineStyle: 16
-OverflowBlockMediaFeature: 64
-OverflowBlockMediaFeatureKeyword: 16
-OverflowInlineMediaFeature: 64
-OverflowInlineMediaFeatureKeyword: 16
-OverflowPosition: 16
-PageRule: 176
-PageRuleBlock: 128
-PageSelector: 40
-PageSelectorList: 24
-Paint: 48
-PaintBox: 16
-PaletteIdentifier: 12
-ParamFunction: 72
-ParamFunctionParams: 48
-PartPseudoElement: 80
-PathFunction: 68
-Percentage: 12
-PerspectiveFunction: 48
-PickerPseudoElement: 64
-PointerMediaFeature: 64
-PointerMediaFeatureKeyword: 16
-PolarColorSpace: 16
-PolygonFunction: 120
-PolygonRound: 40
-Position: 88
-PositionAndSize: 152
-PositionArea: 36
-PositionBlockAxis: 16
-PositionBlockAxisKeyword: 16
-PositionFour: 88
-PositionHorizontal: 24
-PositionHorizontalKeyword: 16
-PositionInlineAxis: 16
-PositionInlineAxisKeyword: 16
-PositionLogical: 16
-PositionOne: 24
-PositionTwo: 48
-PositionVertical: 24
-PositionVerticalKeyword: 16
-PositiveNonZeroInt: 12
-PowFunction: 152
-PredefinedCounter: 16
-PrefersColorSchemeMediaFeature: 64
-PrefersColorSchemeMediaFeatureKeyword: 16
-PrefersContrastMediaFeature: 64
-PrefersContrastMediaFeatureKeyword: 16
-PrefersReducedDataMediaFeature: 64
-PrefersReducedDataMediaFeatureKeyword: 16
-PrefersReducedMotionMediaFeature: 64
-PrefersReducedMotionMediaFeatureKeyword: 16
-PrefersReducedTransparencyMediaFeature: 64
-PrefersReducedTransparencyMediaFeatureKeyword: 16
-PropertyPrelude: 12
-PropertyRule: 144
-PropertyRuleBlock: 112
-PropertyRuleStyleValue: 32
-PseudoClass: 32
-PseudoElement: 44
-PtNameAndClassSelector: 40
-Quote: 16
-RadialExtent: 16
-RadialGradientFunction: 232
-RadialGradientFunctionParams: 208
-RadialShape: 16
-RadialSize: 48
-Ratio: 64
-RectFunction: 168
-RectangularColorSpace: 16
-RelativeColorFunction: 24
-RelativeColorOrigin: 40
-RelativeSize: 16
-RepeatStyle: 32
-RepeatingLinearGradientFunction: 112
-RepeatingLinearGradientFunctionParams: 88
-RepeatingRadialGradientFunction: 232
-RepeatingRadialGradientFunctionParams: 208
-Repetition: 16
-Resolution: 16
-ResolutionOrType: 40
-ReversedCounterName: 36
-RgbChannelKeyword: 16
-RgbFunction: 168
-RgbFunctionParams: 144
-RgbRelativeFunction: 176
-RgbRelativeParams: 152
-RgbaFunction: 168
-RgbaRelativeFunction: 176
-Rotate3dFunction: 168
-Rotate3dFunctionParams: 144
-RotateFunction: 48
-RotatexFunction: 48
-RotateyFunction: 48
-RotatezFunction: 48
-RoundingStrategy: 16
-Rule: 224
-SaturateFunction: 48
-Scale3dFunction: 128
-Scale3dFunctionParams: 104
-ScaleFunction: 88
-ScalexFunction: 48
-ScaleyFunction: 48
-ScalezFunction: 48
-ScanMediaFeature: 64
-ScanMediaFeatureKeyword: 16
-ScriptingMediaFeature: 64
-ScriptingMediaFeatureKeyword: 16
-ScrollStateFeature: 80
-ScrollStateQuery: 96
-ScrollableScrollStateFeatureKeyword: 16
-SelectorComponent: 128
-SelectorList: 24
-SelfPosition: 16
-SepiaFunction: 48
-Shadow: 136
-ShadowPosition: 16
-ShapeBox: 16
-ShapeFunction: 176
-ShapeRectFunction: 344
-SinFunction: 120
-SingleAnimationComposition: 16
-SingleAnimationDirection: 16
-SingleAnimationFillMode: 16
-SingleAnimationIterationCount: 24
-SingleAnimationPlayState: 16
-SingleAnimationTimeline: 16
-SingleAnimationTriggerBehavior: 16
-SingleAnimationTriggerType: 16
-SingleTransition: 248
-SingleTransitionProperty: 16
-SkewFunction: 88
-SkewxFunction: 48
-SkewyFunction: 48
-SlottedPseudoElement: 80
-SmoothCommand: 224
-SnapBlockFunction: 96
-SnapBlockFunctionParams: 72
-SnapBlockKeyword: 16
-SnapInlineFunction: 96
-SnapInlineFunctionParams: 72
-SnapInlineKeyword: 16
-SnappedScrollStateFeatureKeyword: 16
-SpacingTrim: 16
-SpreadShadow: 136
-SqrtFunction: 120
-StartingStyleRule: 128
-StartingStyleRuleBlock: 112
-StatePseudoFunction: 52
-StepPosition: 16
-StepsFunction: 80
-StepsFunctionParams: 56
-StringFunction: 68
-StringFunctionParams: 44
-StringKeyword: 16
-StripesFunction: 48
-StrokeLayer: 272
-StuckScrollStateFeatureKeyword: 16
-StyleFeature: 24
-StyleQuery: 40
-StyleRule: 208
-StyleSheet: 80
-StyleValue: 752
-SuperellipseFunction: 48
-SupportsCondition: 72
-SupportsFeature: 56
-SupportsRule: 224
-SupportsRuleBlock: 128
-SvgPaint: 48
-SvgPaintChildFunction: 48
-SvgTag: 16
-Symbol: 40
-SymbolsFunction: 64
-SymbolsFunctionParams: 40
-SymbolsType: 16
-SyntaxValue: 12
-SystemColor: 16
-Tag: 20
-TanFunction: 120
-Target: 176
-TargetCounterFunction: 152
-TargetCounterParams: 128
-TargetCountersFunction: 176
-TargetCountersParams: 152
-TargetTextFunction: 72
-TargetTextParams: 48
-TextFunctionContent: 16
-TextOverflowSingleAxis: 24
-Time: 16
-Todo: 0
-TrackList: 72
-TransformFunction: 248
-TransformList: 24
-TransitionBehaviorValue: 16
-Translate3dFunction: 128
-Translate3dFunctionParams: 104
-TranslateFunction: 88
-TranslatexFunction: 48
-TranslateyFunction: 48
-TranslatezFunction: 48
-TrySize: 16
-TryTactic: 80
-Unknown: 24
-UnknownAtRule: 64
-UnknownQualifiedRule: 208
-UnknownTag: 12
-Unresolved: 32
-Url: 40
-UrlOrString: 40
-VariationTagValue: 40
-VerticalLineCommand: 56
-VerticalViewportSegmentsMediaFeature: 116
-VideoColorGamutMediaFeature: 64
-VideoColorGamutMediaFeatureKeyword: 16
-VideoDynamicRangeMediaFeature: 64
-VideoDynamicRangeMediaFeatureKeyword: 16
-ViewTransitionGroupPseudoElement: 96
-ViewTransitionImagePairPseudoElement: 96
-ViewTransitionNewPseudoElement: 96
-ViewTransitionOldPseudoElement: 96
-VisualBox: 16
-VoiceAge: 16
-VoiceGender: 16
-WebkitAnimationMediaFeature: 64
-WebkitAnyFunctionalPseudoClass: 64
-WebkitDevicePixelRatioMediaFeature: 116
-WebkitDistrubutedFunctionalPseudoElement: 80
-WebkitFunctionalPseudoClass: 64
-WebkitFunctionalPseudoElement: 80
-WebkitKeyframesRule: 144
-WebkitPseudoClass: 28
-WebkitPseudoElement: 40
-WebkitTransform2dMediaFeature: 64
-WebkitTransform3dMediaFeature: 64
-WebkitTransitionMediaFeature: 64
-WebkitVideoPlayableInlineMediaFeature: 64
-WherePseudoFunction: 64
-WidthContainerFeature: 124
-WidthMediaFeature: 124
-Wildcard: 12
-XywhFunction: 344
-XyzChannelKeyword: 16
+AbsoluteSize: size=16 align=4
+    0: XxSmall
+    1: XSmall
+    2: Small
+    3: Medium
+    4: Large
+    5: XLarge
+    6: XxLarge
+AccentColorStyleValue: size=40 align=8 {
+    0: 0
+}
+AcosFunction: size=144 align=8 {
+    name: 0
+    params: 16
+    close: 128
+}
+AdditiveSymbolsStyleValue: size=24 align=8 {
+    0: 0
+}
+AlignContentStyleValue: size=56 align=8
+    0: Normal
+    1: BaselinePosition
+    2: ContentDistribution
+    3: ContentPosition
+AlignItemsStyleValue: size=56 align=8
+    0: Normal
+    1: Stretch
+    2: BaselinePosition
+    3: SelfPosition
+AlignSelfStyleValue: size=64 align=8
+    0: Auto
+    1: NormalOrSelfPosition
+    2: Stretch
+    3: BaselinePosition
+AlignmentBaselineStyleValue: size=32 align=8
+    0: Baseline
+    1: BaselineMetric
+AllStyleValue: size=16 align=4
+    0: Initial
+    1: Inherit
+    2: Unset
+    3: Revert
+    4: RevertLayer
+    5: RevertRule
+AnchorName: size=24 align=8 {
+    0: 0
+}
+AnchorNameStyleValue: size=32 align=8 {
+    0: 0
+}
+AnchorScopeStyleValue: size=32 align=8
+    0: None
+    1: All
+    2: AnchorNames
+Angle: size=16 align=4
+    0: Grad
+    1: Rad
+    2: Turn
+    3: Deg
+AngleOrNumber: size=20 align=4
+    0: Angle
+    1: Number
+AngleOrZero: size=20 align=4
+    0: Angle
+    1: Zero
+AnimateableFeature: size=16 align=4
+    0: ScrollPosition
+    1: Contents
+    2: BackdropFilter
+    3: ClipPath
+    4: Contain
+    5: Filter
+    6: Isolation
+    7: MixBlendMode
+    8: OffsetPath
+    9: Opacity
+    10: Perspective
+    11: Position
+    12: Rotate
+    13: Scale
+    14: Transform
+    15: TransformStyle
+    16: Translate
+    17: ZIndex
+    18: ViewTransitionName
+    19: Mask
+    20: OffsetPosition
+    21: WebkitBoxReflect
+    22: WebkitMaskBoxImage
+    23: MaskBorder
+    24: WebkitMask
+    25: WebkitPerspective
+    26: WebkitBackdropFilter
+    27: WebkitOverflowScrolling
+    28: MaskImage
+    29: CustomIdent
+AnimationAction: size=16 align=4
+    0: None
+    1: Play
+    2: PlayForwards
+    3: PlayBackwards
+    4: Pause
+    5: Reset
+    6: Replay
+AnimationCompositionStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationDelayEndStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationDelayStartStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationDelayStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationDirectionStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationDurationStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationFillModeStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationIterationCountStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationNameStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationPlayStateStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationRangeCenterStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationRangeEndStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationRangeStartStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationRangeStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationTimelineStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationTimingFunctionStyleValue: size=24 align=8 {
+    0: 0
+}
+AnimationTriggerStyleValue: size=24 align=8 {
+    0: 0
+}
+AnyHoverMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+AnyHoverMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Hover
+AnyPointerMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+AnyPointerMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Coarse
+    2: Fine
+AppearanceStyleValue: size=32 align=8
+    0: None
+    1: Auto
+    2: Base
+    3: BaseSelect
+    4: CompatAuto
+    5: CompatSpecial
+ArcCommand: size=312 align=8 {
+    keyword: 0
+    point: 16
+    params: 160
+}
+ArcCommandParams: size=152 align=8 {
+    radii: 0
+    sweep: 80
+    size: 96
+    rotate: 112
+}
+ArcRadii: size=80 align=8 {
+    keyword: 0
+    horizontal: 16
+    vertical: 48
+}
+ArcRotate: size=40 align=8 {
+    keyword: 0
+    angle: 16
+}
+ArcSize: size=16 align=4
+    0: Large
+    1: Small
+ArcSweep: size=16 align=4
+    0: Cw
+    1: Ccw
+AsinFunction: size=144 align=8 {
+    name: 0
+    params: 16
+    close: 128
+}
+AspectRatioContainerFeature: size=240 align=8
+    0: Left
+    1: Right
+    2: Range
+    3: Exact
+AspectRatioStyleValue: size=88 align=8 {
+    auto: 0
+    ratio: 16
+}
+AtPosition: size=128 align=8 {
+    keyword: 0
+    position: 16
+}
+AtanFunction: size=144 align=8 {
+    name: 0
+    params: 16
+    close: 128
+}
+Attachment: size=16 align=4
+    0: Scroll
+    1: Fixed
+    2: Local
+AttrFunction: size=152 align=8 {
+    name: 0
+    params: 16
+    close: 136
+}
+AttrFunctionParams: size=120 align=8 {
+    0: 0
+    1: 48
+    2: 80
+    3: 96
+}
+AttrName: size=48 align=4 {
+    0: 0
+    1: 16
+    2: 32
+}
+AttrType: size=32 align=4
+    0: Type
+    1: RawString
+    2: Unit
+Attribute: size=128 align=4 {
+    open: 0
+    namespace_prefix: 12
+    attribute: 40
+    operator: 52
+    value: 80
+    modifier: 96
+    close: 112
+}
+AttributeModifier: size=16 align=4
+    0: Sensitive
+    1: Insensitive
+AttributeOperator: size=28 align=4
+    0: Exact
+    1: SpaceList
+    2: LangPrefix
+    3: Prefix
+    4: Suffix
+    5: Contains
+AttributeValue: size=16 align=4
+    0: String
+    1: Ident
+Auto: size=12 align=4 {
+    0: 0
+}
+AutoFillOrFit: size=16 align=4
+    0: AutoFill
+    1: AutoFit
+AutoLineWidthList: size=128 align=8 {
+    start_items: 0
+    auto_repeat: 24
+    end_items: 104
+}
+AutoTrackList: size=296 align=8 {
+    start_leading_names: 0
+    start_items: 56
+    auto_repeat: 80
+    end_leading_names: 216
+    end_items: 272
+}
+BackdropFilterStyleValue: size=40 align=8 {
+    0: 0
+}
+BackfaceVisibilityStyleValue: size=16 align=4
+    0: Visible
+    1: Hidden
+BackgroundAttachmentStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundBlendModeStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundClipStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundColorStyleValue: size=32 align=8 {
+    0: 0
+}
+BackgroundImageStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundOriginStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundPositionStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundRepeatBlockStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundRepeatInlineStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundRepeatStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundRepeatXStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundRepeatYStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundSizeStyleValue: size=24 align=8 {
+    0: 0
+}
+BackgroundStyleValue: size=24 align=8 {
+    0: 0
+}
+BaselineMetric: size=16 align=4
+    0: TextBottom
+    1: Alphabetic
+    2: Ideographic
+    3: Middle
+    4: Central
+    5: Mathematical
+    6: Hanging
+    7: TextTop
+BaselinePosition: size=16 align=4
+    0: First
+    1: Last
+    2: Baseline
+BaselineShiftStyleValue: size=40 align=8
+    0: LengthPercentage
+    1: Sub
+    2: Super
+    3: Top
+    4: Center
+    5: Bottom
+BaselineSourceStyleValue: size=16 align=4
+    0: Auto
+    1: First
+    2: Last
+BasicShape: size=240 align=8
+    0: Rect
+    1: Circle
+    2: Ellipse
+    3: Polygon
+    4: Path
+    5: Shape
+BasicShapeRect: size=488 align=8
+    0: Inset
+    1: Rect
+    2: Xywh
+BgClip: size=16 align=4
+    0: ContentBox
+    1: LayoutBox
+    2: BorderBox
+    3: BorderArea
+    4: Text
+BgLayer: size=384 align=8 {
+    image: 0
+    position: 56
+    repeat: 272
+    attachment: 308
+    origin: 324
+    clip: 340
+    color: 360
+}
+BgPosition: size=112 align=8
+    0: One
+    1: Two
+    2: ThreeHorizontal
+    3: ThreeVertical
+    4: Four
+BgPositionAndSize: size=216 align=8 {
+    position: 0
+    size: 112
+}
+BgSize: size=88 align=8
+    0: AutoOrLengthPercentage
+    1: Cover
+    2: Contain
+BlendMode: size=16 align=4
+    0: Normal
+    1: Darken
+    2: Multiply
+    3: ColorBurn
+    4: Lighten
+    5: Screen
+    6: ColorDodge
+    7: Overlay
+    8: SoftLight
+    9: HardLight
+    10: Difference
+    11: Exclusion
+    12: Hue
+    13: Saturation
+    14: Color
+    15: Luminosity
+BlockEllipsisStyleValue: size=32 align=8
+    0: NoEllipsis
+    1: Auto
+    2: String
+BlockSizeContainerFeature: size=128 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Exact
+BlockSizeStyleValue: size=72 align=8 {
+    0: 0
+}
+BlockStepAlignStyleValue: size=16 align=4
+    0: Auto
+    1: Center
+    2: Start
+    3: End
+BlockStepInsertStyleValue: size=16 align=4
+    0: MarginBox
+    1: PaddingBox
+    2: ContentBox
+BlockStepRoundStyleValue: size=16 align=4
+    0: Up
+    1: Down
+    2: Nearest
+BlockStepSizeStyleValue: size=32 align=8 {
+    0: 0
+}
+BlockStepStyleValue: size=80 align=8 {
+    block_step_size: 0
+    block_step_insert: 32
+    block_step_align: 48
+    block_step_round: 64
+}
+BlurFunction: size=56 align=8 {
+    name: 0
+    radius: 16
+    close: 40
+}
+BookmarkLabelStyleValue: size=32 align=8 {
+    0: 0
+}
+BookmarkLevelStyleValue: size=32 align=8 {
+    0: 0
+}
+BookmarkStateStyleValue: size=16 align=4
+    0: Open
+    1: Closed
+BooleanKeyword: size=16 align=4
+    0: True
+    1: False
+BorderBlockClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderBlockColorStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+BorderBlockEndClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderBlockEndColorStyleValue: size=72 align=8
+    0: Color
+    1: Image1d
+BorderBlockEndRadiusStyleValue: size=144 align=8 {
+    0: 0
+    1: 32
+    2: 64
+}
+BorderBlockEndStyleStyleValue: size=24 align=8 {
+    0: 0
+}
+BorderBlockEndStyleValue: size=96 align=8 {
+    line_width: 0
+    line_style: 40
+    color: 64
+}
+BorderBlockEndWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+BorderBlockStartClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderBlockStartColorStyleValue: size=72 align=8
+    0: Color
+    1: Image1d
+BorderBlockStartRadiusStyleValue: size=144 align=8 {
+    0: 0
+    1: 32
+    2: 64
+}
+BorderBlockStartStyleStyleValue: size=24 align=8 {
+    0: 0
+}
+BorderBlockStartStyleValue: size=96 align=8 {
+    line_width: 0
+    line_style: 40
+    color: 64
+}
+BorderBlockStartWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+BorderBlockStyleStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+BorderBlockStyleValue: size=96 align=8 {
+    0: 0
+}
+BorderBlockWidthStyleValue: size=80 align=8 {
+    0: 0
+    1: 40
+}
+BorderBottomClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderBottomColorStyleValue: size=72 align=8
+    0: Color
+    1: Image1d
+BorderBottomLeftRadiusStyleValue: size=88 align=8 {
+    0: 0
+}
+BorderBottomRadiusStyleValue: size=144 align=8 {
+    0: 0
+    1: 32
+    2: 64
+}
+BorderBottomRightRadiusStyleValue: size=88 align=8 {
+    0: 0
+}
+BorderBottomStyleStyleValue: size=24 align=8 {
+    0: 0
+}
+BorderBottomStyleValue: size=96 align=8 {
+    line_width: 0
+    line_style: 40
+    color: 64
+}
+BorderBottomWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+BorderBoundaryStyleValue: size=16 align=4
+    0: None
+    1: Parent
+    2: Display
+BorderClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderCollapseStyleValue: size=16 align=4
+    0: Separate
+    1: Collapse
+BorderColorStyleValue: size=288 align=8 {
+    0: 0
+    1: 72
+    2: 144
+    3: 216
+}
+BorderEndEndRadiusStyleValue: size=88 align=8 {
+    0: 0
+}
+BorderEndStartRadiusStyleValue: size=88 align=8 {
+    0: 0
+}
+BorderImageOutsetStyleValue: size=128 align=8 {
+    0: 0
+    1: 32
+    2: 64
+    3: 96
+}
+BorderImageRepeatStyleValue: size=32 align=4 {
+    0: 0
+    1: 16
+}
+BorderImageRepeatStyleValueKeywords: size=16 align=4
+    0: Stretch
+    1: Repeat
+    2: Round
+    3: Space
+BorderImageSliceStyleValue: size=112 align=8 {
+    0: 0
+    1: 96
+}
+BorderImageSourceStyleValue: size=64 align=8 {
+    0: 0
+}
+BorderImageWidthStyleValue: size=160 align=8 {
+    0: 0
+    1: 40
+    2: 80
+    3: 120
+}
+BorderInlineClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderInlineColorStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+BorderInlineEndClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderInlineEndColorStyleValue: size=72 align=8
+    0: Color
+    1: Image1d
+BorderInlineEndRadiusStyleValue: size=144 align=8 {
+    0: 0
+    1: 32
+    2: 64
+}
+BorderInlineEndStyleStyleValue: size=24 align=8 {
+    0: 0
+}
+BorderInlineEndStyleValue: size=96 align=8 {
+    line_width: 0
+    line_style: 40
+    color: 64
+}
+BorderInlineEndWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+BorderInlineStartClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderInlineStartColorStyleValue: size=72 align=8
+    0: Color
+    1: Image1d
+BorderInlineStartRadiusStyleValue: size=144 align=8 {
+    0: 0
+    1: 32
+    2: 64
+}
+BorderInlineStartStyleStyleValue: size=24 align=8 {
+    0: 0
+}
+BorderInlineStartStyleValue: size=96 align=8 {
+    line_width: 0
+    line_style: 40
+    color: 64
+}
+BorderInlineStartWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+BorderInlineStyleStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+BorderInlineStyleValue: size=96 align=8 {
+    0: 0
+}
+BorderInlineWidthStyleValue: size=80 align=8 {
+    0: 0
+    1: 40
+}
+BorderLeftClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderLeftColorStyleValue: size=72 align=8
+    0: Color
+    1: Image1d
+BorderLeftRadiusStyleValue: size=144 align=8 {
+    0: 0
+    1: 32
+    2: 64
+}
+BorderLeftStyleStyleValue: size=24 align=8 {
+    0: 0
+}
+BorderLeftStyleValue: size=96 align=8 {
+    line_width: 0
+    line_style: 40
+    color: 64
+}
+BorderLeftWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+BorderLimitStyleValue: size=56 align=8
+    0: All
+    1: Sides
+    2: Corners
+    3: TopLengthPercentage
+    4: RightLengthPercentage
+    5: BottomLengthPercentage
+    6: LeftLengthPercentage
+BorderRadius: size=80 align=8 {
+    0: 0
+    1: 32
+    2: 48
+}
+BorderRadiusStyleValue: size=272 align=8 {
+    0: 0
+    1: 32
+    2: 64
+    3: 96
+    4: 128
+}
+BorderRightClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderRightColorStyleValue: size=72 align=8
+    0: Color
+    1: Image1d
+BorderRightRadiusStyleValue: size=144 align=8 {
+    0: 0
+    1: 32
+    2: 64
+}
+BorderRightStyleStyleValue: size=24 align=8 {
+    0: 0
+}
+BorderRightStyleValue: size=96 align=8 {
+    line_width: 0
+    line_style: 40
+    color: 64
+}
+BorderRightWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+BorderShapeStyleValue: size=568 align=8 {
+    0: 0
+}
+BorderSpacingStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+BorderStartEndRadiusStyleValue: size=88 align=8 {
+    0: 0
+}
+BorderStartStartRadiusStyleValue: size=88 align=8 {
+    0: 0
+}
+BorderStyleStyleValue: size=96 align=8 {
+    0: 0
+    1: 24
+    2: 48
+    3: 72
+}
+BorderStyleValue: size=96 align=8 {
+    line_width: 0
+    line_style: 40
+    color: 64
+}
+BorderTopClipStyleValue: size=32 align=8 {
+    0: 0
+}
+BorderTopColorStyleValue: size=72 align=8
+    0: Color
+    1: Image1d
+BorderTopLeftRadiusStyleValue: size=88 align=8 {
+    0: 0
+}
+BorderTopRadiusStyleValue: size=144 align=8 {
+    0: 0
+    1: 32
+    2: 64
+}
+BorderTopRightRadiusStyleValue: size=88 align=8 {
+    0: 0
+}
+BorderTopStyleStyleValue: size=24 align=8 {
+    0: 0
+}
+BorderTopStyleValue: size=96 align=8 {
+    line_width: 0
+    line_style: 40
+    color: 64
+}
+BorderTopWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+BorderWidthStyleValue: size=160 align=8 {
+    0: 0
+    1: 40
+    2: 80
+    3: 120
+}
+BottomStyleValue: size=40 align=8 {
+    0: 0
+}
+BoxDecorationBreakStyleValue: size=16 align=4
+    0: Slice
+    1: Clone
+BoxShadowBlurStyleValue: size=24 align=8 {
+    0: 0
+}
+BoxShadowColorStyleValue: size=24 align=8 {
+    0: 0
+}
+BoxShadowOffsetStyleValue: size=24 align=8 {
+    0: 0
+}
+BoxShadowPositionStyleValue: size=24 align=8 {
+    0: 0
+}
+BoxShadowPositionStyleValueKeywords: size=16 align=4
+    0: Outset
+    1: Inset
+BoxShadowSpreadStyleValue: size=24 align=8 {
+    0: 0
+}
+BoxShadowStyleValue: size=24 align=8 {
+    0: 0
+}
+BoxSizingStyleValue: size=16 align=4
+    0: ContentBox
+    1: BorderBox
+BoxSnapStyleValue: size=16 align=4
+    0: None
+    1: BlockStart
+    2: BlockEnd
+    3: Center
+    4: Baseline
+    5: LastBaseline
+BreakAfterStyleValue: size=16 align=4
+    0: Auto
+    1: Avoid
+    2: Always
+    3: All
+    4: AvoidPage
+    5: Page
+    6: Left
+    7: Right
+    8: Recto
+    9: Verso
+    10: AvoidColumn
+    11: Column
+    12: AvoidRegion
+    13: Region
+BreakBeforeStyleValue: size=16 align=4
+    0: Auto
+    1: Avoid
+    2: Always
+    3: All
+    4: AvoidPage
+    5: Page
+    6: Left
+    7: Right
+    8: Recto
+    9: Verso
+    10: AvoidColumn
+    11: Column
+    12: AvoidRegion
+    13: Region
+BreakInsideStyleValue: size=16 align=4
+    0: Auto
+    1: Avoid
+    2: AvoidPage
+    3: AvoidColumn
+    4: AvoidRegion
+BrightnessFunction: size=56 align=8 {
+    name: 0
+    value: 16
+    close: 40
+}
+CSSFloat: size=12 align=4 {
+    0: 0
+}
+CSSInt: size=12 align=4 {
+    0: 0
+}
+CalcKeyword: size=16 align=4
+    0: E
+    1: Pi
+    2: Infinity
+    3: NegativeInfinity
+    4: NaN
+CalcProductOperator: size=16 align=4
+    0: Multiply
+    1: Divide
+CalcSizeFunction: size=28 align=4 {
+    name: 0
+    params: 12
+    close: 16
+}
+CalcSumOperator: size=16 align=4
+    0: Add
+    1: Subtract
+CaptionSideStyleValue: size=16 align=4
+    0: Top
+    1: Bottom
+CaretAnimationStyleValue: size=16 align=4
+    0: Auto
+    1: Manual
+CaretColorStyleValue: size=80 align=8 {
+    0: 0
+}
+CaretShapeStyleValue: size=16 align=4
+    0: Auto
+    1: Bar
+    2: Block
+    3: Underscore
+CaretStyleValue: size=112 align=8 {
+    caret_color: 0
+    caret_animation: 80
+    caret_shape: 96
+}
+CharsetRule: size=52 align=4 {
+    at_keyword: 0
+    space: 12
+    string: 24
+    semicolon: 36
+}
+CircleFunction: size=200 align=8 {
+    name: 0
+    radius: 16
+    at: 56
+    close: 184
+}
+CircleRadius: size=40 align=8
+    0: Extent
+    1: Length
+Class: size=24 align=4 {
+    dot: 0
+    name: 12
+}
+ClearStyleValue: size=16 align=4
+    0: InlineStart
+    1: InlineEnd
+    2: BlockStart
+    3: BlockEnd
+    4: Left
+    5: Right
+    6: Top
+    7: Bottom
+    8: BothInline
+    9: BothBlock
+    10: Both
+    11: None
+ClipPathStyleValue: size=288 align=8
+    0: ClipSource
+    1: BasicShapeGeometryBox
+    2: None
+ClipRuleStyleValue: size=16 align=4
+    0: Nonzero
+    1: Evenodd
+ClipStyleValue: size=216 align=8 {
+    0: 0
+}
+Color: size=24 align=8
+    0: Currentcolor
+    1: Transparent
+    2: System
+    3: Hex
+    4: Named
+    5: Function
+ColorAdjustStyleValue: size=16 align=4 {
+    0: 0
+}
+ColorChannelKeyword: size=16 align=4
+    0: R
+    1: G
+    2: B
+    3: X
+    4: Y
+    5: Z
+    6: Alpha
+ColorFunction: size=224 align=8
+    0: Relative
+    1: Color
+    2: ColorMix
+    3: LightDark
+    4: Rgb
+    5: Rgba
+    6: Hsl
+    7: Hsla
+    8: Hwb
+    9: Lab
+    10: Lch
+    11: Oklab
+    12: Oklch
+ColorFunctionColor: size=192 align=8 {
+    name: 0
+    params: 16
+    close: 176
+}
+ColorFunctionColorParams: size=160 align=8 {
+    0: 0
+    1: 16
+    2: 48
+    3: 80
+    4: 112
+    5: 128
+}
+ColorGamutMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+ColorGamutMediaFeatureKeyword: size=16 align=4
+    0: Srgb
+    1: P3
+    2: Rec2020
+ColorIndexMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+ColorInterpolationFiltersStyleValue: size=16 align=4
+    0: Auto
+    1: Srgb
+    2: Linearrgb
+ColorInterpolationMethod: size=60 align=4 {
+    in_keyword: 0
+    color_space: 12
+}
+ColorInterpolationStyleValue: size=16 align=4
+    0: Auto
+    1: Srgb
+    2: Linearrgb
+ColorMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+ColorMixFunction: size=128 align=8 {
+    name: 0
+    interpolation: 12
+    interpolation_comma: 72
+    parts: 88
+    close: 112
+}
+ColorMixPart: size=48 align=8 {
+    color: 0
+    percentage: 24
+}
+ColorRelativeFunction: size=264 align=8 {
+    name: 0
+    params: 16
+    close: 248
+}
+ColorRelativeParams: size=232 align=8 {
+    origin: 0
+    colorspace: 40
+    c1: 56
+    c2: 96
+    c3: 136
+    slash: 176
+    alpha: 192
+}
+ColorSchemeName: size=32 align=8
+    0: Light
+    1: Dark
+    2: Other
+ColorSchemeStyleValue: size=48 align=8 {
+    0: 0
+}
+ColorSpace: size=16 align=4
+    0: Srgb
+    1: SrgbLinear
+    2: DisplayP3
+    3: A98Rgb
+    4: ProphotoRgb
+    5: Rec2020
+    6: Xyz
+    7: XyzD50
+    8: XyzD65
+ColorStopOrHint: size=64 align=8
+    0: Hint
+    1: Stop
+ColorStripe: size=56 align=8 {
+    color: 0
+    thickness: 24
+}
+ColorStyleValue: size=32 align=8 {
+    0: 0
+}
+ColumnCountStyleValue: size=32 align=8 {
+    0: 0
+}
+ColumnFillStyleValue: size=16 align=4
+    0: Auto
+    1: Balance
+    2: BalanceAll
+ColumnGapStyleValue: size=48 align=8
+    0: Normal
+    1: LengthPercentage
+    2: LineWidth
+ColumnHeightStyleValue: size=32 align=8 {
+    0: 0
+}
+ColumnRuleBreakStyleValue: size=16 align=4
+    0: None
+    1: Normal
+    2: Intersection
+ColumnRuleColorStyleValue: size=32 align=8
+    0: LineColorList
+    1: AutoLineColorList
+ColumnRuleInsetCapEndStyleValue: size=48 align=8 {
+    0: 0
+}
+ColumnRuleInsetCapStartStyleValue: size=48 align=8 {
+    0: 0
+}
+ColumnRuleInsetCapStyleValue: size=96 align=8 {
+    0: 0
+    1: 48
+}
+ColumnRuleInsetEndStyleValue: size=48 align=8 {
+    0: 0
+}
+ColumnRuleInsetJunctionEndStyleValue: size=48 align=8 {
+    0: 0
+}
+ColumnRuleInsetJunctionStartStyleValue: size=48 align=8 {
+    0: 0
+}
+ColumnRuleInsetJunctionStyleValue: size=96 align=8 {
+    0: 0
+    1: 48
+}
+ColumnRuleInsetStartStyleValue: size=48 align=8 {
+    0: 0
+}
+ColumnRuleInsetStyleValue: size=208 align=8 {
+    0: 0
+    1: 96
+}
+ColumnRuleStyleStyleValue: size=32 align=8
+    0: LineStyleList
+    1: AutoLineStyleList
+ColumnRuleStyleValue: size=32 align=8 {
+    0: 0
+}
+ColumnRuleVisibilityItemsStyleValue: size=16 align=4
+    0: All
+    1: Around
+    2: Between
+    3: Normal
+ColumnRuleWidthStyleValue: size=144 align=8
+    0: LineWidthList
+    1: AutoLineWidthList
+ColumnSpanStyleValue: size=32 align=8
+    0: None
+    1: Integer
+    2: All
+    3: Auto
+ColumnWidthStyleValue: size=32 align=8 {
+    0: 0
+}
+ColumnWrapStyleValue: size=16 align=4
+    0: Auto
+    1: Nowrap
+    2: Wrap
+ColumnsStyleValue: size=112 align=8 {
+    0: 0
+    1: 64
+}
+Combinator: size=28 align=4
+    0: Child
+    1: NextSibling
+    2: SubsequentSibling
+    3: Column
+    4: Nesting
+    5: Descendant
+CommaOrSlash: size=12 align=4 {
+    0: 0
+}
+CommandEndPoint: size=144 align=8
+    0: ToPosition
+    1: ByCoordinatePair
+CommonLigValues: size=16 align=4
+    0: CommonLigatures
+    1: NoCommonLigatures
+CompatAuto: size=16 align=4
+    0: Searchfield
+    1: Textarea
+    2: Checkbox
+    3: Radio
+    4: Menulist
+    5: Listbox
+    6: Meter
+    7: ProgressBar
+    8: Button
+CompatSpecial: size=16 align=4
+    0: Textfield
+    1: MenulistButton
+CompositingOperator: size=16 align=4
+    0: Clear
+    1: Copy
+    2: SourceOver
+    3: DestinationOver
+    4: SourceIn
+    5: DestinationIn
+    6: SourceOut
+    7: DestinationOut
+    8: SourceAtop
+    9: DestinationAtop
+    10: Xor
+    11: Lighter
+    12: Add
+CompoundSelector: size=24 align=8 {
+    0: 0
+}
+ContainIntrinsicBlockSizeStyleValue: size=48 align=8 {
+    0: 0
+    1: 16
+}
+ContainIntrinsicHeightStyleValue: size=48 align=8 {
+    0: 0
+    1: 16
+}
+ContainIntrinsicInlineSizeStyleValue: size=48 align=8 {
+    0: 0
+    1: 16
+}
+ContainIntrinsicSizeStyleValue: size=96 align=8 {
+    0: 0
+    1: 48
+}
+ContainIntrinsicWidthStyleValue: size=48 align=8 {
+    0: 0
+    1: 16
+}
+ContainStyleValue: size=68 align=4
+    0: None
+    1: Strict
+    2: Content
+    3: Size
+    4: InlineSize
+ContainerCondition: size=288 align=8 {
+    name: 0
+    condition: 16
+}
+ContainerConditionList: size=24 align=8 {
+    0: 0
+}
+ContainerFeature: size=248 align=8
+    0: Width
+    1: Height
+    2: InlineSize
+    3: BlockSize
+    4: AspectRatio
+    5: Orientation
+    6: Style
+    7: ScrollState
+ContainerNameStyleValue: size=32 align=8 {
+    0: 0
+}
+ContainerQuery: size=272 align=8
+    0: Is
+    1: Not
+    2: And
+    3: Or
+ContainerRule: size=176 align=16 {
+    name: 0
+    prelude: 16
+    block: 48
+}
+ContainerRulesBlock: size=128 align=16 {
+    0: 0
+}
+ContainerStyleValue: size=80 align=8 {
+    0: 0
+    1: 32
+}
+ContainerTypeStyleValue: size=36 align=4
+    0: Normal
+    1: Size
+    2: InlineSize
+ContentAltItem: size=184 align=8
+    0: String
+    1: Counter
+    2: AttrFunction
+ContentDistribution: size=16 align=4
+    0: SpaceBetween
+    1: SpaceAround
+    2: SpaceEvenly
+    3: Stretch
+ContentFunction: size=40 align=4 {
+    name: 0
+    params: 12
+    close: 28
+}
+ContentKeyword: size=16 align=4
+    0: Text
+    1: Before
+    2: After
+    3: FirstLetter
+    4: Marker
+ContentList: size=24 align=8 {
+    0: 0
+}
+ContentListItem: size=216 align=8
+    0: String
+    1: Image
+    2: AttrFunction
+    3: Contents
+    4: Quote
+    5: LeaderFunction
+    6: Target
+    7: StringFunction
+    8: ContentFunction
+    9: Counter
+ContentPosition: size=16 align=4
+    0: Center
+    1: Start
+    2: End
+    3: FlexStart
+    4: FlexEnd
+ContentStyleValue: size=104 align=8
+    0: Normal
+    1: None
+    2: ContentReplacement
+    3: ContentList
+ContentVisibilityStyleValue: size=16 align=4
+    0: Visible
+    1: Auto
+    2: Hidden
+ContextualAltValues: size=16 align=4
+    0: Contextual
+    1: NoContextual
+ContinueStyleValue: size=16 align=4
+    0: Auto
+    1: Discard
+    2: Collapse
+ContrastFunction: size=56 align=8 {
+    name: 0
+    value: 16
+    close: 40
+}
+ControlPoint: size=128 align=8
+    0: Position
+    1: RelativeControlPoint
+CoordBox: size=16 align=4
+    0: ContentBox
+    1: PaddingBox
+    2: BorderBox
+    3: FillBox
+    4: StrokeBox
+    5: ViewBox
+CoordinatePair: size=64 align=8 {
+    0: 0
+    1: 32
+}
+CopyIntoStyleValue: size=80 align=8 {
+    0: 0
+}
+CornerBlockEndShapeStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+CornerBlockEndStyleValue: size=288 align=8 {
+    border_top_radius: 0
+    corner_top_shape: 144
+}
+CornerBlockStartShapeStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+CornerBlockStartStyleValue: size=288 align=8 {
+    border_top_radius: 0
+    corner_top_shape: 144
+}
+CornerBottomLeftShapeStyleValue: size=72 align=8 {
+    0: 0
+}
+CornerBottomLeftStyleValue: size=160 align=8 {
+    border_top_left_radius: 0
+    corner_top_left_shape: 88
+}
+CornerBottomRightShapeStyleValue: size=72 align=8 {
+    0: 0
+}
+CornerBottomRightStyleValue: size=160 align=8 {
+    border_top_left_radius: 0
+    corner_top_left_shape: 88
+}
+CornerBottomShapeStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+CornerBottomStyleValue: size=288 align=8 {
+    border_top_radius: 0
+    corner_top_shape: 144
+}
+CornerEndEndShapeStyleValue: size=72 align=8 {
+    0: 0
+}
+CornerEndEndStyleValue: size=160 align=8 {
+    border_top_left_radius: 0
+    corner_top_left_shape: 88
+}
+CornerEndStartShapeStyleValue: size=72 align=8 {
+    0: 0
+}
+CornerEndStartStyleValue: size=160 align=8 {
+    border_top_left_radius: 0
+    corner_top_left_shape: 88
+}
+CornerInlineEndShapeStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+CornerInlineEndStyleValue: size=288 align=8 {
+    border_top_radius: 0
+    corner_top_shape: 144
+}
+CornerInlineStartShapeStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+CornerInlineStartStyleValue: size=288 align=8 {
+    border_top_radius: 0
+    corner_top_shape: 144
+}
+CornerLeftShapeStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+CornerLeftStyleValue: size=288 align=8 {
+    border_top_radius: 0
+    corner_top_shape: 144
+}
+CornerRightShapeStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+CornerRightStyleValue: size=288 align=8 {
+    border_top_radius: 0
+    corner_top_shape: 144
+}
+CornerShapeStyleValue: size=288 align=8 {
+    0: 0
+    1: 72
+    2: 144
+    3: 216
+}
+CornerShapeValue: size=64 align=8
+    0: Round
+    1: Scoop
+    2: Bevel
+    3: Notch
+    4: Square
+    5: Squircle
+    6: SuperellipseFunction
+CornerStartEndShapeStyleValue: size=72 align=8 {
+    0: 0
+}
+CornerStartEndStyleValue: size=160 align=8 {
+    border_top_left_radius: 0
+    corner_top_left_shape: 88
+}
+CornerStartStartShapeStyleValue: size=72 align=8 {
+    0: 0
+}
+CornerStartStartStyleValue: size=160 align=8 {
+    border_top_left_radius: 0
+    corner_top_left_shape: 88
+}
+CornerStyleValue: size=560 align=8 {
+    border_radius: 0
+    corner_shape: 272
+}
+CornerTopLeftShapeStyleValue: size=72 align=8 {
+    0: 0
+}
+CornerTopLeftStyleValue: size=160 align=8 {
+    border_top_left_radius: 0
+    corner_top_left_shape: 88
+}
+CornerTopRightShapeStyleValue: size=72 align=8 {
+    0: 0
+}
+CornerTopRightStyleValue: size=160 align=8 {
+    border_top_left_radius: 0
+    corner_top_left_shape: 88
+}
+CornerTopShapeStyleValue: size=144 align=8 {
+    0: 0
+    1: 72
+}
+CornerTopStyleValue: size=288 align=8 {
+    border_top_radius: 0
+    corner_top_shape: 144
+}
+CosFunction: size=144 align=8 {
+    name: 0
+    params: 16
+    close: 128
+}
+Counter: size=176 align=8
+    0: Counter
+    1: Counters
+CounterFunction: size=144 align=8 {
+    name: 0
+    params: 16
+    close: 128
+}
+CounterFunctionParams: size=112 align=8 {
+    0: 0
+    1: 12
+    2: 32
+}
+CounterIncrementStyleValue: size=32 align=8 {
+    0: 0
+}
+CounterName: size=12 align=4 {
+    0: 0
+}
+CounterResetStyleValue: size=32 align=8 {
+    0: 0
+}
+CounterSetStyleValue: size=32 align=8 {
+    0: 0
+}
+CounterStyle: size=80 align=8
+    0: Predefined
+    1: Named
+    2: SymbolsFunction
+CounterStyleName: size=12 align=4 {
+    0: 0
+}
+CounterStyleRule: size=144 align=16 {
+    name: 0
+    prelude: 12
+    block: 32
+}
+CounterStyleRuleBlock: size=112 align=16 {
+    0: 0
+}
+CounterStyleRuleStyleValue: size=136 align=8
+    0: Unknown
+    1: System
+    2: Symbols
+    3: AdditiveSymbols
+    4: Negative
+    5: Prefix
+    6: Suffix
+    7: Range
+    8: Pad
+    9: SpeakAs
+    10: Fallback
+CountersFunction: size=168 align=8 {
+    name: 0
+    params: 16
+    close: 152
+}
+CountersFunctionParams: size=136 align=8 {
+    0: 0
+    1: 12
+    2: 28
+    3: 40
+    4: 56
+}
+CssAtomSet: size=4 align=4
+    0: _None = 0
+    1: Cap = 1
+    2: Ch = 2
+    3: Cm = 3
+    4: Cqb = 4
+    5: Cqh = 5
+    6: Cqi = 6
+    7: Cqmax = 7
+    8: Cqmin = 8
+    9: Cqw = 9
+    10: Db = 10
+    11: Deg = 11
+    12: Dpcm = 12
+    13: Dpi = 13
+    14: Dppx = 14
+    15: Dvb = 15
+    16: Dvh = 16
+    17: Dvi = 17
+    18: Dvmax = 18
+    19: Dvmin = 19
+    20: Dvw = 20
+    21: Em = 21
+    22: Ex = 22
+    23: Fr = 23
+    24: Grad = 24
+    25: Hz = 25
+    26: Ic = 26
+    27: In = 27
+    28: Khz = 28
+    29: Lh = 29
+    30: Lvb = 30
+    31: Lvh = 31
+    32: Lvi = 32
+    33: Lvmax = 33
+    34: Lvmin = 34
+    35: Lvw = 35
+    36: Mm = 36
+    37: Ms = 37
+    38: Pc = 38
+    39: Percentage = 39
+    40: Pt = 40
+    41: Px = 41
+    42: Q = 42
+    43: Rad = 43
+    44: Rcap = 44
+    45: Rch = 45
+    46: Rem = 46
+    47: Rex = 47
+    48: Ric = 48
+    49: Rlh = 49
+    50: S = 50
+    51: Svb = 51
+    52: Svh = 52
+    53: Svi = 53
+    54: Svmax = 54
+    55: Svmin = 55
+    56: Svw = 56
+    57: Turn = 57
+    58: Vb = 58
+    59: Vh = 59
+    60: Vi = 60
+    61: Vmax = 61
+    62: Vmin = 62
+    63: Vw = 63
+    64: X = 64
+    65: _NDash = 127
+    66: A = 128
+    67: A98Rgb = 129
+    68: Abbr = 130
+    69: Abs = 131
+    70: Absolute = 132
+    71: AbsoluteColorimetric = 133
+    72: AccentColor = 134
+    73: Accentcolor = 135
+    74: Accentcolortext = 136
+    75: Accumulate = 137
+    76: Acos = 138
+    77: Acronym = 139
+    78: Activate = 140
+    79: Active = 141
+    80: Activetext = 142
+    81: Add = 143
+    82: Additive = 144
+    83: AdditiveSymbols = 145
+    84: Address = 146
+    85: After = 147
+    86: Alias = 148
+    87: Aliceblue = 149
+    88: AlignContent = 150
+    89: AlignItems = 151
+    90: AlignSelf = 152
+    91: AlignmentBaseline = 153
+    92: All = 154
+    93: AllPetiteCaps = 155
+    94: AllScroll = 156
+    95: AllSmallCaps = 157
+    96: AllowDiscrete = 158
+    97: AllowEnd = 159
+    98: AllowKeywords = 160
+    99: Alpha = 161
+    100: Alphabetic = 162
+    101: Alternate = 163
+    102: AlternateReverse = 164
+    103: Always = 165
+    104: AnchorName = 166
+    105: AnchorScope = 167
+    106: AnchorValid = 168
+    107: AnchorVisible = 169
+    108: And = 170
+    109: Animate = 171
+    110: Animatemotion = 172
+    111: Animatetransform = 173
+    112: Animation = 174
+    113: AnimationComposition = 175
+    114: AnimationDelay = 176
+    115: AnimationDelayEnd = 177
+    116: AnimationDelayStart = 178
+    117: AnimationDirection = 179
+    118: AnimationDuration = 180
+    119: AnimationFillMode = 181
+    120: AnimationIterationCount = 182
+    121: AnimationName = 183
+    122: AnimationPlayState = 184
+    123: AnimationRange = 185
+    124: AnimationRangeCenter = 186
+    125: AnimationRangeEnd = 187
+    126: AnimationRangeStart = 188
+    127: AnimationTimeline = 189
+    128: AnimationTimingFunction = 190
+    129: AnimationTrigger = 191
+    130: AnimationTriggerBehavior = 192
+    131: AnimationTriggerExitRange = 193
+    132: AnimationTriggerExitRangeEnd = 194
+    133: AnimationTriggerExitRangeStart = 195
+    134: AnimationTriggerRange = 196
+    135: AnimationTriggerRangeEnd = 197
+    136: AnimationTriggerRangeStart = 198
+    137: AnimationTriggerTimeline = 199
+    138: Annotation = 200
+    139: AnnotationXml = 201
+    140: Antialiased = 202
+    141: Antiquewhite = 203
+    142: AnyHover = 204
+    143: AnyLink = 205
+    144: AnyPointer = 206
+    145: Anywhere = 207
+    146: Appearance = 208
+    147: Applet = 209
+    148: Apply = 210
+    149: Approx = 211
+    150: Aqua = 212
+    151: Aquamarine = 213
+    152: ArabicIndic = 214
+    153: Arc = 215
+    154: Arcs = 216
+    155: Area = 217
+    156: Arg = 218
+    157: Armenian = 219
+    158: Around = 220
+    159: Article = 221
+    160: AscentOverride = 222
+    161: Aside = 223
+    162: Asin = 224
+    163: AspectRatio = 225
+    164: At = 226
+    165: Atan = 227
+    166: Atan2 = 228
+    167: Attr = 229
+    168: Audio = 230
+    169: Auto = 231
+    170: AutoFill = 232
+    171: AutoFit = 233
+    172: AutoPhrase = 234
+    173: Autofill = 235
+    174: Avoid = 236
+    175: AvoidColumn = 237
+    176: AvoidFlex = 238
+    177: AvoidLine = 239
+    178: AvoidOrphans = 240
+    179: AvoidPage = 241
+    180: AvoidRegion = 242
+    181: Azure = 243
+    182: B = 244
+    183: Back = 245
+    184: Backdrop = 246
+    185: BackdropFilter = 247
+    186: BackfaceVisibility = 248
+    187: Background = 249
+    188: BackgroundAttachment = 250
+    189: BackgroundBlendMode = 251
+    190: BackgroundClip = 252
+    191: BackgroundColor = 253
+    192: BackgroundImage = 254
+    193: BackgroundOrigin = 255
+    194: BackgroundPosition = 256
+    195: BackgroundPositionBlock = 257
+    196: BackgroundPositionInline = 258
+    197: BackgroundPositionX = 259
+    198: BackgroundPositionY = 260
+    199: BackgroundRepeat = 261
+    200: BackgroundRepeatBlock = 262
+    201: BackgroundRepeatInline = 263
+    202: BackgroundRepeatX = 264
+    203: BackgroundRepeatY = 265
+    204: BackgroundSize = 266
+    205: Backwards = 267
+    206: Balance = 268
+    207: BalanceAll = 269
+    208: Bar = 270
+    209: Base = 271
+    210: BasePalette = 272
+    211: BaseSelect = 273
+    212: Basefont = 274
+    213: Baseline = 275
+    214: BaselineShift = 276
+    215: BaselineSource = 277
+    216: Bdi = 278
+    217: Bdo = 279
+    218: Before = 280
+    219: Beige = 281
+    220: Bengali = 282
+    221: Between = 283
+    222: Bevel = 284
+    223: Bgsound = 285
+    224: Bicubic = 286
+    225: BidiOverride = 287
+    226: Big = 288
+    227: Bind = 289
+    228: Bisque = 290
+    229: Black = 291
+    230: Blanchedalmond = 292
+    231: Blank = 293
+    232: Bleed = 294
+    233: Blink = 295
+    234: Block = 296
+    235: BlockAxis = 297
+    236: BlockEllipsis = 298
+    237: BlockEnd = 299
+    238: BlockSize = 300
+    239: BlockStart = 301
+    240: BlockStep = 302
+    241: BlockStepAlign = 303
+    242: BlockStepInsert = 304
+    243: BlockStepRound = 305
+    244: BlockStepSize = 306
+    245: Blockquote = 307
+    246: Blue = 308
+    247: Blueviolet = 309
+    248: Blur = 310
+    249: Body = 311
+    250: Bold = 312
+    251: Bolder = 313
+    252: BookmarkLabel = 314
+    253: BookmarkLevel = 315
+    254: BookmarkState = 316
+    255: Border = 317
+    256: BorderArea = 318
+    257: BorderBlock = 319
+    258: BorderBlockClip = 320
+    259: BorderBlockColor = 321
+    260: BorderBlockEnd = 322
+    261: BorderBlockEndClip = 323
+    262: BorderBlockEndColor = 324
+    263: BorderBlockEndRadius = 325
+    264: BorderBlockEndStyle = 326
+    265: BorderBlockEndWidth = 327
+    266: BorderBlockStart = 328
+    267: BorderBlockStartClip = 329
+    268: BorderBlockStartColor = 330
+    269: BorderBlockStartRadius = 331
+    270: BorderBlockStartStyle = 332
+    271: BorderBlockStartWidth = 333
+    272: BorderBlockStyle = 334
+    273: BorderBlockWidth = 335
+    274: BorderBottom = 336
+    275: BorderBottomClip = 337
+    276: BorderBottomColor = 338
+    277: BorderBottomLeftRadius = 339
+    278: BorderBottomRadius = 340
+    279: BorderBottomRightRadius = 341
+    280: BorderBottomStyle = 342
+    281: BorderBottomWidth = 343
+    282: BorderBoundary = 344
+    283: BorderBox = 345
+    284: BorderClip = 346
+    285: BorderClipBottom = 347
+    286: BorderClipLeft = 348
+    287: BorderClipRight = 349
+    288: BorderClipTop = 350
+    289: BorderCollapse = 351
+    290: BorderColor = 352
+    291: BorderEndEndRadius = 353
+    292: BorderEndStartRadius = 354
+    293: BorderImage = 355
+    294: BorderImageOutset = 356
+    295: BorderImageRepeat = 357
+    296: BorderImageSlice = 358
+    297: BorderImageSource = 359
+    298: BorderImageWidth = 360
+    299: BorderInline = 361
+    300: BorderInlineClip = 362
+    301: BorderInlineColor = 363
+    302: BorderInlineEnd = 364
+    303: BorderInlineEndClip = 365
+    304: BorderInlineEndColor = 366
+    305: BorderInlineEndRadius = 367
+    306: BorderInlineEndStyle = 368
+    307: BorderInlineEndWidth = 369
+    308: BorderInlineStart = 370
+    309: BorderInlineStartClip = 371
+    310: BorderInlineStartColor = 372
+    311: BorderInlineStartRadius = 373
+    312: BorderInlineStartStyle = 374
+    313: BorderInlineStartWidth = 375
+    314: BorderInlineStyle = 376
+    315: BorderInlineWidth = 377
+    316: BorderLeft = 378
+    317: BorderLeftClip = 379
+    318: BorderLeftColor = 380
+    319: BorderLeftRadius = 381
+    320: BorderLeftStyle = 382
+    321: BorderLeftWidth = 383
+    322: BorderLimit = 384
+    323: BorderRadius = 385
+    324: BorderRight = 386
+    325: BorderRightClip = 387
+    326: BorderRightColor = 388
+    327: BorderRightRadius = 389
+    328: BorderRightStyle = 390
+    329: BorderRightWidth = 391
+    330: BorderShape = 392
+    331: BorderSpacing = 393
+    332: BorderStartEndRadius = 394
+    333: BorderStartStartRadius = 395
+    334: BorderStyle = 396
+    335: BorderTop = 397
+    336: BorderTopClip = 398
+    337: BorderTopColor = 399
+    338: BorderTopLeftRadius = 400
+    339: BorderTopRadius = 401
+    340: BorderTopRightRadius = 402
+    341: BorderTopStyle = 403
+    342: BorderTopWidth = 404
+    343: BorderWidth = 405
+    344: Both = 406
+    345: BothBlock = 407
+    346: BothEdges = 408
+    347: BothInline = 409
+    348: Bottom = 410
+    349: BottomCenter = 411
+    350: BottomLeft = 412
+    351: BottomLeftCorner = 413
+    352: BottomRight = 414
+    353: BottomRightCorner = 415
+    354: BottomToTop = 416
+    355: BoundingBox = 417
+    356: Box = 418
+    357: BoxDecorationBreak = 419
+    358: BoxShadow = 420
+    359: BoxShadowBlur = 421
+    360: BoxShadowColor = 422
+    361: BoxShadowOffset = 423
+    362: BoxShadowPosition = 424
+    363: BoxShadowSpread = 425
+    364: BoxSizing = 426
+    365: BoxSnap = 427
+    366: Br = 428
+    367: Break = 429
+    368: BreakAfter = 430
+    369: BreakAll = 431
+    370: BreakBefore = 432
+    371: BreakInside = 433
+    372: BreakSpaces = 434
+    373: BreakWord = 435
+    374: Brightness = 436
+    375: Brown = 437
+    376: Browser = 438
+    377: Buffering = 439
+    378: Bullets = 440
+    379: Burlywood = 441
+    380: Butt = 442
+    381: Button = 443
+    382: Buttonborder = 444
+    383: Buttonface = 445
+    384: Buttontext = 446
+    385: Bvar = 447
+    386: By = 448
+    387: C = 449
+    388: Cadetblue = 450
+    389: Calc = 451
+    390: CalcSize = 452
+    391: Cambodian = 453
+    392: Canvas = 454
+    393: Canvastext = 455
+    394: CapHeight = 456
+    395: Capitalize = 457
+    396: Caption = 458
+    397: CaptionSide = 459
+    398: Card = 460
+    399: Caret = 461
+    400: CaretAnimation = 462
+    401: CaretColor = 463
+    402: CaretShape = 464
+    403: Cartesianproduct = 465
+    404: Cbytes = 466
+    405: Ccw = 467
+    406: Ceiling = 468
+    407: Cell = 469
+    408: Center = 470
+    409: Central = 471
+    410: Cerror = 472
+    411: ChWidth = 473
+    412: Chain = 474
+    413: Charset = 475
+    414: Chartreuse = 476
+    415: Checkbox = 477
+    416: Checked = 478
+    417: Checkmark = 479
+    418: Child = 480
+    419: Chocolate = 481
+    420: Ci = 482
+    421: Circle = 483
+    422: Cite = 484
+    423: CjkDecimal = 485
+    424: CjkEarthlyBranch = 486
+    425: CjkHeavenlyStem = 487
+    426: Clamp = 488
+    427: Clear = 489
+    428: Click = 490
+    429: Clip = 491
+    430: ClipPath = 492
+    431: ClipRule = 493
+    432: Clippath = 494
+    433: Clone = 495
+    434: Close = 496
+    435: CloseQuote = 497
+    436: Closed = 498
+    437: ClosestCorner = 499
+    438: ClosestSide = 500
+    439: Cn = 501
+    440: Coarse = 502
+    441: Code = 503
+    442: Codomain = 504
+    443: Col = 505
+    444: ColResize = 506
+    445: Colgroup = 507
+    446: Collapse = 508
+    447: Color = 509
+    448: ColorAdjust = 510
+    449: ColorBurn = 511
+    450: ColorDodge = 512
+    451: ColorGamut = 513
+    452: ColorIndex = 514
+    453: ColorInterpolation = 515
+    454: ColorInterpolationFilters = 516
+    455: ColorMix = 517
+    456: ColorProfile = 518
+    457: ColorScheme = 519
+    458: Column = 520
+    459: ColumnCount = 521
+    460: ColumnFill = 522
+    461: ColumnGap = 523
+    462: ColumnHeight = 524
+    463: ColumnOverRow = 525
+    464: ColumnReverse = 526
+    465: ColumnRule = 527
+    466: ColumnRuleBreak = 528
+    467: ColumnRuleColor = 529
+    468: ColumnRuleEdgeInset = 530
+    469: ColumnRuleEdgeInsetEnd = 531
+    470: ColumnRuleEdgeInsetStart = 532
+    471: ColumnRuleInset = 533
+    472: ColumnRuleInsetCap = 534
+    473: ColumnRuleInsetCapEnd = 535
+    474: ColumnRuleInsetCapStart = 536
+    475: ColumnRuleInsetEnd = 537
+    476: ColumnRuleInsetJunction = 538
+    477: ColumnRuleInsetJunctionEnd = 539
+    478: ColumnRuleInsetJunctionStart = 540
+    479: ColumnRuleInsetStart = 541
+    480: ColumnRuleInteriorInset = 542
+    481: ColumnRuleInteriorInsetEnd = 543
+    482: ColumnRuleInteriorInsetStart = 544
+    483: ColumnRuleOutset = 545
+    484: ColumnRuleStyle = 546
+    485: ColumnRuleVisibilityItems = 547
+    486: ColumnRuleWidth = 548
+    487: ColumnSpan = 549
+    488: ColumnWidth = 550
+    489: ColumnWrap = 551
+    490: Columns = 552
+    491: CommonLigatures = 553
+    492: Compact = 554
+    493: Components = 555
+    494: Compose = 556
+    495: Compress = 557
+    496: Condensed = 558
+    497: Condition = 559
+    498: Conjugate = 560
+    499: Consistent = 561
+    500: Constrained = 562
+    501: Contain = 563
+    502: ContainIntrinsicBlockSize = 564
+    503: ContainIntrinsicHeight = 565
+    504: ContainIntrinsicInlineSize = 566
+    505: ContainIntrinsicSize = 567
+    506: ContainIntrinsicWidth = 568
+    507: Container = 569
+    508: ContainerName = 570
+    509: ContainerType = 571
+    510: Content = 572
+    511: ContentBlockSize = 573
+    512: ContentBox = 574
+    513: ContentHeight = 575
+    514: ContentInlineSize = 576
+    515: ContentVisibility = 577
+    516: ContentWidth = 578
+    517: Contents = 579
+    518: ContextMenu = 580
+    519: Contextual = 581
+    520: Continue = 582
+    521: Contrast = 583
+    522: Copy = 584
+    523: CopyInto = 585
+    524: Coral = 586
+    525: Corner = 587
+    526: CornerBlockEnd = 588
+    527: CornerBlockEndShape = 589
+    528: CornerBlockStart = 590
+    529: CornerBlockStartShape = 591
+    530: CornerBottom = 592
+    531: CornerBottomLeft = 593
+    532: CornerBottomLeftShape = 594
+    533: CornerBottomRight = 595
+    534: CornerBottomRightShape = 596
+    535: CornerBottomShape = 597
+    536: CornerEndEnd = 598
+    537: CornerEndEndShape = 599
+    538: CornerEndStart = 600
+    539: CornerEndStartShape = 601
+    540: CornerInlineEnd = 602
+    541: CornerInlineEndShape = 603
+    542: CornerInlineStart = 604
+    543: CornerInlineStartShape = 605
+    544: CornerLeft = 606
+    545: CornerLeftShape = 607
+    546: CornerRight = 608
+    547: CornerRightShape = 609
+    548: CornerShape = 610
+    549: CornerStartEnd = 611
+    550: CornerStartEndShape = 612
+    551: CornerStartStart = 613
+    552: CornerStartStartShape = 614
+    553: CornerTop = 615
+    554: CornerTopLeft = 616
+    555: CornerTopLeftShape = 617
+    556: CornerTopRight = 618
+    557: CornerTopRightShape = 619
+    558: CornerTopShape = 620
+    559: Corners = 621
+    560: Cornflowerblue = 622
+    561: Cornsilk = 623
+    562: Cos = 624
+    563: Counter = 625
+    564: CounterIncrement = 626
+    565: CounterReset = 627
+    566: CounterSet = 628
+    567: CounterStyle = 629
+    568: Counters = 630
+    569: Cover = 631
+    570: Create = 632
+    571: Crimson = 633
+    572: CrispEdges = 634
+    573: Crispedges = 635
+    574: Crop = 636
+    575: Crosshair = 637
+    576: Cs = 638
+    577: Csymbol = 639
+    578: CubicBezier = 640
+    579: Cue = 641
+    580: CueAfter = 642
+    581: CueBefore = 643
+    582: Curl = 644
+    583: Current = 645
+    584: Currentcolor = 646
+    585: Cursive = 647
+    586: Cursor = 648
+    587: Curve = 649
+    588: Custom = 650
+    589: Cw = 651
+    590: Cyan = 652
+    591: Cyclic = 653
+    592: D50 = 654
+    593: D65 = 655
+    594: Dark = 656
+    595: Darkblue = 657
+    596: Darkcyan = 658
+    597: Darken = 659
+    598: Darkgoldenrod = 660
+    599: Darkgray = 661
+    600: Darkgreen = 662
+    601: Darkgrey = 663
+    602: Darkkhaki = 664
+    603: Darkmagenta = 665
+    604: Darkolivegreen = 666
+    605: Darkorange = 667
+    606: Darkorchid = 668
+    607: Darkred = 669
+    608: Darksalmon = 670
+    609: Darkseagreen = 671
+    610: Darkslateblue = 672
+    611: Darkslategray = 673
+    612: Darkslategrey = 674
+    613: Darkturquoise = 675
+    614: Darkviolet = 676
+    615: Dashed = 677
+    616: Dashes = 678
+    617: Data = 679
+    618: Datalist = 680
+    619: Dblclick = 681
+    620: Dd = 682
+    621: Decimal = 683
+    622: DecimalLeadingZero = 684
+    623: Declare = 685
+    624: Decreasing = 686
+    625: Deeppink = 687
+    626: Deepskyblue = 688
+    627: Default = 689
+    628: Defined = 690
+    629: Defs = 691
+    630: Degree = 692
+    631: Del = 693
+    632: Dense = 694
+    633: Desc = 695
+    634: DescentOverride = 696
+    635: DestinationAtop = 697
+    636: DestinationIn = 698
+    637: DestinationOut = 699
+    638: DestinationOver = 700
+    639: Details = 701
+    640: DetailsContent = 702
+    641: Determinant = 703
+    642: Devanagari = 704
+    643: DeviceAspectRatio = 705
+    644: DeviceHeight = 706
+    645: DeviceWidth = 707
+    646: Dfn = 708
+    647: DiagonalFractions = 709
+    648: Dialog = 710
+    649: Diff = 711
+    650: Difference = 712
+    651: Digits = 713
+    652: Dimgray = 714
+    653: Dimgrey = 715
+    654: Dir = 716
+    655: Direction = 717
+    656: Disabled = 718
+    657: Disc = 719
+    658: Discard = 720
+    659: DiscardAfter = 721
+    660: DiscardBefore = 722
+    661: DiscardInner = 723
+    662: DisclousureClosed = 724
+    663: DisclousureOpen = 725
+    664: Discrete = 726
+    665: DiscretionaryLigatures = 727
+    666: Display = 728
+    667: DisplayMode = 729
+    668: DisplayP3 = 730
+    669: Distribute = 731
+    670: Div = 732
+    671: Divergence = 733
+    672: Divide = 734
+    673: Dl = 735
+    674: Document = 736
+    675: Dodgerblue = 737
+    676: Domain = 738
+    677: Domainofapplication = 739
+    678: DominantBaseline = 740
+    679: Dot = 741
+    680: Dotted = 742
+    681: Double = 743
+    682: DoubleCircle = 744
+    683: Down = 745
+    684: Drop = 746
+    685: DropShadow = 747
+    686: Dt = 748
+    687: DynamicRange = 749
+    688: DynamicRangeLimit = 750
+    689: DynamicRangeLimitMix = 751
+    690: E = 752
+    691: EResize = 753
+    692: EachLine = 754
+    693: Ease = 755
+    694: EaseIn = 756
+    695: EaseInOut = 757
+    696: EaseOut = 758
+    697: Economy = 759
+    698: Element = 760
+    699: Ellipse = 761
+    700: Ellipsis = 762
+    701: Else = 763
+    702: Embed = 764
+    703: Emoji = 765
+    704: Empty = 766
+    705: EmptyCells = 767
+    706: Emptyset = 768
+    707: Enabled = 769
+    708: End = 770
+    709: Entry = 771
+    710: EntryCrossing = 772
+    711: Env = 773
+    712: EnvironmentBlending = 774
+    713: Eq = 775
+    714: Equivalent = 776
+    715: Even = 777
+    716: Evenodd = 778
+    717: EventTrigger = 779
+    718: EventTriggerName = 780
+    719: EventTriggerSource = 781
+    720: EwResize = 782
+    721: ExHeight = 783
+    722: Exact = 784
+    723: Exclusion = 785
+    724: Exists = 786
+    725: Exit = 787
+    726: ExitCrossing = 788
+    727: Exp = 789
+    728: Expanded = 790
+    729: Extends = 791
+    730: ExtraCondensed = 792
+    731: ExtraExpanded = 793
+    732: Factorial = 794
+    733: Factorof = 795
+    734: Fade = 796
+    735: Fallback = 797
+    736: False = 798
+    737: Fangsong = 799
+    738: Fantasy = 800
+    739: FarthestCorner = 801
+    740: FarthestSide = 802
+    741: Fast = 803
+    742: Feblend = 804
+    743: Fecolormatrix = 805
+    744: Fecomponenttransfer = 806
+    745: Fecomposite = 807
+    746: Feconvolvematrix = 808
+    747: Fediffuselighting = 809
+    748: Fedisplacementmap = 810
+    749: Fedistantlight = 811
+    750: Fedropshadow = 812
+    751: Feflood = 813
+    752: Fefunca = 814
+    753: Fefuncb = 815
+    754: Fefuncg = 816
+    755: Fefuncr = 817
+    756: Fegaussianblur = 818
+    757: Feimage = 819
+    758: Female = 820
+    759: Femerge = 821
+    760: Femergenode = 822
+    761: Femorphology = 823
+    762: Fencedframe = 824
+    763: Feoffset = 825
+    764: Fepointlight = 826
+    765: Fespecularlighting = 827
+    766: Fespotlight = 828
+    767: Fetile = 829
+    768: Feturbulence = 830
+    769: Field = 831
+    770: FieldSizing = 832
+    771: Fieldset = 833
+    772: Fieldtext = 834
+    773: Figcaption = 835
+    774: Figure = 836
+    775: FileSelectorButton = 837
+    776: Fill = 838
+    777: FillBox = 839
+    778: FillBreak = 840
+    779: FillColor = 841
+    780: FillImage = 842
+    781: FillOpacity = 843
+    782: FillOrigin = 844
+    783: FillPosition = 845
+    784: FillRepeat = 846
+    785: FillRule = 847
+    786: FillSize = 848
+    787: Filled = 849
+    788: Filter = 850
+    789: FilterMarginBottom = 851
+    790: FilterMarginLeft = 852
+    791: FilterMarginRight = 853
+    792: FilterMarginTop = 854
+    793: Fine = 855
+    794: Firebrick = 856
+    795: First = 857
+    796: FirstChild = 858
+    797: FirstExcept = 859
+    798: FirstLetter = 860
+    799: FirstLine = 861
+    800: FirstOfType = 862
+    801: FirstValid = 863
+    802: FitContent = 864
+    803: Fixed = 865
+    804: Flat = 866
+    805: Flex = 867
+    806: FlexBasis = 868
+    807: FlexDirection = 869
+    808: FlexEnd = 870
+    809: FlexFlow = 871
+    810: FlexGrow = 872
+    811: FlexLineCount = 873
+    812: FlexShrink = 874
+    813: FlexStart = 875
+    814: FlexVisual = 876
+    815: FlexWrap = 877
+    816: Flip = 878
+    817: FlipBlock = 879
+    818: FlipInline = 880
+    819: FlipStart = 881
+    820: FlipX = 882
+    821: FlipY = 883
+    822: Float = 884
+    823: FloatDefer = 885
+    824: FloatOffset = 886
+    825: FloatReference = 887
+    826: FloodColor = 888
+    827: FloodOpacity = 889
+    828: Floor = 890
+    829: Floralwhite = 891
+    830: Flow = 892
+    831: FlowFrom = 893
+    832: FlowInto = 894
+    833: FlowRoot = 895
+    834: FlowTolerance = 896
+    835: Fn = 897
+    836: Focus = 898
+    837: FocusVisible = 899
+    838: FocusWithin = 900
+    839: Font = 901
+    840: FontDisplay = 902
+    841: FontFace = 903
+    842: FontFaceFormat = 904
+    843: FontFaceName = 905
+    844: FontFaceRule = 906
+    845: FontFaceSrc = 907
+    846: FontFaceUri = 908
+    847: FontFamily = 909
+    848: FontFeatureSettings = 910
+    849: FontFeatureValues = 911
+    850: FontFormat = 912
+    851: FontKerning = 913
+    852: FontLanguageOverride = 914
+    853: FontNamedInstance = 915
+    854: FontOpticalSizing = 916
+    855: FontPalette = 917
+    856: FontPaletteValues = 918
+    857: FontSize = 919
+    858: FontSizeAdjust = 920
+    859: FontStyle = 921
+    860: FontSynthesis = 922
+    861: FontSynthesisPosition = 923
+    862: FontSynthesisSmallCaps = 924
+    863: FontSynthesisStyle = 925
+    864: FontSynthesisWeight = 926
+    865: FontTech = 927
+    866: FontVariant = 928
+    867: FontVariantAlternates = 929
+    868: FontVariantCaps = 930
+    869: FontVariantEastAsian = 931
+    870: FontVariantEmoji = 932
+    871: FontVariantLigatures = 933
+    872: FontVariantNumeric = 934
+    873: FontVariantPosition = 935
+    874: FontVariationSettings = 936
+    875: FontWeight = 937
+    876: FontWidth = 938
+    877: Footer = 939
+    878: FootnoteDisplay = 940
+    879: FootnotePolicy = 941
+    880: Forall = 942
+    881: ForceEnd = 943
+    882: ForceHidden = 944
+    883: ForcedColorAdjust = 945
+    884: ForcedColors = 946
+    885: Foreignobject = 947
+    886: Forestgreen = 948
+    887: Form = 949
+    888: Forwards = 950
+    889: Frame = 951
+    890: FrameSizing = 952
+    891: Frameset = 953
+    892: From = 954
+    893: FromFont = 955
+    894: FromImage = 956
+    895: Fuchsia = 957
+    896: FullSizeKana = 958
+    897: FullWidth = 959
+    898: Fullscreen = 960
+    899: FullscreenLandscape = 961
+    900: FullscreenPortait = 962
+    901: Future = 963
+    902: G = 964
+    903: Gainsboro = 965
+    904: Gap = 966
+    905: Gaps = 967
+    906: Gcd = 968
+    907: Generic = 969
+    908: Geometricprecision = 970
+    909: Georgian = 971
+    910: Geq = 972
+    911: Ghostwhite = 973
+    912: GlyphOrientationVertical = 974
+    913: Gold = 975
+    914: Goldenrod = 976
+    915: Grab = 977
+    916: Grabbing = 978
+    917: GrammarError = 979
+    918: Gray = 980
+    919: Grayscale = 981
+    920: Graytext = 982
+    921: Green = 983
+    922: Greenyellow = 984
+    923: Grey = 985
+    924: Grid = 986
+    925: GridArea = 987
+    926: GridAutoColumns = 988
+    927: GridAutoFlow = 989
+    928: GridAutoRows = 990
+    929: GridColumn = 991
+    930: GridColumnEnd = 992
+    931: GridColumnStart = 993
+    932: GridColumns = 994
+    933: GridOrder = 995
+    934: GridRow = 996
+    935: GridRowEnd = 997
+    936: GridRowStart = 998
+    937: GridRows = 999
+    938: GridTemplate = 1000
+    939: GridTemplateAreas = 1001
+    940: GridTemplateColumns = 1002
+    941: GridTemplateRows = 1003
+    942: Groove = 1004
+    943: Grow = 1005
+    944: Gt = 1006
+    945: Gujarati = 1007
+    946: Gurmukhi = 1008
+    947: H = 1009
+    948: H1 = 1010
+    949: H2 = 1011
+    950: H3 = 1012
+    951: H4 = 1013
+    952: H5 = 1014
+    953: H6 = 1015
+    954: Hanging = 1016
+    955: HangingPunctuation = 1017
+    956: HardLight = 1018
+    957: Has = 1019
+    958: HasSlotted = 1020
+    959: Head = 1021
+    960: Header = 1022
+    961: Heading = 1023
+    962: Hebrew = 1024
+    963: Height = 1025
+    964: Help = 1026
+    965: Hgroup = 1027
+    966: Hidden = 1028
+    967: Hide = 1029
+    968: High = 1030
+    969: HighQuality = 1031
+    970: Highlight = 1032
+    971: Highlighttext = 1033
+    972: Hiragana = 1034
+    973: HiraganaIroha = 1035
+    974: HistoricalForms = 1036
+    975: HistoricalLigatures = 1037
+    976: Hline = 1038
+    977: Honeydew = 1039
+    978: Horizontal = 1040
+    979: HorizontalTb = 1041
+    980: HorizontalViewportSegments = 1042
+    981: Host = 1043
+    982: HostContext = 1044
+    983: Hotpink = 1045
+    984: Hover = 1046
+    985: Hr = 1047
+    986: Hsl = 1048
+    987: Hsla = 1049
+    988: Html = 1050
+    989: Hue = 1051
+    990: HueRotate = 1052
+    991: Hwb = 1053
+    992: HyphenateCharacter = 1054
+    993: HyphenateLimitChars = 1055
+    994: HyphenateLimitLast = 1056
+    995: HyphenateLimitLines = 1057
+    996: HyphenateLimitZone = 1058
+    997: Hyphens = 1059
+    998: Hypot = 1060
+    999: I = 1061
+    1000: IcHeight = 1062
+    1001: IcWidth = 1063
+    1002: Ident = 1064
+    1003: Ideographic = 1065
+    1004: IdeographicSpace = 1066
+    1005: If = 1067
+    1006: Iframe = 1068
+    1007: Image = 1069
+    1008: ImageAnimation = 1070
+    1009: ImageOrientation = 1071
+    1010: ImageRendering = 1072
+    1011: ImageResolution = 1073
+    1012: ImageSet = 1074
+    1013: Imaginary = 1075
+    1014: Img = 1076
+    1015: Implies = 1077
+    1016: Import = 1078
+    1017: InRange = 1079
+    1018: Increasing = 1080
+    1019: Indeterminate = 1081
+    1020: Indianred = 1082
+    1021: Indigo = 1083
+    1022: Inert = 1084
+    1023: Infinite = 1085
+    1024: Infinity = 1086
+    1025: Inherit = 1087
+    1026: Inherits = 1088
+    1027: Initial = 1089
+    1028: InitialLetter = 1090
+    1029: InitialLetterAlign = 1091
+    1030: InitialLetterWrap = 1092
+    1031: InitialOnly = 1093
+    1032: InitialValue = 1094
+    1033: Inline = 1095
+    1034: InlineAxis = 1096
+    1035: InlineBlock = 1097
+    1036: InlineEnd = 1098
+    1037: InlineFlex = 1099
+    1038: InlineGrid = 1100
+    1039: InlineSize = 1101
+    1040: InlineSizing = 1102
+    1041: InlineStart = 1103
+    1042: InlineTable = 1104
+    1043: Input = 1105
+    1044: InputSecurity = 1106
+    1045: Ins = 1107
+    1046: Inset = 1108
+    1047: InsetBlock = 1109
+    1048: InsetBlockEnd = 1110
+    1049: InsetBlockStart = 1111
+    1050: InsetInline = 1112
+    1051: InsetInlineEnd = 1113
+    1052: InsetInlineStart = 1114
+    1053: Inside = 1115
+    1054: Int = 1116
+    1055: InterCharacter = 1117
+    1056: InterWord = 1118
+    1057: Interactivity = 1119
+    1058: InterestDelay = 1120
+    1059: InterestDelayEnd = 1121
+    1060: InterestDelayStart = 1122
+    1061: Interlace = 1123
+    1062: InterpolateSize = 1124
+    1063: Intersect = 1125
+    1064: Intersection = 1126
+    1065: Interval = 1127
+    1066: Invalid = 1128
+    1067: Inverse = 1129
+    1068: Invert = 1130
+    1069: Inverted = 1131
+    1070: InvertedColors = 1132
+    1071: Is = 1133
+    1072: Isindex = 1134
+    1073: Isolate = 1135
+    1074: IsolateOverride = 1136
+    1075: Isolation = 1137
+    1076: Italic = 1138
+    1077: ItemCross = 1139
+    1078: ItemDirection = 1140
+    1079: ItemFlow = 1141
+    1080: ItemPack = 1142
+    1081: ItemTrack = 1143
+    1082: ItemWrap = 1144
+    1083: Ivory = 1145
+    1084: Jis04 = 1146
+    1085: Jis78 = 1147
+    1086: Jis83 = 1148
+    1087: Jis90 = 1149
+    1088: JumpBoth = 1150
+    1089: JumpEnd = 1151
+    1090: JumpNone = 1152
+    1091: JumpStart = 1153
+    1092: Justify = 1154
+    1093: JustifyAll = 1155
+    1094: JustifyContent = 1156
+    1095: JustifyItems = 1157
+    1096: JustifySelf = 1158
+    1097: Kai = 1159
+    1098: Kannada = 1160
+    1099: Katakana = 1161
+    1100: KatakanaIroha = 1162
+    1101: Kbd = 1163
+    1102: Keep = 1164
+    1103: KeepAll = 1165
+    1104: Keyframes = 1166
+    1105: Keygen = 1167
+    1106: Keypress = 1168
+    1107: Khaki = 1169
+    1108: Khmer = 1170
+    1109: KhmerMul = 1171
+    1110: L = 1172
+    1111: Lab = 1173
+    1112: Label = 1174
+    1113: Lambda = 1175
+    1114: Landscape = 1176
+    1115: Lang = 1177
+    1116: Lao = 1178
+    1117: Laplacian = 1179
+    1118: Large = 1180
+    1119: Larger = 1181
+    1120: Last = 1182
+    1121: LastBaseline = 1183
+    1122: LastChild = 1184
+    1123: LastOfType = 1185
+    1124: Lavender = 1186
+    1125: Lavenderblush = 1187
+    1126: Lawngreen = 1188
+    1127: Layer = 1189
+    1128: Layout = 1190
+    1129: Lch = 1191
+    1130: Lcm = 1192
+    1131: Leader = 1193
+    1132: Leading = 1194
+    1133: Left = 1195
+    1134: LeftBottom = 1196
+    1135: LeftMiddle = 1197
+    1136: LeftToRight = 1198
+    1137: LeftTop = 1199
+    1138: Leftwards = 1200
+    1139: Legacy = 1201
+    1140: Legend = 1202
+    1141: Lemonchiffon = 1203
+    1142: Leq = 1204
+    1143: Less = 1205
+    1144: LetterSpacing = 1206
+    1145: Li = 1207
+    1146: Light = 1208
+    1147: LightDark = 1209
+    1148: Lightblue = 1210
+    1149: Lightcoral = 1211
+    1150: Lightcyan = 1212
+    1151: Lighten = 1213
+    1152: Lighter = 1214
+    1153: Lightgoldenrodyellow = 1215
+    1154: Lightgray = 1216
+    1155: Lightgreen = 1217
+    1156: Lightgrey = 1218
+    1157: LightingColor = 1219
+    1158: Lightpink = 1220
+    1159: Lightsalmon = 1221
+    1160: Lightseagreen = 1222
+    1161: Lightskyblue = 1223
+    1162: Lightslategray = 1224
+    1163: Lightslategrey = 1225
+    1164: Lightsteelblue = 1226
+    1165: Lightyellow = 1227
+    1166: Lime = 1228
+    1167: Limegreen = 1229
+    1168: Limit = 1230
+    1169: Line = 1231
+    1170: LineBreak = 1232
+    1171: LineClamp = 1233
+    1172: LineFitEdge = 1234
+    1173: LineGapOverride = 1235
+    1174: LineGrid = 1236
+    1175: LineHeight = 1237
+    1176: LineHeightStep = 1238
+    1177: LinePadding = 1239
+    1178: LineSnap = 1240
+    1179: LineThrough = 1241
+    1180: LineWidth = 1242
+    1181: Linear = 1243
+    1182: LinearGradient = 1244
+    1183: LinearRgb = 1245
+    1184: Lineargradient = 1246
+    1185: Linearrgb = 1247
+    1186: Linen = 1248
+    1187: LiningNums = 1249
+    1188: Link = 1250
+    1189: LinkParameters = 1251
+    1190: Links = 1252
+    1191: Linktext = 1253
+    1192: List = 1254
+    1193: ListItem = 1255
+    1194: ListStyle = 1256
+    1195: ListStyleImage = 1257
+    1196: ListStylePosition = 1258
+    1197: ListStyleType = 1259
+    1198: Listbox = 1260
+    1199: Listing = 1261
+    1200: LiteralPunctuation = 1262
+    1201: Ln = 1263
+    1202: Local = 1264
+    1203: LocalLink = 1265
+    1204: Log = 1266
+    1205: Logbase = 1267
+    1206: Longer = 1268
+    1207: Loose = 1269
+    1208: Loud = 1270
+    1209: LowerAlpha = 1271
+    1210: LowerArmenian = 1272
+    1211: LowerGreek = 1273
+    1212: LowerRoman = 1274
+    1213: Lowercase = 1275
+    1214: Lowlimit = 1276
+    1215: Lt = 1277
+    1216: Ltr = 1278
+    1217: Luminance = 1279
+    1218: Luminosity = 1280
+    1219: Maction = 1281
+    1220: Magenta = 1282
+    1221: Main = 1283
+    1222: Malayalam = 1284
+    1223: Male = 1285
+    1224: Maligngroup = 1286
+    1225: Malignmark = 1287
+    1226: Mandatory = 1288
+    1227: Manipulation = 1289
+    1228: Manual = 1290
+    1229: Map = 1291
+    1230: Margin = 1292
+    1231: MarginBlock = 1293
+    1232: MarginBlockEnd = 1294
+    1233: MarginBlockStart = 1295
+    1234: MarginBottom = 1296
+    1235: MarginBox = 1297
+    1236: MarginBreak = 1298
+    1237: MarginInline = 1299
+    1238: MarginInlineEnd = 1300
+    1239: MarginInlineStart = 1301
+    1240: MarginLeft = 1302
+    1241: MarginRight = 1303
+    1242: MarginTop = 1304
+    1243: MarginTrim = 1305
+    1244: Mark = 1306
+    1245: Marker = 1307
+    1246: MarkerEnd = 1308
+    1247: MarkerMid = 1309
+    1248: MarkerSide = 1310
+    1249: MarkerStart = 1311
+    1250: Markers = 1312
+    1251: Marks = 1313
+    1252: Marktext = 1314
+    1253: Maroon = 1315
+    1254: Marquee = 1316
+    1255: Mask = 1317
+    1256: MaskBorder = 1318
+    1257: MaskBorderMode = 1319
+    1258: MaskBorderOutset = 1320
+    1259: MaskBorderRepeat = 1321
+    1260: MaskBorderSlice = 1322
+    1261: MaskBorderSource = 1323
+    1262: MaskBorderWidth = 1324
+    1263: MaskClip = 1325
+    1264: MaskComposite = 1326
+    1265: MaskImage = 1327
+    1266: MaskMode = 1328
+    1267: MaskOrigin = 1329
+    1268: MaskPosition = 1330
+    1269: MaskRepeat = 1331
+    1270: MaskSize = 1332
+    1271: MaskType = 1333
+    1272: MatchParent = 1334
+    1273: MatchSelf = 1335
+    1274: MatchSource = 1336
+    1275: Math = 1337
+    1276: MathAuto = 1338
+    1277: Mathematical = 1339
+    1278: Matrix = 1340
+    1279: Matrix3d = 1341
+    1280: Matrixrow = 1342
+    1281: Max = 1343
+    1282: MaxAspectRatio = 1344
+    1283: MaxBlockSize = 1345
+    1284: MaxColor = 1346
+    1285: MaxColorIndex = 1347
+    1286: MaxContent = 1348
+    1287: MaxDeviceAspectRatio = 1349
+    1288: MaxDeviceHeight = 1350
+    1289: MaxDeviceWidth = 1351
+    1290: MaxHeight = 1352
+    1291: MaxHorizontalViewportSegments = 1353
+    1292: MaxInlineSize = 1354
+    1293: MaxLines = 1355
+    1294: MaxMonochrome = 1356
+    1295: MaxResolution = 1357
+    1296: MaxSize = 1358
+    1297: MaxVerticalViewportSegments = 1359
+    1298: MaxWidth = 1360
+    1299: Maximum = 1361
+    1300: Mean = 1362
+    1301: Media = 1363
+    1302: MediaDocument = 1364
+    1303: Median = 1365
+    1304: Medium = 1366
+    1305: Mediumaquamarine = 1367
+    1306: Mediumblue = 1368
+    1307: Mediumorchid = 1369
+    1308: Mediumpurple = 1370
+    1309: Mediumseagreen = 1371
+    1310: Mediumslateblue = 1372
+    1311: Mediumspringgreen = 1373
+    1312: Mediumturquoise = 1374
+    1313: Mediumvioletred = 1375
+    1314: Menclose = 1376
+    1315: Menu = 1377
+    1316: Menuitem = 1378
+    1317: Menulist = 1379
+    1318: MenulistButton = 1380
+    1319: Merge = 1381
+    1320: Merror = 1382
+    1321: Meta = 1383
+    1322: Metadata = 1384
+    1323: Meter = 1385
+    1324: Mfenced = 1386
+    1325: Mfrac = 1387
+    1326: Mfraction = 1388
+    1327: Mglyph = 1389
+    1328: Mi = 1390
+    1329: Middle = 1391
+    1330: Midnightblue = 1392
+    1331: Min = 1393
+    1332: MinAspectRatio = 1394
+    1333: MinBlockSize = 1395
+    1334: MinColor = 1396
+    1335: MinColorIndex = 1397
+    1336: MinContent = 1398
+    1337: MinDeviceAspectRatio = 1399
+    1338: MinDeviceHeight = 1400
+    1339: MinDeviceWidth = 1401
+    1340: MinHeight = 1402
+    1341: MinHorizontalViewportSegments = 1403
+    1342: MinInlineSize = 1404
+    1343: MinIntrinsicSizing = 1405
+    1344: MinMonochrome = 1406
+    1345: MinResolution = 1407
+    1346: MinSize = 1408
+    1347: MinVerticalViewportSegments = 1409
+    1348: MinWidth = 1410
+    1349: MinimalUi = 1411
+    1350: Minimum = 1412
+    1351: Minmax = 1413
+    1352: Mintcream = 1414
+    1353: Minus = 1415
+    1354: MissingGlyph = 1416
+    1355: Mistyrose = 1417
+    1356: Miter = 1418
+    1357: MixBlendMode = 1419
+    1358: Mixed = 1420
+    1359: Mlabeledtr = 1421
+    1360: Mlongdiv = 1422
+    1361: Mmultiscripts = 1423
+    1362: Mn = 1424
+    1363: Mo = 1425
+    1364: Moccasin = 1426
+    1365: Mod = 1427
+    1366: Modal = 1428
+    1367: Mode = 1429
+    1368: Moderate = 1430
+    1369: Modifications = 1431
+    1370: Moment = 1432
+    1371: Momentabout = 1433
+    1372: Mongolian = 1434
+    1373: Monochrome = 1435
+    1374: Monospace = 1436
+    1375: More = 1437
+    1376: MostBlockSize = 1438
+    1377: MostHeight = 1439
+    1378: MostInlineSize = 1440
+    1379: MostWidth = 1441
+    1380: Move = 1442
+    1381: Mover = 1443
+    1382: Mpadded = 1444
+    1383: Mpath = 1445
+    1384: Mphantom = 1446
+    1385: Mprescripts = 1447
+    1386: Mroot = 1448
+    1387: Mrow = 1449
+    1388: Mscarries = 1450
+    1389: Mscarry = 1451
+    1390: Msgroup = 1452
+    1391: Msline = 1453
+    1392: Mspace = 1454
+    1393: Msqrt = 1455
+    1394: Msrow = 1456
+    1395: Mstack = 1457
+    1396: Mstyle = 1458
+    1397: Msub = 1459
+    1398: Msubsup = 1460
+    1399: Msup = 1461
+    1400: Mtable = 1462
+    1401: Mtd = 1463
+    1402: Mtext = 1464
+    1403: Mtr = 1465
+    1404: Multicol = 1466
+    1405: Multiply = 1467
+    1406: Munder = 1468
+    1407: Munderover = 1469
+    1408: Muted = 1470
+    1409: Myanmar = 1471
+    1410: NResize = 1472
+    1411: Namespace = 1473
+    1412: NaN = 1474
+    1413: Narrow = 1475
+    1414: Nastaliq = 1476
+    1415: Nav = 1477
+    1416: NavControls = 1478
+    1417: NavDown = 1479
+    1418: NavLeft = 1480
+    1419: NavRight = 1481
+    1420: NavUp = 1482
+    1421: Navajowhite = 1483
+    1422: Navigation = 1484
+    1423: Navy = 1485
+    1424: NeResize = 1486
+    1425: Near = 1487
+    1426: Nearest = 1488
+    1427: NearestNeighbor = 1489
+    1428: Negative = 1490
+    1429: Neq = 1491
+    1430: NeswResize = 1492
+    1431: Neutral = 1493
+    1432: Never = 1494
+    1433: Nextid = 1495
+    1434: NoClip = 1496
+    1435: NoCloseQuote = 1497
+    1436: NoCommonLigatures = 1498
+    1437: NoCompress = 1499
+    1438: NoContextual = 1500
+    1439: NoDiscretionaryLigatures = 1501
+    1440: NoDrop = 1502
+    1441: NoEllipsis = 1503
+    1442: NoHistoricalLigatures = 1504
+    1443: NoLimit = 1505
+    1444: NoOpenQuote = 1506
+    1445: NoOverflow = 1507
+    1446: NoPreference = 1508
+    1447: NoPunctuation = 1509
+    1448: NoRepeat = 1510
+    1449: NoSkip = 1511
+    1450: Nobr = 1512
+    1451: Noembed = 1513
+    1452: Noframes = 1514
+    1453: None = 1515
+    1454: Nonzero = 1516
+    1455: Normal = 1517
+    1456: Noscript = 1518
+    1457: Not = 1519
+    1458: NotAllowed = 1520
+    1459: Notch = 1521
+    1460: Notin = 1522
+    1461: Notprsubset = 1523
+    1462: Notsubset = 1524
+    1463: Nowrap = 1525
+    1464: NsResize = 1526
+    1465: NthChild = 1527
+    1466: NthCol = 1528
+    1467: NthLastChild = 1529
+    1468: NthLastCol = 1530
+    1469: NthLastOfType = 1531
+    1470: NthOfType = 1532
+    1471: Numbers = 1533
+    1472: Numeric = 1534
+    1473: NumericOnly = 1535
+    1474: NwResize = 1536
+    1475: NwseResize = 1537
+    1476: Object = 1538
+    1477: ObjectFit = 1539
+    1478: ObjectPosition = 1540
+    1479: ObjectViewBox = 1541
+    1480: Oblique = 1542
+    1481: ObliqueOnly = 1543
+    1482: Odd = 1544
+    1483: Of = 1545
+    1484: Off = 1546
+    1485: Offset = 1547
+    1486: OffsetAnchor = 1548
+    1487: OffsetDistance = 1549
+    1488: OffsetPath = 1550
+    1489: OffsetPosition = 1551
+    1490: OffsetRotate = 1552
+    1491: Oklab = 1553
+    1492: Oklch = 1554
+    1493: Ol = 1555
+    1494: Old = 1556
+    1495: Oldlace = 1557
+    1496: OldstyleNums = 1558
+    1497: Olive = 1559
+    1498: Olivedrab = 1560
+    1499: On = 1561
+    1500: Once = 1562
+    1501: Only = 1563
+    1502: OnlyChild = 1564
+    1503: OnlyOfType = 1565
+    1504: Opacity = 1566
+    1505: Opaque = 1567
+    1506: Open = 1568
+    1507: OpenQuote = 1569
+    1508: Optgroup = 1570
+    1509: Optimizelegibility = 1571
+    1510: Optimizespeed = 1572
+    1511: Option = 1573
+    1512: Optional = 1574
+    1513: Or = 1575
+    1514: Orange = 1576
+    1515: Orangered = 1577
+    1516: Orchid = 1578
+    1517: Order = 1579
+    1518: Ordinal = 1580
+    1519: Orientation = 1581
+    1520: Origin = 1582
+    1521: Oriya = 1583
+    1522: Orphans = 1584
+    1523: Otherwise = 1585
+    1524: OutOfRange = 1586
+    1525: Outerproduct = 1587
+    1526: Outline = 1588
+    1527: OutlineColor = 1589
+    1528: OutlineOffset = 1590
+    1529: OutlineStyle = 1591
+    1530: OutlineWidth = 1592
+    1531: Output = 1593
+    1532: Outset = 1594
+    1533: Outside = 1595
+    1534: OutsideShape = 1596
+    1535: Over = 1597
+    1536: Overflow = 1598
+    1537: OverflowAnchor = 1599
+    1538: OverflowBlock = 1600
+    1539: OverflowClipMargin = 1601
+    1540: OverflowClipMarginBlock = 1602
+    1541: OverflowClipMarginBlockEnd = 1603
+    1542: OverflowClipMarginBlockStart = 1604
+    1543: OverflowClipMarginBottom = 1605
+    1544: OverflowClipMarginInline = 1606
+    1545: OverflowClipMarginInlineEnd = 1607
+    1546: OverflowClipMarginInlineStart = 1608
+    1547: OverflowClipMarginLeft = 1609
+    1548: OverflowClipMarginRight = 1610
+    1549: OverflowClipMarginTop = 1611
+    1550: OverflowInline = 1612
+    1551: OverflowWrap = 1613
+    1552: OverflowX = 1614
+    1553: OverflowY = 1615
+    1554: OverlapJoin = 1616
+    1555: Overlay = 1617
+    1556: Overline = 1618
+    1557: Override = 1619
+    1558: OverrideColors = 1620
+    1559: OverscrollBehavior = 1621
+    1560: OverscrollBehaviorBlock = 1622
+    1561: OverscrollBehaviorInline = 1623
+    1562: OverscrollBehaviorX = 1624
+    1563: OverscrollBehaviorY = 1625
+    1564: P = 1626
+    1565: P3 = 1627
+    1566: Pad = 1628
+    1567: Padding = 1629
+    1568: PaddingBlock = 1630
+    1569: PaddingBlockEnd = 1631
+    1570: PaddingBlockStart = 1632
+    1571: PaddingBottom = 1633
+    1572: PaddingBox = 1634
+    1573: PaddingInline = 1635
+    1574: PaddingInlineEnd = 1636
+    1575: PaddingInlineStart = 1637
+    1576: PaddingLeft = 1638
+    1577: PaddingRight = 1639
+    1578: PaddingTop = 1640
+    1579: Page = 1641
+    1580: PageOrientation = 1642
+    1581: Paged = 1643
+    1582: Paint = 1644
+    1583: PaintOrder = 1645
+    1584: Painted = 1646
+    1585: Palegoldenrod = 1647
+    1586: Palegreen = 1648
+    1587: Paleturquoise = 1649
+    1588: Palevioletred = 1650
+    1589: PanDown = 1651
+    1590: PanLeft = 1652
+    1591: PanRight = 1653
+    1592: PanUp = 1654
+    1593: PanX = 1655
+    1594: PanY = 1656
+    1595: Papayawhip = 1657
+    1596: Param = 1658
+    1597: Parent = 1659
+    1598: Part = 1660
+    1599: Partialdiff = 1661
+    1600: Past = 1662
+    1601: Path = 1663
+    1602: Pattern = 1664
+    1603: Pause = 1665
+    1604: PauseAfter = 1666
+    1605: PauseBefore = 1667
+    1606: Paused = 1668
+    1607: Peachpuff = 1669
+    1608: PerLine = 1670
+    1609: PerLineAll = 1671
+    1610: Perceptual = 1672
+    1611: Performance = 1673
+    1612: Permission = 1674
+    1613: Persian = 1675
+    1614: Perspective = 1676
+    1615: PerspectiveOrigin = 1677
+    1616: Peru = 1678
+    1617: PetiteCaps = 1679
+    1618: Pi = 1680
+    1619: Picker = 1681
+    1620: PickerIcon = 1682
+    1621: Picture = 1683
+    1622: PictureInPicture = 1684
+    1623: Piece = 1685
+    1624: Piecewise = 1686
+    1625: PinchZoom = 1687
+    1626: Pink = 1688
+    1627: Pixelated = 1689
+    1628: PlaceContent = 1690
+    1629: PlaceItems = 1691
+    1630: PlaceSelf = 1692
+    1631: Placeholder = 1693
+    1632: PlaceholderShown = 1694
+    1633: Plaintext = 1695
+    1634: Play = 1696
+    1635: PlayBackwards = 1697
+    1636: PlayForwards = 1698
+    1637: Playing = 1699
+    1638: Plum = 1700
+    1639: Plus = 1701
+    1640: PlusLighter = 1702
+    1641: Pointer = 1703
+    1642: PointerEvents = 1704
+    1643: PointerTimeline = 1705
+    1644: PointerTimelineAxis = 1706
+    1645: PointerTimelineName = 1707
+    1646: Polygon = 1708
+    1647: Polyline = 1709
+    1648: PopoverOpen = 1710
+    1649: Portal = 1711
+    1650: Portrait = 1712
+    1651: Position = 1713
+    1652: PositionAnchor = 1714
+    1653: PositionArea = 1715
+    1654: PositionTry = 1716
+    1655: PositionTryFallbacks = 1717
+    1656: PositionTryOrder = 1718
+    1657: PositionVisibility = 1719
+    1658: Pow = 1720
+    1659: Powderblue = 1721
+    1660: Power = 1722
+    1661: Pre = 1723
+    1662: PreLine = 1724
+    1663: PreWrap = 1725
+    1664: PrefersColorScheme = 1726
+    1665: PrefersContrast = 1727
+    1666: PrefersReducedData = 1728
+    1667: PrefersReducedMotion = 1729
+    1668: PrefersReducedTransparency = 1730
+    1669: Prefix = 1731
+    1670: Preserve = 1732
+    1671: Preserve3d = 1733
+    1672: PreserveBreaks = 1734
+    1673: PreserveParentColor = 1735
+    1674: PreserveSpaces = 1736
+    1675: Pretty = 1737
+    1676: Print = 1738
+    1677: PrintColorAdjust = 1739
+    1678: Product = 1740
+    1679: Progress = 1741
+    1680: ProgressBar = 1742
+    1681: Progressive = 1743
+    1682: Property = 1744
+    1683: ProphotoRgb = 1745
+    1684: ProportionalNums = 1746
+    1685: ProportionalWidth = 1747
+    1686: Proximity = 1748
+    1687: Prsubset = 1749
+    1688: Punctuation = 1750
+    1689: Purple = 1751
+    1690: Quotes = 1752
+    1691: Quotient = 1753
+    1692: R = 1754
+    1693: RadialGradient = 1755
+    1694: Radialgradient = 1756
+    1695: Radio = 1757
+    1696: Raise = 1758
+    1697: Range = 1759
+    1698: RawString = 1760
+    1699: Rb = 1761
+    1700: ReadOnly = 1762
+    1701: ReadWrite = 1763
+    1702: ReadingFlow = 1764
+    1703: ReadingOrder = 1765
+    1704: Real = 1766
+    1705: Rebeccapurple = 1767
+    1706: Rec2020 = 1768
+    1707: Rect = 1769
+    1708: Recto = 1770
+    1709: Red = 1771
+    1710: Reduce = 1772
+    1711: Reduced = 1773
+    1712: Regexp = 1774
+    1713: Region = 1775
+    1714: RegionFragment = 1776
+    1715: Relative = 1777
+    1716: RelativeColorimetric = 1778
+    1717: Reln = 1779
+    1718: RenderingIntent = 1780
+    1719: Repeat = 1781
+    1720: RepeatX = 1782
+    1721: RepeatY = 1783
+    1722: RepeatingLinearGradient = 1784
+    1723: RepeatingRadialGradient = 1785
+    1724: Replace = 1786
+    1725: Replay = 1787
+    1726: Required = 1788
+    1727: Reset = 1789
+    1728: Resize = 1790
+    1729: Resolution = 1791
+    1730: Rest = 1792
+    1731: RestAfter = 1793
+    1732: RestBefore = 1794
+    1733: Result = 1795
+    1734: Reverse = 1796
+    1735: Reversed = 1797
+    1736: Revert = 1798
+    1737: RevertLayer = 1799
+    1738: RevertRule = 1800
+    1739: Rgb = 1801
+    1740: Rgba = 1802
+    1741: Ridge = 1803
+    1742: Right = 1804
+    1743: RightBottom = 1805
+    1744: RightMiddle = 1806
+    1745: RightToLeft = 1807
+    1746: RightTop = 1808
+    1747: Rightwards = 1809
+    1748: Root = 1810
+    1749: Rosybrown = 1811
+    1750: Rotate = 1812
+    1751: Rotate3d = 1813
+    1752: RotateLeft = 1814
+    1753: RotateRight = 1815
+    1754: Rotatex = 1816
+    1755: Rotatey = 1817
+    1756: Rotatez = 1818
+    1757: Round = 1819
+    1758: Row = 1820
+    1759: RowGap = 1821
+    1760: RowOverColumn = 1822
+    1761: RowResize = 1823
+    1762: RowReverse = 1824
+    1763: RowRule = 1825
+    1764: RowRuleBreak = 1826
+    1765: RowRuleColor = 1827
+    1766: RowRuleEdgeInset = 1828
+    1767: RowRuleEdgeInsetEnd = 1829
+    1768: RowRuleEdgeInsetStart = 1830
+    1769: RowRuleInset = 1831
+    1770: RowRuleInsetCap = 1832
+    1771: RowRuleInsetCapEnd = 1833
+    1772: RowRuleInsetCapStart = 1834
+    1773: RowRuleInsetEnd = 1835
+    1774: RowRuleInsetJunction = 1836
+    1775: RowRuleInsetJunctionEnd = 1837
+    1776: RowRuleInsetJunctionStart = 1838
+    1777: RowRuleInsetStart = 1839
+    1778: RowRuleInteriorInset = 1840
+    1779: RowRuleInteriorInsetEnd = 1841
+    1780: RowRuleInteriorInsetStart = 1842
+    1781: RowRuleOutset = 1843
+    1782: RowRuleStyle = 1844
+    1783: RowRuleVisibilityItems = 1845
+    1784: RowRuleWidth = 1846
+    1785: Royalblue = 1847
+    1786: Rp = 1848
+    1787: Rt = 1849
+    1788: Rtc = 1850
+    1789: Rtl = 1851
+    1790: Ruby = 1852
+    1791: RubyAlign = 1853
+    1792: RubyBase = 1854
+    1793: RubyBaseContainer = 1855
+    1794: RubyMerge = 1856
+    1795: RubyOverhang = 1857
+    1796: RubyPosition = 1858
+    1797: RubyText = 1859
+    1798: RubyTextContainer = 1860
+    1799: Rule = 1861
+    1800: RuleBreak = 1862
+    1801: RuleColor = 1863
+    1802: RuleEdgeInset = 1864
+    1803: RuleInset = 1865
+    1804: RuleInsetCap = 1866
+    1805: RuleInsetCapEnd = 1867
+    1806: RuleInsetCapStart = 1868
+    1807: RuleInsetEnd = 1869
+    1808: RuleInsetJunction = 1870
+    1809: RuleInsetJunctionEnd = 1871
+    1810: RuleInsetJunctionStart = 1872
+    1811: RuleInsetStart = 1873
+    1812: RuleInteriorInset = 1874
+    1813: RuleOutset = 1875
+    1814: RuleOverlap = 1876
+    1815: RuleStyle = 1877
+    1816: RuleVisibilityItems = 1878
+    1817: RuleWidth = 1879
+    1818: RunIn = 1880
+    1819: Running = 1881
+    1820: SResize = 1882
+    1821: Saddlebrown = 1883
+    1822: Safe = 1884
+    1823: Salmon = 1885
+    1824: Samp = 1886
+    1825: Sandybrown = 1887
+    1826: SansSerif = 1888
+    1827: Saturate = 1889
+    1828: Saturation = 1890
+    1829: Scalarproduct = 1891
+    1830: Scale = 1892
+    1831: Scale3d = 1893
+    1832: ScaleDown = 1894
+    1833: Scalex = 1895
+    1834: Scaley = 1896
+    1835: Scalez = 1897
+    1836: Scan = 1898
+    1837: Scoop = 1899
+    1838: Scope = 1900
+    1839: Screen = 1901
+    1840: Script = 1902
+    1841: Scripting = 1903
+    1842: Scroll = 1904
+    1843: ScrollBehavior = 1905
+    1844: ScrollInitialTarget = 1906
+    1845: ScrollMargin = 1907
+    1846: ScrollMarginBlock = 1908
+    1847: ScrollMarginBlockEnd = 1909
+    1848: ScrollMarginBlockStart = 1910
+    1849: ScrollMarginBottom = 1911
+    1850: ScrollMarginInline = 1912
+    1851: ScrollMarginInlineEnd = 1913
+    1852: ScrollMarginInlineStart = 1914
+    1853: ScrollMarginLeft = 1915
+    1854: ScrollMarginRight = 1916
+    1855: ScrollMarginTop = 1917
+    1856: ScrollMarker = 1918
+    1857: ScrollMarkerGroup = 1919
+    1858: ScrollPadding = 1920
+    1859: ScrollPaddingBlock = 1921
+    1860: ScrollPaddingBlockEnd = 1922
+    1861: ScrollPaddingBlockStart = 1923
+    1862: ScrollPaddingBottom = 1924
+    1863: ScrollPaddingInline = 1925
+    1864: ScrollPaddingInlineEnd = 1926
+    1865: ScrollPaddingInlineStart = 1927
+    1866: ScrollPaddingLeft = 1928
+    1867: ScrollPaddingRight = 1929
+    1868: ScrollPaddingTop = 1930
+    1869: ScrollPosition = 1931
+    1870: ScrollSnapAlign = 1932
+    1871: ScrollSnapStop = 1933
+    1872: ScrollSnapType = 1934
+    1873: ScrollState = 1935
+    1874: ScrollTargetGroup = 1936
+    1875: ScrollTimeline = 1937
+    1876: ScrollTimelineAxis = 1938
+    1877: ScrollTimelineName = 1939
+    1878: Scrollable = 1940
+    1879: Scrollbar = 1941
+    1880: ScrollbarColor = 1942
+    1881: ScrollbarGutter = 1943
+    1882: ScrollbarWidth = 1944
+    1883: Scrolled = 1945
+    1884: Sdev = 1946
+    1885: SeResize = 1947
+    1886: Seagreen = 1948
+    1887: Search = 1949
+    1888: Seashell = 1950
+    1889: Section = 1951
+    1890: Seeking = 1952
+    1891: Select = 1953
+    1892: Selectedcontent = 1954
+    1893: Selecteditem = 1955
+    1894: Selecteditemtext = 1956
+    1895: Selection = 1957
+    1896: Selector = 1958
+    1897: SelfBlockEnd = 1959
+    1898: SelfBlockStart = 1960
+    1899: SelfEnd = 1961
+    1900: SelfInlineEnd = 1962
+    1901: SelfInlineStart = 1963
+    1902: SelfStart = 1964
+    1903: Semantics = 1965
+    1904: SemiCondensed = 1966
+    1905: SemiExpanded = 1967
+    1906: Sep = 1968
+    1907: Separate = 1969
+    1908: Sepia = 1970
+    1909: Serif = 1971
+    1910: Sesame = 1972
+    1911: Set = 1973
+    1912: Setdiff = 1974
+    1913: Shape = 1975
+    1914: ShapeBox = 1976
+    1915: ShapeImageThreshold = 1977
+    1916: ShapeInside = 1978
+    1917: ShapeMargin = 1979
+    1918: ShapeOutside = 1980
+    1919: ShapePadding = 1981
+    1920: ShapeRendering = 1982
+    1921: Share = 1983
+    1922: Shorter = 1984
+    1923: Show = 1985
+    1924: Shrink = 1986
+    1925: Sides = 1987
+    1926: Sideways = 1988
+    1927: SidewaysLr = 1989
+    1928: SidewaysRl = 1990
+    1929: Sienna = 1991
+    1930: Sign = 1992
+    1931: Silent = 1993
+    1932: Silver = 1994
+    1933: Simplified = 1995
+    1934: Sin = 1996
+    1935: Size = 1997
+    1936: SizeAdjust = 1998
+    1937: Skew = 1999
+    1938: Skewx = 2000
+    1939: Skewy = 2001
+    1940: SkipAll = 2002
+    1941: SkipLineThrough = 2003
+    1942: SkipOverline = 2004
+    1943: SkipUnderline = 2005
+    1944: Skyblue = 2006
+    1945: SlashedZero = 2007
+    1946: Slateblue = 2008
+    1947: Slategray = 2009
+    1948: Slategrey = 2010
+    1949: Slice = 2011
+    1950: SliderOrientation = 2012
+    1951: Slot = 2013
+    1952: Slotted = 2014
+    1953: Slow = 2015
+    1954: Small = 2016
+    1955: SmallCaps = 2017
+    1956: Smaller = 2018
+    1957: Smooth = 2019
+    1958: Snap = 2020
+    1959: SnapBlock = 2021
+    1960: SnapInline = 2022
+    1961: Snapped = 2023
+    1962: Snow = 2024
+    1963: Soft = 2025
+    1964: SoftLight = 2026
+    1965: Solid = 2027
+    1966: SomeProp = 2028
+    1967: Source = 2029
+    1968: SourceAtop = 2030
+    1969: SourceIn = 2031
+    1970: SourceOrder = 2032
+    1971: SourceOut = 2033
+    1972: SourceOver = 2034
+    1973: Space = 2035
+    1974: SpaceAll = 2036
+    1975: SpaceAround = 2037
+    1976: SpaceBetween = 2038
+    1977: SpaceEvenly = 2039
+    1978: SpaceFirst = 2040
+    1979: Spacer = 2041
+    1980: Spaces = 2042
+    1981: Span = 2043
+    1982: SpanAll = 2044
+    1983: SpanBlockEnd = 2045
+    1984: SpanBlockStart = 2046
+    1985: SpanBottom = 2047
+    1986: SpanEnd = 2048
+    1987: SpanInlineEnd = 2049
+    1988: SpanInlineStart = 2050
+    1989: SpanLeft = 2051
+    1990: SpanRight = 2052
+    1991: SpanSelfBlockEnd = 2053
+    1992: SpanSelfBlockStart = 2054
+    1993: SpanSelfEnd = 2055
+    1994: SpanSelfInlineEnd = 2056
+    1995: SpanSelfInlineStart = 2057
+    1996: SpanSelfStart = 2058
+    1997: SpanStart = 2059
+    1998: SpanTop = 2060
+    1999: SpanXEnd = 2061
+    2000: SpanXSelfEnd = 2062
+    2001: SpanXSelfStart = 2063
+    2002: SpanXStart = 2064
+    2003: SpanYEnd = 2065
+    2004: SpanYSelfEnd = 2066
+    2005: SpanYSelfStart = 2067
+    2006: SpanYStart = 2068
+    2007: SpanningItem = 2069
+    2008: SpatialNavigationAction = 2070
+    2009: SpatialNavigationContain = 2071
+    2010: SpatialNavigationFunction = 2072
+    2011: Speak = 2073
+    2012: SpeakAs = 2074
+    2013: SpellOut = 2075
+    2014: SpellingError = 2076
+    2015: Spread = 2077
+    2016: Springgreen = 2078
+    2017: Sqrt = 2079
+    2018: Square = 2080
+    2019: Squircle = 2081
+    2020: Src = 2082
+    2021: Srgb = 2083
+    2022: SrgbLinear = 2084
+    2023: Stable = 2085
+    2024: StackedFractions = 2086
+    2025: Stalled = 2087
+    2026: Standalone = 2088
+    2027: Standard = 2089
+    2028: Start = 2090
+    2029: StartingStyle = 2091
+    2030: State = 2092
+    2031: Static = 2093
+    2032: Steelblue = 2094
+    2033: StepEnd = 2095
+    2034: StepStart = 2096
+    2035: Steps = 2097
+    2036: Sticky = 2098
+    2037: Stop = 2099
+    2038: Stopped = 2100
+    2039: Stretch = 2101
+    2040: Strict = 2102
+    2041: Strike = 2103
+    2042: String = 2104
+    2043: StringSet = 2105
+    2044: Stripes = 2106
+    2045: Stroke = 2107
+    2046: StrokeAlign = 2108
+    2047: StrokeBox = 2109
+    2048: StrokeBreak = 2110
+    2049: StrokeColor = 2111
+    2050: StrokeDashCorner = 2112
+    2051: StrokeDashJustify = 2113
+    2052: StrokeDasharray = 2114
+    2053: StrokeDashoffset = 2115
+    2054: StrokeImage = 2116
+    2055: StrokeLinecap = 2117
+    2056: StrokeLinejoin = 2118
+    2057: StrokeMiterlimit = 2119
+    2058: StrokeOpacity = 2120
+    2059: StrokeOrigin = 2121
+    2060: StrokePosition = 2122
+    2061: StrokeRepeat = 2123
+    2062: StrokeSize = 2124
+    2063: StrokeWidth = 2125
+    2064: Strong = 2126
+    2065: Stuck = 2127
+    2066: Style = 2128
+    2067: Sub = 2129
+    2068: Subgrid = 2130
+    2069: SubpixelAntialiased = 2131
+    2070: Subset = 2132
+    2071: Subtractive = 2133
+    2072: Suffix = 2134
+    2073: Sum = 2135
+    2074: Summary = 2136
+    2075: Sup = 2137
+    2076: Super = 2138
+    2077: Superellipse = 2139
+    2078: Supports = 2140
+    2079: Svg = 2141
+    2080: SwResize = 2142
+    2081: Swap = 2143
+    2082: Switch = 2144
+    2083: Symbol = 2145
+    2084: Symbolic = 2146
+    2085: Symbols = 2147
+    2086: Syntax = 2148
+    2087: System = 2149
+    2088: SystemUi = 2150
+    2089: TabSize = 2151
+    2090: Table = 2152
+    2091: TableCaption = 2153
+    2092: TableCell = 2154
+    2093: TableColumn = 2155
+    2094: TableColumnGroup = 2156
+    2095: TableFooterGroup = 2157
+    2096: TableHeaderGroup = 2158
+    2097: TableLayout = 2159
+    2098: TableRow = 2160
+    2099: TableRowGroup = 2161
+    2100: Tabs = 2162
+    2101: TabularNums = 2163
+    2102: Tamil = 2164
+    2103: Tan = 2165
+    2104: Target = 2166
+    2105: TargetCounter = 2167
+    2106: TargetCounters = 2168
+    2107: TargetCurrent = 2169
+    2108: TargetText = 2170
+    2109: TargetWithin = 2171
+    2110: Tbody = 2172
+    2111: Td = 2173
+    2112: Teal = 2174
+    2113: Telugu = 2175
+    2114: Template = 2176
+    2115: Tendsto = 2177
+    2116: Text = 2178
+    2117: TextAlign = 2179
+    2118: TextAlignAll = 2180
+    2119: TextAlignLast = 2181
+    2120: TextAutospace = 2182
+    2121: TextBottom = 2183
+    2122: TextBox = 2184
+    2123: TextBoxEdge = 2185
+    2124: TextBoxTrim = 2186
+    2125: TextCombineUpright = 2187
+    2126: TextDecoration = 2188
+    2127: TextDecorationColor = 2189
+    2128: TextDecorationInset = 2190
+    2129: TextDecorationLine = 2191
+    2130: TextDecorationSkip = 2192
+    2131: TextDecorationSkipBox = 2193
+    2132: TextDecorationSkipInk = 2194
+    2133: TextDecorationSkipSelf = 2195
+    2134: TextDecorationSkipSpaces = 2196
+    2135: TextDecorationStyle = 2197
+    2136: TextDecorationThickness = 2198
+    2137: TextEmphasis = 2199
+    2138: TextEmphasisColor = 2200
+    2139: TextEmphasisPosition = 2201
+    2140: TextEmphasisSkip = 2202
+    2141: TextEmphasisStyle = 2203
+    2142: TextFit = 2204
+    2143: TextGroupAlign = 2205
+    2144: TextIndent = 2206
+    2145: TextJustify = 2207
+    2146: TextOrientation = 2208
+    2147: TextOverflow = 2209
+    2148: TextRendering = 2210
+    2149: TextShadow = 2211
+    2150: TextSizeAdjust = 2212
+    2151: TextSpacing = 2213
+    2152: TextSpacingTrim = 2214
+    2153: TextTop = 2215
+    2154: TextTransform = 2216
+    2155: TextUnderlineOffset = 2217
+    2156: TextUnderlinePosition = 2218
+    2157: TextWrap = 2219
+    2158: TextWrapMode = 2220
+    2159: TextWrapStyle = 2221
+    2160: Textarea = 2222
+    2161: Textfield = 2223
+    2162: Textpath = 2224
+    2163: Tfoot = 2225
+    2164: Th = 2226
+    2165: Thai = 2227
+    2166: Thead = 2228
+    2167: Thick = 2229
+    2168: Thin = 2230
+    2169: Thistle = 2231
+    2170: Tibetan = 2232
+    2171: Time = 2233
+    2172: TimelineScope = 2234
+    2173: TimelineTrigger = 2235
+    2174: TimelineTriggerActivationRange = 2236
+    2175: TimelineTriggerActivationRangeEnd = 2237
+    2176: TimelineTriggerActivationRangeStart = 2238
+    2177: TimelineTriggerActiveRange = 2239
+    2178: TimelineTriggerActiveRangeEnd = 2240
+    2179: TimelineTriggerActiveRangeStart = 2241
+    2180: TimelineTriggerName = 2242
+    2181: TimelineTriggerSource = 2243
+    2182: Times = 2244
+    2183: Title = 2245
+    2184: TitlingCaps = 2246
+    2185: To = 2247
+    2186: ToZero = 2248
+    2187: Tomato = 2249
+    2188: Top = 2250
+    2189: TopCenter = 2251
+    2190: TopLeft = 2252
+    2191: TopLeftCorner = 2253
+    2192: TopRight = 2254
+    2193: TopRightCorner = 2255
+    2194: TopToBottom = 2256
+    2195: Touch = 2257
+    2196: TouchAction = 2258
+    2197: Tr = 2259
+    2198: Track = 2260
+    2199: Traditional = 2261
+    2200: Transform = 2262
+    2201: TransformBox = 2263
+    2202: TransformOrigin = 2264
+    2203: TransformStyle = 2265
+    2204: Transition = 2266
+    2205: TransitionBehavior = 2267
+    2206: TransitionDelay = 2268
+    2207: TransitionDuration = 2269
+    2208: TransitionProperty = 2270
+    2209: TransitionTimingFunction = 2271
+    2210: Translate = 2272
+    2211: Translate3d = 2273
+    2212: Translatex = 2274
+    2213: Translatey = 2275
+    2214: Translatez = 2276
+    2215: Transparent = 2277
+    2216: Transpose = 2278
+    2217: Triangle = 2279
+    2218: TriggerScope = 2280
+    2219: TrimAll = 2281
+    2220: TrimBoth = 2282
+    2221: TrimEnd = 2283
+    2222: TrimStart = 2284
+    2223: True = 2285
+    2224: Tspan = 2286
+    2225: Tt = 2287
+    2226: Turquoise = 2288
+    2227: Type = 2289
+    2228: Types = 2290
+    2229: U = 2291
+    2230: UiMonospace = 2292
+    2231: UiRounded = 2293
+    2232: UiSansSerif = 2294
+    2233: UiSerif = 2295
+    2234: Ul = 2296
+    2235: UltraCondensed = 2297
+    2236: UltraExpanded = 2298
+    2237: Under = 2299
+    2238: Underline = 2300
+    2239: Underscore = 2301
+    2240: Unicase = 2302
+    2241: Unicode = 2303
+    2242: UnicodeBidi = 2304
+    2243: UnicodeRange = 2305
+    2244: Union = 2306
+    2245: Unsafe = 2307
+    2246: Unset = 2308
+    2247: Up = 2309
+    2248: Update = 2310
+    2249: Uplimit = 2311
+    2250: UpperAlpha = 2312
+    2251: UpperArmenian = 2313
+    2252: UpperLatin = 2314
+    2253: UpperRoman = 2315
+    2254: Uppercase = 2316
+    2255: Upright = 2317
+    2256: Url = 2318
+    2257: UrlPrefix = 2319
+    2258: Use = 2320
+    2259: UserInvalid = 2321
+    2260: UserSelect = 2322
+    2261: Valid = 2323
+    2262: Var = 2324
+    2263: Variance = 2325
+    2264: Vector = 2326
+    2265: Vectorproduct = 2327
+    2266: Verso = 2328
+    2267: Vertical = 2329
+    2268: VerticalAlign = 2330
+    2269: VerticalLr = 2331
+    2270: VerticalRl = 2332
+    2271: VerticalText = 2333
+    2272: VerticalViewportSegments = 2334
+    2273: Video = 2335
+    2274: VideoColorGamut = 2336
+    2275: VideoDynamicRange = 2337
+    2276: View = 2338
+    2277: ViewBox = 2339
+    2278: ViewTimeline = 2340
+    2279: ViewTimelineAxis = 2341
+    2280: ViewTimelineInset = 2342
+    2281: ViewTimelineName = 2343
+    2282: ViewTransition = 2344
+    2283: ViewTransitionClass = 2345
+    2284: ViewTransitionGroup = 2346
+    2285: ViewTransitionImagePair = 2347
+    2286: ViewTransitionName = 2348
+    2287: ViewTransitionNew = 2349
+    2288: ViewTransitionOld = 2350
+    2289: ViewTransitionScope = 2351
+    2290: Violet = 2352
+    2291: Visibility = 2353
+    2292: Visible = 2354
+    2293: Visiblefill = 2355
+    2294: Visiblepainted = 2356
+    2295: Visiblestroke = 2357
+    2296: Visited = 2358
+    2297: Visitedtext = 2359
+    2298: Vline = 2360
+    2299: VoiceBalance = 2361
+    2300: VoiceDuration = 2362
+    2301: VoiceFamily = 2363
+    2302: VoicePitch = 2364
+    2303: VoiceRange = 2365
+    2304: VoiceRate = 2366
+    2305: VoiceStress = 2367
+    2306: VoiceVolume = 2368
+    2307: VolumeLocked = 2369
+    2308: W = 2370
+    2309: WResize = 2371
+    2310: Wait = 2372
+    2311: Wavy = 2373
+    2312: Wbr = 2374
+    2313: Weak = 2375
+    2314: Weight = 2376
+    2315: Wheat = 2377
+    2316: Where = 2378
+    2317: White = 2379
+    2318: WhiteSpace = 2380
+    2319: WhiteSpaceCollapse = 2381
+    2320: WhiteSpaceTrim = 2382
+    2321: Whitesmoke = 2383
+    2322: Widows = 2384
+    2323: Width = 2385
+    2324: WillChange = 2386
+    2325: WindowDrag = 2387
+    2326: WindowsVista = 2388
+    2327: WindowsWin10 = 2389
+    2328: WindowsWin7 = 2390
+    2329: WindowsWin8 = 2391
+    2330: WindowsXp = 2392
+    2331: With = 2393
+    2332: WordBreak = 2394
+    2333: WordSpaceTransform = 2395
+    2334: WordSpacing = 2396
+    2335: WordWrap = 2397
+    2336: Words = 2398
+    2337: Wrap = 2399
+    2338: WrapAfter = 2400
+    2339: WrapBefore = 2401
+    2340: WrapFlow = 2402
+    2341: WrapInside = 2403
+    2342: WrapReverse = 2404
+    2343: WrapThrough = 2405
+    2344: WritingMode = 2406
+    2345: XEnd = 2407
+    2346: XFast = 2408
+    2347: XLarge = 2409
+    2348: XLoud = 2410
+    2349: XSelfEnd = 2411
+    2350: XSelfStart = 2412
+    2351: XSlow = 2413
+    2352: XSmall = 2414
+    2353: XSoft = 2415
+    2354: XStart = 2416
+    2355: XStrong = 2417
+    2356: XWeak = 2418
+    2357: Xmp = 2419
+    2358: Xo = 2420
+    2359: Xor = 2421
+    2360: XxLarge = 2422
+    2361: XxSmall = 2423
+    2362: Xywh = 2424
+    2363: Xyz = 2425
+    2364: XyzD50 = 2426
+    2365: XyzD65 = 2427
+    2366: Y = 2428
+    2367: YEnd = 2429
+    2368: YSelfEnd = 2430
+    2369: YSelfStart = 2431
+    2370: YStart = 2432
+    2371: Yellow = 2433
+    2372: Yellowgreen = 2434
+    2373: Young = 2435
+    2374: Z = 2436
+    2375: ZIndex = 2437
+    2376: ZeroIfExtrinsic = 2438
+    2377: ZeroIfScroll = 2439
+    2378: Zoom = 2440
+    2379: ZoomIn = 2441
+    2380: ZoomOut = 2442
+    2381: _NegInfinity = 2443
+    2382: _WebkitAlignContent = 8388608
+    2383: _WebkitAlignItems = 8388609
+    2384: _WebkitAlignSelf = 8388610
+    2385: _WebkitAnimatingFullScreenTransition = 8388611
+    2386: _WebkitAnimation = 8388612
+    2387: _WebkitAnimationDelay = 8388613
+    2388: _WebkitAnimationDuration = 8388614
+    2389: _WebkitAnimationFillMode = 8388615
+    2390: _WebkitAnimationIterationCount = 8388616
+    2391: _WebkitAnimationName = 8388617
+    2392: _WebkitAnimationTimingFunction = 8388618
+    2393: _WebkitAny = 8388619
+    2394: _WebkitAnyLink = 8388620
+    2395: _WebkitAppearance = 8388621
+    2396: _WebkitAutofill = 8388622
+    2397: _WebkitAutofillAndObscured = 8388623
+    2398: _WebkitAutofillStrongPassword = 8388624
+    2399: _WebkitAutofillStrongPasswordViewable = 8388625
+    2400: _WebkitBackdropFilter = 8388626
+    2401: _WebkitBackfaceVisibility = 8388627
+    2402: _WebkitBackgroundClip = 8388628
+    2403: _WebkitBackgroundSize = 8388629
+    2404: _WebkitBox = 8388630
+    2405: _WebkitBoxAlign = 8388631
+    2406: _WebkitBoxDecorationBreak = 8388632
+    2407: _WebkitBoxDirection = 8388633
+    2408: _WebkitBoxFlex = 8388634
+    2409: _WebkitBoxOrdinalGroup = 8388635
+    2410: _WebkitBoxOrient = 8388636
+    2411: _WebkitBoxPack = 8388637
+    2412: _WebkitBoxReflect = 8388638
+    2413: _WebkitBoxShadow = 8388639
+    2414: _WebkitBoxSizing = 8388640
+    2415: _WebkitCalendarPickerIndicator = 8388641
+    2416: _WebkitCapsLockIndicator = 8388642
+    2417: _WebkitClipPath = 8388643
+    2418: _WebkitColorSwatch = 8388644
+    2419: _WebkitColorSwatchWrapper = 8388645
+    2420: _WebkitColumnCount = 8388646
+    2421: _WebkitColumnGap = 8388647
+    2422: _WebkitContactsAutoFillButton = 8388648
+    2423: _WebkitCredentialsAutoFillButton = 8388649
+    2424: _WebkitCreditCardAutoFillButton = 8388650
+    2425: _WebkitDateAndTimeValue = 8388651
+    2426: _WebkitDatetimeEdit = 8388652
+    2427: _WebkitDatetimeEditDayField = 8388653
+    2428: _WebkitDatetimeEditFieldsWrapper = 8388654
+    2429: _WebkitDatetimeEditHourField = 8388655
+    2430: _WebkitDatetimeEditMeridiemField = 8388656
+    2431: _WebkitDatetimeEditMillisecondField = 8388657
+    2432: _WebkitDatetimeEditMinute = 8388658
+    2433: _WebkitDatetimeEditMinuteField = 8388659
+    2434: _WebkitDatetimeEditMonthField = 8388660
+    2435: _WebkitDatetimeEditSecondField = 8388661
+    2436: _WebkitDatetimeEditText = 8388662
+    2437: _WebkitDatetimeEditYearField = 8388663
+    2438: _WebkitDetailsMarker = 8388664
+    2439: _WebkitDevicePixelRatio = 8388665
+    2440: _WebkitDistributed = 8388666
+    2441: _WebkitDrag = 8388667
+    2442: _WebkitFileUploadButton = 8388668
+    2443: _WebkitFilter = 8388669
+    2444: _WebkitFlex = 8388670
+    2445: _WebkitFlexBasis = 8388671
+    2446: _WebkitFlexDirection = 8388672
+    2447: _WebkitFlexFlow = 8388673
+    2448: _WebkitFlexGrow = 8388674
+    2449: _WebkitFlexWrap = 8388675
+    2450: _WebkitFontSmoothing = 8388676
+    2451: _WebkitFullPageMedia = 8388677
+    2452: _WebkitFullScreen = 8388678
+    2453: _WebkitFullScreenAncestor = 8388679
+    2454: _WebkitFullScreenControlsHidden = 8388680
+    2455: _WebkitFullScreenDocument = 8388681
+    2456: _WebkitGenericCueRoot = 8388682
+    2457: _WebkitGrab = 8388683
+    2458: _WebkitGrabbing = 8388684
+    2459: _WebkitInlineBox = 8388685
+    2460: _WebkitInlineFlex = 8388686
+    2461: _WebkitInnerSpinButton = 8388687
+    2462: _WebkitInputPlaceholder = 8388688
+    2463: _WebkitJustifyContent = 8388689
+    2464: _WebkitKeyframes = 8388690
+    2465: _WebkitLineClamp = 8388691
+    2466: _WebkitListButton = 8388692
+    2467: _WebkitMarginEnd = 8388693
+    2468: _WebkitMask = 8388694
+    2469: _WebkitMaskBoxImage = 8388695
+    2470: _WebkitMaskPosition = 8388696
+    2471: _WebkitMaskSize = 8388697
+    2472: _WebkitMatchParent = 8388698
+    2473: _WebkitMaxContent = 8388699
+    2474: _WebkitMaxDevicePixelRatio = 8388700
+    2475: _WebkitMediaTextTrackContainer = 8388701
+    2476: _WebkitMediaTextTrackDisplay = 8388702
+    2477: _WebkitMediaTextTrackDisplayBackdrop = 8388703
+    2478: _WebkitMediaTextTrackRegion = 8388704
+    2479: _WebkitMediaTextTrackRegionContainer = 8388705
+    2480: _WebkitMeterBar = 8388706
+    2481: _WebkitMeterEvenLessGoodValue = 8388707
+    2482: _WebkitMeterInnerElement = 8388708
+    2483: _WebkitMeterOptimumValue = 8388709
+    2484: _WebkitMeterSuboptimumValue = 8388710
+    2485: _WebkitMinContent = 8388711
+    2486: _WebkitMinDevicePixelRatio = 8388712
+    2487: _WebkitOrder = 8388713
+    2488: _WebkitOuterSpinButton = 8388714
+    2489: _WebkitOverflowScrolling = 8388715
+    2490: _WebkitPasswordAutoFillButton = 8388716
+    2491: _WebkitPerspective = 8388717
+    2492: _WebkitPrintColorAdjust = 8388718
+    2493: _WebkitProgressBar = 8388719
+    2494: _WebkitProgressInnerElement = 8388720
+    2495: _WebkitProgressValue = 8388721
+    2496: _WebkitResizer = 8388722
+    2497: _WebkitScrollbar = 8388723
+    2498: _WebkitScrollbarButton = 8388724
+    2499: _WebkitScrollbarCorner = 8388725
+    2500: _WebkitScrollbarThumb = 8388726
+    2501: _WebkitScrollbarTrack = 8388727
+    2502: _WebkitScrollbarTrackPiece = 8388728
+    2503: _WebkitSearchCancelButton = 8388729
+    2504: _WebkitSearchDecoration = 8388730
+    2505: _WebkitSearchResultsButton = 8388731
+    2506: _WebkitSliderContainer = 8388732
+    2507: _WebkitSliderRunnableTrack = 8388733
+    2508: _WebkitSliderThumb = 8388734
+    2509: _WebkitSticky = 8388735
+    2510: _WebkitTapHighlightColor = 8388736
+    2511: _WebkitTextDecoration = 8388737
+    2512: _WebkitTextDecorationColor = 8388738
+    2513: _WebkitTextDecorationSkipInk = 8388739
+    2514: _WebkitTextFillColor = 8388740
+    2515: _WebkitTextSizeAdjust = 8388741
+    2516: _WebkitTextStroke = 8388742
+    2517: _WebkitTextStrokeColor = 8388743
+    2518: _WebkitTextStrokeWidth = 8388744
+    2519: _WebkitTextfieldDecorationContainer = 8388745
+    2520: _WebkitTouchCallout = 8388746
+    2521: _WebkitTransform = 8388747
+    2522: _WebkitTransform2d = 8388748
+    2523: _WebkitTransform3d = 8388749
+    2524: _WebkitTransformOrigin = 8388750
+    2525: _WebkitTransition = 8388751
+    2526: _WebkitTransitionDelay = 8388752
+    2527: _WebkitTransitionDuration = 8388753
+    2528: _WebkitTransitionProperty = 8388754
+    2529: _WebkitTransitionTimingFunction = 8388755
+    2530: _WebkitUserDrag = 8388756
+    2531: _WebkitUserSelect = 8388757
+    2532: _WebkitValidationBubble = 8388758
+    2533: _WebkitValidationBubbleArrow = 8388759
+    2534: _WebkitValidationBubbleArrowClipper = 8388760
+    2535: _WebkitValidationBubbleBody = 8388761
+    2536: _WebkitValidationBubbleHeading = 8388762
+    2537: _WebkitValidationBubbleIcon = 8388763
+    2538: _WebkitValidationBubbleMessage = 8388764
+    2539: _WebkitValidationBubbleTextBlock = 8388765
+    2540: _WebkitVideoPlayableInline = 8388766
+    2541: _MozAnonymousBlock = 10485760
+    2542: _MozAnonymousItem = 10485761
+    2543: _MozAnonymousPositionedBlock = 10485762
+    2544: _MozAny = 10485763
+    2545: _MozAnyLink = 10485764
+    2546: _MozAppearance = 10485765
+    2547: _MozBlockInsideInlineWrapper = 10485766
+    2548: _MozBlockRubyContent = 10485767
+    2549: _MozBox = 10485768
+    2550: _MozBoxSizing = 10485769
+    2551: _MozBroken = 10485770
+    2552: _MozButtonContent = 10485771
+    2553: _MozCanvas = 10485772
+    2554: _MozCellContent = 10485773
+    2555: _MozColorSwatch = 10485774
+    2556: _MozColumnContent = 10485775
+    2557: _MozColumnCount = 10485776
+    2558: _MozColumnGap = 10485777
+    2559: _MozColumnSet = 10485778
+    2560: _MozColumnSpanWrapper = 10485779
+    2561: _MozDeviceOrientation = 10485780
+    2562: _MozDevicePixelRatio = 10485781
+    2563: _MozDocument = 10485782
+    2564: _MozDragOver = 10485783
+    2565: _MozDropdownList = 10485784
+    2566: _MozFieldsetContent = 10485785
+    2567: _MozFilter = 10485786
+    2568: _MozFirstLetterContinuation = 10485787
+    2569: _MozFirstNode = 10485788
+    2570: _MozFlex = 10485789
+    2571: _MozFlexbox = 10485790
+    2572: _MozFocusInner = 10485791
+    2573: _MozFocusOuter = 10485792
+    2574: _MozFocusring = 10485793
+    2575: _MozFramesetBlank = 10485794
+    2576: _MozFullScreen = 10485795
+    2577: _MozFullScreenAncestor = 10485796
+    2578: _MozHandlerBlocked = 10485797
+    2579: _MozHandlerCrashed = 10485798
+    2580: _MozHandlerDisabled = 10485799
+    2581: _MozHframesetBorder = 10485800
+    2582: _MozHtmlCanvasContent = 10485801
+    2583: _MozImagesInMenus = 10485802
+    2584: _MozInlineBox = 10485803
+    2585: _MozInlineStack = 10485804
+    2586: _MozInlineTable = 10485805
+    2587: _MozLastNode = 10485806
+    2588: _MozLineFrame = 10485807
+    2589: _MozListBullet = 10485808
+    2590: _MozListNumber = 10485809
+    2591: _MozLoading = 10485810
+    2592: _MozLocaleDir = 10485811
+    2593: _MozLwtheme = 10485812
+    2594: _MozLwthemeBrighttext = 10485813
+    2595: _MozLwthemeDarktext = 10485814
+    2596: _MozMacGraphiteTheme = 10485815
+    2597: _MozMaemoClassicTheme = 10485816
+    2598: _MozMathmlAnonymousBlock = 10485817
+    2599: _MozMaxContent = 10485818
+    2600: _MozMaxDevicePixelRatio = 10485819
+    2601: _MozMeterBar = 10485820
+    2602: _MozMeterOptimum = 10485821
+    2603: _MozMeterSubOptimum = 10485822
+    2604: _MozMeterSubSubOptimum = 10485823
+    2605: _MozMinContent = 10485824
+    2606: _MozMinDevicePixelRatio = 10485825
+    2607: _MozNativeAnonymous = 10485826
+    2608: _MozNumberSpinBox = 10485827
+    2609: _MozNumberSpinDown = 10485828
+    2610: _MozNumberSpinUp = 10485829
+    2611: _MozOnlyWhitespace = 10485830
+    2612: _MozOofPlaceholder = 10485831
+    2613: _MozOsVersion = 10485832
+    2614: _MozOsxFontSmoothing = 10485833
+    2615: _MozPage = 10485834
+    2616: _MozPageBreak = 10485835
+    2617: _MozPageContent = 10485836
+    2618: _MozPageSequence = 10485837
+    2619: _MozPagebreak = 10485838
+    2620: _MozPagecontent = 10485839
+    2621: _MozPlaceholder = 10485840
+    2622: _MozPlaceholderShown = 10485841
+    2623: _MozPrintedSheet = 10485842
+    2624: _MozProgressBar = 10485843
+    2625: _MozRangeProgress = 10485844
+    2626: _MozRangeThumb = 10485845
+    2627: _MozRangeTrack = 10485846
+    2628: _MozReadOnly = 10485847
+    2629: _MozReadWrite = 10485848
+    2630: _MozReveal = 10485849
+    2631: _MozRuby = 10485850
+    2632: _MozRubyBase = 10485851
+    2633: _MozRubyBaseContainer = 10485852
+    2634: _MozRubyText = 10485853
+    2635: _MozRubyTextContainer = 10485854
+    2636: _MozScrolledCanvas = 10485855
+    2637: _MozScrolledContent = 10485856
+    2638: _MozScrolledPageSequence = 10485857
+    2639: _MozSearchClearButton = 10485858
+    2640: _MozSelection = 10485859
+    2641: _MozSubmitInvalid = 10485860
+    2642: _MozSuppressed = 10485861
+    2643: _MozSvgForeignContent = 10485862
+    2644: _MozSvgMarkerAnonChild = 10485863
+    2645: _MozSvgMarkerOuterSvgAnonChild = 10485864
+    2646: _MozSvgText = 10485865
+    2647: _MozTable = 10485866
+    2648: _MozTableCell = 10485867
+    2649: _MozTableColumn = 10485868
+    2650: _MozTableColumnGroup = 10485869
+    2651: _MozTableOuter = 10485870
+    2652: _MozTableRow = 10485871
+    2653: _MozTableRowGroup = 10485872
+    2654: _MozTableWrapper = 10485873
+    2655: _MozTextControlEditingRoot = 10485874
+    2656: _MozTextControlPreview = 10485875
+    2657: _MozTouchEnabled = 10485876
+    2658: _MozTransition = 10485877
+    2659: _MozTreeCell = 10485878
+    2660: _MozTreeCellText = 10485879
+    2661: _MozTreeCheckbox = 10485880
+    2662: _MozTreeColumn = 10485881
+    2663: _MozTreeDropFeedback = 10485882
+    2664: _MozTreeImage = 10485883
+    2665: _MozTreeIndentation = 10485884
+    2666: _MozTreeLine = 10485885
+    2667: _MozTreeRow = 10485886
+    2668: _MozTreeSeparator = 10485887
+    2669: _MozTreeTwisty = 10485888
+    2670: _MozUiInvalid = 10485889
+    2671: _MozUiValid = 10485890
+    2672: _MozUserDisabled = 10485891
+    2673: _MozUserSelect = 10485892
+    2674: _MozVframesetBorder = 10485893
+    2675: _MozViewport = 10485894
+    2676: _MozViewportScroll = 10485895
+    2677: _MozWindowInactive = 10485896
+    2678: _MsAutohidingScrollbar = 12582912
+    2679: _MsBackdrop = 12582913
+    2680: _MsBoxSizing = 12582914
+    2681: _MsBrowse = 12582915
+    2682: _MsCheck = 12582916
+    2683: _MsClear = 12582917
+    2684: _MsColumnCount = 12582918
+    2685: _MsDevicePixelRatio = 12582919
+    2686: _MsExpand = 12582920
+    2687: _MsFill = 12582921
+    2688: _MsFillLower = 12582922
+    2689: _MsFillUpper = 12582923
+    2690: _MsFilter = 12582924
+    2691: _MsFlex = 12582925
+    2692: _MsFlexAlign = 12582926
+    2693: _MsFlexDirection = 12582927
+    2694: _MsFlexFlow = 12582928
+    2695: _MsFlexItemAlign = 12582929
+    2696: _MsFlexLinePack = 12582930
+    2697: _MsFlexNegative = 12582931
+    2698: _MsFlexOrder = 12582932
+    2699: _MsFlexPack = 12582933
+    2700: _MsFlexPositive = 12582934
+    2701: _MsFlexPreferredSize = 12582935
+    2702: _MsFlexWrap = 12582936
+    2703: _MsFlexbox = 12582937
+    2704: _MsFullscreen = 12582938
+    2705: _MsGrid = 12582939
+    2706: _MsHighContrast = 12582940
+    2707: _MsInterpolationMode = 12582941
+    2708: _MsImeAlign = 12582942
+    2709: _MsInlineFlex = 12582943
+    2710: _MsInlineFlexbox = 12582944
+    2711: _MsInputPlaceholder = 12582945
+    2712: _MsMaxColumnCount = 12582946
+    2713: _MsMaxDevicepixelRatio = 12582947
+    2714: _MsMinColumnCount = 12582948
+    2715: _MsMinDevicePixelRatio = 12582949
+    2716: _MsOverflowStyle = 12582950
+    2717: _MsPlaceholder = 12582951
+    2718: _MsReveal = 12582952
+    2719: _MsSelection = 12582953
+    2720: _MsTextSizeAdjust = 12582954
+    2721: _MsThumb = 12582955
+    2722: _MsTicksAfter = 12582956
+    2723: _MsTicksBefore = 12582957
+    2724: _MsTooltip = 12582958
+    2725: _MsTouchAction = 12582959
+    2726: _MsTrack = 12582960
+    2727: _MsTransform = 12582961
+    2728: _MsTransformOrigin = 12582962
+    2729: _MsTransition = 12582963
+    2730: _MsUserSelect = 12582964
+    2731: _MsValue = 12582965
+    2732: _MsViewState = 12582966
+    2733: _MsWordBreak = 12582967
+    2734: _OBoxSizing = 14680064
+    2735: _ODevicePixelRatio = 14680065
+    2736: _OFilter = 14680066
+    2737: _OFlex = 14680067
+    2738: _OInnerSpinButton = 14680068
+    2739: _OMaxDevicePixelRatio = 14680069
+    2740: _OMinDevicePixelRatio = 14680070
+    2741: _OObjectFit = 14680071
+    2742: _OOuterSpinButton = 14680072
+    2743: _OPlaceholder = 14680073
+    2744: _OPrefocus = 14680074
+    2745: _OScrollbar = 14680075
+    2746: _OScrollbarThumb = 14680076
+    2747: _OScrollbarTrack = 14680077
+    2748: _OScrollbarTrackPiece = 14680078
+    2749: _OSelection = 14680079
+CubicBezierFunction: size=176 align=8 {
+    name: 0
+    params: 16
+    close: 160
+}
+CubicBezierFunctionParams: size=144 align=8 {
+    x1: 0
+    c1: 24
+    x2: 40
+    c2: 64
+    y1: 80
+    c3: 104
+    y2: 120
+}
+CueAfterStyleValue: size=80 align=8 {
+    0: 0
+}
+CueBeforeStyleValue: size=80 align=8 {
+    0: 0
+}
+CueStyleValue: size=160 align=8 {
+    0: 0
+    1: 80
+}
+CursorImage: size=112 align=8
+    0: Url
+    1: UrlSet
+CursorPredefined: size=16 align=4
+    0: Auto
+    1: Default
+    2: None
+    3: ContextMenu
+    4: Help
+    5: Pointer
+    6: Progress
+    7: Wait
+    8: Cell
+    9: Crosshair
+    10: Text
+    11: VerticalText
+    12: Alias
+    13: Copy
+    14: Move
+    15: NoDrop
+    16: NotAllowed
+    17: Grab
+    18: Grabbing
+    19: EResize
+    20: NResize
+    21: NeResize
+    22: NwResize
+    23: SResize
+    24: SeResize
+    25: SwResize
+    26: WResize
+    27: EwResize
+    28: NsResize
+    29: NeswResize
+    30: NwseResize
+    31: ColResize
+    32: RowResize
+    33: AllScroll
+    34: ZoomIn
+    35: ZoomOut
+    36: _WebkitGrab
+    37: _WebkitGrabbing
+CursorStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+CurveCommand: size=464 align=8 {
+    keyword: 0
+    target: 16
+}
+CurveTarget: size=448 align=8
+    0: ToPositionWithControlPoint
+    1: ByCoordinatePairWithRelativeControlPointRelativeControlPoint
+Custom: size=24 align=8 {
+    0: 0
+}
+CustomDimension: size=12 align=4 {
+    0: 0
+}
+CustomElementTag: size=12 align=4 {
+    0: 0
+}
+CustomIdent: size=12 align=4 {
+    0: 0
+}
+DashedIdent: size=12 align=4 {
+    0: 0
+}
+Decibel: size=12 align=4 {
+    0: 0
+}
+DeviceHeightMediaFeature: size=128 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+DeviceWidthMediaFeature: size=128 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+DirPseudoFunction: size=56 align=4 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 40
+}
+DirValue: size=16 align=4
+    0: Rtl
+    1: Ltr
+DirectionStyleValue: size=16 align=4
+    0: Ltr
+    1: Rtl
+DiscretionaryLigValues: size=16 align=4
+    0: DiscretionaryLigatures
+    1: NoDiscretionaryLigatures
+DisplayBox: size=16 align=4
+    0: Contents
+    1: None
+DisplayInside: size=16 align=4
+    0: Flow
+    1: FlowRoot
+    2: Table
+    3: Flex
+    4: Grid
+    5: Ruby
+DisplayInternal: size=16 align=4
+    0: TableRowGroup
+    1: TableHeaderGroup
+    2: TableFooterGroup
+    3: TableRow
+    4: TableCell
+    5: TableColumnGroup
+    6: TableColumn
+    7: TableCaption
+    8: RubyBase
+    9: RubyText
+    10: RubyBaseContainer
+    11: RubyTextContainer
+DisplayLegacy: size=16 align=4
+    0: InlineBlock
+    1: InlineTable
+    2: InlineFlex
+    3: InlineGrid
+DisplayLegacyVendor: size=16 align=4
+    0: LegacyBox
+    1: WebkitBox
+    2: WebkitInlineBox
+    3: WebkitFlex
+    4: WebkitInlineFlex
+    5: MozBox
+    6: MozInlineBox
+    7: MozFlex
+    8: MozFlexbox
+    9: MozInlineStack
+    10: MsFlex
+    11: MsInlineFlex
+    12: MsFlexbox
+    13: MsInlineFlexbox
+    14: MsGrid
+    15: OFlex
+DisplayListitem: size=44 align=4 {
+    outside: 0
+    inside: 16
+    list_item: 32
+}
+DisplayListitemInside: size=16 align=4
+    0: Flow
+    1: FlowRoot
+DisplayModeMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+DisplayModeMediaFeatureKeyword: size=16 align=4
+    0: Fullscreen
+    1: Standalone
+    2: MinimalUi
+    3: Browser
+    4: PictureInPicture
+DisplayOutside: size=16 align=4
+    0: Block
+    1: Inline
+    2: RunIn
+DisplayStyleValue: size=64 align=8
+    0: DisplayOutsideInside
+    1: DisplayListitem
+    2: DisplayInternal
+    3: DisplayBox
+    4: DisplayLegacy
+    5: DisplayLegacyVendor
+DocumentMatcher: size=40 align=4
+    0: Url
+    1: UrlFunction
+    2: UrlPrefix
+    3: Domain
+    4: MediaDocument
+    5: Regexp
+DocumentMatcherList: size=24 align=8 {
+    0: 0
+}
+DocumentRule: size=160 align=16 {
+    name: 0
+    prelude: 16
+    block: 48
+}
+DocumentRuleBlock: size=112 align=16 {
+    0: 0
+}
+DominantBaselineStyleValue: size=32 align=8 {
+    0: 0
+}
+DropShadowFunction: size=128 align=8 {
+    name: 0
+    color: 16
+    offset_x: 40
+    offset_y: 64
+    blur_radius: 88
+    close: 112
+}
+DynamicRangeLimitMixFunction: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+DynamicRangeLimitMixFunctionParams: size=88 align=8 {
+    0: 0
+    1: 64
+}
+DynamicRangeLimitStyleValue: size=64 align=8
+    0: Standard
+    1: NoLimit
+    2: Constrained
+    3: DynamicRangeLimitMixFunction
+DynamicRangeMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+DynamicRangeMediaFeatureKeyword: size=16 align=4
+    0: Standard
+    1: High
+EasingFunction: size=184 align=8
+    0: Linear
+    1: Ease
+    2: EaseIn
+    3: EaseOut
+    4: EaseInOut
+    5: StepStart
+    6: StepEnd
+    7: LinearFunction
+    8: CubicBezierFunction
+    9: StepsFunction
+EastAsianVariantValues: size=16 align=4
+    0: Jis78
+    1: Jis83
+    2: Jis90
+    3: Jis04
+    4: Simplified
+    5: Traditional
+EastAsianWidthValues: size=16 align=4
+    0: FullWidth
+    1: ProportionalWidth
+EllipseFunction: size=232 align=8 {
+    name: 0
+    size: 16
+    at: 88
+    close: 216
+}
+EmptyCellsStyleValue: size=16 align=4
+    0: Show
+    1: Hide
+EnvironmentBlendingMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+EnvironmentBlendingMediaFeatureKeyword: size=16 align=4
+    0: Opaque
+    1: Additive
+    2: Subtractive
+EventTriggerEvent: size=40 align=4
+    0: Activate
+    1: Click
+    2: Touch
+    3: Dblclick
+    4: KeypressFunction
+EventTriggerNameStyleValue: size=32 align=8 {
+    0: 0
+}
+EventTriggerSourceStyleValue: size=24 align=8 {
+    0: 0
+}
+EventTriggerStyleValue: size=32 align=8 {
+    0: 0
+}
+ExpFunction: size=144 align=8 {
+    name: 0
+    params: 16
+    close: 128
+}
+ExplicitTrackList: size=80 align=8 {
+    leading_names: 0
+    items: 56
+}
+FallbackStyleValue: size=12 align=4 {
+    0: 0
+}
+FeatureTagToggle: size=32 align=8
+    0: On
+    1: Off
+    2: Integer
+FeatureTagValue: size=48 align=8 {
+    0: 0
+    1: 16
+}
+FieldSizingStyleValue: size=16 align=4
+    0: Fixed
+    1: Content
+FillBreakStyleValue: size=16 align=4
+    0: BoundingBox
+    1: Slice
+    2: Clone
+FillColorStyleValue: size=32 align=8 {
+    0: 0
+}
+FillImageStyleValue: size=24 align=8 {
+    0: 0
+}
+FillLayer: size=368 align=8 {
+    image: 0
+    position: 72
+    repeat: 288
+    origin: 324
+    color: 344
+}
+FillOpacityStyleValue: size=24 align=8 {
+    0: 0
+}
+FillOrigin: size=16 align=4
+    0: MatchParent
+    1: FillBox
+    2: StrokeBox
+    3: ContentBox
+    4: PaddingBox
+    5: BorderBox
+FillOriginStyleValue: size=16 align=4
+    0: MatchParent
+    1: FillBox
+    2: StrokeBox
+    3: ContentBox
+    4: PaddingBox
+    5: BorderBox
+FillPositionStyleValue: size=24 align=8 {
+    0: 0
+}
+FillRepeatStyleValue: size=24 align=8 {
+    0: 0
+}
+FillRuleStyleValue: size=16 align=4
+    0: Nonzero
+    1: Evenodd
+FillSizeStyleValue: size=24 align=8 {
+    0: 0
+}
+FillStyleValue: size=24 align=8 {
+    0: 0
+}
+FilterFunction: size=136 align=8
+    0: Blur
+    1: Brightness
+    2: Contrast
+    3: DropShadow
+    4: Grayscale
+    5: HueRotate
+    6: Invert
+    7: Opacity
+    8: Saturate
+    9: Sepia
+FilterStyleValue: size=40 align=8 {
+    0: 0
+}
+FilterValue: size=144 align=8
+    0: FilterFunction
+    1: Url
+FilterValueList: size=24 align=8 {
+    0: 0
+}
+FitContentFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+FixedSize: size=136 align=8
+    0: FixedBreadth
+    1: MinmaxFunction
+Flex: size=12 align=4 {
+    0: 0
+}
+FlexBasisStyleValue: size=80 align=8
+    0: Content
+    1: Width
+FlexDirectionStyleValue: size=16 align=4
+    0: Row
+    1: RowReverse
+    2: Column
+    3: ColumnReverse
+FlexFlowStyleValue: size=52 align=4 {
+    flex_direction: 0
+    flex_wrap: 16
+}
+FlexGrowStyleValue: size=24 align=8 {
+    0: 0
+}
+FlexLineCountStyleValue: size=24 align=8 {
+    0: 0
+}
+FlexShrinkStyleValue: size=24 align=8 {
+    0: 0
+}
+FlexStyleValue: size=136 align=8 {
+    0: 0
+}
+FlexStyleValueOptions: size=128 align=8 {
+    flex_grow: 0
+    flex_basis: 48
+}
+FlexWrapStyleValue: size=36 align=4
+    0: Nowrap
+    1: Wrap
+    2: WrapReverse
+FloatDeferStyleValue: size=32 align=8
+    0: Integer
+    1: Last
+    2: None
+FloatOffsetStyleValue: size=32 align=8 {
+    0: 0
+}
+FloatReferenceStyleValue: size=16 align=4
+    0: Inline
+    1: Column
+    2: Region
+    3: Page
+FloatStyleValue: size=120 align=8
+    0: BlockStart
+    1: BlockEnd
+    2: InlineStart
+    3: InlineEnd
+    4: SnapBlock
+    5: SnapBlockFunction
+    6: SnapInline
+    7: SnapInlineFunction
+    8: Left
+    9: Right
+    10: Top
+    11: Bottom
+    12: None
+FloodColorStyleValue: size=32 align=8 {
+    0: 0
+}
+FloodOpacityStyleValue: size=24 align=8 {
+    0: 0
+}
+FlowFromStyleValue: size=32 align=8 {
+    0: 0
+}
+FlowIntoStyleValue: size=48 align=8
+    0: None
+    1: CustomIdentElement
+    2: CustomIdentContent
+    3: CustomIdent
+FlowToleranceStyleValue: size=40 align=8
+    0: Normal
+    1: LengthPercentage
+    2: Infinite
+FontFaceRule: size=128 align=16 {
+    name: 0
+    block: 16
+}
+FontFaceRuleBlock: size=112 align=16 {
+    0: 0
+}
+FontFaceRuleStyleValue: size=664 align=8 {
+    0: 0
+}
+FontFamilyName: size=32 align=8
+    0: String
+    1: CustomIdents
+FontFamilyStyleValue: size=24 align=8 {
+    0: 0
+}
+FontFeatureSettingsStyleValue: size=32 align=8 {
+    0: 0
+}
+FontKerningStyleValue: size=16 align=4
+    0: Auto
+    1: Normal
+    2: None
+FontLanguageOverrideStyleValue: size=32 align=8 {
+    0: 0
+}
+FontOpticalSizingStyleValue: size=16 align=4
+    0: Auto
+    1: None
+FontPaletteStyleValue: size=32 align=8
+    0: Normal
+    1: Light
+    2: Dark
+    3: PaletteIdentifier
+    4: PaletteMixFunction
+FontSizeAdjustStyleValue: size=48 align=8
+    0: None
+    1: ExHeightFromFont
+    2: CapHeightFromFont
+    3: ChWidthFromFont
+    4: IcWidthFromFont
+    5: IcHeightFromFont
+    6: FromFont
+    7: ExHeightNumber
+    8: CapHeightNumber
+    9: ChWidthNumber
+    10: IcWidthNumber
+    11: IcHeightNumber
+    12: Number
+FontSizeStyleValue: size=40 align=8
+    0: AbsoluteSize
+    1: RelativeSize
+    2: LengthPercentage
+    3: Math
+FontStyleStyleValue: size=48 align=8
+    0: Normal
+    1: Italic
+    2: Left
+    3: Right
+    4: Oblique
+FontSynthesisPositionStyleValue: size=16 align=4
+    0: Auto
+    1: None
+FontSynthesisSmallCapsStyleValue: size=16 align=4
+    0: Auto
+    1: None
+FontSynthesisStyleStyleValue: size=16 align=4
+    0: Auto
+    1: None
+    2: ObliqueOnly
+FontSynthesisStyleValue: size=68 align=4 {
+    0: 0
+}
+FontSynthesisStyleValueOptions: size=64 align=4 {
+    weight: 0
+    style: 16
+    small_caps: 32
+    position: 48
+}
+FontSynthesisWeightStyleValue: size=16 align=4
+    0: Auto
+    1: None
+FontVariantCapsStyleValue: size=16 align=4
+    0: Normal
+    1: SmallCaps
+    2: AllSmallCaps
+    3: PetiteCaps
+    4: AllPetiteCaps
+    5: Unicase
+    6: TitlingCaps
+FontVariantEastAsianStyleValue: size=72 align=8 {
+    0: 0
+}
+FontVariantEastAsianStyleValueOptions: size=64 align=8 {
+    east_asian_variant_values: 0
+    east_asian_width_values: 24
+    ruby: 48
+}
+FontVariantEmojiStyleValue: size=16 align=4
+    0: Normal
+    1: Text
+    2: Emoji
+    3: Unicode
+FontVariantLigaturesStyleValue: size=104 align=8
+    0: Normal
+    1: None
+    2: CommonLigValuesDiscretionaryLigValuesHistoricalLigValuesContextualAltValues
+FontVariantNumericStyleValue: size=112 align=8 {
+    0: 0
+}
+FontVariantNumericStyleValueOptions: size=104 align=8 {
+    numeric_figure_values: 0
+    numeric_spacing_values: 24
+    numeric_fraction_values: 48
+    ordinal: 72
+    slashed_zero: 88
+}
+FontVariantPositionStyleValue: size=16 align=4
+    0: Normal
+    1: Sub
+    2: Super
+FontVariationSettingsStyleValue: size=32 align=8 {
+    0: 0
+}
+FontWeightAbsolute: size=32 align=8
+    0: Normal
+    1: Bold
+    2: Number
+FontWeightStyleValue: size=48 align=8
+    0: FontWeightAbsolute
+    1: Bolder
+    2: Lighter
+FontWidthStyleValue: size=32 align=8
+    0: Normal
+    1: Percentage
+    2: UltraCondensed
+    3: ExtraCondensed
+    4: Condensed
+    5: SemiCondensed
+    6: SemiExpanded
+    7: Expanded
+    8: ExtraExpanded
+    9: UltraExpanded
+FootnoteDisplayStyleValue: size=16 align=4
+    0: Block
+    1: Inline
+    2: Compact
+FootnotePolicyStyleValue: size=16 align=4
+    0: Auto
+    1: Line
+    2: Block
+ForcedColorAdjustStyleValue: size=16 align=4
+    0: Auto
+    1: None
+    2: PreserveParentColor
+ForcedColorsMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+ForcedColorsMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Active
+FrameSizingStyleValue: size=16 align=4
+    0: Auto
+    1: ContentWidth
+    2: ContentHeight
+    3: ContentBlockSize
+    4: ContentInlineSize
+Frequency: size=16 align=4
+    0: Hz
+    1: Khz
+FunctionalPseudoClass: size=112 align=8
+    0: Dir
+    1: Has
+    2: Heading
+    3: Host
+    4: HostContext
+    5: Is
+    6: Lang
+    7: Not
+    8: NthChild
+    9: NthCol
+    10: NthLastChild
+    11: NthLastCol
+    12: NthLastOfType
+    13: NthOfType
+    14: State
+    15: Where
+FunctionalPseudoElement: size=112 align=8
+    0: Highlight
+    1: Part
+    2: Picker
+    3: Slotted
+    4: ViewTransitionGroup
+    5: ViewTransitionImagePair
+    6: ViewTransitionNew
+    7: ViewTransitionOld
+GapRepeatRule: size=80 align=8 {
+    name: 0
+    count: 12
+    comma: 28
+    rules: 40
+    close: 64
+}
+GapRuleList: size=24 align=8 {
+    0: 0
+}
+GapRuleOrRepeat: size=88 align=8
+    0: GapRule
+    1: GapRepeatRule
+GapStyleValue: size=96 align=8 {
+    0: 0
+    1: 48
+}
+GenericFontFamily: size=56 align=8
+    0: GenericScriptSpecific
+    1: GenericComplete
+    2: GenericIncomplete
+GenericVoice: size=56 align=8 {
+    age: 0
+    gender: 16
+    variant: 32
+}
+GeometryBox: size=24 align=4
+    0: ShapeBox
+    1: FillBox
+    2: StrokeBox
+    3: ViewBox
+GlyphOrientationVerticalStyleValue: size=16 align=4
+    0: Auto
+    1: Literal0deg
+    2: Literal90deg
+    3: Literal0
+    4: Literal90
+Gradient: size=24 align=8
+    0: LinearGradientFunction
+    1: RepeatingLinearGradientFunction
+    2: RadialGradientFunction
+    3: RepeatingRadialGradientFunction
+GrayscaleFunction: size=56 align=8 {
+    name: 0
+    value: 16
+    close: 40
+}
+GridAreaStyleValue: size=336 align=8 {
+    0: 0
+    1: 72
+    2: 160
+    3: 248
+}
+GridAutoColumnsStyleValue: size=24 align=8 {
+    0: 0
+}
+GridAutoFlowStyleValue: size=36 align=4
+    0: Row
+    1: Column
+GridAutoRowsStyleValue: size=24 align=8 {
+    0: 0
+}
+GridColumnEndStyleValue: size=72 align=8 {
+    0: 0
+}
+GridColumnStartStyleValue: size=72 align=8 {
+    0: 0
+}
+GridColumnStyleValue: size=160 align=8 {
+    0: 0
+    1: 72
+}
+GridLine: size=64 align=8
+    0: Auto
+    1: Span
+    2: Area
+    3: Placement
+GridMediaFeature: size=64 align=4
+    0: WithValue
+    1: Bare
+GridRowEndStyleValue: size=72 align=8 {
+    0: 0
+}
+GridRowStartStyleValue: size=72 align=8 {
+    0: 0
+}
+GridRowStyleValue: size=160 align=8 {
+    0: 0
+    1: 72
+}
+GridStyleValue: size=656 align=8
+    0: GridTemplate
+    1: GridTemplateRowsAutoFlowDense
+    2: AutoFlowDenseGridAutoRowsGridTemplateColumns
+GridTemplateAreasStyleValue: size=32 align=8 {
+    0: 0
+}
+GridTemplateColumnsStyleValue: size=312 align=8
+    0: None
+    1: TrackList
+    2: AutoTrackList
+    3: Subgrid
+GridTemplateRowsStyleValue: size=312 align=8
+    0: None
+    1: TrackList
+    2: AutoTrackList
+    3: Subgrid
+GridTemplateStyleValue: size=648 align=8
+    0: None
+    1: GridTemplateRowsGridTemplateColumns
+    2: String
+HangingPunctuationStyleValue: size=52 align=4
+    0: None
+    1: ForceEnd
+    2: AllowEnd
+HasPseudoFunction: size=64 align=8 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 48
+}
+HeadingPseudoFunction: size=64 align=8 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 48
+}
+HeightContainerFeature: size=128 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Exact
+HeightMediaFeature: size=128 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+HeightStyleValue: size=72 align=8
+    0: Auto
+    1: LengthPercentage
+    2: MinContent
+    3: MaxContent
+    4: FitContentFunction
+    5: CalcSizeFunction
+    6: Stretch
+    7: FitContent
+    8: Contain
+    9: _WebkitMaxContent
+    10: _MozMaxContent
+    11: _WebkitMinContent
+    12: _MozMinContent
+HighlightPseudoElement: size=60 align=4 {
+    colons: 0
+    function: 24
+    value: 36
+    close: 48
+}
+HistoricalLigValues: size=16 align=4
+    0: HistoricalLigatures
+    1: NoHistoricalLigatures
+HorizontalLineClause: size=72 align=8
+    0: ToHorizontalLineValue
+    1: ByLengthPercentage
+HorizontalLineCommand: size=88 align=8 {
+    keyword: 0
+    clause: 16
+}
+HorizontalLineValue: size=40 align=8
+    0: LengthPercentage
+    1: Left
+    2: Center
+    3: Right
+    4: XStart
+    5: XEnd
+HorizontalViewportSegmentsMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+HostContextPseudoFunction: size=64 align=8 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 48
+}
+HostPseudoFunction: size=64 align=8 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 48
+}
+HoverMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+HoverMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Hover
+HslChannelKeyword: size=16 align=4
+    0: H
+    1: S
+    2: L
+    3: Alpha
+HslFunction: size=216 align=8 {
+    name: 0
+    params: 16
+    close: 200
+}
+HslFunctionParams: size=184 align=8 {
+    0: 0
+    1: 40
+    2: 56
+    3: 88
+    4: 104
+    5: 136
+    6: 152
+}
+HslRelativeFunction: size=256 align=8 {
+    name: 0
+    params: 16
+    close: 240
+}
+HslRelativeParams: size=224 align=8 {
+    origin: 0
+    hue: 40
+    saturation: 88
+    lightness: 128
+    slash: 168
+    alpha: 184
+}
+HslaFunction: size=216 align=8 {
+    name: 0
+    params: 16
+    close: 200
+}
+HslaRelativeFunction: size=256 align=8 {
+    name: 0
+    params: 16
+    close: 240
+}
+HtmlNonConformingTag: size=16 align=4
+    0: Acronym
+    1: Applet
+    2: Basefont
+    3: Bgsound
+    4: Big
+    5: Blink
+    6: Center
+    7: Dir
+    8: Font
+    9: Frame
+    10: Frameset
+    11: Isindex
+    12: Keygen
+    13: Listing
+    14: Marquee
+    15: Menuitem
+    16: Multicol
+    17: Nextid
+    18: Nobr
+    19: Noembed
+    20: Noframes
+    21: Param
+    22: Plaintext
+    23: Rb
+    24: Rtc
+    25: Spacer
+    26: Strike
+    27: Tt
+    28: Xmp
+HtmlNonStandardTag: size=16 align=4
+    0: Fencedframe
+    1: Portal
+    2: Permission
+    3: Selectedcontent
+HtmlTag: size=16 align=4
+    0: A
+    1: Abbr
+    2: Address
+    3: Area
+    4: Article
+    5: Aside
+    6: Audio
+    7: B
+    8: Base
+    9: Bdi
+    10: Bdo
+    11: Blockquote
+    12: Body
+    13: Br
+    14: Button
+    15: Canvas
+    16: Caption
+    17: Cite
+    18: Code
+    19: Col
+    20: Colgroup
+    21: Data
+    22: Datalist
+    23: Dd
+    24: Del
+    25: Details
+    26: Dfn
+    27: Dialog
+    28: Div
+    29: Dl
+    30: Dt
+    31: Em
+    32: Embed
+    33: Fieldset
+    34: Figcaption
+    35: Figure
+    36: Footer
+    37: Form
+    38: H1
+    39: H2
+    40: H3
+    41: H4
+    42: H5
+    43: H6
+    44: Head
+    45: Header
+    46: Hgroup
+    47: Hr
+    48: Html
+    49: I
+    50: Iframe
+    51: Img
+    52: Input
+    53: Ins
+    54: Kbd
+    55: Label
+    56: Legend
+    57: Li
+    58: Link
+    59: Main
+    60: Map
+    61: Mark
+    62: Menu
+    63: Meta
+    64: Meter
+    65: Nav
+    66: Noscript
+    67: Object
+    68: Ol
+    69: Optgroup
+    70: Option
+    71: Output
+    72: P
+    73: Picture
+    74: Pre
+    75: Progress
+    76: Q
+    77: Rp
+    78: Rt
+    79: Ruby
+    80: S
+    81: Samp
+    82: Script
+    83: Search
+    84: Section
+    85: Select
+    86: Slot
+    87: Small
+    88: Source
+    89: Span
+    90: Strong
+    91: Style
+    92: Sub
+    93: Summary
+    94: Sup
+    95: Table
+    96: Tbody
+    97: Td
+    98: Template
+    99: Textarea
+    100: Tfoot
+    101: Th
+    102: Thead
+    103: Time
+    104: Title
+    105: Tr
+    106: Track
+    107: U
+    108: Ul
+    109: Var
+    110: Video
+    111: Wbr
+HueInterpolationDirection: size=16 align=4
+    0: Shorter
+    1: Longer
+    2: Increasing
+    3: Decreasing
+HueInterpolationMethod: size=28 align=4 {
+    direction: 0
+    hue_keyword: 16
+}
+HueRotateFunction: size=64 align=8 {
+    name: 0
+    angle: 16
+    close: 48
+}
+HwbChannelKeyword: size=16 align=4
+    0: H
+    1: W
+    2: B
+    3: Alpha
+HwbFunction: size=184 align=8 {
+    name: 0
+    params: 16
+    close: 168
+}
+HwbFunctionParams: size=152 align=8 {
+    0: 0
+    1: 40
+    2: 72
+    3: 104
+    4: 120
+}
+HwbRelativeFunction: size=256 align=8 {
+    name: 0
+    params: 16
+    close: 240
+}
+HwbRelativeParams: size=224 align=8 {
+    origin: 0
+    hue: 40
+    whiteness: 88
+    blackness: 128
+    slash: 168
+    alpha: 184
+}
+HyphenateCharacterStyleValue: size=32 align=8 {
+    0: 0
+}
+HyphenateLimitCharsStyleValue: size=96 align=8 {
+    0: 0
+    1: 32
+    2: 64
+}
+HyphenateLimitLastStyleValue: size=16 align=4
+    0: None
+    1: Always
+    2: Column
+    3: Page
+    4: Spread
+HyphenateLimitLinesStyleValue: size=32 align=8
+    0: NoLimit
+    1: Integer
+HyphenateLimitZoneStyleValue: size=32 align=8 {
+    0: 0
+}
+HyphensStyleValue: size=16 align=4
+    0: None
+    1: Manual
+    2: Auto
+Id: size=12 align=4 {
+    0: 0
+}
+IfCondition: size=224 align=8
+    0: Else
+    1: Expr
+IfConditionExpr: size=216 align=8
+    0: Is
+    1: Not
+    2: And
+    3: Or
+IfTest: size=192 align=8
+    0: SupportsDeclaration
+    1: Supports
+    2: Media
+    3: Style
+    4: Group
+    5: GeneralEnclosed
+Image: size=48 align=8
+    0: Url
+    1: Gradient
+Image1d: size=56 align=8 {
+    0: 0
+}
+ImageAnimationStyleValue: size=16 align=4
+    0: Normal
+    1: Paused
+    2: Stopped
+    3: Running
+ImageOrientationStyleValue: size=48 align=8
+    0: FromImage
+    1: None
+    2: Flip
+ImageRenderingStyleValue: size=16 align=4
+    0: Auto
+    1: Smooth
+    2: HighQuality
+    3: Pixelated
+    4: CrispEdges
+ImageResolutionStyleValue: size=56 align=8 {
+    0: 0
+    1: 40
+}
+ImageSetFunction: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+ImageSetParams: size=104 align=8
+    0: Image
+    1: String
+ImportLayer: size=80 align=8
+    0: Layer
+    1: LayerFunction
+ImportLayerFunction: size=72 align=8 {
+    name: 0
+    layer: 16
+    close: 56
+}
+ImportRule: size=296 align=8 {
+    name: 0
+    url: 12
+    layer: 56
+    supports_condition: 136
+    media_condition: 256
+    semicolon: 280
+}
+ImportSupportsFunction: size=120 align=8 {
+    name: 0
+    condition: 16
+    close: 104
+}
+InflexibleBreadth: size=40 align=8
+    0: LengthPercentage
+    1: MinContent
+    2: MaxContent
+    3: Auto
+InheritsValue: size=16 align=4
+    0: True
+    1: False
+InitialLetterStyleValue: size=56 align=8
+    0: Normal
+    1: NumberInteger
+    2: NumberDrop
+    3: NumberRaise
+    4: Number
+InitialLetterWrapStyleValue: size=40 align=8
+    0: None
+    1: First
+    2: All
+    3: Grid
+    4: LengthPercentage
+InlineSizeContainerFeature: size=128 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Exact
+InlineSizeStyleValue: size=72 align=8 {
+    0: 0
+}
+InlineSizingStyleValue: size=16 align=4
+    0: Normal
+    1: Stretch
+InputSecurityStyleValue: size=16 align=4
+    0: Auto
+    1: None
+InsetBlockEndStyleValue: size=40 align=8 {
+    0: 0
+}
+InsetBlockStartStyleValue: size=40 align=8 {
+    0: 0
+}
+InsetBlockStyleValue: size=80 align=8 {
+    0: 0
+    1: 40
+}
+InsetFunction: size=448 align=8 {
+    name: 0
+    params: 16
+    close: 432
+}
+InsetFunctionParams: size=416 align=8 {
+    0: 0
+    1: 32
+    2: 64
+    3: 96
+    4: 128
+}
+InsetInlineEndStyleValue: size=40 align=8 {
+    0: 0
+}
+InsetInlineStartStyleValue: size=40 align=8 {
+    0: 0
+}
+InsetInlineStyleValue: size=80 align=8 {
+    0: 0
+    1: 40
+}
+InsetStyleValue: size=160 align=8 {
+    0: 0
+    1: 40
+    2: 80
+    3: 120
+}
+InsetValue: size=40 align=8
+    0: LengthPercentage
+    1: OverlapJoin
+InteractivityStyleValue: size=16 align=4
+    0: Auto
+    1: Inert
+InterestDelayEndStyleValue: size=32 align=8 {
+    0: 0
+}
+InterestDelayStartStyleValue: size=32 align=8 {
+    0: 0
+}
+InterestDelayStyleValue: size=64 align=8 {
+    0: 0
+    1: 32
+}
+InterpolateSizeStyleValue: size=16 align=4
+    0: NumericOnly
+    1: AllowKeywords
+InterpolationColorSpace: size=48 align=4
+    0: Rectangular
+    1: Polar
+InvertFunction: size=56 align=8 {
+    name: 0
+    value: 16
+    close: 40
+}
+InvertedColorsMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+InvertedColorsMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Inverted
+IsPseudoFunction: size=64 align=8 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 48
+}
+IsolationMode: size=16 align=4
+    0: Auto
+    1: Isolate
+IsolationStyleValue: size=24 align=8 {
+    0: 0
+}
+JustifyContentStyleValue: size=56 align=8
+    0: Normal
+    1: ContentDistribution
+    2: ContentPosition
+    3: Left
+    4: Right
+JustifyItemsStyleValue: size=56 align=8
+    0: Normal
+    1: Stretch
+    2: BaselinePosition
+    3: SelfPosition
+    4: Left
+    5: Right
+    6: Legacy
+    7: LegacyLeft
+    8: LegacyRight
+    9: LegacyCenter
+JustifySelfStyleValue: size=56 align=8
+    0: Auto
+    1: Normal
+    2: SelfPosition
+    3: Left
+    4: Right
+    5: Stretch
+    6: BaselinePosition
+Keyframe: size=208 align=16 {
+    0: 0
+}
+KeyframeSelector: size=16 align=4
+    0: From
+    1: To
+    2: Percent
+KeyframeSelectors: size=24 align=8 {
+    0: 0
+}
+KeyframesName: size=16 align=4
+    0: Ident
+    1: String
+KeyframesRule: size=144 align=16 {
+    name: 0
+    prelude: 12
+    block: 32
+}
+KeyframesRuleBlock: size=112 align=16 {
+    0: 0
+}
+KeypressFunction: size=36 align=4 {
+    name: 0
+    params: 12
+    close: 24
+}
+LabChannelKeyword: size=16 align=4
+    0: L
+    1: A
+    2: B
+    3: Alpha
+LabFunction: size=176 align=8 {
+    name: 0
+    params: 16
+    close: 160
+}
+LabFunctionParams: size=144 align=8 {
+    0: 0
+    1: 32
+    2: 64
+    3: 96
+    4: 112
+}
+LabRelativeFunction: size=248 align=8 {
+    name: 0
+    params: 16
+    close: 232
+}
+LabRelativeParams: size=216 align=8 {
+    origin: 0
+    l: 40
+    a: 80
+    b: 120
+    slash: 160
+    alpha: 176
+}
+LangPseudoFunction: size=64 align=8 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 48
+}
+LangValue: size=16 align=4
+    0: Ident
+    1: String
+LangValues: size=24 align=8 {
+    0: 0
+}
+LayerName: size=40 align=8 {
+    0: 0
+    1: 16
+}
+LayerNameList: size=24 align=8 {
+    0: 0
+}
+LayerRule: size=192 align=16 {
+    name: 0
+    prelude: 16
+    block: 48
+    semicolon: 176
+}
+LayerRuleBlock: size=128 align=16 {
+    0: 0
+}
+LayoutBox: size=16 align=4
+    0: ContentBox
+    1: PaddingBox
+    2: BorderBox
+    3: MarginBox
+LchChannelKeyword: size=16 align=4
+    0: L
+    1: C
+    2: H
+    3: Alpha
+LchFunction: size=184 align=8 {
+    name: 0
+    params: 16
+    close: 168
+}
+LchFunctionParams: size=152 align=8 {
+    0: 0
+    1: 32
+    2: 64
+    3: 104
+    4: 120
+}
+LchRelativeFunction: size=256 align=8 {
+    name: 0
+    params: 16
+    close: 240
+}
+LchRelativeParams: size=224 align=8 {
+    origin: 0
+    lightness: 40
+    chroma: 80
+    hue: 120
+    slash: 168
+    alpha: 184
+}
+LeaderFunction: size=40 align=4 {
+    name: 0
+    params: 12
+    close: 28
+}
+LeaderType: size=16 align=4
+    0: Dotted
+    1: Solid
+    2: Space
+    3: String
+LeftStyleValue: size=40 align=8 {
+    0: 0
+}
+LegacyPseudoElement: size=28 align=4
+    0: After
+    1: Before
+    2: FirstLetter
+    3: FirstLine
+Length: size=16 align=4
+    0: Zero
+    1: Em
+    2: Rem
+    3: Ex
+    4: Rex
+    5: Cap
+    6: Rcap
+    7: Ch
+    8: Rch
+    9: Ic
+    10: Ric
+    11: Lh
+    12: Rlh
+    13: Vw
+    14: Svw
+    15: Lvw
+    16: Dvw
+    17: Vh
+    18: Svh
+    19: Lvh
+    20: Dvh
+    21: Vi
+    22: Svi
+    23: Lvi
+    24: Dvi
+    25: Vb
+    26: Svb
+    27: Lvb
+    28: Dvb
+    29: Vmin
+    30: Svmin
+    31: Lvmin
+    32: Dvmin
+    33: Vmax
+    34: Svmax
+    35: Lvmax
+    36: Dvmax
+    37: Cm
+    38: Mm
+    39: Q
+    40: In
+    41: Pc
+    42: Pt
+    43: Px
+    44: Cqw
+    45: Cqh
+    46: Cqi
+    47: Cqb
+    48: Cqmin
+    49: Cqmax
+LengthPercentage: size=20 align=4
+    0: Zero
+    1: Length
+    2: Percent
+LengthPercentageNumber: size=20 align=4
+    0: Length
+    1: Percent
+    2: Number
+LengthPercentageOrFlex: size=24 align=4
+    0: Flex
+    1: LengthPercentage
+LetterSpacingStyleValue: size=40 align=8 {
+    0: 0
+}
+LightDarkFunction: size=96 align=8 {
+    name: 0
+    light: 16
+    comma: 40
+    dark: 56
+    close: 80
+}
+LightingColorStyleValue: size=32 align=8 {
+    0: 0
+}
+LineBreakStyleValue: size=16 align=4
+    0: Auto
+    1: Loose
+    2: Normal
+    3: Strict
+    4: Anywhere
+LineClampStyleValue: size=80 align=8 {
+    0: 0
+}
+LineCommand: size=160 align=8 {
+    keyword: 0
+    point: 16
+}
+LineFitEdgeStyleValue: size=32 align=8
+    0: Leading
+    1: TextEdge
+LineGridStyleValue: size=16 align=4
+    0: MatchParent
+    1: Create
+LineHeightStepStyleValue: size=24 align=8 {
+    0: 0
+}
+LineHeightStyleValue: size=40 align=8
+    0: Normal
+    1: Number
+    2: LengthPercentage
+LineNameList: size=24 align=8 {
+    0: 0
+}
+LineNames: size=56 align=8 {
+    open: 0
+    idents: 16
+    close: 40
+}
+LinePaddingStyleValue: size=24 align=8 {
+    0: 0
+}
+LineSnapStyleValue: size=16 align=4
+    0: None
+    1: Baseline
+    2: Contain
+LineStyle: size=16 align=4
+    0: None
+    1: Hidden
+    2: Dotted
+    3: Dashed
+    4: Solid
+    5: Double
+    6: Groove
+    7: Ridge
+    8: Inset
+    9: Outset
+LineWidth: size=32 align=8
+    0: Thin
+    1: Medium
+    2: Thick
+    3: Length
+LineWidthList: size=24 align=8 {
+    0: 0
+}
+LineWidthOrRepeat: size=88 align=8
+    0: LineWidth
+    1: RepeatFunction
+LinearDirection: size=56 align=8
+    0: Angle
+    1: Named
+LinearFunction: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+LinearFunctionParams: size=72 align=8 {
+    0: 0
+    1: 24
+    2: 48
+}
+LinearGradientFunction: size=128 align=8 {
+    name: 0
+    params: 16
+    close: 112
+}
+LinearGradientFunctionParams: size=96 align=8 {
+    0: 0
+    1: 56
+    2: 72
+}
+LinkParametersStyleValue: size=32 align=8 {
+    0: 0
+}
+ListStyleImageStyleValue: size=64 align=8 {
+    0: 0
+}
+ListStylePositionStyleValue: size=16 align=4
+    0: Inside
+    1: Outside
+ListStyleStyleValue: size=176 align=8 {
+    list_style_position: 0
+    list_style_image: 16
+    list_style_type: 80
+}
+ListStyleTypeStyleValue: size=96 align=8
+    0: CounterStyle
+    1: String
+    2: None
+LogFunction: size=176 align=8 {
+    name: 0
+    value: 16
+    comma: 128
+    base: 144
+    close: 160
+}
+MarginBlockEndStyleValue: size=40 align=8 {
+    0: 0
+}
+MarginBlockStartStyleValue: size=40 align=8 {
+    0: 0
+}
+MarginBlockStyleValue: size=80 align=8 {
+    0: 0
+    1: 40
+}
+MarginBottomStyleValue: size=40 align=8 {
+    0: 0
+}
+MarginBreakStyleValue: size=16 align=4
+    0: Auto
+    1: Keep
+    2: Discard
+MarginInlineEndStyleValue: size=40 align=8 {
+    0: 0
+}
+MarginInlineStartStyleValue: size=40 align=8 {
+    0: 0
+}
+MarginInlineStyleValue: size=80 align=8 {
+    0: 0
+    1: 40
+}
+MarginLeftStyleValue: size=40 align=8 {
+    0: 0
+}
+MarginRightStyleValue: size=40 align=8 {
+    0: 0
+}
+MarginRule: size=144 align=16
+    0: TopLeftCorner
+    1: TopLeft
+    2: TopCenter
+    3: TopRight
+    4: TopRightCorner
+    5: RightTop
+    6: RightMiddle
+    7: RightBottom
+    8: BottomRightCorner
+    9: BottomRight
+    10: BottomCenter
+    11: BottomLeft
+    12: BottomLeftCorner
+    13: LeftBottom
+    14: LeftMiddle
+    15: LeftTop
+MarginRuleBlock: size=112 align=16 {
+    0: 0
+}
+MarginStyleValue: size=160 align=8 {
+    0: 0
+    1: 40
+    2: 80
+    3: 120
+}
+MarginTopStyleValue: size=40 align=8 {
+    0: 0
+}
+MarginTrimStyleValue: size=68 align=4
+    0: None
+    1: BlockInline
+    2: BlockStartInlineStartBlockEndInlineEnd
+MarkerEndStyleValue: size=56 align=8 {
+    0: 0
+}
+MarkerMidStyleValue: size=56 align=8 {
+    0: 0
+}
+MarkerSideStyleValue: size=16 align=4
+    0: MatchSelf
+    1: MatchParent
+MarkerStartStyleValue: size=56 align=8 {
+    0: 0
+}
+MarkerStyleValue: size=56 align=8 {
+    0: 0
+}
+MaskBorderModeStyleValue: size=16 align=4
+    0: Luminance
+    1: Alpha
+MaskBorderOutsetStyleValue: size=128 align=8 {
+    0: 0
+}
+MaskBorderRepeatStyleValue: size=32 align=4 {
+    0: 0
+}
+MaskBorderSliceStyleValue: size=112 align=8 {
+    0: 0
+}
+MaskBorderSourceStyleValue: size=64 align=8 {
+    0: 0
+}
+MaskBorderWidthStyleValue: size=160 align=8 {
+    0: 0
+}
+MaskClipStyleValue: size=24 align=8 {
+    0: 0
+}
+MaskCompositeStyleValue: size=24 align=8 {
+    0: 0
+}
+MaskImageStyleValue: size=24 align=8 {
+    0: 0
+}
+MaskModeStyleValue: size=24 align=8 {
+    0: 0
+}
+MaskOriginStyleValue: size=24 align=8 {
+    0: 0
+}
+MaskPositionStyleValue: size=24 align=8 {
+    0: 0
+}
+MaskRepeatStyleValue: size=24 align=8 {
+    0: 0
+}
+MaskSizeStyleValue: size=24 align=8 {
+    0: 0
+}
+MaskStyleValue: size=24 align=8 {
+    0: 0
+}
+MaskTypeStyleValue: size=16 align=4
+    0: Luminance
+    1: Alpha
+MaskingMode: size=16 align=4
+    0: Alpha
+    1: Luminance
+    2: MatchSource
+MathmlTag: size=16 align=4
+    0: Abs
+    1: And
+    2: Annotation
+    3: AnnotationXml
+    4: Apply
+    5: Approx
+    6: Arg
+    7: Bind
+    8: Bvar
+    9: Card
+    10: Cartesianproduct
+    11: Cbytes
+    12: Ceiling
+    13: Cerror
+    14: Ci
+    15: Cn
+    16: Codomain
+    17: Compose
+    18: Condition
+    19: Conjugate
+    20: Cs
+    21: Csymbol
+    22: Curl
+    23: Declare
+    24: Degree
+    25: Determinant
+    26: Diff
+    27: Divergence
+    28: Divide
+    29: Domain
+    30: Domainofapplication
+    31: Emptyset
+    32: Eq
+    33: Equivalent
+    34: Exists
+    35: Exp
+    36: Factorial
+    37: Factorof
+    38: Floor
+    39: Fn
+    40: Forall
+    41: Gcd
+    42: Geq
+    43: Grad
+    44: Gt
+    45: Ident
+    46: Image
+    47: Imaginary
+    48: Img
+    49: Implies
+    50: In
+    51: Int
+    52: Intersect
+    53: Interval
+    54: Inverse
+    55: Lambda
+    56: Laplacian
+    57: Lcm
+    58: Leq
+    59: Limit
+    60: List
+    61: Ln
+    62: Log
+    63: Logbase
+    64: Lowlimit
+    65: Lt
+    66: Maction
+    67: Maligngroup
+    68: Malignmark
+    69: Math
+    70: Matrix
+    71: Matrixrow
+    72: Max
+    73: Mean
+    74: Median
+    75: Menclose
+    76: Merror
+    77: Mfenced
+    78: Mfrac
+    79: Mfraction
+    80: Mglyph
+    81: Mi
+    82: Min
+    83: Minus
+    84: Mlabeledtr
+    85: Mlongdiv
+    86: Mmultiscripts
+    87: Mn
+    88: Mo
+    89: Mode
+    90: Moment
+    91: Momentabout
+    92: Mover
+    93: Mpadded
+    94: Mphantom
+    95: Mprescripts
+    96: Mroot
+    97: Mrow
+    98: Ms
+    99: Mscarries
+    100: Mscarry
+    101: Msgroup
+    102: Msline
+    103: Mspace
+    104: Msqrt
+    105: Msrow
+    106: Mstack
+    107: Mstyle
+    108: Msub
+    109: Msubsup
+    110: Msup
+    111: Mtable
+    112: Mtd
+    113: Mtext
+    114: Mtr
+    115: Munder
+    116: Munderover
+    117: Neq
+    118: None
+    119: Not
+    120: Notin
+    121: Notprsubset
+    122: Notsubset
+    123: Or
+    124: Otherwise
+    125: Outerproduct
+    126: Partialdiff
+    127: Piece
+    128: Piecewise
+    129: Plus
+    130: Power
+    131: Product
+    132: Prsubset
+    133: Quotient
+    134: Real
+    135: Reln
+    136: Rem
+    137: Root
+    138: Scalarproduct
+    139: Sdev
+    140: Selector
+    141: Semantics
+    142: Sep
+    143: Set
+    144: Setdiff
+    145: Share
+    146: Sin
+    147: Subset
+    148: Sum
+    149: Tendsto
+    150: Times
+    151: Transpose
+    152: Union
+    153: Uplimit
+    154: Variance
+    155: Vector
+    156: Vectorproduct
+    157: Xo
+Matrix3dFunction: size=656 align=8 {
+    name: 0
+    params: 16
+    close: 640
+}
+Matrix3dFunctionParams: size=624 align=8 {
+    0: 0
+    1: 24
+    2: 40
+    3: 64
+    4: 80
+    5: 104
+    6: 120
+    7: 144
+    8: 160
+    9: 184
+    10: 200
+    11: 224
+    12: 240
+    13: 264
+    14: 280
+    15: 304
+    16: 320
+    17: 344
+    18: 360
+    19: 384
+    20: 400
+    21: 424
+    22: 440
+    23: 464
+    24: 480
+    25: 504
+    26: 520
+    27: 544
+    28: 560
+    29: 584
+    30: 600
+}
+MatrixFunction: size=256 align=8 {
+    name: 0
+    params: 16
+    close: 240
+}
+MatrixFunctionParams: size=224 align=8 {
+    0: 0
+    1: 24
+    2: 40
+    3: 64
+    4: 80
+    5: 104
+    6: 120
+    7: 144
+    8: 160
+    9: 184
+    10: 200
+}
+MaxBlockSizeStyleValue: size=72 align=8 {
+    0: 0
+}
+MaxHeightStyleValue: size=72 align=8
+    0: None
+    1: LengthPercentage
+    2: MinContent
+    3: MaxContent
+    4: FitContentFunction
+    5: CalcSizeFunction
+    6: Stretch
+    7: FitContent
+    8: Contain
+    9: _WebkitMaxContent
+    10: _MozMaxContent
+    11: _WebkitMinContent
+    12: _MozMinContent
+MaxInlineSizeStyleValue: size=72 align=8 {
+    0: 0
+}
+MaxLinesStyleValue: size=32 align=8 {
+    0: 0
+}
+MaxWidthStyleValue: size=72 align=8
+    0: None
+    1: LengthPercentage
+    2: MinContent
+    3: MaxContent
+    4: FitContentFunction
+    5: CalcSizeFunction
+    6: Stretch
+    7: FitContent
+    8: Contain
+    9: _WebkitMaxContent
+    10: _MozMaxContent
+    11: _WebkitMinContent
+    12: _MozMinContent
+MediaCondition: size=152 align=8
+    0: Is
+    1: Not
+    2: And
+    3: Or
+MediaFeature: size=132 align=4
+    0: AnyHover
+    1: AnyPointer
+    2: AspectRatio
+    3: Color
+    4: ColorGamut
+    5: ColorIndex
+    6: DeviceAspectRatio
+    7: DeviceHeight
+    8: DeviceWidth
+    9: DisplayMode
+    10: DynamicRange
+    11: EnvironmentBlending
+    12: ForcedColors
+    13: Grid
+    14: Height
+    15: HorizontalViewportSegments
+    16: Hover
+    17: InvertedColors
+    18: Monochrome
+    19: NavControls
+    20: Orientation
+    21: OverflowBlock
+    22: OverflowInline
+    23: Pointer
+    24: PrefersColorScheme
+    25: PrefersContrast
+    26: PrefersReducedData
+    27: PrefersReducedMotion
+    28: PrefersReducedTransparency
+    29: Resolution
+    30: Scan
+    31: Scripting
+    32: Update
+    33: VerticalViewportSegments
+    34: VideoColorGamut
+    35: VideoDynamicRange
+    36: Width
+    37: WebkitAnimationMediaFeature
+    38: WebkitDevicePixelRatioMediaFeature
+    39: WebkitTransform2dMediaFeature
+    40: WebkitTransform3dMediaFeature
+    41: WebkitTransitionMediaFeature
+    42: WebkitVideoPlayableInlineMediaFeature
+    43: MozDeviceOrientationMediaFeature
+    44: MozDevicePixelRatioMediaFeature
+    45: MozMacGraphiteThemeMediaFeature
+    46: MozMaemoClassicMediaFeature
+    47: MozImagesInMenusMediaFeature
+    48: MozOsVersionMenusMediaFeature
+    49: MsHighContrastMediaFeature
+    50: MsViewStateMediaFeature
+    51: MsImeAlignMediaFeature
+    52: MsDevicePixelRatioMediaFeature
+    53: MsColumnCountMediaFeature
+    54: ODevicePixelRatioMediaFeature
+    55: Hack
+MediaPreCondition: size=16 align=4
+    0: Not
+    1: Only
+MediaQuery: size=200 align=8 {
+    precondition: 0
+    media_type: 16
+    and: 32
+    condition: 48
+}
+MediaQueryList: size=24 align=8 {
+    0: 0
+}
+MediaRule: size=176 align=16 {
+    name: 0
+    prelude: 16
+    block: 48
+}
+MediaRuleBlock: size=128 align=16 {
+    0: 0
+}
+MediaType: size=16 align=4
+    0: All
+    1: Print
+    2: Screen
+    3: Custom
+MinBlockSizeStyleValue: size=72 align=8 {
+    0: 0
+}
+MinHeightStyleValue: size=72 align=8
+    0: Auto
+    1: LengthPercentage
+    2: MinContent
+    3: MaxContent
+    4: FitContentFunction
+    5: CalcSizeFunction
+    6: Stretch
+    7: FitContent
+    8: Contain
+    9: _WebkitMaxContent
+    10: _MozMaxContent
+    11: _WebkitMinContent
+    12: _MozMinContent
+MinInlineSizeStyleValue: size=72 align=8 {
+    0: 0
+}
+MinIntrinsicSizingStyleValue: size=36 align=4
+    0: Legacy
+    1: ZeroIfScrollZeroIfExtrinsic
+MinWidthStyleValue: size=72 align=8
+    0: Auto
+    1: LengthPercentage
+    2: MinContent
+    3: MaxContent
+    4: FitContentFunction
+    5: CalcSizeFunction
+    6: Stretch
+    7: FitContent
+    8: Contain
+    9: _WebkitMaxContent
+    10: _MozMaxContent
+    11: _WebkitMinContent
+    12: _MozMinContent
+MinmaxFunction: size=128 align=8 {
+    name: 0
+    min: 16
+    comma: 56
+    max: 72
+    close: 112
+}
+MixBlendModeStyleValue: size=32 align=8
+    0: BlendMode
+    1: PlusLighter
+MonochromeMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+MoveCommand: size=160 align=8 {
+    keyword: 0
+    point: 16
+}
+MozAppearanceStyleValue: size=32 align=8
+    0: None
+    1: Auto
+    2: Base
+    3: BaseSelect
+    4: CompatAuto
+    5: CompatSpecial
+MozBoxSizingStyleValue: size=16 align=4
+    0: ContentBox
+    1: BorderBox
+MozColumnCountStyleValue: size=32 align=8 {
+    0: 0
+}
+MozColumnGapStyleValue: size=48 align=8
+    0: Normal
+    1: LengthPercentage
+    2: LineWidth
+MozDeviceOrientationMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+MozDeviceOrientationMediaFeatureKeyword: size=16 align=4
+    0: Portrait
+    1: Landscape
+MozDevicePixelRatioMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+MozDocumentRule: size=160 align=16 {
+    name: 0
+    prelude: 16
+    block: 48
+}
+MozFilterStyleValue: size=40 align=8 {
+    0: 0
+}
+MozFunctionalPseudoClass: size=60 align=4
+    0: LocaleDir
+MozFunctionalPseudoElement: size=88 align=8
+    0: TreeCell
+    1: TreeCellText
+    2: TreeCheckbox
+    3: TreeColumn
+    4: TreeImage
+    5: TreeLine
+    6: TreeRow
+    7: TreeSeparator
+    8: TreeTwisty
+MozFunctionalPseudoElementKeyword: size=16 align=4
+    0: TreeCell
+    1: TreeCellText
+    2: TreeCheckbox
+    3: TreeColumn
+    4: TreeImage
+    5: TreeLine
+    6: TreeRow
+    7: TreeSeparator
+    8: TreeTwisty
+MozImagesInMenusMediaFeature: size=64 align=4
+    0: WithValue
+    1: Bare
+MozLocaleDirFunctionalPseudoClass: size=56 align=4 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 40
+}
+MozMacGraphiteThemeMediaFeature: size=64 align=4
+    0: WithValue
+    1: Bare
+MozMaemoClassicMediaFeature: size=64 align=4
+    0: WithValue
+    1: Bare
+MozOsVersionMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+MozOsVersionMediaFeatureKeyword: size=16 align=4
+    0: WindowsVista
+    1: WindowsXp
+    2: WindowsWin7
+    3: WindowsWin8
+    4: WindowsWin10
+MozOsxFontSmoothingStyleValue: size=16 align=4
+    0: Auto
+    1: Grayscale
+MozPseudoClass: size=28 align=4
+    0: Any
+    1: AnyLink
+    2: Broken
+    3: DragOver
+    4: FirstNode
+    5: FocusRing
+    6: FullScreen
+    7: FullScreenAncestor
+    8: HandlerBlocked
+    9: HandlerCrashed
+    10: HandlerDisabled
+    11: LastNode
+    12: Loading
+    13: LwTheme
+    14: LwThemeBrighttext
+    15: LwThemeDarktext
+    16: MeterOptimum
+    17: MeterSubOptimum
+    18: MeterSubSubOptimum
+    19: NativeAnonymous
+    20: OnlyWhitespace
+    21: PlaceholderShown
+    22: ReadOnly
+    23: ReadWrite
+    24: SubmitInvalid
+    25: Suppressed
+    26: UiInvalid
+    27: UiValid
+    28: UserDisabled
+    29: WindowInactive
+MozPseudoElement: size=40 align=4
+    0: AnonymousBlock
+    1: AnonymousItem
+    2: AnonymousPositionedBlock
+    3: BlockInsideInlineWrapper
+    4: BlockRubyContent
+    5: ButtonContent
+    6: Canvas
+    7: CellContent
+    8: ColorSwatch
+    9: ColumnContent
+    10: ColumnSet
+    11: ColumnSpanWrapper
+    12: DropdownList
+    13: FieldsetContent
+    14: FirstLetterContinuation
+    15: FocusInner
+    16: FocusOuter
+    17: FramesetBlank
+    18: HframesetBorder
+    19: HtmlCanvasContent
+    20: InlineTable
+    21: LineFrame
+    22: ListBullet
+    23: ListNumber
+    24: MathmlAnonymousBlock
+    25: MeterBar
+    26: NumberSpinBox
+    27: NumberSpinDown
+    28: NumberSpinUp
+    29: OofPlaceholder
+    30: Page
+    31: PageBreak
+    32: PageContent
+    33: PageSequence
+    34: Pagebreak
+    35: Pagecontent
+    36: Placeholder
+    37: PrintedSheet
+    38: ProgressBar
+    39: RangeProgress
+    40: RangeThumb
+    41: RangeTrack
+    42: Reveal
+    43: Ruby
+    44: RubyBase
+    45: RubyBaseContainer
+    46: RubyText
+    47: RubyTextContainer
+    48: ScrolledCanvas
+    49: ScrolledContent
+    50: ScrolledPageSequence
+    51: SearchClearButton
+    52: Selection
+    53: SvgForeignContent
+    54: SvgMarkerAnonChild
+    55: SvgMarkerOuterSvgAnonChild
+    56: SvgText
+    57: Table
+    58: TableCell
+    59: TableColumn
+    60: TableColumnGroup
+    61: TableOuter
+    62: TableRow
+    63: TableRowGroup
+    64: TableWrapper
+    65: TextControlEditingRoot
+    66: TextControlPreview
+    67: TreeCell
+    68: TreeCheckbox
+    69: TreeDropFeedback
+    70: TreeIndentation
+    71: TreeSeparator
+    72: VframesetBorder
+    73: Viewport
+    74: ViewportScroll
+MozTouchEnabledMediaFeature: size=64 align=4
+    0: WithValue
+    1: Bare
+MozTransitionStyleValue: size=24 align=8 {
+    0: 0
+}
+MozUserSelectStyleValue: size=16 align=4
+    0: Auto
+    1: Text
+    2: None
+    3: All
+MsBoxSizingStyleValue: size=16 align=4
+    0: ContentBox
+    1: BorderBox
+MsColumnCountMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+MsDevicePixelRatioMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+MsFilterStyleValue: size=32 align=8
+    0: None
+    1: String
+    2: FilterValueList
+MsFlexAlignStyleValue: size=16 align=4
+    0: Start
+    1: End
+    2: Center
+    3: Stretch
+    4: Baseline
+MsFlexDirectionStyleValue: size=16 align=4
+    0: Row
+    1: RowReverse
+    2: Column
+    3: ColumnReverse
+MsFlexFlowStyleValue: size=52 align=4 {
+    flex_direction: 0
+    flex_wrap: 16
+}
+MsFlexItemAlignStyleValue: size=16 align=4
+    0: Auto
+    1: Start
+    2: End
+    3: Center
+    4: Stretch
+    5: Baseline
+MsFlexLinePackStyleValue: size=16 align=4
+    0: Start
+    1: End
+    2: Center
+    3: Justify
+    4: Distribute
+    5: Stretch
+MsFlexNegativeStyleValue: size=24 align=8 {
+    0: 0
+}
+MsFlexOrderStyleValue: size=24 align=8 {
+    0: 0
+}
+MsFlexPackStyleValue: size=16 align=4
+    0: Start
+    1: End
+    2: Center
+    3: Justify
+    4: Distribute
+MsFlexPositiveStyleValue: size=24 align=8 {
+    0: 0
+}
+MsFlexPreferredSizeStyleValue: size=80 align=8
+    0: Content
+    1: Width
+MsFlexStyleValue: size=136 align=8 {
+    0: 0
+}
+MsFlexStyleValueOptions: size=128 align=8 {
+    flex_grow: 0
+    flex_basis: 48
+}
+MsFlexWrapStyleValue: size=16 align=4
+    0: Nowrap
+    1: Wrap
+    2: WrapReverse
+MsHighContrastMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+MsHighContrastMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Active
+MsImeAlignMediaFeature: size=64 align=4
+    0: WithValue
+    1: Bare
+MsImeAlignMediaFeatureKeyword: size=12 align=4 {
+    0: 0
+}
+MsInterpolationModeStyleValue: size=16 align=4
+    0: NearestNeighbor
+    1: Bicubic
+MsOverflowStyleStyleValue: size=16 align=4
+    0: Auto
+    1: None
+    2: Scrollbar
+    3: _MsAutohidingScrollbar
+MsPseudoClass: size=28 align=4
+    0: Fullscreen
+    1: InputPlaceholder
+MsPseudoElement: size=40 align=4
+    0: Backdrop
+    1: Browse
+    2: Check
+    3: Clear
+    4: Expand
+    5: Fill
+    6: FillUpper
+    7: FillLower
+    8: InputPlaceholder
+    9: Placeholder
+    10: Reveal
+    11: Selection
+    12: Thumb
+    13: TicksAfter
+    14: TicksBefore
+    15: Tooltip
+    16: Track
+    17: Value
+MsTextSizeAdjustStyleValue: size=32 align=8 {
+    0: 0
+}
+MsTouchActionStyleValue: size=52 align=4
+    0: Auto
+    1: None
+    2: PanXPanY
+    3: PanXPanUp
+    4: PanXPanDown
+    5: PanLeftPanY
+    6: PanLeftPanUp
+    7: PanLeftPanDown
+    8: PanRightPanY
+    9: PanRightPanUp
+    10: PanRightPanDown
+    11: Manipulation
+MsTransformOriginStyleValue: size=128 align=8
+    0: PositionOne
+    1: PositionTwo
+MsTransformStyleValue: size=40 align=8 {
+    0: 0
+}
+MsTransitionStyleValue: size=24 align=8 {
+    0: 0
+}
+MsUserSelectStyleValue: size=16 align=4
+    0: Auto
+    1: Text
+    2: None
+    3: All
+MsViewStateMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+MsViewStateMediaFeatureKeyword: size=16 align=4
+    0: Snapped
+    1: FullscreenPortait
+    2: FullscreenLandscape
+MsWordBreakStyleValue: size=16 align=4
+    0: Normal
+    1: BreakAll
+    2: KeepAll
+    3: Manual
+    4: AutoPhrase
+    5: BreakWord
+NameRepeat: size=104 align=8 {
+    name: 0
+    params: 16
+    close: 88
+}
+NameRepeatCount: size=32 align=8
+    0: Integer
+    1: AutoFill
+NameRepeatParams: size=72 align=8 {
+    count: 0
+    comma: 32
+    names: 48
+}
+NamedColor: size=16 align=4
+    0: Aliceblue
+    1: Antiquewhite
+    2: Aqua
+    3: Aquamarine
+    4: Azure
+    5: Beige
+    6: Bisque
+    7: Black
+    8: Blanchedalmond
+    9: Blue
+    10: Blueviolet
+    11: Brown
+    12: Burlywood
+    13: Cadetblue
+    14: Chartreuse
+    15: Chocolate
+    16: Coral
+    17: Cornflowerblue
+    18: Cornsilk
+    19: Crimson
+    20: Cyan
+    21: Darkblue
+    22: Darkcyan
+    23: Darkgoldenrod
+    24: Darkgray
+    25: Darkgreen
+    26: Darkgrey
+    27: Darkkhaki
+    28: Darkmagenta
+    29: Darkolivegreen
+    30: Darkorange
+    31: Darkorchid
+    32: Darkred
+    33: Darksalmon
+    34: Darkseagreen
+    35: Darkslateblue
+    36: Darkslategray
+    37: Darkslategrey
+    38: Darkturquoise
+    39: Darkviolet
+    40: Deeppink
+    41: Deepskyblue
+    42: Dimgray
+    43: Dimgrey
+    44: Dodgerblue
+    45: Firebrick
+    46: Floralwhite
+    47: Forestgreen
+    48: Fuchsia
+    49: Gainsboro
+    50: Ghostwhite
+    51: Gold
+    52: Goldenrod
+    53: Gray
+    54: Green
+    55: Greenyellow
+    56: Grey
+    57: Honeydew
+    58: Hotpink
+    59: Indianred
+    60: Indigo
+    61: Ivory
+    62: Khaki
+    63: Lavender
+    64: Lavenderblush
+    65: Lawngreen
+    66: Lemonchiffon
+    67: Lightblue
+    68: Lightcoral
+    69: Lightcyan
+    70: Lightgoldenrodyellow
+    71: Lightgray
+    72: Lightgreen
+    73: Lightgrey
+    74: Lightpink
+    75: Lightsalmon
+    76: Lightseagreen
+    77: Lightskyblue
+    78: Lightslategray
+    79: Lightslategrey
+    80: Lightsteelblue
+    81: Lightyellow
+    82: Lime
+    83: Limegreen
+    84: Linen
+    85: Magenta
+    86: Maroon
+    87: Mediumaquamarine
+    88: Mediumblue
+    89: Mediumorchid
+    90: Mediumpurple
+    91: Mediumseagreen
+    92: Mediumslateblue
+    93: Mediumspringgreen
+    94: Mediumturquoise
+    95: Mediumvioletred
+    96: Midnightblue
+    97: Mintcream
+    98: Mistyrose
+    99: Moccasin
+    100: Navajowhite
+    101: Navy
+    102: Oldlace
+    103: Olive
+    104: Olivedrab
+    105: Orange
+    106: Orangered
+    107: Orchid
+    108: Palegoldenrod
+    109: Palegreen
+    110: Paleturquoise
+    111: Palevioletred
+    112: Papayawhip
+    113: Peachpuff
+    114: Peru
+    115: Pink
+    116: Plum
+    117: Powderblue
+    118: Purple
+    119: Rebeccapurple
+    120: Red
+    121: Rosybrown
+    122: Royalblue
+    123: Saddlebrown
+    124: Salmon
+    125: Sandybrown
+    126: Seagreen
+    127: Seashell
+    128: Sienna
+    129: Silver
+    130: Skyblue
+    131: Slateblue
+    132: Slategray
+    133: Slategrey
+    134: Snow
+    135: Springgreen
+    136: Steelblue
+    137: Tan
+    138: Teal
+    139: Thistle
+    140: Tomato
+    141: Turquoise
+    142: Violet
+    143: Wheat
+    144: White
+    145: Whitesmoke
+    146: Yellow
+    147: Yellowgreen
+NamedDirection: size=16 align=4
+    0: Bottom
+    1: Top
+    2: Left
+    3: Right
+Namespace: size=52 align=4 {
+    prefix: 0
+    tag: 28
+}
+NamespacePrefix: size=28 align=4
+    0: None
+    1: Name
+    2: Wildcard
+NamespaceRule: size=88 align=4 {
+    name: 0
+    prefix: 12
+    resource: 28
+    semicolon: 72
+}
+NamespaceTag: size=24 align=4
+    0: Wildcard
+    1: Tag
+NavControlsMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+NavControlsMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Back
+NegativeStyleValue: size=128 align=8 {
+    0: 0
+    1: 64
+}
+NestedGroupRule: size=224 align=16
+    0: Container
+    1: Layer
+    2: Media
+    3: Scope
+    4: Supports
+    5: UnknownAt
+    6: Style
+    7: Unknown
+    8: Declarations
+NotPseudoFunction: size=64 align=8 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 48
+}
+Nth: size=60 align=4
+    0: Odd
+    1: Even
+    2: Integer
+    3: Anb
+NthChildPseudoFunction: size=100 align=4 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 84
+}
+NthColPseudoFunction: size=100 align=4 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 84
+}
+NthLastChildPseudoFunction: size=100 align=4 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 84
+}
+NthLastColPseudoFunction: size=100 align=4 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 84
+}
+NthLastOfTypePseudoFunction: size=100 align=4 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 84
+}
+NthOfTypePseudoFunction: size=100 align=4 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 84
+}
+NumberLength: size=20 align=4
+    0: Number
+    1: Length
+NumberOrInfinity: size=16 align=4
+    0: Number
+    1: Infinity
+    2: NegInfinity
+NumberOrPercentage: size=16 align=4
+    0: Number
+    1: Percentage
+NumberPercentage: size=16 align=4
+    0: Number
+    1: Percentage
+NumericFigureValues: size=16 align=4
+    0: LiningNums
+    1: OldstyleNums
+NumericFractionValues: size=16 align=4
+    0: DiagonalFractions
+    1: StackedFractions
+NumericSpacingValues: size=16 align=4
+    0: ProportionalNums
+    1: TabularNums
+OBoxSizingStyleValue: size=16 align=4
+    0: ContentBox
+    1: BorderBox
+ODevicePixelRatioMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+OFilterStyleValue: size=40 align=8 {
+    0: 0
+}
+OObjectFitStyleValue: size=36 align=4
+    0: Fill
+    1: None
+    2: Contain
+    3: Cover
+OPseudoClass: size=28 align=4
+    0: Prefocus
+OPseudoElement: size=40 align=4
+    0: InnerSpinButton
+    1: OuterSpinButton
+    2: Placeholder
+    3: Scrollbar
+    4: ScrollbarThumb
+    5: ScrollbarTrack
+    6: ScrollbarTrackPiece
+    7: Selection
+ObjectFitStyleValue: size=36 align=4
+    0: Fill
+    1: None
+    2: Contain
+    3: Cover
+ObjectPositionStyleValue: size=120 align=8 {
+    0: 0
+}
+ObjectViewBoxStyleValue: size=504 align=8 {
+    0: 0
+}
+OffsetAnchorStyleValue: size=128 align=8 {
+    0: 0
+}
+OffsetDistanceStyleValue: size=32 align=8 {
+    0: 0
+}
+OffsetPath: size=48 align=8
+    0: RayFunction
+    1: Url
+    2: BasicShape
+OffsetPathStyleValue: size=88 align=8 {
+    0: 0
+}
+OffsetPositionStyleValue: size=128 align=8
+    0: Normal
+    1: Auto
+    2: Position
+OffsetRotateStyleValue: size=48 align=8
+    0: Auto
+    1: Reverse
+OklabFunction: size=176 align=8 {
+    name: 0
+    params: 16
+    close: 160
+}
+OklabRelativeFunction: size=248 align=8 {
+    name: 0
+    params: 16
+    close: 232
+}
+OklchFunction: size=184 align=8 {
+    name: 0
+    params: 16
+    close: 168
+}
+OklchRelativeFunction: size=256 align=8 {
+    name: 0
+    params: 16
+    close: 240
+}
+OpacityFunction: size=56 align=8 {
+    name: 0
+    value: 16
+    close: 40
+}
+OpacityStyleValue: size=24 align=8 {
+    0: 0
+}
+OpacityValue: size=16 align=4
+    0: Number
+    1: Percent
+OpentypeTag: size=12 align=4 {
+    0: 0
+}
+OrderStyleValue: size=24 align=8 {
+    0: 0
+}
+OrientationContainerFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+OrientationContainerFeatureKeyword: size=16 align=4
+    0: Portrait
+    1: Landscape
+OrientationMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+OrientationMediaFeatureKeyword: size=16 align=4
+    0: Portrait
+    1: Landscape
+OrphansStyleValue: size=24 align=8 {
+    0: 0
+}
+OutlineColorStyleValue: size=80 align=8 {
+    0: 0
+}
+OutlineLineStyle: size=16 align=4
+    0: None
+    1: Hidden
+    2: Dotted
+    3: Dashed
+    4: Solid
+    5: Double
+    6: Groove
+    7: Ridge
+    8: Inset
+    9: Outset
+OutlineOffsetStyleValue: size=24 align=8 {
+    0: 0
+}
+OutlineStyleStyleValue: size=32 align=8 {
+    0: 0
+}
+OutlineStyleValue: size=152 align=8 {
+    outline_width: 0
+    outline_style: 40
+    outline_color: 72
+}
+OutlineWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+OverflowAnchorStyleValue: size=16 align=4
+    0: Auto
+    1: None
+OverflowBlockMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+OverflowBlockMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Scroll
+    2: Paged
+OverflowBlockStyleValue: size=16 align=4
+    0: Visible
+    1: Hidden
+    2: Clip
+    3: Scroll
+    4: Auto
+OverflowClipMarginBlockEndStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginBlockStartStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginBlockStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginBottomStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginInlineEndStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginInlineStartStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginInlineStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginLeftStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginRightStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowClipMarginTopStyleValue: size=48 align=8 {
+    visual_box: 0
+    length: 24
+}
+OverflowInlineMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+OverflowInlineMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Scroll
+OverflowInlineStyleValue: size=16 align=4
+    0: Visible
+    1: Hidden
+    2: Clip
+    3: Scroll
+    4: Auto
+OverflowPosition: size=16 align=4
+    0: Unsafe
+    1: Safe
+OverflowStyleValue: size=32 align=4 {
+    0: 0
+    1: 16
+}
+OverflowWrapStyleValue: size=16 align=4
+    0: Normal
+    1: BreakWord
+    2: Anywhere
+OverflowXStyleValue: size=16 align=4
+    0: Visible
+    1: Hidden
+    2: Clip
+    3: Scroll
+    4: Auto
+OverflowYStyleValue: size=16 align=4
+    0: Visible
+    1: Hidden
+    2: Clip
+    3: Scroll
+    4: Auto
+OverlayStyleValue: size=16 align=4
+    0: None
+    1: Auto
+OverscrollBehaviorBlockStyleValue: size=16 align=4
+    0: Contain
+    1: None
+    2: Auto
+    3: Chain
+OverscrollBehaviorInlineStyleValue: size=16 align=4
+    0: Contain
+    1: None
+    2: Auto
+    3: Chain
+OverscrollBehaviorStyleValue: size=32 align=4 {
+    0: 0
+    1: 16
+}
+OverscrollBehaviorStyleValueKeywords: size=16 align=4
+    0: Contain
+    1: None
+    2: Auto
+    3: Chain
+OverscrollBehaviorXStyleValue: size=16 align=4
+    0: Contain
+    1: None
+    2: Auto
+    3: Chain
+OverscrollBehaviorYStyleValue: size=16 align=4
+    0: Contain
+    1: None
+    2: Auto
+    3: Chain
+PadStyleValue: size=88 align=8 {
+    0: 0
+    1: 24
+}
+PaddingBlockEndStyleValue: size=32 align=8 {
+    0: 0
+}
+PaddingBlockStartStyleValue: size=32 align=8 {
+    0: 0
+}
+PaddingBlockStyleValue: size=64 align=8 {
+    0: 0
+    1: 32
+}
+PaddingBottomStyleValue: size=32 align=8 {
+    0: 0
+}
+PaddingInlineEndStyleValue: size=32 align=8 {
+    0: 0
+}
+PaddingInlineStartStyleValue: size=32 align=8 {
+    0: 0
+}
+PaddingInlineStyleValue: size=64 align=8 {
+    0: 0
+    1: 32
+}
+PaddingLeftStyleValue: size=32 align=8 {
+    0: 0
+}
+PaddingRightStyleValue: size=32 align=8 {
+    0: 0
+}
+PaddingStyleValue: size=128 align=8 {
+    0: 0
+    1: 32
+    2: 64
+    3: 96
+}
+PaddingTopStyleValue: size=32 align=8 {
+    0: 0
+}
+PageRule: size=176 align=16 {
+    name: 0
+    prelude: 16
+    block: 48
+}
+PageRuleBlock: size=128 align=16 {
+    0: 0
+}
+PageSelector: size=40 align=8 {
+    page_type: 0
+    pseudos: 16
+}
+PageSelectorList: size=24 align=8 {
+    0: 0
+}
+PageStyleValue: size=32 align=8 {
+    0: 0
+}
+Paint: size=72 align=8
+    0: None
+    1: Image
+    2: SvgPaint
+PaintBox: size=16 align=4
+    0: ContentBox
+    1: PaddingBox
+    2: BorderBox
+    3: FillBox
+    4: StrokeBox
+PaintOrderStyleValue: size=52 align=4 {
+    0: 0
+}
+PaintOrderStyleValueOptions: size=48 align=4 {
+    fill: 0
+    stroke: 16
+    markers: 32
+}
+PaletteIdentifier: size=12 align=4 {
+    0: 0
+}
+ParamFunction: size=80 align=8 {
+    name: 0
+    params: 16
+    close: 64
+}
+ParamFunctionParams: size=48 align=8 {
+    ident: 0
+    comma: 12
+    value: 24
+}
+PartPseudoElement: size=80 align=8 {
+    colons: 0
+    function: 24
+    value: 40
+    close: 64
+}
+PathFunction: size=68 align=4 {
+    name: 0
+    fill_rule: 12
+    comma: 28
+    path: 44
+    close: 56
+}
+PauseAfterStyleValue: size=32 align=8
+    0: Time
+    1: None
+    2: XWeak
+    3: Weak
+    4: Medium
+    5: Strong
+    6: XStrong
+PauseBeforeStyleValue: size=32 align=8
+    0: Time
+    1: None
+    2: XWeak
+    3: Weak
+    4: Medium
+    5: Strong
+    6: XStrong
+PauseStyleValue: size=64 align=8 {
+    0: 0
+    1: 32
+}
+Percentage: size=12 align=4 {
+    0: 0
+}
+PerspectiveFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+PerspectiveOriginStyleValue: size=120 align=8 {
+    0: 0
+}
+PerspectiveStyleValue: size=32 align=8 {
+    0: 0
+}
+PickerPseudoElement: size=64 align=4 {
+    colons: 0
+    function: 24
+    value: 36
+    close: 48
+}
+PlaceContentStyleValue: size=112 align=8 {
+    0: 0
+    1: 56
+}
+PlaceItemsStyleValue: size=112 align=8 {
+    0: 0
+    1: 56
+}
+PlaceSelfStyleValue: size=120 align=8 {
+    0: 0
+    1: 64
+}
+PointerEventsStyleValue: size=16 align=4
+    0: Auto
+    1: None
+    2: All
+    3: Fill
+    4: Stroke
+    5: Visible
+    6: Painted
+    7: Visiblepainted
+    8: Visiblefill
+    9: Visiblestroke
+    10: BoundingBox
+PointerMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+PointerMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: Coarse
+    2: Fine
+PointerTimelineAxisStyleValue: size=24 align=8 {
+    0: 0
+}
+PointerTimelineAxisStyleValueKeywords: size=16 align=4
+    0: Block
+    1: Inline
+    2: X
+    3: Y
+PointerTimelineNameStyleValue: size=24 align=8 {
+    0: 0
+}
+PointerTimelineStyleValue: size=24 align=8 {
+    0: 0
+}
+PolarColorSpace: size=16 align=4
+    0: Hsl
+    1: Hwb
+    2: Lch
+    3: Oklch
+PolygonFunction: size=128 align=8 {
+    name: 0
+    fill_rule: 12
+    round: 32
+    comma: 72
+    points: 88
+    close: 112
+}
+PolygonRound: size=40 align=8 {
+    keyword: 0
+    radius: 16
+}
+Position: size=112 align=8
+    0: One
+    1: Two
+    2: Four
+PositionAnchorStyleValue: size=40 align=8
+    0: Normal
+    1: None
+    2: Auto
+    3: AnchorName
+    4: MatchParent
+PositionAndSize: size=216 align=8 {
+    position: 0
+    size: 112
+}
+PositionArea: size=36 align=4
+    0: Physical
+    1: Logical
+    2: SelfLogical
+    3: Position
+    4: SelfPosition
+PositionAreaStyleValue: size=56 align=8 {
+    0: 0
+}
+PositionBlockAxis: size=16 align=4
+    0: BlockStart
+    1: BlockEnd
+    2: Center
+PositionBlockAxisKeyword: size=16 align=4
+    0: BlockStart
+    1: BlockEnd
+PositionFour: size=104 align=8
+    0: Physical
+    1: FlowRelative
+    2: Logical
+PositionHorizontal: size=40 align=8
+    0: Left
+    1: Right
+    2: Center
+    3: XStart
+    4: XEnd
+    5: LengthPercentage
+PositionHorizontalKeyword: size=16 align=4
+    0: Left
+    1: Right
+    2: XStart
+    3: XEnd
+PositionInlineAxis: size=16 align=4
+    0: InlineStart
+    1: InlineEnd
+    2: Center
+PositionInlineAxisKeyword: size=16 align=4
+    0: InlineStart
+    1: InlineEnd
+PositionLogical: size=16 align=4
+    0: Start
+    1: End
+PositionOne: size=40 align=8
+    0: Left
+    1: Right
+    2: Center
+    3: Top
+    4: Bottom
+    5: XStart
+    6: XEnd
+    7: YStart
+    8: YEnd
+    9: BlockStart
+    10: BlockEnd
+    11: InlineStart
+    12: InlineEnd
+    13: Start
+    14: End
+    15: LengthPercentage
+PositionStyleValue: size=16 align=4
+    0: Static
+    1: Relative
+    2: Absolute
+    3: Sticky
+    4: Fixed
+    5: _WebkitSticky
+PositionTryFallbacksStyleValue: size=32 align=8 {
+    0: 0
+}
+PositionTryOrderStyleValue: size=32 align=8 {
+    0: 0
+}
+PositionTryStyleValue: size=64 align=8 {
+    0: 0
+    1: 32
+}
+PositionTwo: size=88 align=8
+    0: Physical
+    1: FlowRelative
+    2: Logical
+PositionVertical: size=40 align=8
+    0: Top
+    1: Bottom
+    2: Center
+    3: YStart
+    4: YEnd
+    5: LengthPercentage
+PositionVerticalKeyword: size=16 align=4
+    0: Top
+    1: Bottom
+    2: YStart
+    3: YEnd
+PositionVisibilityStyleValue: size=52 align=4
+    0: Always
+    1: AnchorValidAnchorVisibleNoOverflow
+PositiveNonZeroInt: size=12 align=4 {
+    0: 0
+}
+PowFunction: size=176 align=8 {
+    name: 0
+    base: 16
+    comma: 128
+    exponent: 144
+    close: 160
+}
+PredefinedCounter: size=16 align=4
+    0: Decimal
+    1: DecimalLeadingZero
+    2: ArabicIndic
+    3: Armenian
+    4: UpperArmenian
+    5: LowerArmenian
+    6: Bengali
+    7: Cambodian
+    8: Khmer
+    9: CjkDecimal
+    10: Devanagari
+    11: Georgian
+    12: Gujarati
+    13: Gurmukhi
+    14: Hebrew
+    15: Kannada
+    16: Lao
+    17: Malayalam
+    18: Mongolian
+    19: Myanmar
+    20: Oriya
+    21: Persian
+    22: LowerRoman
+    23: UpperRoman
+    24: Tamil
+    25: Telugu
+    26: Thai
+    27: Tibetan
+    28: LowerAlpha
+    29: UpperAlpha
+    30: UpperLatin
+    31: LowerGreek
+    32: Hiragana
+    33: HiraganaIroha
+    34: Katakana
+    35: KatakanaIroha
+    36: Disc
+    37: Square
+    38: DisclousureOpen
+    39: DisclousureClosed
+    40: CjkEarthlyBranch
+    41: CjkHeavenlyStem
+PrefersColorSchemeMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+PrefersColorSchemeMediaFeatureKeyword: size=16 align=4
+    0: Light
+    1: Dark
+PrefersContrastMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+PrefersContrastMediaFeatureKeyword: size=16 align=4
+    0: NoPreference
+    1: Less
+    2: More
+    3: Custom
+PrefersReducedDataMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+PrefersReducedDataMediaFeatureKeyword: size=16 align=4
+    0: NoPreference
+    1: Reduce
+PrefersReducedMotionMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+PrefersReducedMotionMediaFeatureKeyword: size=16 align=4
+    0: NoPreference
+    1: Reduce
+PrefersReducedTransparencyMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+PrefersReducedTransparencyMediaFeatureKeyword: size=16 align=4
+    0: NoPreference
+    1: Reduce
+PrefixStyleValue: size=64 align=8 {
+    0: 0
+}
+PrintColorAdjustStyleValue: size=16 align=4
+    0: Economy
+    1: Exact
+PropertyPrelude: size=12 align=4 {
+    0: 0
+}
+PropertyRule: size=144 align=16 {
+    name: 0
+    prelude: 12
+    block: 32
+}
+PropertyRuleBlock: size=112 align=16 {
+    0: 0
+}
+PropertyRuleStyleValue: size=32 align=8
+    0: InitialValue
+    1: Syntax
+    2: Inherits
+    3: Unknown
+PseudoClass: size=32 align=4
+    0: Active
+    1: AnyLink
+    2: Autofill
+    3: Blank
+    4: Buffering
+    5: Checked
+    6: Current
+    7: Default
+    8: Defined
+    9: Disabled
+    10: Empty
+    11: Enabled
+    12: First
+    13: FirstChild
+    14: FirstOfType
+    15: Focus
+    16: FocusVisible
+    17: FocusWithin
+    18: Fullscreen
+    19: Future
+    20: HasSlotted
+    21: Host
+    22: Heading
+    23: Hover
+    24: InRange
+    25: Indeterminate
+    26: Invalid
+    27: LastChild
+    28: LastOfType
+    29: Left
+    30: Link
+    31: LocalLink
+    32: Modal
+    33: Muted
+    34: OnlyChild
+    35: OnlyOfType
+    36: Open
+    37: Optional
+    38: OutOfRange
+    39: Past
+    40: Paused
+    41: PictureInPicture
+    42: PlaceholderShown
+    43: Playing
+    44: PopoverOpen
+    45: ReadOnly
+    46: ReadWrite
+    47: Required
+    48: Right
+    49: Root
+    50: Scope
+    51: Seeking
+    52: Stalled
+    53: Target
+    54: TargetCurrent
+    55: TargetWithin
+    56: UserInvalid
+    57: Valid
+    58: Visited
+    59: VolumeLocked
+    60: Webkit
+    61: Moz
+    62: Ms
+    63: O
+PseudoElement: size=44 align=4
+    0: After
+    1: Backdrop
+    2: Before
+    3: Checkmark
+    4: Column
+    5: Cue
+    6: DetailsContent
+    7: FileSelectorButton
+    8: FirstLetter
+    9: FirstLine
+    10: GrammarError
+    11: Marker
+    12: PickerIcon
+    13: Placeholder
+    14: ScrollMarker
+    15: ScrollMarkerGroup
+    16: Selection
+    17: SpellingError
+    18: TargetText
+    19: ViewTransition
+    20: Webkit
+    21: Moz
+    22: Ms
+    23: O
+PtNameAndClassSelector: size=48 align=8
+    0: Wildcard
+    1: Named
+    2: Classes
+Quote: size=16 align=4
+    0: OpenQuote
+    1: CloseQuote
+    2: NoOpenQuote
+    3: NoCloseQuote
+QuotesStyleValue: size=32 align=8
+    0: Auto
+    1: None
+    2: MatchParent
+    3: String
+RadialExtent: size=16 align=4
+    0: ClosestCorner
+    1: ClosestSide
+    2: FarthestCorner
+    3: FarthestSide
+RadialGradientFunction: size=288 align=8 {
+    name: 0
+    params: 16
+    close: 272
+}
+RadialGradientFunctionParams: size=256 align=8 {
+    0: 0
+    1: 72
+    2: 88
+    3: 104
+    4: 216
+    5: 232
+}
+RadialShape: size=16 align=4
+    0: Circle
+    1: Ellipse
+RadialSize: size=72 align=8
+    0: Extent
+    1: Circular
+    2: Elliptical
+Ratio: size=64 align=8 {
+    numerator: 0
+    slash: 24
+    denominator: 40
+}
+ReadingFlowStyleValue: size=16 align=4
+    0: Normal
+    1: SourceOrder
+    2: FlexVisual
+    3: FlexFlow
+    4: GridRows
+    5: GridColumns
+    6: GridOrder
+ReadingOrderStyleValue: size=24 align=8 {
+    0: 0
+}
+RectFunction: size=208 align=8 {
+    name: 0
+    top: 16
+    comma1: 48
+    right: 64
+    comma2: 96
+    bottom: 112
+    comma3: 144
+    left: 160
+    close: 192
+}
+RectangularColorSpace: size=16 align=4
+    0: Srgb
+    1: SrgbLinear
+    2: DisplayP3
+    3: A98Rgb
+    4: ProphotoRgb
+    5: Rec2020
+    6: Lab
+    7: Oklab
+    8: Xyz
+    9: XyzD50
+    10: XyzD65
+RegionFragmentStyleValue: size=16 align=4
+    0: Auto
+    1: Break
+RelativeColorFunction: size=24 align=8
+    0: Color
+    1: Rgb
+    2: Rgba
+    3: Hsl
+    4: Hsla
+    5: Hwb
+    6: Lab
+    7: Lch
+    8: Oklab
+    9: Oklch
+RelativeColorOrigin: size=40 align=8 {
+    from_keyword: 0
+    color: 16
+}
+RelativeControlPoint: size=88 align=8 {
+    0: 0
+    1: 72
+}
+RelativeControlPointKeywords: size=16 align=4
+    0: Start
+    1: End
+    2: Origin
+RelativeSize: size=16 align=4
+    0: Larger
+    1: Smaller
+RepeatStyle: size=36 align=4
+    0: RepeatX
+    1: RepeatY
+    2: Repetition
+RepeatingLinearGradientFunction: size=128 align=8 {
+    name: 0
+    params: 16
+    close: 112
+}
+RepeatingLinearGradientFunctionParams: size=96 align=8 {
+    0: 0
+    1: 56
+    2: 72
+}
+RepeatingRadialGradientFunction: size=288 align=8 {
+    name: 0
+    params: 16
+    close: 272
+}
+RepeatingRadialGradientFunctionParams: size=256 align=8 {
+    0: 0
+    1: 72
+    2: 88
+    3: 104
+    4: 216
+    5: 232
+}
+Repetition: size=16 align=4
+    0: Repeat
+    1: Space
+    2: Round
+    3: NoRepeat
+ResizeStyleValue: size=16 align=4
+    0: None
+    1: Both
+    2: Horizontal
+    3: Vertical
+    4: Block
+    5: Inline
+Resolution: size=16 align=4
+    0: Dpi
+    1: Dpcm
+    2: Dppx
+    3: X
+ResolutionOrType: size=48 align=8
+    0: Resolution
+    1: Type
+RestAfterStyleValue: size=32 align=8
+    0: Time
+    1: None
+    2: XWeak
+    3: Weak
+    4: Medium
+    5: Strong
+    6: XStrong
+RestBeforeStyleValue: size=32 align=8
+    0: Time
+    1: None
+    2: XWeak
+    3: Weak
+    4: Medium
+    5: Strong
+    6: XStrong
+RestStyleValue: size=64 align=8 {
+    0: 0
+    1: 32
+}
+ReversedCounterName: size=36 align=4 {
+    function: 0
+    name: 12
+    close: 24
+}
+RgbChannelKeyword: size=16 align=4
+    0: R
+    1: G
+    2: B
+    3: Alpha
+RgbFunction: size=208 align=8 {
+    name: 0
+    params: 16
+    close: 192
+}
+RgbFunctionParams: size=176 align=8 {
+    0: 0
+    1: 32
+    2: 48
+    3: 80
+    4: 96
+    5: 128
+    6: 144
+}
+RgbRelativeFunction: size=248 align=8 {
+    name: 0
+    params: 16
+    close: 232
+}
+RgbRelativeParams: size=216 align=8 {
+    origin: 0
+    red: 40
+    green: 80
+    blue: 120
+    slash: 160
+    alpha: 176
+}
+RgbaFunction: size=208 align=8 {
+    name: 0
+    params: 16
+    close: 192
+}
+RgbaRelativeFunction: size=248 align=8 {
+    name: 0
+    params: 16
+    close: 232
+}
+RightStyleValue: size=40 align=8 {
+    0: 0
+}
+Rotate3dFunction: size=184 align=8 {
+    name: 0
+    params: 16
+    close: 168
+}
+Rotate3dFunctionParams: size=152 align=8 {
+    0: 0
+    1: 24
+    2: 40
+    3: 64
+    4: 80
+    5: 104
+    6: 120
+}
+RotateFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+RotatexFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+RotateyFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+RotatezFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+RoundingStrategy: size=16 align=4
+    0: Nearest
+    1: Up
+    2: Down
+    3: ToZero
+    4: LineWidth
+RowGapStyleValue: size=48 align=8
+    0: Normal
+    1: LengthPercentage
+    2: LineWidth
+RowRuleBreakStyleValue: size=16 align=4
+    0: None
+    1: Normal
+    2: Intersection
+RowRuleColorStyleValue: size=32 align=8
+    0: LineColorList
+    1: AutoLineColorList
+RowRuleInsetCapEndStyleValue: size=48 align=8 {
+    0: 0
+}
+RowRuleInsetCapStartStyleValue: size=48 align=8 {
+    0: 0
+}
+RowRuleInsetCapStyleValue: size=96 align=8 {
+    0: 0
+    1: 48
+}
+RowRuleInsetEndStyleValue: size=48 align=8 {
+    0: 0
+}
+RowRuleInsetJunctionEndStyleValue: size=48 align=8 {
+    0: 0
+}
+RowRuleInsetJunctionStartStyleValue: size=48 align=8 {
+    0: 0
+}
+RowRuleInsetJunctionStyleValue: size=96 align=8 {
+    0: 0
+    1: 48
+}
+RowRuleInsetStartStyleValue: size=48 align=8 {
+    0: 0
+}
+RowRuleInsetStyleValue: size=208 align=8 {
+    0: 0
+    1: 96
+}
+RowRuleStyleStyleValue: size=32 align=8
+    0: LineStyleList
+    1: AutoLineStyleList
+RowRuleStyleValue: size=32 align=8 {
+    0: 0
+}
+RowRuleVisibilityItemsStyleValue: size=16 align=4
+    0: All
+    1: Around
+    2: Between
+    3: Normal
+RowRuleWidthStyleValue: size=144 align=8
+    0: LineWidthList
+    1: AutoLineWidthList
+RubyAlignStyleValue: size=16 align=4
+    0: Start
+    1: Center
+    2: SpaceBetween
+    3: SpaceAround
+RubyMergeStyleValue: size=16 align=4
+    0: Separate
+    1: Merge
+    2: Auto
+RubyOverhangStyleValue: size=16 align=4
+    0: Auto
+    1: Spaces
+    2: None
+RubyPositionStyleValue: size=36 align=4
+    0: Over
+    1: Under
+    2: InterCharacter
+Rule: size=224 align=16
+    0: Charset
+    1: ColorProfile
+    2: Container
+    3: CounterStyle
+    4: FontFace
+    5: FontFeatureValues
+    6: FontPaletteValues
+    7: Keyframes
+    8: Layer
+    9: Media
+    10: Namespace
+    11: Page
+    12: Property
+    13: Scope
+    14: StartingStyle
+    15: Document
+    16: WebkitKeyframes
+    17: MozDocument
+    18: Import
+    19: Supports
+    20: UnknownAt
+    21: Style
+    22: Unknown
+RuleBreakStyleValue: size=16 align=4 {
+    0: 0
+}
+RuleColorStyleValue: size=32 align=8 {
+    0: 0
+}
+RuleInsetCapStyleValue: size=96 align=8 {
+    0: 0
+}
+RuleInsetEndStyleValue: size=48 align=8 {
+    0: 0
+}
+RuleInsetJunctionStyleValue: size=96 align=8 {
+    0: 0
+}
+RuleInsetStartStyleValue: size=48 align=8 {
+    0: 0
+}
+RuleInsetStyleValue: size=208 align=8 {
+    0: 0
+}
+RuleOverlapStyleValue: size=16 align=4
+    0: RowOverColumn
+    1: ColumnOverRow
+RuleStyleStyleValue: size=32 align=8 {
+    0: 0
+}
+RuleStyleValue: size=32 align=8 {
+    0: 0
+}
+RuleVisibilityItemsStyleValue: size=16 align=4 {
+    0: 0
+}
+RuleWidthStyleValue: size=144 align=8 {
+    0: 0
+}
+RunningStyleValue: size=24 align=8 {
+    0: 0
+}
+SaturateFunction: size=56 align=8 {
+    name: 0
+    value: 16
+    close: 40
+}
+Scale3dFunction: size=136 align=8 {
+    name: 0
+    params: 16
+    close: 120
+}
+Scale3dFunctionParams: size=104 align=8 {
+    0: 0
+    1: 24
+    2: 40
+    3: 64
+    4: 80
+}
+ScaleFunction: size=96 align=8 {
+    name: 0
+    params: 16
+    close: 80
+}
+ScaleStyleValue: size=80 align=8 {
+    0: 0
+}
+ScalexFunction: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+ScaleyFunction: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+ScalezFunction: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+ScanMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+ScanMediaFeatureKeyword: size=16 align=4
+    0: Interlace
+    1: Progressive
+ScriptingMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+ScriptingMediaFeatureKeyword: size=16 align=4
+    0: None
+    1: InitialOnly
+    2: Enabled
+ScrollBehaviorStyleValue: size=16 align=4
+    0: Auto
+    1: Smooth
+ScrollInitialTargetStyleValue: size=16 align=4
+    0: None
+    1: Nearest
+ScrollMarginBlockEndStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollMarginBlockStartStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollMarginBlockStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+ScrollMarginBottomStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollMarginInlineEndStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollMarginInlineStartStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollMarginInlineStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+ScrollMarginLeftStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollMarginRightStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollMarginStyleValue: size=96 align=8 {
+    0: 0
+    1: 24
+    2: 48
+    3: 72
+}
+ScrollMarginTopStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollMarkerGroupStyleValue: size=36 align=4
+    0: None
+    1: BeforeLinks
+    2: BeforeTabs
+    3: AfterLinks
+    4: AfterTabs
+ScrollPaddingBlockEndStyleValue: size=40 align=8 {
+    0: 0
+}
+ScrollPaddingBlockStartStyleValue: size=40 align=8 {
+    0: 0
+}
+ScrollPaddingBlockStyleValue: size=80 align=8 {
+    0: 0
+    1: 40
+}
+ScrollPaddingBottomStyleValue: size=40 align=8 {
+    0: 0
+}
+ScrollPaddingInlineEndStyleValue: size=40 align=8 {
+    0: 0
+}
+ScrollPaddingInlineStartStyleValue: size=40 align=8 {
+    0: 0
+}
+ScrollPaddingInlineStyleValue: size=80 align=8 {
+    0: 0
+    1: 40
+}
+ScrollPaddingLeftStyleValue: size=40 align=8 {
+    0: 0
+}
+ScrollPaddingRightStyleValue: size=40 align=8 {
+    0: 0
+}
+ScrollPaddingStyleValue: size=160 align=8 {
+    0: 0
+    1: 40
+    2: 80
+    3: 120
+}
+ScrollPaddingTopStyleValue: size=40 align=8 {
+    0: 0
+}
+ScrollSnapAlignStyleValue: size=32 align=4 {
+    0: 0
+    1: 16
+}
+ScrollSnapAlignStyleValueKeywords: size=16 align=4
+    0: None
+    1: Start
+    2: End
+    3: Center
+ScrollSnapStopStyleValue: size=16 align=4
+    0: Normal
+    1: Always
+ScrollSnapTypeStyleValue: size=28 align=4
+    0: None
+    1: XMandatory
+    2: XProximity
+    3: X
+    4: YMandatory
+    5: YProximity
+    6: Y
+    7: BlockMandatory
+    8: BlockProximity
+    9: Block
+    10: InlineMandatory
+    11: InlineProximity
+    12: Inline
+    13: BothMandatory
+    14: BothProximity
+    15: Both
+ScrollStateFeature: size=80 align=4
+    0: Stuck
+    1: Snapped
+    2: Scrollable
+ScrollStateQuery: size=104 align=8
+    0: Is
+    1: Not
+    2: And
+    3: Or
+ScrollTargetGroupStyleValue: size=16 align=4
+    0: None
+    1: Auto
+ScrollTimelineAxisStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollTimelineAxisStyleValueKeywords: size=16 align=4
+    0: Block
+    1: Inline
+    2: X
+    3: Y
+ScrollTimelineNameStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollTimelineStyleValue: size=24 align=8 {
+    0: 0
+}
+ScrollableScrollStateFeatureKeyword: size=16 align=4
+    0: None
+    1: Top
+    2: Right
+    3: Bottom
+    4: Left
+    5: BlockStart
+    6: InlineStart
+    7: BlockEnd
+    8: InlineEnd
+    9: X
+    10: Y
+    11: Block
+    12: Inline
+    13: Discrete
+ScrollbarColorStyleValue: size=72 align=8 {
+    0: 0
+}
+ScrollbarGutterStyleValue: size=32 align=4 {
+    0: 0
+}
+ScrollbarWidthStyleValue: size=16 align=4
+    0: Auto
+    1: Thin
+    2: None
+SelectorComponent: size=136 align=8
+    0: Id
+    1: Class
+    2: Tag
+    3: Wildcard
+    4: Combinator
+    5: Attribute
+    6: PseudoClass
+    7: PseudoElement
+    8: FunctionalPseudoElement
+    9: LegacyPseudoElement
+    10: FunctionalPseudoClass
+    11: Namespace
+SelectorList: size=24 align=8 {
+    0: 0
+}
+SelfPosition: size=16 align=4
+    0: Center
+    1: Start
+    2: End
+    3: SelfStart
+    4: SelfEnd
+    5: FlexStart
+    6: FlexEnd
+SepiaFunction: size=56 align=8 {
+    name: 0
+    value: 16
+    close: 40
+}
+Shadow: size=136 align=8 {
+    color: 0
+    offset: 24
+    inset: 120
+}
+ShadowPosition: size=16 align=4
+    0: Inset
+    1: Outset
+ShapeBox: size=20 align=4
+    0: VisualBox
+    1: MarginBox
+ShapeCommand: size=480 align=8
+    0: MoveCommand
+    1: LineCommand
+    2: Close
+    3: HorizontalLineCommand
+    4: VerticalLineCommand
+    5: CurveCommand
+    6: SmoothCommand
+    7: ArcCommand
+ShapeFunction: size=208 align=8 {
+    name: 0
+    fill_rule: 12
+    from: 28
+    position: 40
+    comma: 152
+    commands: 168
+    close: 192
+}
+ShapeImageThresholdStyleValue: size=24 align=8 {
+    0: 0
+}
+ShapeInsideStyleValue: size=272 align=8
+    0: Auto
+    1: OutsideShape
+    2: ShapeBox
+    3: Image
+    4: Display
+ShapeMarginStyleValue: size=32 align=8 {
+    0: 0
+}
+ShapeOutsideStyleValue: size=288 align=8
+    0: None
+    1: BasicShapeShapeBox
+    2: Image
+ShapePaddingStyleValue: size=32 align=8 {
+    0: 0
+}
+ShapeRectFunction: size=480 align=8 {
+    name: 0
+    params: 16
+    close: 464
+}
+ShapeRectFunctionParams: size=448 align=8 {
+    0: 0
+    1: 40
+    2: 80
+    3: 120
+    4: 160
+}
+ShapeRenderingStyleValue: size=16 align=4
+    0: Auto
+    1: Optimizespeed
+    2: Crispedges
+    3: Geometricprecision
+SinFunction: size=144 align=8 {
+    name: 0
+    params: 16
+    close: 128
+}
+SingleAdditiveSymbolsStyleValue: size=88 align=8 {
+    0: 0
+    1: 24
+}
+SingleAnimationComposition: size=16 align=4
+    0: Replace
+    1: Add
+    2: Accumulate
+SingleAnimationDelayStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+SingleAnimationDirection: size=16 align=4
+    0: Normal
+    1: Reverse
+    2: Alternate
+    3: AlternateReverse
+SingleAnimationFillMode: size=16 align=4
+    0: None
+    1: Forwards
+    2: Backwards
+    3: Both
+SingleAnimationIterationCount: size=32 align=8
+    0: Infinite
+    1: Number
+SingleAnimationPlayState: size=16 align=4
+    0: Running
+    1: Paused
+SingleAnimationRangeCenterStyleValue: size=64 align=8
+    0: Normal
+    1: LengthPercentage
+    2: TimelineRangeCenterSubject
+SingleAnimationRangeEndStyleValue: size=64 align=8
+    0: Normal
+    1: LengthPercentage
+    2: TimelineRangeName
+SingleAnimationRangeStartStyleValue: size=64 align=8
+    0: Normal
+    1: LengthPercentage
+    2: TimelineRangeName
+SingleAnimationRangeStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+SingleAnimationTimeline: size=16 align=4
+    0: Auto
+    1: None
+SingleAnimationTriggerBehavior: size=16 align=4
+    0: Once
+    1: Repeat
+    2: Alternate
+    3: State
+SingleAnimationTriggerType: size=16 align=4
+    0: Once
+    1: Repeat
+    2: Alternate
+    3: State
+SingleContainIntrinsicSizeStyleValue: size=48 align=8 {
+    0: 0
+    1: 16
+}
+SingleMaskClipStyleValue: size=32 align=8
+    0: CoordBox
+    1: NoClip
+SinglePointerTimelineStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+SingleScrollTimelineStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+SingleTimelineTriggerActivationRangeEndStyleValue: size=64 align=8
+    0: Normal
+    1: LengthPercentage
+    2: TimelineRangeName
+SingleTimelineTriggerActivationRangeStartStyleValue: size=64 align=8
+    0: Normal
+    1: LengthPercentage
+    2: TimelineRangeName
+SingleTimelineTriggerActivationRangeStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+SingleTimelineTriggerActiveRangeEndStyleValue: size=64 align=8
+    0: Auto
+    1: Normal
+    2: LengthPercentage
+    3: TimelineRangeName
+SingleTimelineTriggerActiveRangeStartStyleValue: size=64 align=8
+    0: Auto
+    1: Normal
+    2: LengthPercentage
+    3: TimelineRangeName
+SingleTimelineTriggerActiveRangeStyleValue: size=48 align=8 {
+    0: 0
+    1: 24
+}
+SingleTransition: size=272 align=8 {
+    property: 0
+    duration: 24
+    easing: 48
+    delay: 232
+    behavior: 256
+}
+SingleTransitionProperty: size=16 align=4
+    0: All
+    1: CustomIdent
+SingleViewTimelineInsetStyleValue: size=80 align=8 {
+    0: 0
+    1: 40
+}
+SingleViewTimelineStyleValue: size=80 align=8 {
+    0: 0
+    1: 24
+}
+SkewFunction: size=112 align=8 {
+    name: 0
+    params: 16
+    close: 96
+}
+SkewxFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+SkewyFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+SliderOrientationStyleValue: size=16 align=4
+    0: Auto
+    1: LeftToRight
+    2: RightToLeft
+    3: TopToBottom
+    4: BottomToTop
+SlottedPseudoElement: size=80 align=8 {
+    colons: 0
+    function: 24
+    value: 40
+    close: 64
+}
+SmoothCommand: size=312 align=8 {
+    keyword: 0
+    target: 16
+}
+SmoothTarget: size=296 align=8
+    0: ToPosition
+    1: ByCoordinatePairWithRelativeControlPoint
+SnapBlockFunction: size=112 align=8 {
+    name: 0
+    params: 16
+    close: 96
+}
+SnapBlockFunctionParams: size=80 align=8 {
+    0: 0
+    1: 32
+    2: 48
+    3: 64
+}
+SnapBlockKeyword: size=16 align=4
+    0: Start
+    1: End
+    2: Near
+SnapInlineFunction: size=112 align=8 {
+    name: 0
+    params: 16
+    close: 96
+}
+SnapInlineFunctionParams: size=80 align=8 {
+    0: 0
+    1: 32
+    2: 48
+    3: 64
+}
+SnapInlineKeyword: size=16 align=4
+    0: Left
+    1: Right
+    2: Near
+SnappedScrollStateFeatureKeyword: size=16 align=4
+    0: None
+    1: X
+    2: Y
+    3: Block
+    4: Inline
+    5: Both
+    6: Discrete
+SpacingTrim: size=16 align=4
+    0: SpaceAll
+    1: Normal
+    2: SpaceFirst
+    3: TrimStart
+    4: TrimBoth
+    5: TrimAll
+SpatialNavigationActionStyleValue: size=16 align=4
+    0: Auto
+    1: Focus
+    2: Scroll
+SpatialNavigationContainStyleValue: size=16 align=4
+    0: Auto
+    1: Contain
+SpatialNavigationFunctionStyleValue: size=16 align=4
+    0: Normal
+    1: Grid
+SpeakAsStyleValue: size=32 align=8
+    0: Auto
+    1: Bullets
+    2: Numbers
+    3: Words
+    4: SpellOut
+    5: CounterStyleName
+SpeakStyleValue: size=16 align=4
+    0: Auto
+    1: Never
+    2: Always
+SpreadShadow: size=144 align=8 {
+    color: 0
+    offset: 24
+    blur: 80
+    spread: 104
+    position: 128
+}
+SqrtFunction: size=144 align=8 {
+    name: 0
+    params: 16
+    close: 128
+}
+StartingStyleRule: size=128 align=16 {
+    name: 0
+    block: 16
+}
+StartingStyleRuleBlock: size=112 align=16 {
+    0: 0
+}
+StatePseudoFunction: size=52 align=4 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 36
+}
+StepPosition: size=16 align=4
+    0: JumpStart
+    1: JumpEnd
+    2: JumpNone
+    3: JumpBoth
+    4: Start
+    5: End
+StepsFunction: size=88 align=8 {
+    name: 0
+    params: 16
+    close: 72
+}
+StepsFunctionParams: size=56 align=8 {
+    0: 0
+    1: 24
+    2: 40
+}
+StringFunction: size=68 align=4 {
+    name: 0
+    params: 12
+    close: 56
+}
+StringFunctionParams: size=44 align=4 {
+    ident: 0
+    comma: 12
+    keyword: 28
+}
+StringKeyword: size=16 align=4
+    0: First
+    1: Start
+    2: Last
+    3: FirstExcept
+StringSetStyleValue: size=32 align=8 {
+    0: 0
+}
+StripesFunction: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+StrokeAlignStyleValue: size=16 align=4
+    0: Center
+    1: Inset
+    2: Outset
+StrokeBreakStyleValue: size=16 align=4
+    0: BoundingBox
+    1: Slice
+    2: Clone
+StrokeColorStyleValue: size=24 align=8 {
+    0: 0
+}
+StrokeDashCornerStyleValue: size=32 align=8 {
+    0: 0
+}
+StrokeDashJustifyStyleValue: size=52 align=4
+    0: None
+    1: Stretch
+    2: Compress
+StrokeDasharrayStyleValue: size=32 align=8 {
+    0: 0
+}
+StrokeDashoffsetStyleValue: size=32 align=8 {
+    0: 0
+}
+StrokeImageStyleValue: size=24 align=8 {
+    0: 0
+}
+StrokeLayer: size=368 align=8 {
+    image: 0
+    position: 72
+    repeat: 288
+    origin: 324
+    color: 344
+}
+StrokeLinecapStyleValue: size=16 align=4
+    0: Butt
+    1: Round
+    2: Square
+StrokeLinejoinStyleValue: size=36 align=4
+    0: CropBevel
+    1: CropRound
+    2: CropFallback
+    3: ArcsBevel
+    4: ArcsRound
+    5: ArcsFallback
+    6: MiterBevel
+    7: MiterRound
+    8: MiterFallback
+StrokeMiterlimitStyleValue: size=24 align=8 {
+    0: 0
+}
+StrokeOpacityStyleValue: size=24 align=8 {
+    0: 0
+}
+StrokeOriginStyleValue: size=16 align=4
+    0: MatchParent
+    1: FillBox
+    2: StrokeBox
+    3: ContentBox
+    4: PaddingBox
+    5: BorderBox
+StrokePositionStyleValue: size=24 align=8 {
+    0: 0
+}
+StrokeRepeatStyleValue: size=24 align=8 {
+    0: 0
+}
+StrokeSizeStyleValue: size=24 align=8 {
+    0: 0
+}
+StrokeStyleValue: size=24 align=8 {
+    0: 0
+}
+StrokeWidthStyleValue: size=24 align=8 {
+    0: 0
+}
+StuckScrollStateFeatureKeyword: size=16 align=4
+    0: None
+    1: Top
+    2: Right
+    3: Bottom
+    4: Left
+    5: BlockStart
+    6: InlineStart
+    7: BlockEnd
+    8: InlineEnd
+    9: Discrete
+StyleFeature: size=24 align=8
+    0: Declaration
+    1: CustomProperty
+StyleQuery: size=48 align=8
+    0: Is
+    1: Not
+    2: And
+    3: Or
+StyleRule: size=208 align=16 {
+    rule: 0
+}
+StyleSheet: size=80 align=16 {
+    rules: 0
+    meta: 32
+}
+StyleValue: size=664 align=8
+    0: Initial
+    1: Inherit
+    2: Unset
+    3: Revert
+    4: RevertLayer
+    5: Custom
+    6: Unresolved
+    7: Unknown
+    8: AccentColor
+    9: AdditiveSymbols
+    10: AlignContent
+    11: AlignItems
+    12: AlignSelf
+    13: AlignmentBaseline
+    14: All
+    15: AnchorName
+    16: AnchorScope
+    17: AnimationComposition
+    18: AnimationDelayEnd
+    19: AnimationDelayStart
+    20: AnimationDelay
+    21: AnimationDirection
+    22: AnimationDuration
+    23: AnimationFillMode
+    24: AnimationIterationCount
+    25: AnimationName
+    26: AnimationPlayState
+    27: AnimationRangeCenter
+    28: AnimationRangeEnd
+    29: AnimationRangeStart
+    30: AnimationRange
+    31: Animation
+    32: AnimationTimeline
+    33: AnimationTimingFunction
+    34: AnimationTrigger
+    35: Appearance
+    36: AspectRatio
+    37: BackdropFilter
+    38: BackfaceVisibility
+    39: BackgroundAttachment
+    40: BackgroundBlendMode
+    41: BackgroundClip
+    42: BackgroundColor
+    43: BackgroundImage
+    44: BackgroundOrigin
+    45: BackgroundPosition
+    46: BackgroundRepeatBlock
+    47: BackgroundRepeatInline
+    48: BackgroundRepeat
+    49: BackgroundRepeatX
+    50: BackgroundRepeatY
+    51: BackgroundSize
+    52: Background
+    53: BaselineShift
+    54: BaselineSource
+    55: BlockEllipsis
+    56: BlockSize
+    57: BlockStepAlign
+    58: BlockStepInsert
+    59: BlockStepRound
+    60: BlockStepSize
+    61: BlockStep
+    62: BookmarkLabel
+    63: BookmarkLevel
+    64: BookmarkState
+    65: BorderBlockClip
+    66: BorderBlockColor
+    67: BorderBlockEndClip
+    68: BorderBlockEndColor
+    69: BorderBlockEndRadius
+    70: BorderBlockEndStyle
+    71: BorderBlockEnd
+    72: BorderBlockEndWidth
+    73: BorderBlockStartClip
+    74: BorderBlockStartColor
+    75: BorderBlockStartRadius
+    76: BorderBlockStartStyle
+    77: BorderBlockStart
+    78: BorderBlockStartWidth
+    79: BorderBlockStyle
+    80: BorderBlock
+    81: BorderBlockWidth
+    82: BorderBottomClip
+    83: BorderBottomColor
+    84: BorderBottomLeftRadius
+    85: BorderBottomRadius
+    86: BorderBottomRightRadius
+    87: BorderBottomStyle
+    88: BorderBottom
+    89: BorderBottomWidth
+    90: BorderBoundary
+    91: BorderClip
+    92: BorderCollapse
+    93: BorderColor
+    94: BorderEndEndRadius
+    95: BorderEndStartRadius
+    96: BorderImageOutset
+    97: BorderImageRepeat
+    98: BorderImageSlice
+    99: BorderImageSource
+    100: BorderImageWidth
+    101: BorderInlineClip
+    102: BorderInlineColor
+    103: BorderInlineEndClip
+    104: BorderInlineEndColor
+    105: BorderInlineEndRadius
+    106: BorderInlineEndStyle
+    107: BorderInlineEnd
+    108: BorderInlineEndWidth
+    109: BorderInlineStartClip
+    110: BorderInlineStartColor
+    111: BorderInlineStartRadius
+    112: BorderInlineStartStyle
+    113: BorderInlineStart
+    114: BorderInlineStartWidth
+    115: BorderInlineStyle
+    116: BorderInline
+    117: BorderInlineWidth
+    118: BorderLeftClip
+    119: BorderLeftColor
+    120: BorderLeftRadius
+    121: BorderLeftStyle
+    122: BorderLeft
+    123: BorderLeftWidth
+    124: BorderLimit
+    125: BorderRadius
+    126: BorderRightClip
+    127: BorderRightColor
+    128: BorderRightRadius
+    129: BorderRightStyle
+    130: BorderRight
+    131: BorderRightWidth
+    132: BorderShape
+    133: BorderSpacing
+    134: BorderStartEndRadius
+    135: BorderStartStartRadius
+    136: BorderStyle
+    137: Border
+    138: BorderTopClip
+    139: BorderTopColor
+    140: BorderTopLeftRadius
+    141: BorderTopRadius
+    142: BorderTopRightRadius
+    143: BorderTopStyle
+    144: BorderTop
+    145: BorderTopWidth
+    146: BorderWidth
+    147: Bottom
+    148: BoxDecorationBreak
+    149: BoxShadowBlur
+    150: BoxShadowColor
+    151: BoxShadowOffset
+    152: BoxShadowPosition
+    153: BoxShadowSpread
+    154: BoxShadow
+    155: BoxSizing
+    156: BoxSnap
+    157: BreakAfter
+    158: BreakBefore
+    159: BreakInside
+    160: CaptionSide
+    161: CaretAnimation
+    162: CaretColor
+    163: CaretShape
+    164: Caret
+    165: Clear
+    166: ClipPath
+    167: ClipRule
+    168: Clip
+    169: ColorAdjust
+    170: ColorInterpolationFilters
+    171: ColorInterpolation
+    172: ColorScheme
+    173: Color
+    174: ColumnCount
+    175: ColumnFill
+    176: ColumnGap
+    177: ColumnHeight
+    178: ColumnRuleBreak
+    179: ColumnRuleColor
+    180: ColumnRuleInsetCapEnd
+    181: ColumnRuleInsetCapStart
+    182: ColumnRuleInsetCap
+    183: ColumnRuleInsetEnd
+    184: ColumnRuleInsetJunctionEnd
+    185: ColumnRuleInsetJunctionStart
+    186: ColumnRuleInsetJunction
+    187: ColumnRuleInsetStart
+    188: ColumnRuleInset
+    189: ColumnRuleStyle
+    190: ColumnRule
+    191: ColumnRuleVisibilityItems
+    192: ColumnRuleWidth
+    193: ColumnSpan
+    194: ColumnWidth
+    195: ColumnWrap
+    196: Columns
+    197: ContainIntrinsicBlockSize
+    198: ContainIntrinsicHeight
+    199: ContainIntrinsicInlineSize
+    200: ContainIntrinsicSize
+    201: ContainIntrinsicWidth
+    202: Contain
+    203: ContainerName
+    204: Container
+    205: ContainerType
+    206: Content
+    207: ContentVisibility
+    208: Continue
+    209: CopyInto
+    210: CornerBlockEndShape
+    211: CornerBlockEnd
+    212: CornerBlockStartShape
+    213: CornerBlockStart
+    214: CornerBottomLeftShape
+    215: CornerBottomLeft
+    216: CornerBottomRightShape
+    217: CornerBottomRight
+    218: CornerBottomShape
+    219: CornerBottom
+    220: CornerEndEndShape
+    221: CornerEndEnd
+    222: CornerEndStartShape
+    223: CornerEndStart
+    224: CornerInlineEndShape
+    225: CornerInlineEnd
+    226: CornerInlineStartShape
+    227: CornerInlineStart
+    228: CornerLeftShape
+    229: CornerLeft
+    230: CornerRightShape
+    231: CornerRight
+    232: CornerShape
+    233: CornerStartEndShape
+    234: CornerStartEnd
+    235: CornerStartStartShape
+    236: CornerStartStart
+    237: Corner
+    238: CornerTopLeftShape
+    239: CornerTopLeft
+    240: CornerTopRightShape
+    241: CornerTopRight
+    242: CornerTopShape
+    243: CornerTop
+    244: CounterIncrement
+    245: CounterReset
+    246: CounterSet
+    247: CueAfter
+    248: CueBefore
+    249: Cue
+    250: Cursor
+    251: Direction
+    252: Display
+    253: DominantBaseline
+    254: DynamicRangeLimit
+    255: EmptyCells
+    256: EventTriggerName
+    257: EventTriggerSource
+    258: EventTrigger
+    259: Fallback
+    260: FieldSizing
+    261: FillBreak
+    262: FillColor
+    263: FillImage
+    264: FillOpacity
+    265: FillOrigin
+    266: FillPosition
+    267: FillRepeat
+    268: FillRule
+    269: FillSize
+    270: Fill
+    271: Filter
+    272: FlexBasis
+    273: FlexDirection
+    274: FlexFlow
+    275: FlexGrow
+    276: FlexLineCount
+    277: FlexShrink
+    278: Flex
+    279: FlexWrap
+    280: FloatDefer
+    281: FloatOffset
+    282: FloatReference
+    283: Float
+    284: FloodColor
+    285: FloodOpacity
+    286: FlowFrom
+    287: FlowInto
+    288: FlowTolerance
+    289: FontFamily
+    290: FontFeatureSettings
+    291: FontKerning
+    292: FontLanguageOverride
+    293: FontOpticalSizing
+    294: FontPalette
+    295: FontSizeAdjust
+    296: FontSize
+    297: FontStyle
+    298: FontSynthesisPosition
+    299: FontSynthesisSmallCaps
+    300: FontSynthesisStyle
+    301: FontSynthesis
+    302: FontSynthesisWeight
+    303: FontVariantCaps
+    304: FontVariantEastAsian
+    305: FontVariantEmoji
+    306: FontVariantLigatures
+    307: FontVariantNumeric
+    308: FontVariantPosition
+    309: FontVariationSettings
+    310: FontWeight
+    311: FontWidth
+    312: FootnoteDisplay
+    313: FootnotePolicy
+    314: ForcedColorAdjust
+    315: FrameSizing
+    316: Gap
+    317: GlyphOrientationVertical
+    318: GridArea
+    319: GridAutoColumns
+    320: GridAutoFlow
+    321: GridAutoRows
+    322: GridColumnEnd
+    323: GridColumnStart
+    324: GridColumn
+    325: GridRowEnd
+    326: GridRowStart
+    327: GridRow
+    328: Grid
+    329: GridTemplateAreas
+    330: GridTemplateColumns
+    331: GridTemplateRows
+    332: GridTemplate
+    333: HangingPunctuation
+    334: Height
+    335: HyphenateCharacter
+    336: HyphenateLimitChars
+    337: HyphenateLimitLast
+    338: HyphenateLimitLines
+    339: HyphenateLimitZone
+    340: Hyphens
+    341: ImageAnimation
+    342: ImageOrientation
+    343: ImageRendering
+    344: ImageResolution
+    345: InitialLetter
+    346: InitialLetterWrap
+    347: InlineSize
+    348: InlineSizing
+    349: InputSecurity
+    350: InsetBlockEnd
+    351: InsetBlockStart
+    352: InsetBlock
+    353: InsetInlineEnd
+    354: InsetInlineStart
+    355: InsetInline
+    356: Inset
+    357: Interactivity
+    358: InterestDelayEnd
+    359: InterestDelayStart
+    360: InterestDelay
+    361: InterpolateSize
+    362: Isolation
+    363: JustifyContent
+    364: JustifyItems
+    365: JustifySelf
+    366: Left
+    367: LetterSpacing
+    368: LightingColor
+    369: LineBreak
+    370: LineClamp
+    371: LineFitEdge
+    372: LineGrid
+    373: LineHeightStep
+    374: LineHeight
+    375: LinePadding
+    376: LineSnap
+    377: LinkParameters
+    378: ListStyleImage
+    379: ListStylePosition
+    380: ListStyle
+    381: ListStyleType
+    382: MarginBlockEnd
+    383: MarginBlockStart
+    384: MarginBlock
+    385: MarginBottom
+    386: MarginBreak
+    387: MarginInlineEnd
+    388: MarginInlineStart
+    389: MarginInline
+    390: MarginLeft
+    391: MarginRight
+    392: Margin
+    393: MarginTop
+    394: MarginTrim
+    395: MarkerEnd
+    396: MarkerMid
+    397: MarkerSide
+    398: MarkerStart
+    399: Marker
+    400: MaskBorderMode
+    401: MaskBorderOutset
+    402: MaskBorderRepeat
+    403: MaskBorderSlice
+    404: MaskBorderSource
+    405: MaskBorderWidth
+    406: MaskClip
+    407: MaskComposite
+    408: MaskImage
+    409: MaskMode
+    410: MaskOrigin
+    411: MaskPosition
+    412: MaskRepeat
+    413: MaskSize
+    414: Mask
+    415: MaskType
+    416: MaxBlockSize
+    417: MaxHeight
+    418: MaxInlineSize
+    419: MaxLines
+    420: MaxWidth
+    421: MinBlockSize
+    422: MinHeight
+    423: MinInlineSize
+    424: MinIntrinsicSizing
+    425: MinWidth
+    426: MixBlendMode
+    427: _MozAppearance
+    428: _MozBoxSizing
+    429: _MozColumnCount
+    430: _MozColumnGap
+    431: _MozFilter
+    432: _MozOsxFontSmoothing
+    433: _MozTransition
+    434: _MozUserSelect
+    435: _MsBoxSizing
+    436: _MsFilter
+    437: _MsFlexAlign
+    438: _MsFlexDirection
+    439: _MsFlexFlow
+    440: _MsFlexItemAlign
+    441: _MsFlexLinePack
+    442: _MsFlexNegative
+    443: _MsFlexOrder
+    444: _MsFlexPack
+    445: _MsFlexPositive
+    446: _MsFlexPreferredSize
+    447: _MsFlex
+    448: _MsFlexWrap
+    449: _MsInterpolationMode
+    450: _MsOverflowStyle
+    451: _MsTextSizeAdjust
+    452: _MsTouchAction
+    453: _MsTransformOrigin
+    454: _MsTransform
+    455: _MsTransition
+    456: _MsUserSelect
+    457: _MsWordBreak
+    458: Negative
+    459: _OBoxSizing
+    460: _OFilter
+    461: _OObjectFit
+    462: ObjectFit
+    463: ObjectPosition
+    464: ObjectViewBox
+    465: OffsetAnchor
+    466: OffsetDistance
+    467: OffsetPath
+    468: OffsetPosition
+    469: OffsetRotate
+    470: Opacity
+    471: Order
+    472: Orphans
+    473: OutlineColor
+    474: OutlineOffset
+    475: OutlineStyle
+    476: Outline
+    477: OutlineWidth
+    478: OverflowAnchor
+    479: OverflowBlock
+    480: OverflowClipMarginBlockEnd
+    481: OverflowClipMarginBlockStart
+    482: OverflowClipMarginBlock
+    483: OverflowClipMarginBottom
+    484: OverflowClipMarginInlineEnd
+    485: OverflowClipMarginInlineStart
+    486: OverflowClipMarginInline
+    487: OverflowClipMarginLeft
+    488: OverflowClipMarginRight
+    489: OverflowClipMargin
+    490: OverflowClipMarginTop
+    491: OverflowInline
+    492: Overflow
+    493: OverflowWrap
+    494: OverflowX
+    495: OverflowY
+    496: Overlay
+    497: OverscrollBehaviorBlock
+    498: OverscrollBehaviorInline
+    499: OverscrollBehavior
+    500: OverscrollBehaviorX
+    501: OverscrollBehaviorY
+    502: Pad
+    503: PaddingBlockEnd
+    504: PaddingBlockStart
+    505: PaddingBlock
+    506: PaddingBottom
+    507: PaddingInlineEnd
+    508: PaddingInlineStart
+    509: PaddingInline
+    510: PaddingLeft
+    511: PaddingRight
+    512: Padding
+    513: PaddingTop
+    514: Page
+    515: PaintOrder
+    516: PauseAfter
+    517: PauseBefore
+    518: Pause
+    519: PerspectiveOrigin
+    520: Perspective
+    521: PlaceContent
+    522: PlaceItems
+    523: PlaceSelf
+    524: PointerEvents
+    525: PointerTimelineAxis
+    526: PointerTimelineName
+    527: PointerTimeline
+    528: PositionAnchor
+    529: PositionArea
+    530: Position
+    531: PositionTryFallbacks
+    532: PositionTryOrder
+    533: PositionTry
+    534: PositionVisibility
+    535: Prefix
+    536: PrintColorAdjust
+    537: Quotes
+    538: ReadingFlow
+    539: ReadingOrder
+    540: RegionFragment
+    541: Resize
+    542: RestAfter
+    543: RestBefore
+    544: Rest
+    545: Right
+    546: RowGap
+    547: RowRuleBreak
+    548: RowRuleColor
+    549: RowRuleInsetCapEnd
+    550: RowRuleInsetCapStart
+    551: RowRuleInsetCap
+    552: RowRuleInsetEnd
+    553: RowRuleInsetJunctionEnd
+    554: RowRuleInsetJunctionStart
+    555: RowRuleInsetJunction
+    556: RowRuleInsetStart
+    557: RowRuleInset
+    558: RowRuleStyle
+    559: RowRule
+    560: RowRuleVisibilityItems
+    561: RowRuleWidth
+    562: RubyAlign
+    563: RubyMerge
+    564: RubyOverhang
+    565: RubyPosition
+    566: RuleBreak
+    567: RuleColor
+    568: RuleInsetCap
+    569: RuleInsetEnd
+    570: RuleInsetJunction
+    571: RuleInsetStart
+    572: RuleInset
+    573: RuleOverlap
+    574: RuleStyle
+    575: Rule
+    576: RuleVisibilityItems
+    577: RuleWidth
+    578: Running
+    579: Scale
+    580: ScrollBehavior
+    581: ScrollInitialTarget
+    582: ScrollMarginBlockEnd
+    583: ScrollMarginBlockStart
+    584: ScrollMarginBlock
+    585: ScrollMarginBottom
+    586: ScrollMarginInlineEnd
+    587: ScrollMarginInlineStart
+    588: ScrollMarginInline
+    589: ScrollMarginLeft
+    590: ScrollMarginRight
+    591: ScrollMargin
+    592: ScrollMarginTop
+    593: ScrollMarkerGroup
+    594: ScrollPaddingBlockEnd
+    595: ScrollPaddingBlockStart
+    596: ScrollPaddingBlock
+    597: ScrollPaddingBottom
+    598: ScrollPaddingInlineEnd
+    599: ScrollPaddingInlineStart
+    600: ScrollPaddingInline
+    601: ScrollPaddingLeft
+    602: ScrollPaddingRight
+    603: ScrollPadding
+    604: ScrollPaddingTop
+    605: ScrollSnapAlign
+    606: ScrollSnapStop
+    607: ScrollSnapType
+    608: ScrollTargetGroup
+    609: ScrollTimelineAxis
+    610: ScrollTimelineName
+    611: ScrollTimeline
+    612: ScrollbarColor
+    613: ScrollbarGutter
+    614: ScrollbarWidth
+    615: ShapeImageThreshold
+    616: ShapeInside
+    617: ShapeMargin
+    618: ShapeOutside
+    619: ShapePadding
+    620: ShapeRendering
+    621: SliderOrientation
+    622: SpatialNavigationAction
+    623: SpatialNavigationContain
+    624: SpatialNavigationFunction
+    625: SpeakAs
+    626: Speak
+    627: StringSet
+    628: StrokeAlign
+    629: StrokeBreak
+    630: StrokeColor
+    631: StrokeDashCorner
+    632: StrokeDashJustify
+    633: StrokeDasharray
+    634: StrokeDashoffset
+    635: StrokeImage
+    636: StrokeLinecap
+    637: StrokeLinejoin
+    638: StrokeMiterlimit
+    639: StrokeOpacity
+    640: StrokeOrigin
+    641: StrokePosition
+    642: StrokeRepeat
+    643: StrokeSize
+    644: Stroke
+    645: StrokeWidth
+    646: Suffix
+    647: Symbols
+    648: System
+    649: TabSize
+    650: TableLayout
+    651: TextAlignAll
+    652: TextAlignLast
+    653: TextAlign
+    654: TextAutospace
+    655: TextBoxEdge
+    656: TextBox
+    657: TextBoxTrim
+    658: TextCombineUpright
+    659: TextDecorationColor
+    660: TextDecorationInset
+    661: TextDecorationLine
+    662: TextDecorationSkipBox
+    663: TextDecorationSkipInk
+    664: TextDecorationSkipSelf
+    665: TextDecorationSkipSpaces
+    666: TextDecorationSkip
+    667: TextDecorationStyle
+    668: TextDecoration
+    669: TextDecorationThickness
+    670: TextEmphasisColor
+    671: TextEmphasisPosition
+    672: TextEmphasisSkip
+    673: TextEmphasisStyle
+    674: TextEmphasis
+    675: TextFit
+    676: TextGroupAlign
+    677: TextIndent
+    678: TextJustify
+    679: TextOrientation
+    680: TextOverflow
+    681: TextRendering
+    682: TextShadow
+    683: TextSizeAdjust
+    684: TextSpacing
+    685: TextSpacingTrim
+    686: TextTransform
+    687: TextUnderlineOffset
+    688: TextUnderlinePosition
+    689: TextWrapMode
+    690: TextWrapStyle
+    691: TextWrap
+    692: TimelineScope
+    693: TimelineTriggerActivationRangeEnd
+    694: TimelineTriggerActivationRangeStart
+    695: TimelineTriggerActivationRange
+    696: TimelineTriggerActiveRangeEnd
+    697: TimelineTriggerActiveRangeStart
+    698: TimelineTriggerActiveRange
+    699: TimelineTriggerName
+    700: TimelineTriggerSource
+    701: TimelineTrigger
+    702: Top
+    703: TouchAction
+    704: TransformBox
+    705: TransformOrigin
+    706: TransformStyle
+    707: Transform
+    708: TransitionBehavior
+    709: TransitionDelay
+    710: TransitionDuration
+    711: TransitionProperty
+    712: Transition
+    713: TransitionTimingFunction
+    714: Translate
+    715: TriggerScope
+    716: UnicodeBidi
+    717: UserSelect
+    718: VerticalAlign
+    719: ViewTimelineAxis
+    720: ViewTimelineInset
+    721: ViewTimelineName
+    722: ViewTimeline
+    723: ViewTransitionClass
+    724: ViewTransitionGroup
+    725: ViewTransitionName
+    726: ViewTransitionScope
+    727: Visibility
+    728: VoiceBalance
+    729: VoiceDuration
+    730: VoiceFamily
+    731: VoiceRate
+    732: VoiceStress
+    733: VoiceVolume
+    734: _WebkitAlignContent
+    735: _WebkitAlignItems
+    736: _WebkitAlignSelf
+    737: _WebkitAnimationDelay
+    738: _WebkitAnimationDuration
+    739: _WebkitAnimationFillMode
+    740: _WebkitAnimationIterationCount
+    741: _WebkitAnimationName
+    742: _WebkitAnimationTimingFunction
+    743: _WebkitAppearance
+    744: _WebkitBackfaceVisibility
+    745: _WebkitBackgroundClip
+    746: _WebkitBackgroundSize
+    747: _WebkitBoxAlign
+    748: _WebkitBoxDecorationBreak
+    749: _WebkitBoxDirection
+    750: _WebkitBoxFlex
+    751: _WebkitBoxOrdinalGroup
+    752: _WebkitBoxOrient
+    753: _WebkitBoxPack
+    754: _WebkitBoxShadow
+    755: _WebkitBoxSizing
+    756: _WebkitClipPath
+    757: _WebkitColumnCount
+    758: _WebkitColumnGap
+    759: _WebkitFilter
+    760: _WebkitFlexBasis
+    761: _WebkitFlexDirection
+    762: _WebkitFlexFlow
+    763: _WebkitFlexGrow
+    764: _WebkitFlex
+    765: _WebkitFlexWrap
+    766: _WebkitFontSmoothing
+    767: _WebkitJustifyContent
+    768: _WebkitLineClamp
+    769: _WebkitMarginEnd
+    770: _WebkitMaskPosition
+    771: _WebkitMaskSize
+    772: _WebkitOrder
+    773: _WebkitOverflowScrolling
+    774: _WebkitPerspective
+    775: _WebkitPrintColorAdjust
+    776: _WebkitTapHighlightColor
+    777: _WebkitTextDecorationColor
+    778: _WebkitTextDecorationSkipInk
+    779: _WebkitTextDecoration
+    780: _WebkitTextFillColor
+    781: _WebkitTextSizeAdjust
+    782: _WebkitTextStrokeColor
+    783: _WebkitTextStroke
+    784: _WebkitTextStrokeWidth
+    785: _WebkitTouchCallout
+    786: _WebkitTransformOrigin
+    787: _WebkitTransform
+    788: _WebkitTransitionDelay
+    789: _WebkitTransitionDuration
+    790: _WebkitTransitionProperty
+    791: _WebkitTransition
+    792: _WebkitTransitionTimingFunction
+    793: _WebkitUserDrag
+    794: _WebkitUserSelect
+    795: WhiteSpaceCollapse
+    796: WhiteSpace
+    797: WhiteSpaceTrim
+    798: Widows
+    799: Width
+    800: WillChange
+    801: WindowDrag
+    802: WordBreak
+    803: WordSpaceTransform
+    804: WordSpacing
+    805: WordWrap
+    806: WrapAfter
+    807: WrapBefore
+    808: WrapFlow
+    809: WrapInside
+    810: WrapThrough
+    811: WritingMode
+    812: ZIndex
+    813: Zoom
+SuffixStyleValue: size=64 align=8 {
+    0: 0
+}
+SuperellipseFunction: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+SupportsCondition: size=88 align=8
+    0: Is
+    1: Not
+    2: And
+    3: Or
+SupportsFeature: size=64 align=8
+    0: FontTech
+    1: FontFormat
+    2: Selector
+    3: Property
+    4: Condition
+SupportsRule: size=240 align=16 {
+    name: 0
+    prelude: 16
+    block: 112
+}
+SupportsRuleBlock: size=128 align=16 {
+    0: 0
+}
+SvgPaint: size=64 align=8
+    0: Child
+    1: ChildFunction
+SvgPaintChildFunction: size=56 align=8 {
+    function: 0
+    index: 16
+    close: 40
+}
+SvgTag: size=16 align=4
+    0: A
+    1: Animate
+    2: Animatemotion
+    3: Animatetransform
+    4: Circle
+    5: Clippath
+    6: Defs
+    7: Desc
+    8: Discard
+    9: Ellipse
+    10: Feblend
+    11: Fecolormatrix
+    12: Fecomponenttransfer
+    13: Fecomposite
+    14: Feconvolvematrix
+    15: Fediffuselighting
+    16: Fedisplacementmap
+    17: Fedistantlight
+    18: Fedropshadow
+    19: Feflood
+    20: Fefunca
+    21: Fefuncb
+    22: Fefuncg
+    23: Fefuncr
+    24: Fegaussianblur
+    25: Feimage
+    26: Femerge
+    27: Femergenode
+    28: Femorphology
+    29: Feoffset
+    30: Fepointlight
+    31: Fespecularlighting
+    32: Fespotlight
+    33: Fetile
+    34: Feturbulence
+    35: Filter
+    36: Foreignobject
+    37: G
+    38: Image
+    39: Line
+    40: Lineargradient
+    41: Marker
+    42: Mask
+    43: Metadata
+    44: Mpath
+    45: Path
+    46: Pattern
+    47: Polygon
+    48: Polyline
+    49: Radialgradient
+    50: Rect
+    51: Script
+    52: Set
+    53: Stop
+    54: Style
+    55: Svg
+    56: Switch
+    57: Symbol
+    58: Text
+    59: Textpath
+    60: Title
+    61: Tspan
+    62: Use
+    63: View
+Symbol: size=56 align=8
+    0: String
+    1: Image
+SymbolsFunction: size=72 align=8 {
+    name: 0
+    params: 16
+    close: 56
+}
+SymbolsFunctionParams: size=40 align=8 {
+    symbols_type: 0
+    symbols: 16
+}
+SymbolsStyleValue: size=24 align=8 {
+    0: 0
+}
+SymbolsType: size=16 align=4
+    0: Cyclic
+    1: Numeric
+    2: Alphabetic
+    3: Symbolic
+    4: Fixed
+SyntaxValue: size=12 align=4 {
+    0: 0
+}
+SystemColor: size=16 align=4
+    0: Accentcolor
+    1: Accentcolortext
+    2: Activetext
+    3: Buttonborder
+    4: Buttonface
+    5: Buttontext
+    6: Canvas
+    7: Canvastext
+    8: Field
+    9: Fieldtext
+    10: Graytext
+    11: Highlight
+    12: Highlighttext
+    13: Linktext
+    14: Mark
+    15: Marktext
+    16: Selecteditem
+    17: Selecteditemtext
+    18: Visitedtext
+SystemStyleValue: size=48 align=8
+    0: Cyclic
+    1: Numeric
+    2: Alphabetic
+    3: Symbolic
+    4: Additive
+    5: Fixed
+    6: ExtendsCounterStyleName
+TabSizeStyleValue: size=32 align=8 {
+    0: 0
+}
+TableLayoutStyleValue: size=16 align=4
+    0: Auto
+    1: Fixed
+Tag: size=20 align=4
+    0: Html
+    1: HtmlNonStandard
+    2: HtmlNonConforming
+    3: Svg
+    4: Mathml
+    5: CustomElement
+    6: Unknown
+TanFunction: size=144 align=8 {
+    name: 0
+    params: 16
+    close: 128
+}
+Target: size=208 align=8
+    0: TargetCounter
+    1: TargetCounters
+    2: TargetText
+TargetCounterFunction: size=176 align=8 {
+    name: 0
+    params: 16
+    close: 160
+}
+TargetCounterParams: size=144 align=8 {
+    0: 0
+    1: 16
+    2: 32
+    3: 44
+    4: 64
+}
+TargetCountersFunction: size=200 align=8 {
+    name: 0
+    params: 16
+    close: 184
+}
+TargetCountersParams: size=168 align=8 {
+    0: 0
+    1: 16
+    2: 32
+    3: 44
+    4: 60
+    5: 72
+    6: 88
+}
+TargetTextFunction: size=72 align=4 {
+    name: 0
+    params: 12
+    close: 60
+}
+TargetTextParams: size=48 align=4 {
+    0: 0
+    1: 16
+    2: 32
+}
+TextAlignAllStyleValue: size=32 align=8
+    0: Start
+    1: End
+    2: Left
+    3: Right
+    4: Center
+    5: String
+    6: Justify
+    7: MatchParent
+    8: _WebkitMatchParent
+TextAlignLastStyleValue: size=16 align=4
+    0: Auto
+    1: Start
+    2: End
+    3: Left
+    4: Right
+    5: Center
+    6: Justify
+    7: MatchParent
+TextAlignStyleValue: size=32 align=8
+    0: Start
+    1: End
+    2: Left
+    3: Right
+    4: Center
+    5: String
+    6: Justify
+    7: MatchParent
+    8: JustifyAll
+    9: _WebkitMatchParent
+TextAutospaceStyleValue: size=32 align=8
+    0: Normal
+    1: Autospace
+    2: Auto
+TextBoxEdgeStyleValue: size=32 align=8 {
+    0: 0
+}
+TextBoxStyleValue: size=56 align=8 {
+    0: 0
+}
+TextBoxTrimStyleValue: size=16 align=4
+    0: None
+    1: TrimStart
+    2: TrimEnd
+    3: TrimBoth
+TextCombineUprightStyleValue: size=48 align=8
+    0: None
+    1: All
+    2: Digits
+TextDecorationColorStyleValue: size=32 align=8 {
+    0: 0
+}
+TextDecorationInsetStyleValue: size=56 align=8 {
+    0: 0
+}
+TextDecorationLineStyleValue: size=68 align=4
+    0: None
+    1: UnderlineOverlineLineThroughBlink
+    2: SpellingError
+    3: GrammarError
+TextDecorationSkipBoxStyleValue: size=16 align=4
+    0: None
+    1: All
+TextDecorationSkipInkStyleValue: size=16 align=4
+    0: Auto
+    1: None
+    2: All
+TextDecorationSkipSelfStyleValue: size=52 align=4
+    0: Auto
+    1: SkipAll
+    2: SkipUnderlineSkipOverlineSkipLineThrough
+    3: NoSkip
+TextDecorationSkipSpacesStyleValue: size=36 align=4
+    0: None
+    1: All
+    2: StartEnd
+TextDecorationSkipStyleValue: size=16 align=4
+    0: None
+    1: Auto
+TextDecorationStyleStyleValue: size=16 align=4
+    0: Solid
+    1: Double
+    2: Dotted
+    3: Dashed
+    4: Wavy
+TextDecorationStyleValue: size=168 align=8 {
+    text_decoration_line: 0
+    text_decoration_thickness: 72
+    text_decoration_style: 120
+    text_decoration_color: 136
+}
+TextDecorationThicknessStyleValue: size=48 align=8
+    0: Auto
+    1: FromFont
+    2: LengthPercentage
+    3: LineWidth
+TextEmphasisColorStyleValue: size=32 align=8 {
+    0: 0
+}
+TextEmphasisPositionStyleValue: size=28 align=4
+    0: OverRight
+    1: OverLeft
+    2: Over
+    3: UnderRight
+    4: UnderLeft
+    5: Under
+TextEmphasisSkipStyleValue: size=64 align=4 {
+    spaces: 0
+    punctuation: 16
+    symbols: 32
+    narrow: 48
+}
+TextEmphasisStyleStyleValue: size=40 align=8
+    0: None
+    1: FilledDot
+    2: FilledCircle
+    3: FilledDoubleCircle
+    4: FilledTriangle
+    5: FilledSesame
+    6: OpenDot
+    7: OpenCircle
+    8: OpenDoubleCircle
+    9: OpenTriangle
+    10: OpenSesame
+    11: String
+TextEmphasisStyleValue: size=72 align=8 {
+    text_emphasis_style: 0
+    text_emphasis_color: 40
+}
+TextFitStyleValue: size=56 align=8 {
+    0: 0
+    1: 16
+    2: 32
+}
+TextFitStyleValueKeywords: size=16 align=4
+    0: None
+    1: Grow
+    2: Shrink
+    3: Consistent
+    4: PerLine
+    5: PerLineAll
+TextFunctionContent: size=16 align=4
+    0: Content
+    1: Before
+    2: After
+    3: FirstLetter
+TextGroupAlignStyleValue: size=16 align=4
+    0: None
+    1: Start
+    2: End
+    3: Left
+    4: Right
+    5: Center
+TextIndentStyleValue: size=64 align=8 {
+    0: 0
+    1: 32
+    2: 48
+}
+TextJustifyStyleValue: size=36 align=4
+    0: Auto
+    1: None
+    2: InterWord
+    3: InterCharacter
+    4: Ruby
+TextOrientationStyleValue: size=16 align=4
+    0: Mixed
+    1: Upright
+    2: Sideways
+TextOverflowSingleAxis: size=32 align=8
+    0: Clip
+    1: Ellipsis
+    2: Fade
+    3: String
+    4: FadeFunction
+TextOverflowStyleValue: size=64 align=8 {
+    0: 0
+    1: 32
+}
+TextRenderingStyleValue: size=16 align=4
+    0: Auto
+    1: Optimizespeed
+    2: Optimizelegibility
+    3: Geometricprecision
+TextShadowStyleValue: size=32 align=8 {
+    0: 0
+}
+TextSizeAdjustStyleValue: size=32 align=8 {
+    0: 0
+}
+TextSpacingStyleValue: size=56 align=8 {
+    0: 0
+}
+TextSpacingTrimStyleValue: size=32 align=8 {
+    0: 0
+}
+TextTransformStyleValue: size=52 align=4
+    0: None
+    1: Capitalize
+    2: Uppercase
+    3: Lowercase
+    4: MathAuto
+TextUnderlineOffsetStyleValue: size=40 align=8 {
+    0: 0
+}
+TextUnderlinePositionStyleValue: size=36 align=4
+    0: Auto
+    1: FromFontLeft
+    2: FromFontRight
+    3: UnderLeft
+    4: UnderRight
+TextWrapModeStyleValue: size=16 align=4
+    0: Wrap
+    1: Nowrap
+TextWrapStyleStyleValue: size=16 align=4
+    0: Auto
+    1: Balance
+    2: Stable
+    3: Pretty
+    4: AvoidOrphans
+TextWrapStyleValue: size=32 align=4 {
+    text_wrap_mode: 0
+    text_wrap_style: 16
+}
+Time: size=16 align=4
+    0: Ms
+    1: S
+TimelineRangeName: size=16 align=4
+    0: Cover
+    1: Contain
+    2: Entry
+    3: Exit
+    4: EntryCrossing
+    5: ExitCrossing
+    6: Scroll
+TimelineScopeStyleValue: size=32 align=8
+    0: None
+    1: All
+    2: DashedIdents
+TimelineTriggerActivationRangeEndStyleValue: size=24 align=8 {
+    0: 0
+}
+TimelineTriggerActivationRangeStartStyleValue: size=24 align=8 {
+    0: 0
+}
+TimelineTriggerActivationRangeStyleValue: size=24 align=8 {
+    0: 0
+}
+TimelineTriggerActiveRangeEndStyleValue: size=24 align=8 {
+    0: 0
+}
+TimelineTriggerActiveRangeStartStyleValue: size=24 align=8 {
+    0: 0
+}
+TimelineTriggerActiveRangeStyleValue: size=24 align=8 {
+    0: 0
+}
+TimelineTriggerNameStyleValue: size=32 align=8 {
+    0: 0
+}
+TimelineTriggerSourceStyleValue: size=24 align=8 {
+    0: 0
+}
+TimelineTriggerStyleValue: size=32 align=8 {
+    0: 0
+}
+Todo: size=1 align=1
+    0: Todo = 0
+TopStyleValue: size=40 align=8 {
+    0: 0
+}
+TouchActionStyleValue: size=52 align=4
+    0: Auto
+    1: None
+    2: PanXPanY
+    3: PanXPanUp
+    4: PanXPanDown
+    5: PanLeftPanY
+    6: PanLeftPanUp
+    7: PanLeftPanDown
+    8: PanRightPanY
+    9: PanRightPanUp
+    10: PanRightPanDown
+    11: Manipulation
+TrackBreadth: size=40 align=8
+    0: LengthPercentage
+    1: Flex
+    2: MinContent
+    3: MaxContent
+    4: Auto
+TrackList: size=80 align=8 {
+    leading_names: 0
+    items: 56
+}
+TrackSize: size=136 align=8
+    0: TrackBreadth
+    1: MinmaxFunction
+    2: FitContentFunction
+TransformBoxStyleValue: size=16 align=4
+    0: ContentBox
+    1: BorderBox
+    2: FillBox
+    3: StrokeBox
+    4: ViewBox
+TransformFunction: size=264 align=8
+    0: Matrix
+    1: Matrix3d
+    2: Translate
+    3: Translate3d
+    4: TranslateX
+    5: TranslateY
+    6: TranslateZ
+    7: Scale
+    8: Scale3d
+    9: ScaleX
+    10: ScaleY
+    11: ScaleZ
+    12: Rotate
+    13: Rotate3d
+    14: RotateX
+    15: RotateY
+    16: RotateZ
+    17: Skew
+    18: SkewX
+    19: SkewY
+    20: Perspective
+TransformList: size=24 align=8 {
+    0: 0
+}
+TransformOriginStyleValue: size=128 align=8
+    0: PositionOne
+    1: PositionTwo
+TransformStyleStyleValue: size=16 align=4
+    0: Flat
+    1: Preserve3d
+TransformStyleValue: size=40 align=8 {
+    0: 0
+}
+TransitionBehaviorStyleValue: size=24 align=8 {
+    0: 0
+}
+TransitionBehaviorValue: size=16 align=4
+    0: Normal
+    1: AllowDiscrete
+TransitionDelayStyleValue: size=24 align=8 {
+    0: 0
+}
+TransitionDurationStyleValue: size=24 align=8 {
+    0: 0
+}
+TransitionPropertyStyleValue: size=32 align=8 {
+    0: 0
+}
+TransitionStyleValue: size=24 align=8 {
+    0: 0
+}
+TransitionTimingFunctionStyleValue: size=24 align=8 {
+    0: 0
+}
+Translate3dFunction: size=152 align=8 {
+    name: 0
+    params: 16
+    close: 136
+}
+Translate3dFunctionParams: size=120 align=8 {
+    0: 0
+    1: 32
+    2: 48
+    3: 80
+    4: 96
+}
+TranslateFunction: size=112 align=8 {
+    name: 0
+    x: 16
+    comma: 48
+    y: 64
+    close: 96
+}
+TranslateStyleValue: size=96 align=8 {
+    0: 0
+}
+TranslatexFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+TranslateyFunction: size=64 align=8 {
+    name: 0
+    params: 16
+    close: 48
+}
+TranslatezFunction: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+TriggerScopeStyleValue: size=32 align=8
+    0: None
+    1: All
+    2: DashedIdents
+TrySize: size=16 align=4
+    0: MostWidth
+    1: MostHeight
+    2: MostBlockSize
+    3: MostInlineSize
+TryTactic: size=80 align=4 {
+    flip_block: 0
+    flip_inline: 16
+    flip_start: 32
+    flip_x: 48
+    flip_y: 64
+}
+UnicodeBidiStyleValue: size=16 align=4
+    0: Normal
+    1: Embed
+    2: Isolate
+    3: BidiOverride
+    4: IsolateOverride
+    5: Plaintext
+Unknown: size=24 align=8 {
+    0: 0
+}
+UnknownAtRule: size=64 align=8 {
+    name: 0
+    prelude: 16
+    block: 40
+}
+UnknownQualifiedRule: size=208 align=16 {
+    0: 0
+}
+UnknownTag: size=12 align=4 {
+    0: 0
+}
+Unresolved: size=32 align=8 {
+    tokens: 0
+    expected: 24
+}
+Url: size=40 align=4
+    0: Url
+    1: UrlFunction
+    2: SrcFunction
+UrlOrString: size=44 align=4
+    0: Url
+    1: String
+UserSelectStyleValue: size=16 align=4
+    0: Auto
+    1: Text
+    2: None
+    3: Contain
+    4: All
+VariationTagValue: size=40 align=8 {
+    0: 0
+    1: 16
+}
+VerticalAlignStyleValue: size=96 align=8
+    0: First
+    1: Last
+VerticalLineClause: size=72 align=8
+    0: ToVerticalLineValue
+    1: ByLengthPercentage
+VerticalLineCommand: size=88 align=8 {
+    keyword: 0
+    clause: 16
+}
+VerticalLineValue: size=40 align=8
+    0: LengthPercentage
+    1: Top
+    2: Center
+    3: Bottom
+    4: YStart
+    5: YEnd
+VerticalViewportSegmentsMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+VideoColorGamutMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+VideoColorGamutMediaFeatureKeyword: size=16 align=4
+    0: Srgb
+    1: P3
+    2: Rec2020
+VideoDynamicRangeMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+VideoDynamicRangeMediaFeatureKeyword: size=16 align=4
+    0: Standard
+    1: Hight
+ViewTimelineAxisStyleValue: size=24 align=8 {
+    0: 0
+}
+ViewTimelineAxisStyleValueKeywords: size=16 align=4
+    0: Block
+    1: Inline
+    2: X
+    3: Y
+ViewTimelineInsetStyleValue: size=24 align=8 {
+    0: 0
+}
+ViewTimelineNameStyleValue: size=24 align=8 {
+    0: 0
+}
+ViewTimelineStyleValue: size=24 align=8 {
+    0: 0
+}
+ViewTransitionClassStyleValue: size=32 align=8 {
+    0: 0
+}
+ViewTransitionGroupPseudoElement: size=104 align=8 {
+    colons: 0
+    function: 24
+    value: 40
+    close: 88
+}
+ViewTransitionGroupStyleValue: size=32 align=8
+    0: Normal
+    1: Contain
+    2: Nearest
+    3: CustomIdent
+ViewTransitionImagePairPseudoElement: size=104 align=8 {
+    colons: 0
+    function: 24
+    value: 40
+    close: 88
+}
+ViewTransitionNameStyleValue: size=32 align=8 {
+    0: 0
+}
+ViewTransitionNewPseudoElement: size=104 align=8 {
+    colons: 0
+    function: 24
+    value: 40
+    close: 88
+}
+ViewTransitionOldPseudoElement: size=104 align=8 {
+    colons: 0
+    function: 24
+    value: 40
+    close: 88
+}
+ViewTransitionScopeStyleValue: size=16 align=4
+    0: None
+    1: All
+VisibilityStyleValue: size=16 align=4
+    0: Visible
+    1: Hidden
+    2: ForceHidden
+    3: Collapse
+VisualBox: size=16 align=4
+    0: ContentBox
+    1: PaddingBox
+    2: BorderBox
+VoiceAge: size=16 align=4
+    0: Child
+    1: Young
+    2: Old
+VoiceBalanceStyleValue: size=32 align=8
+    0: Number
+    1: Left
+    2: Center
+    3: Right
+    4: Leftwards
+    5: Rightwards
+VoiceDurationStyleValue: size=32 align=8 {
+    0: 0
+}
+VoiceFamilyName: size=32 align=8
+    0: String
+    1: CustomIdents
+VoiceFamilyStyleValue: size=32 align=8
+    0: VoiceFamilyNameGenericVoice
+    1: Preserve
+VoiceGender: size=16 align=4
+    0: Male
+    1: Female
+    2: Neutral
+VoiceRateStyleValue: size=48 align=8
+    0: Normal
+    1: XSlow
+    2: Slow
+    3: Medium
+    4: Fast
+    5: XFast
+VoiceStressStyleValue: size=16 align=4
+    0: Normal
+    1: Strong
+    2: Moderate
+    3: None
+    4: Reduced
+VoiceVolumeStyleValue: size=48 align=8
+    0: Silent
+    1: XSoft
+    2: Soft
+    3: Medium
+    4: Loud
+    5: XLoud
+WebkitAlignContentStyleValue: size=56 align=8
+    0: Normal
+    1: BaselinePosition
+    2: ContentDistribution
+    3: ContentPosition
+WebkitAlignItemsStyleValue: size=56 align=8
+    0: Normal
+    1: Stretch
+    2: BaselinePosition
+    3: SelfPosition
+WebkitAlignSelfStyleValue: size=64 align=8
+    0: Auto
+    1: NormalOrSelfPosition
+    2: Stretch
+    3: BaselinePosition
+WebkitAnimationDelayStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitAnimationDurationStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitAnimationFillModeStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitAnimationIterationCountStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitAnimationMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+WebkitAnimationNameStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitAnimationTimingFunctionStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitAnyFunctionalPseudoClass: size=64 align=8 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 48
+}
+WebkitAppearanceStyleValue: size=32 align=8
+    0: None
+    1: Auto
+    2: Base
+    3: BaseSelect
+    4: CompatAuto
+    5: CompatSpecial
+WebkitBackfaceVisibilityStyleValue: size=16 align=4
+    0: Visible
+    1: Hidden
+WebkitBackgroundClipStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitBackgroundSizeStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitBoxAlignStyleValue: size=16 align=4
+    0: Stretch
+    1: Start
+    2: End
+    3: Center
+    4: Baseline
+WebkitBoxDecorationBreakStyleValue: size=16 align=4
+    0: Clone
+    1: Slice
+WebkitBoxDirectionStyleValue: size=16 align=4
+    0: Normal
+    1: Reverse
+WebkitBoxFlexStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitBoxOrdinalGroupStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitBoxOrientStyleValue: size=16 align=4
+    0: Horizontal
+    1: Vertical
+    2: InlineAxis
+    3: BlockAxis
+WebkitBoxPackStyleValue: size=16 align=4
+    0: Start
+    1: End
+    2: Center
+    3: Justify
+WebkitBoxShadowStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitBoxSizingStyleValue: size=16 align=4
+    0: ContentBox
+    1: BorderBox
+WebkitClipPathStyleValue: size=288 align=8
+    0: None
+    1: ClipSource
+    2: BasicShapeGeometryBox
+WebkitColumnCountStyleValue: size=32 align=8 {
+    0: 0
+}
+WebkitColumnGapStyleValue: size=48 align=8
+    0: Normal
+    1: LengthPercentage
+    2: LineWidth
+WebkitDevicePixelRatioMediaFeature: size=120 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+WebkitDistrubutedFunctionalPseudoElement: size=80 align=8 {
+    colons: 0
+    function: 24
+    value: 40
+    close: 64
+}
+WebkitFilterStyleValue: size=40 align=8 {
+    0: 0
+}
+WebkitFlexBasisStyleValue: size=80 align=8
+    0: Content
+    1: Width
+WebkitFlexDirectionStyleValue: size=16 align=4
+    0: Row
+    1: RowReverse
+    2: Column
+    3: ColumnReverse
+WebkitFlexFlowStyleValue: size=52 align=4 {
+    flex_direction: 0
+    flex_wrap: 16
+}
+WebkitFlexGrowStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitFlexStyleValue: size=136 align=8 {
+    0: 0
+}
+WebkitFlexStyleValueOptions: size=128 align=8 {
+    flex_grow: 0
+    flex_basis: 48
+}
+WebkitFlexWrapStyleValue: size=16 align=4
+    0: Nowrap
+    1: Wrap
+    2: WrapReverse
+WebkitFontSmoothingStyleValue: size=16 align=4
+    0: Auto
+    1: None
+    2: Antialiased
+    3: SubpixelAntialiased
+WebkitFunctionalPseudoClass: size=72 align=8
+    0: Any
+WebkitFunctionalPseudoElement: size=88 align=8
+    0: Distributed
+WebkitJustifyContentStyleValue: size=56 align=8
+    0: Normal
+    1: ContentDistribution
+    2: ContentPosition
+    3: Left
+    4: Right
+WebkitKeyframesRule: size=144 align=16 {
+    name: 0
+    prelude: 12
+    block: 32
+}
+WebkitLineClampStyleValue: size=32 align=8 {
+    0: 0
+}
+WebkitMarginEndStyleValue: size=40 align=8 {
+    0: 0
+}
+WebkitMaskPositionStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitMaskSizeStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitOrderStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitOverflowScrollingStyleValue: size=16 align=4
+    0: Auto
+    1: Touch
+WebkitPerspectiveStyleValue: size=32 align=8 {
+    0: 0
+}
+WebkitPrintColorAdjustStyleValue: size=16 align=4
+    0: Economy
+    1: Exact
+WebkitPseudoClass: size=28 align=4
+    0: AnimatingFullScreenTransition
+    1: AnyLink
+    2: Autofill
+    3: AutofillAndObscured
+    4: AutofillStrongPassword
+    5: AutofillStrongPasswordViewable
+    6: Drag
+    7: FullPageMedia
+    8: FullScreen
+    9: FullScreenAncestor
+    10: FullScreenControlsHidden
+    11: FullScreenDocument
+WebkitPseudoElement: size=40 align=4
+    0: CalendarDatePickerIndicator
+    1: CapsLockIndicator
+    2: ColorSwatch
+    3: ColorSwatchWrapper
+    4: ContactsAutoFillButton
+    5: CredentialsAutoFillButton
+    6: CreditCardAutoFillButton
+    7: DateAndTimeValue
+    8: DatetimeEdit
+    9: DatetimeEditDayField
+    10: DatetimeEditFieldsWrapper
+    11: DatetimeEditHourField
+    12: DatetimeEditMeridiemField
+    13: DatetimeEditMillisecondField
+    14: DatetimeEditMinute
+    15: DatetimeEditMinuteField
+    16: DatetimeEditMonthField
+    17: DatetimeEditSecondField
+    18: DatetimeEditText
+    19: DatetimeEditYearField
+    20: DetailsMarker
+    21: FileUploadButton
+    22: GenericCueRoot
+    23: InputPlaceholder
+    24: InnerSpinButton
+    25: ListButton
+    26: MediaTextTrackContainer
+    27: MediaTextTrackDisplay
+    28: MediaTextTrackDisplayBackdrop
+    29: MediaTextTrackRegion
+    30: MediaTextTrackRegionContainer
+    31: MeterBar
+    32: MeterEvenLessGoodValue
+    33: MeterInnerElement
+    34: MeterOptimumValue
+    35: MeterSuboptimumValue
+    36: OuterSpinButton
+    37: ProgressBar
+    38: ProgressInnerElement
+    39: ProgressValue
+    40: Resizer
+    41: Scrollbar
+    42: ScrollbarButton
+    43: ScrollbarCorner
+    44: ScrollbarThumb
+    45: ScrollbarTrack
+    46: ScrollbarTrackPiece
+    47: SearchCancelButton
+    48: SearchDecoration
+    49: SearchResultsButton
+    50: SliderContainer
+    51: SliderRunnableTrack
+    52: SliderThumb
+    53: PasswordAutoFillButton
+    54: TextfieldDecorationContainer
+    55: ValidationBubble
+    56: ValidationBubbleArrow
+    57: ValidationBubbleArrowClipper
+    58: ValidationBubbleBody
+    59: ValidationBubbleHeading
+    60: ValidationBubbleIcon
+    61: ValidationBubbleMessage
+    62: ValidationBubbleTextBlock
+WebkitTapHighlightColorStyleValue: size=32 align=8 {
+    0: 0
+}
+WebkitTextDecorationColorStyleValue: size=32 align=8 {
+    0: 0
+}
+WebkitTextDecorationSkipInkStyleValue: size=16 align=4
+    0: Auto
+    1: None
+    2: All
+WebkitTextDecorationStyleValue: size=168 align=8 {
+    text_decoration_line: 0
+    text_decoration_thickness: 72
+    text_decoration_style: 120
+    text_decoration_color: 136
+}
+WebkitTextFillColorStyleValue: size=32 align=8 {
+    0: 0
+}
+WebkitTextSizeAdjustStyleValue: size=32 align=8 {
+    0: 0
+}
+WebkitTextStrokeColorStyleValue: size=32 align=8 {
+    0: 0
+}
+WebkitTextStrokeStyleValue: size=72 align=8 {
+    webkit_text_stroke_width: 0
+    webkit_text_stroke_color: 40
+}
+WebkitTextStrokeWidthStyleValue: size=40 align=8 {
+    0: 0
+}
+WebkitTouchCalloutStyleValue: size=16 align=4
+    0: Default
+    1: None
+WebkitTransform2dMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+WebkitTransform3dMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+WebkitTransformOriginStyleValue: size=128 align=8
+    0: PositionOne
+    1: PositionTwo
+WebkitTransformStyleValue: size=40 align=8 {
+    0: 0
+}
+WebkitTransitionDelayStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitTransitionDurationStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitTransitionMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+WebkitTransitionPropertyStyleValue: size=32 align=8 {
+    0: 0
+}
+WebkitTransitionStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitTransitionTimingFunctionStyleValue: size=24 align=8 {
+    0: 0
+}
+WebkitUserDragStyleValue: size=16 align=4
+    0: Auto
+    1: None
+    2: Element
+WebkitUserSelectStyleValue: size=16 align=4
+    0: Auto
+    1: Text
+    2: None
+    3: All
+WebkitVideoPlayableInlineMediaFeature: size=68 align=4
+    0: WithValue
+    1: Bare
+WherePseudoFunction: size=64 align=8 {
+    colon: 0
+    function: 12
+    value: 24
+    close: 48
+}
+WhiteSpaceCollapseStyleValue: size=16 align=4
+    0: Collapse
+    1: Discard
+    2: Preserve
+    3: PreserveBreaks
+    4: PreserveSpaces
+    5: BreakSpaces
+WhiteSpaceStyleValue: size=88 align=4
+    0: Normal
+    1: Pre
+    2: PreWrap
+    3: PreLine
+    4: WhiteSpaceCollapseTextWrapModeWhiteSpaceTrim
+WhiteSpaceTrimStyleValue: size=52 align=4 {
+    0: 0
+}
+WhiteSpaceTrimStyleValueOptions: size=48 align=4 {
+    discard_before: 0
+    discard_after: 16
+    discard_inner: 32
+}
+WidowsStyleValue: size=24 align=8 {
+    0: 0
+}
+WidthContainerFeature: size=128 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Exact
+WidthMediaFeature: size=128 align=4
+    0: Left
+    1: Right
+    2: Range
+    3: Min
+    4: Max
+    5: Exact
+WidthStyleValue: size=72 align=8
+    0: Auto
+    1: LengthPercentage
+    2: MinContent
+    3: MaxContent
+    4: FitContentFunction
+    5: CalcSizeFunction
+    6: Stretch
+    7: FitContent
+    8: Contain
+    9: _WebkitMaxContent
+    10: _MozMaxContent
+    11: _WebkitMinContent
+    12: _MozMinContent
+Wildcard: size=12 align=4 {
+    0: 0
+}
+WillChangeStyleValue: size=32 align=8 {
+    0: 0
+}
+WindowDragStyleValue: size=16 align=4
+    0: None
+    1: Move
+WordBreakStyleValue: size=16 align=4
+    0: Normal
+    1: BreakAll
+    2: KeepAll
+    3: Manual
+    4: AutoPhrase
+    5: BreakWord
+WordSpaceTransformStyleValue: size=32 align=4
+    0: None
+    1: SpaceAutoPhrase
+    2: IdeographicSpaceAutoPhrase
+WordSpacingStyleValue: size=40 align=8 {
+    0: 0
+}
+WordWrapStyleValue: size=16 align=4
+    0: Normal
+    1: BreakWord
+    2: Anywhere
+WrapAfterStyleValue: size=16 align=4
+    0: Auto
+    1: Avoid
+    2: AvoidLine
+    3: AvoidFlex
+    4: Line
+    5: Flex
+WrapBeforeStyleValue: size=16 align=4
+    0: Auto
+    1: Avoid
+    2: AvoidLine
+    3: AvoidFlex
+    4: Line
+    5: Flex
+WrapFlowStyleValue: size=16 align=4
+    0: Auto
+    1: Both
+    2: Start
+    3: End
+    4: Minimum
+    5: Maximum
+    6: Clear
+WrapInsideStyleValue: size=16 align=4
+    0: Auto
+    1: Avoid
+WrapThroughStyleValue: size=16 align=4
+    0: Wrap
+    1: None
+WritingModeStyleValue: size=16 align=4
+    0: HorizontalTb
+    1: VerticalRl
+    2: VerticalLr
+    3: SidewaysRl
+    4: SidewaysLr
+XywhFunction: size=448 align=8 {
+    name: 0
+    params: 16
+    close: 432
+}
+XywhFunctionParams: size=416 align=8 {
+    0: 0
+    1: 64
+    2: 96
+    3: 128
+}
+XyzChannelKeyword: size=16 align=4
+    0: X
+    1: Y
+    2: Z
+    3: Alpha
+ZIndexStyleValue: size=32 align=8 {
+    0: 0
+}
+ZoomStyleValue: size=24 align=8 {
+    0: 0
+}

--- a/crates/css_ast/src/types/basic_shape.rs
+++ b/crates/css_ast/src/types/basic_shape.rs
@@ -1,7 +1,6 @@
-#![allow(unused)]
 use super::prelude::*;
-
 use crate::{BasicShapeRect, CircleFunction, EllipseFunction, PathFunction, PolygonFunction, ShapeFunction};
+use css_parse::Box;
 
 /// <https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape>
 ///
@@ -14,7 +13,7 @@ use crate::{BasicShapeRect, CircleFunction, EllipseFunction, PathFunction, Polyg
 #[cfg_attr(feature = "visitable", derive(csskit_derives::Visitable), visit(self))]
 #[derive(csskit_derives::NodeWithMetadata)]
 pub enum BasicShape<'a> {
-	Rect(BasicShapeRect<'a>),
+	Rect(Box<'a, BasicShapeRect<'a>>),
 	Circle(CircleFunction<'a>),
 	Ellipse(EllipseFunction<'a>),
 	Polygon(PolygonFunction<'a>),

--- a/crates/css_ast/tests/allocations.rs
+++ b/crates/css_ast/tests/allocations.rs
@@ -62,9 +62,9 @@ fn allocation_test() {
 	// XXX: If these fail because the numbers go down, great! If they go up, investigate why.
 	#[cfg(feature = "csskit_arena")]
 	{
-		assert_eq!(simple_alloc.used_bytes(), 1216);
-		assert_eq!(escaped_alloc.used_bytes(), 6528);
-		assert_eq!(big_alloc.used_bytes(), 112_786_800);
+		assert_eq!(simple_alloc.used_bytes(), 1136);
+		assert_eq!(escaped_alloc.used_bytes(), 6384);
+		assert_eq!(big_alloc.used_bytes(), 109_831_608);
 	}
 	#[cfg(all(feature = "bumpalo", not(feature = "csskit_arena")))]
 	{

--- a/crates/css_parse/Cargo.toml
+++ b/crates/css_parse/Cargo.toml
@@ -38,7 +38,7 @@ derive_atom_set = { workspace = true } # @release
 insta = { workspace = true }
 glob = { workspace = true }
 dhat = { workspace = true }
-inventory = { workspace = true }
+stable_type_layout = { workspace = true }  # @release
 
 [features]
 default = ["bumpalo"]

--- a/crates/css_parse/src/layout_test.rs
+++ b/crates/css_parse/src/layout_test.rs
@@ -1,25 +1,5 @@
-//! Size tripwire: snapshots `size_of` for every `#[node]` type in this crate,
-//! collected via `inventory`. An accidental size change fails the snapshot
-//! loudly. Kept `#[cfg(test)]` so it adds no runtime cost or dependency to
-//! shipped builds.
-
-pub(crate) struct LayoutInfo {
-	pub name: &'static str,
-	pub size: usize,
-}
-inventory::collect!(LayoutInfo);
-
-fn render() -> String {
-	let mut infos: Vec<&LayoutInfo> = inventory::iter::<LayoutInfo>.into_iter().collect();
-	infos.sort_by_key(|info| info.name);
-	let mut out = String::new();
-	for info in infos {
-		out.push_str(&format!("{}: {}\n", info.name, info.size));
-	}
-	out
-}
-
 #[test]
 fn assert_layouts() {
+	use stable_type_layout::render;
 	insta::assert_snapshot!("assert_layouts", render());
 }

--- a/crates/css_parse/src/snapshots/css_parse__layout_test__assert_layouts.snap
+++ b/crates/css_parse/src/snapshots/css_parse__layout_test__assert_layouts.snap
@@ -2,9 +2,38 @@
 source: crates/css_parse/src/layout_test.rs
 expression: render()
 ---
-BadDeclaration: 24
-BangImportant: 24
-ComponentValue: 56
-ComponentValues: 24
-FunctionBlock: 48
-SimpleBlock: 56
+BadDeclaration: size=24 align=8 {
+    0: 0
+}
+BangImportant: size=24 align=4 {
+    bang: 0
+    important: 12
+}
+ComponentValue: size=64 align=8
+    0: SimpleBlock
+    1: Function
+    2: Whitespace
+    3: Number
+    4: Dimension
+    5: Ident
+    6: AtKeyword
+    7: Hash
+    8: String
+    9: Url
+    10: Delim
+    11: Colon
+    12: Semicolon
+    13: Comma
+ComponentValues: size=24 align=8 {
+    values: 0
+}
+FunctionBlock: size=56 align=8 {
+    name: 0
+    params: 16
+    close: 40
+}
+SimpleBlock: size=56 align=8 {
+    open: 0
+    values: 16
+    close: 40
+}

--- a/crates/css_parse/tests/allocations.rs
+++ b/crates/css_parse/tests/allocations.rs
@@ -61,9 +61,9 @@ fn allocation_test() {
 	// XXX: If these fail because the numbers go down, great! If they go up, investigate why.
 	#[cfg(feature = "csskit_arena")]
 	{
-		assert_eq!(simple_alloc.used_bytes(), 392);
-		assert_eq!(escaped_alloc.used_bytes(), 616);
-		assert_eq!(big_alloc.used_bytes(), 51_939_384);
+		assert_eq!(simple_alloc.used_bytes(), 448);
+		assert_eq!(escaped_alloc.used_bytes(), 704);
+		assert_eq!(big_alloc.used_bytes(), 59_355_416);
 	}
 	#[cfg(all(feature = "bumpalo", not(feature = "csskit_arena")))]
 	{

--- a/crates/csskit_proc_macro/src/generate.rs
+++ b/crates/csskit_proc_macro/src/generate.rs
@@ -1,3 +1,4 @@
+use crate::repr::{Shape, shape_to_repr};
 use crate::type_renames::get_type_rename;
 use css_value_definition_parser::*;
 use heck::{ToPascalCase, ToSnakeCase};
@@ -628,7 +629,9 @@ impl DefExt for Def {
 				})
 				.collect();
 			let keyword_name = Self::keyword_ident(ident);
+			let keyword_repr = shape_to_repr(Shape::DataEnum { variants: keywords.len() });
 			quote! {
+				#keyword_repr
 				#[derive(
 					::csskit_derives::Parse,
 					::csskit_derives::Peek,
@@ -906,7 +909,8 @@ impl GenerateDefinition for Def {
 						}
 					}
 				};
-				quote! { #struct_attrs #vis struct #ident #type_generics #where_clause #members }
+				let struct_repr = shape_to_repr(Shape::Struct);
+				quote! { #struct_repr #struct_attrs #vis struct #ident #type_generics #where_clause #members }
 			}
 			DataType::Enum => match self {
 				Self::Combinator(children, DefCombinatorStyle::Alternatives) => {
@@ -1069,7 +1073,8 @@ impl GenerateDefinition for Def {
 							}
 						})
 						.collect();
-					quote! { #vis enum #ident #type_generics #where_clause { #variants } }
+					let enum_repr = shape_to_repr(Shape::DataEnum { variants: children.len() });
+					quote! { #enum_repr #vis enum #ident #type_generics #where_clause { #variants } }
 				}
 				Self::Combinator(_, _) => {
 					Error::new(ident.span(), "cannot generate non-Alternatives combinators in enum")

--- a/crates/csskit_proc_macro/src/layout.rs
+++ b/crates/csskit_proc_macro/src/layout.rs
@@ -1,0 +1,76 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{GenericParam, Generics, Ident};
+
+/// The number of lifetime parameters a node type carries, or `None` when it also
+/// carries a type or const generic parameter.
+///
+/// A type-generic node has no single layout, so it cannot derive one `TypeLayout` or
+/// self-register a single `TypeLayoutInfo`. Such types still receive their `#[repr]`;
+/// their concrete instantiations are covered where they are monomorphised.
+fn lifetimes(generics: &Generics) -> Option<usize> {
+	let mut lifetimes = 0usize;
+	for param in &generics.params {
+		match param {
+			GenericParam::Lifetime(_) => lifetimes += 1,
+			GenericParam::Type(_) | GenericParam::Const(_) => return None,
+		}
+	}
+	Some(lifetimes)
+}
+
+/// The `TypeLayout` derive a node type carries in test builds, or nothing when the
+/// type is generic over a type/const parameter.
+pub fn derive_attr(generics: &Generics) -> TokenStream {
+	if lifetimes(generics).is_none() {
+		return quote! {};
+	}
+	quote! { #[cfg_attr(test, derive(::stable_type_layout::TypeLayout))] }
+}
+
+/// Registers a node type's layout with the crate's `layout_test` collector so its
+/// size, field offsets and variant discriminants are snapshot tested. Emits nothing
+/// when the type is generic over a type/const parameter.
+pub fn registration(ident: &Ident, generics: &Generics) -> TokenStream {
+	let Some(lifetimes) = lifetimes(generics) else {
+		return quote! {};
+	};
+	let ty = if lifetimes == 0 {
+		quote! { #ident }
+	} else {
+		let statics = std::iter::repeat_n(quote! { 'static }, lifetimes);
+		quote! { #ident<#(#statics),*> }
+	};
+	quote! {
+		#[cfg(test)]
+		::stable_type_layout::register!(#ty);
+	}
+}
+
+/// Parses a token stream of generated items and re-emits it, giving every struct and
+/// enum its [`derive_attr`] and [`registration`]. Used by the `#[syntax]` generator,
+/// whose bodies (main type + helper types) exist only as generated tokens.
+pub fn annotate_items(items: &TokenStream) -> TokenStream {
+	let file = match syn::parse2::<syn::File>(items.clone()) {
+		Ok(file) => file,
+		Err(err) => {
+			let message = format!("generated items could not be parsed for layout registration: {err}");
+			return quote! { ::core::compile_error!(#message); };
+		}
+	};
+	let mut out = quote! {};
+	for item in &file.items {
+		let (ident, generics) = match item {
+			syn::Item::Struct(s) => (&s.ident, &s.generics),
+			syn::Item::Enum(e) => (&e.ident, &e.generics),
+			_ => {
+				out.extend(quote! { #item });
+				continue;
+			}
+		};
+		let attr = derive_attr(generics);
+		let registration = registration(ident, generics);
+		out.extend(quote! { #attr #item #registration });
+	}
+	out
+}

--- a/crates/csskit_proc_macro/src/lib.rs
+++ b/crates/csskit_proc_macro/src/lib.rs
@@ -3,7 +3,9 @@ use proc_macro::TokenStream;
 use syn::{DeriveInput, parse_macro_input};
 
 mod generate;
+mod layout;
 mod node;
+mod repr;
 mod syntax;
 mod type_renames;
 

--- a/crates/csskit_proc_macro/src/node.rs
+++ b/crates/csskit_proc_macro/src/node.rs
@@ -1,46 +1,30 @@
+use crate::repr::{Shape, shape_to_repr};
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{DeriveInput, GenericParam};
+use syn::{Data, DeriveInput, Fields};
 
-/// Expands `#[node]` on a hand-bodied struct/enum: re-emits it unchanged and, in
-/// test builds only, registers its `size_of` with the crate's `layout_test`
-/// collector so the size tripwire snapshot catches accidental size regressions.
-///
-/// `#[node]` injects no `#[repr]` and carries no runtime cost: the registration
-/// is `#[cfg(test)]`, so non-test builds see the type verbatim.
+/// Expands `#[node]` on a hand-bodied struct/enum, adding the appropriate `#[repr(...)]` tag and registering its
+/// layout with the crate's `layout_test` collector so the sizes are snapshot tested.
 pub fn generate(ast: DeriveInput) -> TokenStream {
-	let name = ast.ident.to_string();
-	let registration = match concrete_ty(&ast) {
-		Some(ty) => quote! {
-			#[cfg(test)]
-			::inventory::submit! {
-				crate::layout_test::LayoutInfo { name: #name, size: ::core::mem::size_of::<#ty>() }
+	let shape = match &ast.data {
+		Data::Struct(_) | Data::Union(_) => Shape::Struct,
+		Data::Enum(data) => {
+			let variants = data.variants.len();
+			if data.variants.iter().all(|v| matches!(v.fields, Fields::Unit)) {
+				let wide = data.variants.iter().any(|v| v.discriminant.is_some());
+				Shape::FieldlessEnum { variants, wide }
+			} else {
+				Shape::DataEnum { variants }
 			}
-		},
-		None => quote! {},
+		}
 	};
+	let repr = shape_to_repr(shape);
+	let derive_attr = crate::layout::derive_attr(&ast.generics);
+	let registration = crate::layout::registration(&ast.ident, &ast.generics);
 	quote! {
+		#repr
+		#derive_attr
 		#ast
 		#registration
-	}
-}
-
-/// The concrete type reference used in `size_of`, substituting `'static` for
-/// every lifetime. Returns `None` when the type is generic over a type or const
-/// parameter, since it has no single size to record.
-fn concrete_ty(ast: &DeriveInput) -> Option<TokenStream> {
-	let ident = &ast.ident;
-	let mut lifetimes = 0usize;
-	for param in &ast.generics.params {
-		match param {
-			GenericParam::Lifetime(_) => lifetimes += 1,
-			_ => return None,
-		}
-	}
-	if lifetimes == 0 {
-		Some(quote! { #ident })
-	} else {
-		let statics = (0..lifetimes).map(|_| quote! { 'static });
-		Some(quote! { #ident<#(#statics),*> })
 	}
 }

--- a/crates/csskit_proc_macro/src/repr.rs
+++ b/crates/csskit_proc_macro/src/repr.rs
@@ -1,0 +1,49 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// The structural shape of a node type, which determines its `#[repr(...)]`.
+///
+/// This is the single source of truth shared by the `#[syntax]` generator and the
+/// `#[node]` attribute macro so generated and hand-written node types cannot drift.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Shape {
+	/// A struct: `#[repr(C)]`.
+	Struct,
+	/// A fieldless (C-like) enum: `#[repr(uN)]`. `wide` forces `u32` when the enum
+	/// carries explicit discriminant values (whose magnitude may exceed the width
+	/// implied by the variant count).
+	FieldlessEnum { variants: usize, wide: bool },
+	/// A data-carrying enum: `#[repr(C, uN)]`.
+	DataEnum { variants: usize },
+}
+
+/// The tag width for an enum with `variants` variants: `u8` if it fits, else `u16`.
+///
+/// A `u8` discriminant can hold up to 256 distinct values (`0..=255`).
+fn tag_ty(variants: usize) -> TokenStream {
+	if variants <= 256 {
+		quote! { u8 }
+	} else {
+		quote! { u16 }
+	}
+}
+
+/// Maps a node's [`Shape`] to the `#[repr(...)]` attribute it must carry so the
+/// generated JS deserialiser reads a stable, declaration-order layout.
+pub fn shape_to_repr(shape: Shape) -> TokenStream {
+	match shape {
+		Shape::Struct => quote! { #[repr(C)] },
+		Shape::FieldlessEnum { variants, wide } => {
+			let tag = if wide {
+				quote! { u32 }
+			} else {
+				tag_ty(variants)
+			};
+			quote! { #[repr(#tag)] }
+		}
+		Shape::DataEnum { variants } => {
+			let tag = tag_ty(variants);
+			quote! { #[repr(C, #tag)] }
+		}
+	}
+}

--- a/crates/csskit_proc_macro/src/syntax.rs
+++ b/crates/csskit_proc_macro/src/syntax.rs
@@ -80,6 +80,9 @@ pub fn generate(defs: Def, ast: DeriveInput) -> TokenStream {
 		quote! {}
 	};
 
+	let additonal_defs = crate::layout::annotate_items(&additonal_defs);
+	let def = crate::layout::annotate_items(&def);
+
 	quote! {
 		#additonal_defs
 

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_struct_with_range.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_struct_with_range.snap
@@ -3,9 +3,13 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 #[parse(all_must_occur)]
 struct Foo<'a>(
     #[atom(CssAtomSet::Auto)]
     pub ::css_parse::T![Ident],
     pub crate::CalcableValue<'a, crate::Ranged<crate::Percentage, 0i32, 100i32>>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_with_group_alternatives.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__all_must_occur_with_group_alternatives.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Legacy)]
     Legacy(::css_parse::T![Ident]),
@@ -28,3 +30,5 @@ enum Foo {
         ::css_parse::T![Ident],
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__alternatives_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__alternatives_with_checks_derive_parse.snap
@@ -3,8 +3,12 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Bar)]
     Bar(::css_parse::T![Ident]),
     Angle(Option<crate::CalcableValue<'a, crate::Ranged<crate::Angle, -90i32, 90i32>>>),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_and_length_with_range.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_and_length_with_range.snap
@@ -3,9 +3,13 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 #[parse(all_must_occur)]
 struct Foo<'a>(
     #[atom(CssAtomSet::Auto)]
     pub ::css_parse::T![Ident],
     pub crate::CalcableValue<'a, crate::Ranged<crate::Length, 0i32, 100i32>>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_fixed_multiplier.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_fixed_multiplier.snap
@@ -3,8 +3,12 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub crate::AutoOr<
         (crate::Value<'a, crate::Color<'a>>, crate::Value<'a, crate::Color<'a>>),
     >,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse, Visitable)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Auto)]
@@ -11,3 +13,5 @@ enum Foo {
     #[atom(CssAtomSet::None)]
     None(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none_or_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_none_or_type.snap
@@ -2,4 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(pub crate::AutoNoneOr<crate::CalcableValue<'a, crate::Length>>);
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks.snap
@@ -2,8 +2,12 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub crate::AutoOr<
         crate::CalcableValue<'a, crate::Ranged<crate::Angle, -90i32, 90i32>>,
     >,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__auto_or_type_with_checks_derive_parse.snap
@@ -3,8 +3,12 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub crate::AutoOr<
         crate::CalcableValue<'a, crate::Ranged<crate::Angle, -90i32, 90i32>>,
     >,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bg_image.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bg_image.snap
@@ -2,4 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(pub crate::Value<'a, crate::BgImage<'a>>);
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bound_range_multiplier_with_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bound_range_multiplier_with_keyword.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     Length(
         crate::CalcableValue<'a, crate::Length>,
@@ -11,3 +13,5 @@ enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_multiplier_of_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_multiplier_of_keywords.snap
@@ -2,6 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 #[derive(
     ::csskit_derives::Parse,
     ::csskit_derives::Peek,
@@ -27,10 +29,16 @@ pub enum FooKeywords {
     #[atom(CssAtomSet::Bar)]
     Bar(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(FooKeywords);
 #[derive(Visitable, Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     #[cfg_attr(feature = "visitable", visit(skip))]
     pub FooKeywords,
     #[cfg_attr(feature = "visitable", visit(skip))]
     pub Option<FooKeywords>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__bounded_range_multiplier_is_optimized_to_options_with_lifetimes_when_necessary.snap
@@ -2,7 +2,11 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub crate::BorderTopColorStyleValue<'a>,
     pub Option<crate::BorderTopColorStyleValue<'a>>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional2_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional2_keyword.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
@@ -15,3 +17,5 @@ enum Foo<'a> {
         ::css_parse::T![Ident],
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 #[parse(one_must_occur)]
 struct Foo {
     #[cfg_attr(feature = "visitable", visit(skip))]
@@ -15,3 +17,5 @@ struct Foo {
     #[atom(CssAtomSet::Baz)]
     pub baz: Option<::css_parse::T![Ident]>,
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords_with_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_all_keywords_with_derive_parse.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse, Visitable)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 #[parse(one_must_occur)]
 struct Foo {
     #[cfg_attr(feature = "visitable", visit(skip))]
@@ -15,3 +17,5 @@ struct Foo {
     #[atom(CssAtomSet::Baz)]
     pub baz: Option<::css_parse::T![Ident]>,
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_keyword.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
@@ -14,3 +16,5 @@ enum Foo<'a> {
         ::css_parse::T![Ident],
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_last_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__combinator_optional_last_keyword.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
@@ -14,3 +16,5 @@ enum Foo<'a> {
         Option<crate::Value<'a, crate::Color<'a>>>,
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_all_optionals.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_all_optionals.snap
@@ -1,10 +1,13 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
-assertion_line: 150
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a> {
     pub caret_color: Option<crate::CaretColorStyleValue<'a>>,
     pub caret_animation: Option<crate::CaretAnimationStyleValue>,
     pub caret_shape: Option<crate::CaretShapeStyleValue>,
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_type.snap
@@ -3,8 +3,12 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     CalcSizeFunction(crate::CalcSizeFunction),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_variant_with_args.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_variant_with_args.snap
@@ -3,8 +3,12 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::FitContent)]
     FitContent(::css_parse::T![Ident]),
     FitContentFunction(crate::FitContentFunction<'a>),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_variant_with_multiplier_args.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_function_variant_with_multiplier_args.snap
@@ -3,4 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(pub crate::NormalOr<crate::StylesetFunction<'a>>);
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
@@ -10,3 +12,5 @@ enum Foo<'a> {
         crate::CalcableValue<'a, crate::NonNegative<crate::LengthPercentage>>,
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__custom_type_with_checks_derive_parse.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
@@ -10,3 +12,5 @@ enum Foo<'a> {
         crate::CalcableValue<'a, crate::NonNegative<crate::LengthPercentage>>,
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_list.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_list.snap
@@ -2,6 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 #[derive(
     ::csskit_derives::Parse,
     ::csskit_derives::Peek,
@@ -22,9 +24,15 @@ expression: pretty
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(skip))]
 pub enum FooKeywords {}
+#[cfg(test)]
+::stable_type_layout::register!(FooKeywords);
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub Option<::css_parse::Vec<'a, (::css_parse::T![Ident], ::css_parse::T![,])>>,
     #[atom(CssAtomSet::Bar)]
     pub FooKeywords,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_with_nested_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_keyword_group_with_nested_options.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[parse(one_must_occur)]
     Foo {
@@ -23,3 +25,5 @@ enum Foo<'a> {
         qux: Option<::css_parse::T![Ident]>,
     },
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_type_with_lifetime.snap
@@ -2,7 +2,11 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     Color(crate::Value<'a, crate::Color<'a>>),
     Image1d(crate::Value<'a, crate::Image1d<'a>>),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_group_in_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_group_in_options.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Nowrap)]
     Nowrap(::css_parse::T![Ident]),
@@ -21,3 +23,5 @@ enum Foo {
         balance: Option<::css_parse::T![Ident]>,
     },
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_keyword_options.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::None)]
     None(::css_parse::T![Ident]),
@@ -22,3 +24,5 @@ enum Foo {
     #[atom(CssAtomSet::GrammarError)]
     GrammarError(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__enum_with_variable_count_type.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
@@ -10,3 +12,5 @@ enum Foo<'a> {
         ::css_parse::CommaSeparated<'a, crate::Value<'a, crate::AnimateableFeature>>,
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__just_optional.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__just_optional.snap
@@ -2,7 +2,11 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub Option<crate::Value<'a, crate::Color<'a>>>,
     pub Option<crate::Value<'a, crate::Color<'a>>>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_bounded_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_bounded_type.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
@@ -12,3 +14,5 @@ enum Foo<'a> {
         Option<crate::CalcableValue<'a, crate::Ranged<crate::Angle, -90i32, 90i32>>>,
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_int_literal.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_int_literal.snap
@@ -2,7 +2,11 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     Keyword(::css_parse::T![Ident]),
     Literal2(crate::Exact<crate::CSSInt, 2i32>),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_int_literal_dimension_literal.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_int_literal_dimension_literal.snap
@@ -3,9 +3,13 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Keyword)]
     Keyword(::css_parse::T![Ident]),
     Literal1(crate::Exact<crate::CSSInt, 1i32>),
     Literal1deg(#[atom(CssAtomSet::Deg)] crate::Exact<::css_parse::T![Dimension], 1i32>),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_only_alternation_group_in_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__keyword_only_alternation_group_in_options.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[parse(one_must_occur)]
     Wrap {
@@ -19,3 +21,5 @@ enum Foo {
         balance: Option<::css_parse::T![Ident]>,
     },
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__literal_with_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__literal_with_derive_parse.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     Literal0deg(#[atom(CssAtomSet::Deg)] crate::Exact<::css_parse::T![Dimension], 0i32>),
     Literal90deg(
@@ -10,3 +12,5 @@ enum Foo {
         crate::Exact<::css_parse::T![Dimension], 90i32>,
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiple_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiple_keywords.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Black)]
     Black(::css_parse::T![Ident]),
@@ -13,3 +15,5 @@ enum Foo {
     #[atom(CssAtomSet::Pink)]
     Pink(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiple_keywords_derive_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiple_keywords_derive_parse.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Black)]
     Black(::css_parse::T![Ident]),
@@ -13,3 +15,5 @@ enum Foo {
     #[atom(CssAtomSet::Pink)]
     Pink(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_keywords.snap
@@ -2,6 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 #[derive(
     ::csskit_derives::Parse,
     ::csskit_derives::Peek,
@@ -27,6 +29,12 @@ pub enum FooKeywords {
     #[atom(CssAtomSet::Inset)]
     Inset(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(FooKeywords);
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub ::css_parse::CommaSeparated<'a, crate::Value<'a, crate::FooKeywords>>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_types.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_comma_separated_types.snap
@@ -2,6 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
 #[derive(
     ::csskit_derives::Parse,
     ::csskit_derives::Peek,
@@ -20,10 +21,17 @@ expression: pretty
 #[metadata(delegate)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
+#[repr(C, u8)]
 enum SingleFoo<'a> {
     #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     Bar(crate::Value<'a, crate::Bar>),
 }
+#[cfg(test)]
+::stable_type_layout::register!(SingleFoo < 'static >);
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::SingleFoo<'a>>);
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_just_keywords.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_just_keywords.snap
@@ -2,6 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 #[derive(
     ::csskit_derives::Parse,
     ::csskit_derives::Peek,
@@ -27,4 +29,10 @@ pub enum FooKeywords {
     #[atom(CssAtomSet::Inset)]
     Inset(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(FooKeywords);
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(pub ::css_parse::Vec<'a, crate::Value<'a, crate::FooKeywords>>);
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_two_type_alternatives.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__multiplier_with_two_type_alternatives.snap
@@ -2,9 +2,13 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Baz<'a>(
     pub ::css_parse::CommaSeparated<
         'a,
         ::css_parse::Either<crate::Value<'a, crate::Foo>, crate::Value<'a, crate::Bar>>,
     >,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Baz < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_combinator_with_checks_derives_parse.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_combinator_with_checks_derives_parse.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Bar)]
     Bar(::css_parse::T![Ident]),
@@ -12,3 +14,5 @@ enum Foo<'a> {
         Option<crate::CalcableValue<'a, crate::Ranged<crate::Angle, -90i32, 90i32>>>,
     ),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_custom_function_last_option.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__ordered_custom_function_last_option.snap
@@ -1,9 +1,12 @@
 ---
 source: crates/csskit_proc_macro/src/test/test_generate.rs
-assertion_line: 157
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub crate::CaretColorStyleValue<'a>,
     pub Option<crate::CaretAnimationStyleValue>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__simple_all_must_occur.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__simple_all_must_occur.snap
@@ -2,5 +2,9 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 #[parse(all_must_occur)]
 struct Foo<'a>(pub crate::CalcableValue<'a, crate::Length>, pub ::css_parse::T![Ident]);
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_keyword_group_options_with_style_values.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_keyword_group_options_with_style_values.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[parse(one_must_occur)]
     First {
@@ -19,3 +21,5 @@ enum Foo<'a> {
         baseline_shift: Option<crate::BaselineShiftStyleValue<'a>>,
     },
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_nonor_keyword_options.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_nonor_keyword_options.snap
@@ -2,6 +2,7 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
 #[derive(
     ::csskit_derives::Parse,
     ::csskit_derives::Peek,
@@ -20,6 +21,7 @@ expression: pretty
 #[metadata(delegate)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize), serde())]
 #[cfg_attr(feature = "visitable", derive(::csskit_derives::Visitable), visit(children))]
+#[repr(C)]
 #[parse(one_must_occur)]
 struct FooOptions {
     #[cfg_attr(feature = "visitable", visit(skip))]
@@ -35,5 +37,11 @@ struct FooOptions {
     #[atom(CssAtomSet::Position)]
     pub position: Option<::css_parse::T![Ident]>,
 }
+#[cfg(test)]
+::stable_type_layout::register!(FooOptions);
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo(pub crate::NoneOr<crate::FooOptions>);
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_with_one_or_more_commas.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_with_one_or_more_commas.snap
@@ -2,6 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub ::css_parse::CommaSeparated<
         'a,
@@ -9,3 +11,5 @@ struct Foo<'a>(
         0usize,
     >,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_with_variable_count_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__struct_with_variable_count_type.snap
@@ -2,6 +2,10 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub ::css_parse::CommaSeparated<'a, crate::Value<'a, crate::AnimateableFeature>>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_auto_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_auto_color2_optimized.snap
@@ -3,9 +3,13 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Visitable, Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     Color(crate::Value<'a, crate::Color<'a>>, crate::Value<'a, crate::Color<'a>>),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_color2_optimized.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_fixed_range_color2_optimized.snap
@@ -2,7 +2,11 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub crate::Value<'a, crate::Color<'a>>,
     pub crate::Value<'a, crate::Color<'a>>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_group_type_keyword.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_group_type_keyword.snap
@@ -3,8 +3,12 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     Length(crate::CalcableValue<'a, crate::Positive<crate::Length>>),
     #[atom(CssAtomSet::LineThrough)]
     LineThrough(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type.snap
@@ -2,4 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(pub crate::CalcableValue<'a, crate::Integer>);
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_lone_type_with_lifetime.snap
@@ -2,4 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(pub crate::Value<'a, crate::Image<'a>>);
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_vec_type_with_lifetime.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_vec_type_with_lifetime.snap
@@ -2,4 +2,8 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(pub ::css_parse::CommaSeparated<'a, crate::Value<'a, crate::Image<'a>>>);
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_parse_skips_impl.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_parse_skips_impl.snap
@@ -3,9 +3,13 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     #[atom(CssAtomSet::Bar)]
     Bar(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_visitable_adds_attributes.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_derive_visitable_adds_attributes.snap
@@ -3,6 +3,8 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse, Visitable)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo {
     #[cfg_attr(feature = "visitable", visit(skip))]
     #[atom(CssAtomSet::Foo)]
@@ -11,3 +13,5 @@ enum Foo {
     #[atom(CssAtomSet::Bar)]
     Bar(::css_parse::T![Ident]),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_multiplier_oneormore.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_multiplier_oneormore.snap
@@ -3,8 +3,12 @@ source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
 #[derive(Parse)]
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C, u8)]
 enum Foo<'a> {
     #[atom(CssAtomSet::Foo)]
     Foo(::css_parse::T![Ident]),
     Lengths(::css_parse::Vec<'a, crate::CalcableValue<'a, crate::Length>>),
 }
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_multiplier_range.snap
+++ b/crates/csskit_proc_macro/src/test/snapshots/csskit_proc_macro__test__test_generate__value_with_multiplier_range.snap
@@ -2,9 +2,13 @@
 source: crates/csskit_proc_macro/src/test/test_generate.rs
 expression: pretty
 ---
+#[cfg_attr(test, derive(::stable_type_layout::TypeLayout))]
+#[repr(C)]
 struct Foo<'a>(
     pub crate::CalcableValue<'a, crate::Length>,
     pub crate::CalcableValue<'a, crate::Length>,
     pub Option<crate::CalcableValue<'a, crate::Length>>,
     pub Option<crate::CalcableValue<'a, crate::Length>>,
 );
+#[cfg(test)]
+::stable_type_layout::register!(Foo < 'static >);

--- a/crates/stable_type_layout/Cargo.toml
+++ b/crates/stable_type_layout/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "stable-type-layout"
+version.workspace = true
+authors.workspace = true
+description = "Layout descriptors for struct or enum types with an inventory registry."
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+bench = false
+
+[dependencies]
+inventory = { workspace = true }
+stable_type_layout_derive = { workspace = true }  # @release

--- a/crates/stable_type_layout/src/lib.rs
+++ b/crates/stable_type_layout/src/lib.rs
@@ -1,0 +1,237 @@
+#![deny(warnings)]
+//! Layout descriptors for struct or enum types with an inventory registry.
+//!
+//! [`TypeLayout`] is derivable and exposes a `const` [`TypeLayoutInfo`] holding a type's name, size, minimum alignment,
+//! field offsets and enum variant discriminants.
+//!
+//! ```
+//! use stable_type_layout::{Field, TypeLayout, TypeStructure};
+//!
+//! #[derive(TypeLayout)]
+//! #[repr(C)]
+//! struct Foo {
+//!     a: u8,
+//!     b: u32,
+//! }
+//!
+//! const LAYOUT: stable_type_layout::TypeLayoutInfo = <Foo as TypeLayout>::TYPE_LAYOUT;
+//! assert_eq!(LAYOUT.name, "Foo");
+//! assert_eq!((LAYOUT.size, LAYOUT.align), (8, 4));
+//! assert_eq!(
+//!     LAYOUT.structure,
+//!     TypeStructure::Struct { fields: &[Field { name: "a", offset: 0 }, Field { name: "b", offset: 4 }] }
+//! );
+//! ```
+//!
+//! Types can additionally [`register!`] themselves into a crate-wide [`inventory`] registry, which can be used for
+//! snapshot testing, so a field, variant reorder, or a size change can be caught.
+
+extern crate self as stable_type_layout;
+
+pub use inventory;
+pub use stable_type_layout_derive::TypeLayout;
+
+/// A field's name and byte offset within its type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Field {
+	pub name: &'static str,
+	pub offset: usize,
+}
+
+/// An enum variant's name, declaration index and discriminant.
+///
+/// `discriminant` is the compiler-assigned tag value, recorded only for fieldless enums where it can be read on stable
+/// via an `as` cast. Data-carrying variants record `None`; their `index` still pins declaration order, which is what a
+/// `#[repr(C, uN)]` tag is derived from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Variant {
+	pub name: &'static str,
+	pub index: usize,
+	pub discriminant: Option<i64>,
+}
+
+/// Whether a type is a struct, union or enum, and the fields or variants it holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeStructure {
+	Struct { fields: &'static [Field] },
+	Union { fields: &'static [Field] },
+	Enum { variants: &'static [Variant] },
+}
+
+/// The concrete memory layout of a type: its name, size, minimum alignment and
+/// [`TypeStructure`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TypeLayoutInfo {
+	pub name: &'static str,
+	pub size: usize,
+	pub align: usize,
+	pub structure: TypeStructure,
+}
+
+/// A type whose memory layout is known at compile time.
+pub trait TypeLayout: Sized {
+	const TYPE_LAYOUT: TypeLayoutInfo;
+}
+
+inventory::collect!(TypeLayoutInfo);
+
+/// Registers a type's [`TypeLayoutInfo`] with the registry read by [`all`] and [`render`].
+///
+/// ```
+/// use stable_type_layout::TypeLayout;
+///
+/// #[derive(TypeLayout)]
+/// #[repr(C)]
+/// struct Registered(u32);
+///
+/// stable_type_layout::register!(Registered);
+/// assert!(stable_type_layout::all().iter().any(|info| info.name == "Registered"));
+/// ```
+#[macro_export]
+macro_rules! register {
+	($ty:ty) => {
+		$crate::inventory::submit! { <$ty as $crate::TypeLayout>::TYPE_LAYOUT }
+	};
+}
+
+/// Every registered [`TypeLayoutInfo`], sorted by type name (deterministic order for snapshotting).
+pub fn all() -> Vec<&'static TypeLayoutInfo> {
+	let mut infos: Vec<&'static TypeLayoutInfo> = inventory::iter::<TypeLayoutInfo>.into_iter().collect();
+	infos.sort_by_key(|info| info.name);
+	infos
+}
+
+/// Render every registered layout as a stable, human-readable string for snapshot assertions.
+pub fn render() -> String {
+	let mut out = String::new();
+	for info in all() {
+		out.push_str(info.name);
+		out.push_str(&format!(": size={} align={}", info.size, info.align));
+		let fields = match info.structure {
+			TypeStructure::Struct { fields } | TypeStructure::Union { fields } => fields,
+			TypeStructure::Enum { variants } => {
+				for variant in variants {
+					match variant.discriminant {
+						Some(discriminant) => {
+							out.push_str(&format!("\n    {}: {} = {}", variant.index, variant.name, discriminant))
+						}
+						None => out.push_str(&format!("\n    {}: {}", variant.index, variant.name)),
+					}
+				}
+				&[]
+			}
+		};
+		if fields.is_empty() {
+			out.push('\n');
+		} else {
+			out.push_str(" {\n");
+			for field in fields {
+				out.push_str(&format!("    {}: {}\n", field.name, field.offset));
+			}
+			out.push_str("}\n");
+		}
+	}
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[derive(TypeLayout)]
+	#[repr(C)]
+	struct SmallFirst {
+		small: u8,
+		large: u64,
+	}
+
+	#[derive(TypeLayout)]
+	#[repr(C)]
+	struct LargeFirst {
+		large: u64,
+		small: u8,
+	}
+
+	#[derive(TypeLayout)]
+	#[repr(u8)]
+	enum Fieldless {
+		Zero,
+		Seven = 7,
+		Eight,
+	}
+
+	#[allow(dead_code)]
+	#[derive(TypeLayout)]
+	#[repr(C, u8)]
+	enum DataCarrying {
+		Unit,
+		Payload(u32),
+	}
+
+	#[derive(TypeLayout)]
+	#[repr(C)]
+	struct Tuple<'a>(&'a str, u8);
+
+	#[derive(TypeLayout)]
+	#[repr(C)]
+	struct Unit;
+
+	register!(Fieldless);
+	register!(Tuple<'static>);
+	register!(Unit);
+
+	fn fields_of(info: TypeLayoutInfo) -> &'static [Field] {
+		match info.structure {
+			TypeStructure::Struct { fields } | TypeStructure::Union { fields } => fields,
+			TypeStructure::Enum { .. } => panic!("not a struct"),
+		}
+	}
+
+	#[test]
+	fn reorder_changes_field_offsets() {
+		let small_first = fields_of(SmallFirst::TYPE_LAYOUT);
+		let large_first = fields_of(LargeFirst::TYPE_LAYOUT);
+		assert_eq!(small_first, &[Field { name: "small", offset: 0 }, Field { name: "large", offset: 8 }]);
+		assert_eq!(large_first, &[Field { name: "large", offset: 0 }, Field { name: "small", offset: 8 }]);
+	}
+
+	#[test]
+	fn records_explicit_and_implicit_discriminants() {
+		assert_eq!(
+			Fieldless::TYPE_LAYOUT.structure,
+			TypeStructure::Enum {
+				variants: &[
+					Variant { name: "Zero", index: 0, discriminant: Some(0) },
+					Variant { name: "Seven", index: 1, discriminant: Some(7) },
+					Variant { name: "Eight", index: 2, discriminant: Some(8) },
+				]
+			}
+		);
+	}
+
+	#[test]
+	fn data_carrying_variants_pin_index_only() {
+		assert_eq!(
+			DataCarrying::TYPE_LAYOUT.structure,
+			TypeStructure::Enum {
+				variants: &[
+					Variant { name: "Unit", index: 0, discriminant: None },
+					Variant { name: "Payload", index: 1, discriminant: None },
+				]
+			}
+		);
+	}
+
+	#[test]
+	fn tuple_fields_are_named_by_index() {
+		assert_eq!(fields_of(Tuple::TYPE_LAYOUT), &[Field { name: "0", offset: 0 }, Field { name: "1", offset: 16 }]);
+	}
+
+	#[test]
+	fn renders_every_registered_type() {
+		assert_eq!(
+			render(),
+			"Fieldless: size=1 align=1\n    0: Zero = 0\n    1: Seven = 7\n    2: Eight = 8\nTuple: size=24 align=8 {\n    0: 0\n    1: 16\n}\nUnit: size=0 align=1\n"
+		);
+	}
+}

--- a/crates/stable_type_layout_derive/Cargo.toml
+++ b/crates/stable_type_layout_derive/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "stable-type-layout-derive"
+version.workspace = true
+authors.workspace = true
+description = "Derive macro for stable-type-layout's TypeLayout trait."
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+bench = false
+proc-macro = true
+
+[dependencies]
+syn = { workspace = true, features = ["derive", "parsing", "printing", "proc-macro"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }

--- a/crates/stable_type_layout_derive/src/lib.rs
+++ b/crates/stable_type_layout_derive/src/lib.rs
@@ -1,0 +1,88 @@
+#![deny(warnings)]
+//! Derive macro for `stable_type_layout::TypeLayout`.
+//!
+//! Use it through the [`stable-type-layout`](https://docs.rs/stable-type-layout) crate, which re-exports this macro
+//! alongside the trait it implements.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, Ident, Index, parse_macro_input};
+
+/// Implements `TypeLayout`, recording the type's size, alignment, field offsets and enum variant discriminants as a
+/// `const`.
+///
+/// Structs and unions record every field's name and byte offset. Enums record every variant's name and declaration
+/// index, plus its discriminant when the enum is fieldless. Lifetime, type and const parameters are carried onto the
+/// impl, so a generic type describes whichever instantiation is asked for.
+///
+/// See the `stable_type_layout` crate docs for examples; this crate cannot depend on it to run one here.
+#[proc_macro_derive(TypeLayout)]
+pub fn derive_type_layout(input: TokenStream) -> TokenStream {
+	let ast = parse_macro_input!(input as DeriveInput);
+	let ident = &ast.ident;
+	let name = ident.to_string();
+	let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+	let structure = match &ast.data {
+		Data::Struct(data) => {
+			let fields = fields(&data.fields);
+			quote! { ::stable_type_layout::TypeStructure::Struct { fields: &[#(#fields),*] } }
+		}
+		Data::Union(data) => {
+			let fields = data.fields.named.iter().map(|f| named_field(f.ident.as_ref().unwrap()));
+			quote! { ::stable_type_layout::TypeStructure::Union { fields: &[#(#fields),*] } }
+		}
+		Data::Enum(data) => {
+			// A fieldless enum is castable, so its real compiler-assigned tag value can be recorded. A data-carrying variant
+			// is not, and only its index is pinned.
+			let fieldless = data.variants.iter().all(|v| matches!(v.fields, Fields::Unit));
+			let variants = data.variants.iter().enumerate().map(|(index, variant)| {
+				let variant_ident = &variant.ident;
+				let variant_name = variant_ident.to_string();
+				let discriminant = if fieldless {
+					quote! { ::core::option::Option::Some(Self::#variant_ident as i64) }
+				} else {
+					quote! { ::core::option::Option::None }
+				};
+				quote! {
+					::stable_type_layout::Variant {
+						name: #variant_name,
+						index: #index,
+						discriminant: #discriminant,
+					}
+				}
+			});
+			quote! { ::stable_type_layout::TypeStructure::Enum { variants: &[#(#variants),*] } }
+		}
+	};
+	quote! {
+		impl #impl_generics ::stable_type_layout::TypeLayout for #ident #ty_generics #where_clause {
+			const TYPE_LAYOUT: ::stable_type_layout::TypeLayoutInfo = ::stable_type_layout::TypeLayoutInfo {
+				name: #name,
+				size: ::core::mem::size_of::<Self>(),
+				align: ::core::mem::align_of::<Self>(),
+				structure: #structure,
+			};
+		}
+	}
+	.into()
+}
+
+fn fields(fields: &Fields) -> Vec<TokenStream2> {
+	match fields {
+		Fields::Named(named) => named.named.iter().map(|f| named_field(f.ident.as_ref().unwrap())).collect(),
+		Fields::Unnamed(unnamed) => (0..unnamed.unnamed.len())
+			.map(|i| {
+				let index = Index::from(i);
+				let name = i.to_string();
+				quote! { ::stable_type_layout::Field { name: #name, offset: ::core::mem::offset_of!(Self, #index) } }
+			})
+			.collect(),
+		Fields::Unit => vec![],
+	}
+}
+
+fn named_field(ident: &Ident) -> TokenStream2 {
+	let name = ident.to_string();
+	quote! { ::stable_type_layout::Field { name: #name, offset: ::core::mem::offset_of!(Self, #ident) } }
+}


### PR DESCRIPTION
In https://github.com/csskit/csskit/pull/1323 we introduced `#[node]` which also introduced snapshot tests to replace the hundreds of size_of assertions. This provides a good foundation for us to build out APIs in other languages, but in order for a stable ABI we need to guarantee layout of these nodes.

So this change ensures all Nodes are repr(C) to ensure stability, and incorporates stable-type-layout - a new crate which collects layout information about each field and exposes it at runtime, useful for both testing and integration.